### PR TITLE
Add global DAG index (Flux.GraphIndex) and public graph inspection APIs

### DIFF
--- a/lib/flux.ex
+++ b/lib/flux.ex
@@ -46,6 +46,11 @@ defmodule Flux do
   Assets can depend on other assets. Flux uses those dependency declarations to derive the
   execution graph automatically.
 
+  Flux models those relationships as a directed acyclic graph (DAG), not as a strict tree.
+  Shared upstream assets are therefore allowed, cycles are rejected, and a later runtime
+  planner can ensure an asset runs at most once in a single run even when multiple downstream
+  assets depend on it.
+
   In practice, this means users generally do not need to manually define pipelines. When an
   asset is run, Flux can compute the dependency graph for the requested target and form the
   execution pipeline from that graph.
@@ -126,6 +131,10 @@ defmodule Flux do
       Flux.list_assets(MyApp.SalesETL)
 
       Flux.get_asset({MyApp.SalesETL, :normalize_orders})
+
+      Flux.upstream_assets({MyApp.GoldETL, :fact_sales})
+
+      Flux.dependency_graph({MyApp.GoldETL, :fact_sales}, tags: [:warehouse])
 
       Flux.run({MyApp.GoldETL, :fact_sales})
 
@@ -211,12 +220,18 @@ defmodule Flux do
   ## Configuration lifecycle
 
   The global asset registry is loaded from application config during startup and
-  then kept in memory for fast lookups.
+  then kept in memory for fast lookups. Flux also builds a global dependency
+  graph index during startup from that same canonical asset catalog.
+
+  The graph index is intended to stay read-only for the lifetime of the booted
+  node and supports DAG validation, upstream and downstream inspection,
+  transitive dependency queries, and deterministic topological ordering for
+  later execution planning.
 
   That means changes to `config :flux, asset_modules: [...]` are not picked up
   automatically by an already-running node. In normal usage, update the config
-  and restart the host application so Flux reloads the configured registry
-  during boot.
+  and restart the host application so Flux reloads the configured registry and
+  dependency graph during boot.
 
   ## Public API responsibilities
 
@@ -224,6 +239,7 @@ defmodule Flux do
 
     * asset discovery
     * asset inspection
+    * dependency graph inspection
     * run execution
     * run inspection
     * listing historical runs
@@ -254,7 +270,7 @@ defmodule Flux do
 
     * `Flux` defines the intended public API first
     * asset authoring and compile-time metadata collection now back module-level inspection APIs
-    * dependencies declared by assets will define the execution graph
+    * dependencies declared by assets now build a startup-loaded global DAG index
     * runtime execution, eventing, and storage will be implemented underneath that API
 
   This module therefore acts as both:
@@ -281,11 +297,12 @@ defmodule Flux do
     3. per-module asset introspection through `Flux` - done
     4. global registry and configured asset discovery - done
     5. startup registry loading and caching - done
-    6. dependency resolution and graph construction
-    7. execution planning
-    8. run model and in-memory execution
-    9. run storage and retrieval
-    10. live run event subscriptions
+    6. dependency resolution and graph construction - in progress
+    7. graph inspection queries - in progress
+    8. execution planning
+    9. run model and in-memory execution
+    10. run storage and retrieval
+    11. live run event subscriptions
 
   """
 
@@ -421,6 +438,112 @@ defmodule Flux do
     end
   end
 
+  @typedoc """
+  Direction used by dependency graph inspection APIs.
+  """
+  @type dependency_direction :: Flux.GraphIndex.direction()
+
+  @typedoc """
+  Options for dependency graph inspection APIs.
+  """
+  @type graph_opts :: [
+          direction: dependency_direction(),
+          include_target: boolean(),
+          transitive: boolean(),
+          tags: [Flux.Asset.tag()],
+          kinds: [Flux.Asset.kind()],
+          modules: [module()],
+          names: [atom()]
+        ]
+
+  @doc """
+  List upstream assets for a target reference.
+
+  This query delegates to the startup-built global DAG index and returns asset
+  metadata rather than bare refs so operator tooling can inspect tags, docs,
+  source locations, and kinds together with dependency shape.
+
+  ## Examples
+
+      iex> Flux.upstream_assets({Unknown.Module, :normalize_orders})
+      {:error, :not_asset_module}
+
+  ## TODO
+
+    * Keep this backed by `Flux.GraphIndex.related_assets/2`
+    * Keep the default query transitive so planners and UIs get the full closure
+    * Add richer view-specific formatting later rather than here
+  """
+  @spec upstream_assets(asset_ref(), graph_opts()) ::
+          {:ok, [asset()]} | {:error, asset_error() | term()}
+  def upstream_assets({module, name}, opts \\ [])
+      when is_atom(module) and is_atom(name) and is_list(opts) do
+    if asset_module?(module) do
+      Flux.GraphIndex.related_assets(
+        {module, name},
+        opts |> Keyword.put_new(:direction, :upstream) |> Keyword.put_new(:include_target, false)
+      )
+    else
+      {:error, :not_asset_module}
+    end
+  end
+
+  @doc """
+  List downstream assets for a target reference.
+
+  ## Examples
+
+      iex> Flux.downstream_assets({Unknown.Module, :normalize_orders})
+      {:error, :not_asset_module}
+
+  ## TODO
+
+    * Keep this backed by `Flux.GraphIndex.related_assets/2`
+    * Support immediate and transitive traversal through `transitive: false | true`
+    * Keep filtering in the graph layer rather than duplicating it in the facade
+  """
+  @spec downstream_assets(asset_ref(), graph_opts()) ::
+          {:ok, [asset()]} | {:error, asset_error() | term()}
+  def downstream_assets({module, name}, opts \\ [])
+      when is_atom(module) and is_atom(name) and is_list(opts) do
+    if asset_module?(module) do
+      Flux.GraphIndex.related_assets(
+        {module, name},
+        Keyword.put_new(opts, :direction, :downstream)
+      )
+    else
+      {:error, :not_asset_module}
+    end
+  end
+
+  @doc """
+  Build a filtered dependency subgraph for a target reference.
+
+  This returns another `%Flux.GraphIndex{}` limited to the selected asset set,
+  which keeps graph queries and planner inputs on one canonical shape.
+
+  ## Examples
+
+      iex> Flux.dependency_graph({Unknown.Module, :normalize_orders})
+      {:error, :not_asset_module}
+
+  ## TODO
+
+    * Keep this backed by `Flux.GraphIndex.subgraph/2`
+    * Use this as the input boundary for execution planning
+    * Extend filtering only when real UI or planner needs appear
+  """
+  @spec dependency_graph(asset_ref(), graph_opts()) ::
+          {:ok, Flux.GraphIndex.t()} | {:error, asset_error() | term()}
+  def dependency_graph({module, name}, opts \\ [])
+      when is_atom(module) and is_atom(name) and is_list(opts) do
+    if asset_module?(module) do
+      Flux.GraphIndex.subgraph({module, name}, opts)
+    else
+      {:error, :not_asset_module}
+    end
+  end
+
   @doc false
   @spec asset_module?(module()) :: boolean()
   def asset_module?(module) when is_atom(module) do
@@ -454,11 +577,13 @@ defmodule Flux do
 
   ## TODO
 
-    * Implement after asset authoring, introspection, and dependency graph construction exist
+    * Implement on top of the startup-built DAG index in `Flux.GraphIndex`
     * Delegate to `Flux.Runner.run/2`
     * Define the return contract, likely `{:ok, run}` or `{:error, reason}`
     * Support `dependencies: :all | :none` first
-    * Add more advanced inclusion or exclusion rules only if truly needed
+    * Plan execution from a target subgraph with run-once semantics
+    * Add parallel scheduling only after the basic plan format is stable
+    * Add freshness-aware skipping after the planner can reason about materialized assets
   """
   @spec run(asset_ref(), run_opts()) :: term()
   def run({module, name}, opts \\ [])

--- a/lib/flux/application.ex
+++ b/lib/flux/application.ex
@@ -5,7 +5,8 @@ defmodule Flux.Application do
 
   @impl true
   def start(_type, _args) do
-    with :ok <- Flux.Registry.load() do
+    with :ok <- Flux.Registry.load(),
+         :ok <- Flux.GraphIndex.load() do
       Supervisor.start_link([], strategy: :one_for_one, name: Flux.Supervisor)
     end
   end

--- a/lib/flux/graph_index.ex
+++ b/lib/flux/graph_index.ex
@@ -1,0 +1,520 @@
+defmodule Flux.GraphIndex do
+  @moduledoc """
+  Global dependency graph index for configured Flux assets.
+
+  `Flux.GraphIndex` builds a read-only directed acyclic graph (DAG) from the
+  canonical asset catalog loaded by `Flux.Registry`. The index is computed
+  during application startup and cached in `:persistent_term` for fast,
+  repeated read access.
+
+  The graph is intended to support:
+
+    * validating that every declared dependency exists
+    * rejecting circular dependencies
+    * upstream and downstream graph traversal
+    * deterministic topological ordering for later planning layers
+    * transitive dependency queries for graph inspection APIs
+
+  Flux models dependencies as a DAG rather than a tree. Shared upstream assets
+  are therefore allowed and are expected to execute at most once within a run,
+  even when multiple downstream assets depend on them.
+  """
+
+  alias Flux.Asset
+  alias Flux.Ref
+
+  @index_key {__MODULE__, :index}
+
+  @typedoc """
+  Canonical cached dependency index.
+  """
+  @type t :: %__MODULE__{
+          assets_by_ref: %{Ref.t() => Asset.t()},
+          upstream: %{Ref.t() => MapSet.t(Ref.t())},
+          downstream: %{Ref.t() => MapSet.t(Ref.t())},
+          transitive_upstream: %{Ref.t() => MapSet.t(Ref.t())},
+          transitive_downstream: %{Ref.t() => MapSet.t(Ref.t())},
+          topo_order: [Ref.t()],
+          topo_rank: %{Ref.t() => non_neg_integer()}
+        }
+
+  @typedoc """
+  Graph construction errors.
+  """
+  @type error ::
+          {:missing_dependency, Ref.t(), Ref.t()}
+          | {:cycle, [Ref.t()]}
+          | Flux.Registry.error()
+
+  @typedoc """
+  Direction used when selecting related assets or subgraphs.
+  """
+  @type direction :: :upstream | :downstream | :both
+
+  @typedoc """
+  Metadata filters applied to graph queries.
+
+  When `tags` are provided, an asset matches if it includes at least one of the
+  requested tags. Other filters require membership in the provided list.
+  """
+  @type filter_opts :: [
+          direction: direction(),
+          include_target: boolean(),
+          transitive: boolean(),
+          tags: [Asset.tag()],
+          kinds: [Asset.kind()],
+          modules: [module()],
+          names: [atom()]
+        ]
+
+  defstruct assets_by_ref: %{},
+            upstream: %{},
+            downstream: %{},
+            transitive_upstream: %{},
+            transitive_downstream: %{},
+            topo_order: [],
+            topo_rank: %{}
+
+  @doc """
+  Return the cached global dependency index.
+  """
+  @spec get() :: {:ok, t()} | {:error, error()}
+  def get do
+    case :persistent_term.get(@index_key, :undefined) do
+      :undefined -> load_and_fetch_index()
+      %__MODULE__{} = index -> {:ok, index}
+    end
+  end
+
+  @doc """
+  Build and cache the dependency index from the current registry catalog.
+  """
+  @spec load() :: :ok | {:error, error()}
+  def load do
+    with {:ok, assets} <- Flux.Registry.list_assets(),
+         {:ok, %__MODULE__{} = index} <- build_index(assets) do
+      :persistent_term.put(@index_key, index)
+      :ok
+    end
+  end
+
+  @doc false
+  @spec reload() :: :ok | {:error, error()}
+  def reload, do: load()
+
+  @doc """
+  Return the immediate upstream dependencies for an asset.
+  """
+  @spec upstream_of(Ref.t()) :: {:ok, [Ref.t()]} | {:error, error() | :asset_not_found}
+  def upstream_of(ref) do
+    with {:ok, index} <- get(),
+         {:ok, refs} <- fetch_set(index.upstream, ref) do
+      {:ok, sort_refs(refs, index)}
+    end
+  end
+
+  @doc """
+  Return the immediate downstream dependents for an asset.
+  """
+  @spec downstream_of(Ref.t()) :: {:ok, [Ref.t()]} | {:error, error() | :asset_not_found}
+  def downstream_of(ref) do
+    with {:ok, index} <- get(),
+         {:ok, refs} <- fetch_set(index.downstream, ref) do
+      {:ok, sort_refs(refs, index)}
+    end
+  end
+
+  @doc """
+  Return the full recursive upstream closure for an asset.
+  """
+  @spec transitive_upstream_of(Ref.t()) :: {:ok, [Ref.t()]} | {:error, error() | :asset_not_found}
+  def transitive_upstream_of(ref) do
+    with {:ok, index} <- get(),
+         {:ok, refs} <- fetch_set(index.transitive_upstream, ref) do
+      {:ok, sort_refs(refs, index)}
+    end
+  end
+
+  @doc """
+  Return the full recursive downstream closure for an asset.
+  """
+  @spec transitive_downstream_of(Ref.t()) ::
+          {:ok, [Ref.t()]} | {:error, error() | :asset_not_found}
+  def transitive_downstream_of(ref) do
+    with {:ok, index} <- get(),
+         {:ok, refs} <- fetch_set(index.transitive_downstream, ref) do
+      {:ok, sort_refs(refs, index)}
+    end
+  end
+
+  @doc """
+  Return related assets for a reference.
+
+  By default this returns the full transitive upstream asset list for the
+  target, which is the most useful shape for dependency inspection and later
+  planning layers.
+  """
+  @spec related_assets(Ref.t(), filter_opts()) ::
+          {:ok, [Asset.t()]} | {:error, error() | :asset_not_found}
+  def related_assets(ref, opts \\ []) when is_list(opts) do
+    with {:ok, index} <- get(),
+         {:ok, refs} <- selected_refs(index, ref, opts) do
+      refs = maybe_include_target(refs, ref, Keyword.get(opts, :include_target, false))
+
+      {:ok,
+       refs
+       |> assets_for_refs(index)
+       |> filter_assets(opts)
+       |> sort_assets(index)}
+    end
+  end
+
+  @doc """
+  Return a filtered subgraph rooted at a specific asset reference.
+
+  The returned value is another `%Flux.GraphIndex{}` limited to the selected
+  refs so callers can reuse the same traversal and lookup helpers against a
+  target-specific graph view.
+  """
+  @spec subgraph(Ref.t(), filter_opts()) :: {:ok, t()} | {:error, error() | :asset_not_found}
+  def subgraph(ref, opts \\ []) when is_list(opts) do
+    with {:ok, index} <- get(),
+         {:ok, refs} <- selected_refs(index, ref, Keyword.put_new(opts, :transitive, true)) do
+      refs = maybe_include_target(refs, ref, Keyword.get(opts, :include_target, true))
+
+      include_target? = Keyword.get(opts, :include_target, true)
+
+      refs
+      |> assets_for_refs(index)
+      |> filter_assets(opts)
+      |> ensure_target_present(ref, include_target?, index)
+      |> project_assets()
+      |> build_index()
+    end
+  end
+
+  @doc """
+  Return the cached global topological order.
+  """
+  @spec topological_order() :: {:ok, [Ref.t()]} | {:error, error()}
+  def topological_order do
+    with {:ok, index} <- get() do
+      {:ok, index.topo_order}
+    end
+  end
+
+  @doc """
+  Build a graph index from canonical asset metadata.
+  """
+  @spec build_index([Asset.t()]) :: {:ok, t()} | {:error, error()}
+  def build_index(assets) when is_list(assets) do
+    with {:ok, assets_by_ref} <- build_assets_by_ref(assets),
+         {:ok, upstream, downstream} <- build_adjacency(assets, assets_by_ref),
+         {:ok, topo_order} <- topological_sort(upstream, downstream),
+         transitive_upstream <- build_transitive_index(upstream),
+         transitive_downstream <- build_transitive_index(downstream) do
+      {:ok,
+       %__MODULE__{
+         assets_by_ref: assets_by_ref,
+         upstream: upstream,
+         downstream: downstream,
+         transitive_upstream: transitive_upstream,
+         transitive_downstream: transitive_downstream,
+         topo_order: topo_order,
+         topo_rank: build_topo_rank(topo_order)
+       }}
+    end
+  end
+
+  defp selected_refs(index, ref, opts) do
+    transitive? = Keyword.get(opts, :transitive, true)
+
+    case {Keyword.get(opts, :direction, :upstream), transitive?} do
+      {:upstream, false} ->
+        fetch_set(index.upstream, ref)
+
+      {:downstream, false} ->
+        fetch_set(index.downstream, ref)
+
+      {:upstream, true} ->
+        fetch_set(index.transitive_upstream, ref)
+
+      {:downstream, true} ->
+        fetch_set(index.transitive_downstream, ref)
+
+      {:both, false} ->
+        with {:ok, upstream} <- fetch_set(index.upstream, ref),
+             {:ok, downstream} <- fetch_set(index.downstream, ref) do
+          {:ok, MapSet.union(upstream, downstream)}
+        end
+
+      {:both, true} ->
+        with {:ok, upstream} <- fetch_set(index.transitive_upstream, ref),
+             {:ok, downstream} <- fetch_set(index.transitive_downstream, ref) do
+          {:ok, MapSet.union(upstream, downstream)}
+        end
+    end
+  end
+
+  defp maybe_include_target(refs, ref, true), do: MapSet.put(refs, ref)
+  defp maybe_include_target(refs, _ref, false), do: refs
+
+  defp assets_for_refs(refs, index) do
+    refs
+    |> Enum.map(&Map.fetch!(index.assets_by_ref, &1))
+  end
+
+  defp filter_assets(assets, opts) do
+    tags = Keyword.get(opts, :tags)
+    kinds = Keyword.get(opts, :kinds)
+    modules = Keyword.get(opts, :modules)
+    names = Keyword.get(opts, :names)
+
+    Enum.filter(assets, fn asset ->
+      matches_tags?(asset, tags) and
+        matches_membership?(asset.kind, kinds) and
+        matches_membership?(asset.module, modules) and
+        matches_membership?(asset.name, names)
+    end)
+  end
+
+  defp matches_tags?(_asset, nil), do: true
+  defp matches_tags?(_asset, []), do: true
+
+  defp matches_tags?(asset, tags) when is_list(tags) do
+    asset.tags
+    |> MapSet.new()
+    |> MapSet.disjoint?(MapSet.new(tags))
+    |> Kernel.not()
+  end
+
+  defp matches_membership?(_value, nil), do: true
+  defp matches_membership?(_value, []), do: true
+  defp matches_membership?(value, values) when is_list(values), do: value in values
+
+  defp ensure_target_present(assets, ref, true, index) do
+    if Enum.any?(assets, &(&1.ref == ref)) do
+      assets
+    else
+      [Map.fetch!(index.assets_by_ref, ref) | assets]
+    end
+  end
+
+  defp ensure_target_present(assets, _ref, false, _index), do: assets
+
+  defp project_assets(assets) do
+    refs = MapSet.new(Enum.map(assets, & &1.ref))
+
+    Enum.map(assets, fn asset ->
+      %{asset | depends_on: Enum.filter(asset.depends_on, &MapSet.member?(refs, &1))}
+    end)
+  end
+
+  defp sort_assets(assets, index) do
+    Enum.sort(assets, fn left, right ->
+      left_rank = Map.fetch!(index.topo_rank, left.ref)
+      right_rank = Map.fetch!(index.topo_rank, right.ref)
+
+      cond do
+        left_rank < right_rank -> true
+        left_rank > right_rank -> false
+        true -> compare_refs(left.ref, right.ref)
+      end
+    end)
+  end
+
+  defp load_and_fetch_index do
+    with :ok <- load() do
+      {:ok, :persistent_term.get(@index_key)}
+    end
+  end
+
+  defp build_assets_by_ref(assets) do
+    {:ok, Map.new(assets, &{&1.ref, &1})}
+  end
+
+  defp build_adjacency(assets, assets_by_ref) do
+    empty_sets = Map.new(assets, &{&1.ref, MapSet.new()})
+
+    Enum.reduce_while(assets, {:ok, empty_sets, empty_sets}, fn %Asset{} = asset,
+                                                                {:ok, upstream, downstream} ->
+      Enum.reduce_while(asset.depends_on, {:ok, upstream, downstream}, fn dependency,
+                                                                          {:ok, current_upstream,
+                                                                           current_downstream} ->
+        if Map.has_key?(assets_by_ref, dependency) do
+          {:cont,
+           {:ok, Map.update!(current_upstream, asset.ref, &MapSet.put(&1, dependency)),
+            Map.update!(current_downstream, dependency, &MapSet.put(&1, asset.ref))}}
+        else
+          {:halt, {:error, {:missing_dependency, asset.ref, dependency}}}
+        end
+      end)
+      |> case do
+        {:ok, _updated_upstream, _updated_downstream} = ok -> {:cont, ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp topological_sort(upstream, downstream) do
+    indegree = Map.new(upstream, fn {ref, dependencies} -> {ref, MapSet.size(dependencies)} end)
+
+    queue =
+      indegree
+      |> Enum.filter(fn {_ref, count} -> count == 0 end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.sort(&compare_refs/2)
+
+    consume_topology(queue, indegree, downstream, [])
+    |> case do
+      {:ok, order} when length(order) == map_size(upstream) -> {:ok, order}
+      {:ok, _partial_order} -> {:error, {:cycle, cycle_path(upstream)}}
+    end
+  end
+
+  defp consume_topology([], indegree, _downstream, order) do
+    remaining = Enum.any?(indegree, fn {_ref, count} -> count > 0 end)
+
+    if remaining do
+      {:ok, order}
+    else
+      {:ok, Enum.reverse(order)}
+    end
+  end
+
+  defp consume_topology([ref | rest], indegree, downstream, order) do
+    {updated_indegree, newly_ready} =
+      downstream
+      |> Map.fetch!(ref)
+      |> Enum.reduce({indegree, []}, fn dependent, {current_indegree, ready} ->
+        next_count = Map.fetch!(current_indegree, dependent) - 1
+        next_indegree = Map.put(current_indegree, dependent, next_count)
+
+        if next_count == 0 do
+          {next_indegree, [dependent | ready]}
+        else
+          {next_indegree, ready}
+        end
+      end)
+
+    next_queue = Enum.sort(rest ++ newly_ready, &compare_refs/2)
+    consume_topology(next_queue, updated_indegree, downstream, [ref | order])
+  end
+
+  defp build_transitive_index(adjacency) do
+    Map.new(adjacency, fn {ref, _neighbors} ->
+      {ref, reachable_from(ref, adjacency, MapSet.new())}
+    end)
+  end
+
+  defp reachable_from(ref, adjacency, visited) do
+    adjacency
+    |> Map.fetch!(ref)
+    |> Enum.reduce(visited, fn neighbor, acc ->
+      if MapSet.member?(acc, neighbor) do
+        acc
+      else
+        acc = MapSet.put(acc, neighbor)
+        reachable_from(neighbor, adjacency, acc)
+      end
+    end)
+  end
+
+  defp cycle_path(upstream) do
+    refs = Map.keys(upstream) |> Enum.sort(&compare_refs/2)
+
+    Enum.reduce_while(refs, MapSet.new(), fn ref, globally_visited ->
+      if MapSet.member?(globally_visited, ref) do
+        {:cont, globally_visited}
+      else
+        case dfs_cycle(ref, upstream, globally_visited, [], MapSet.new()) do
+          {:ok, cycle} -> {:halt, cycle}
+          {:error, visited} -> {:cont, visited}
+        end
+      end
+    end)
+    |> case do
+      %MapSet{} -> []
+      cycle -> cycle
+    end
+  end
+
+  defp dfs_cycle(ref, upstream, globally_visited, path, stack) do
+    next_path = [ref | path]
+    next_stack = MapSet.put(stack, ref)
+    next_visited = MapSet.put(globally_visited, ref)
+
+    Enum.reduce_while(Map.fetch!(upstream, ref), {:error, next_visited}, fn dependency,
+                                                                            {:error,
+                                                                             current_visited} ->
+      cond do
+        MapSet.member?(next_stack, dependency) ->
+          {:halt, {:ok, extract_cycle([dependency | next_path], dependency)}}
+
+        MapSet.member?(current_visited, dependency) ->
+          {:cont, {:error, current_visited}}
+
+        true ->
+          case dfs_cycle(dependency, upstream, current_visited, next_path, next_stack) do
+            {:ok, cycle} -> {:halt, {:ok, cycle}}
+            {:error, visited} -> {:cont, {:error, visited}}
+          end
+      end
+    end)
+  end
+
+  defp extract_cycle(path, repeated_ref) do
+    cycle =
+      path
+      |> Enum.reverse()
+      |> Enum.drop_while(&(&1 != repeated_ref))
+
+    case cycle do
+      [] -> []
+      [_single] -> [repeated_ref, repeated_ref]
+      _many -> cycle
+    end
+  end
+
+  defp build_topo_rank(order) do
+    order
+    |> Enum.with_index()
+    |> Map.new(fn {ref, index} -> {ref, index} end)
+  end
+
+  defp fetch_set(index, ref) do
+    case Map.fetch(index, ref) do
+      {:ok, refs} -> {:ok, refs}
+      :error -> {:error, :asset_not_found}
+    end
+  end
+
+  defp sort_refs(refs, index) do
+    Enum.sort(refs, fn left, right ->
+      left_rank = Map.fetch!(index.topo_rank, left)
+      right_rank = Map.fetch!(index.topo_rank, right)
+
+      cond do
+        left_rank < right_rank -> true
+        left_rank > right_rank -> false
+        true -> compare_refs(left, right)
+      end
+    end)
+  end
+
+  defp compare_refs({left_module, left_name}, {right_module, right_name}) do
+    case compare_terms(left_module, right_module) do
+      :lt -> true
+      :gt -> false
+      :eq -> compare_terms(left_name, right_name) != :gt
+    end
+  end
+
+  defp compare_terms(left, right) do
+    cond do
+      left < right -> :lt
+      left > right -> :gt
+      true -> :eq
+    end
+  end
+end

--- a/test/flux_test.exs
+++ b/test/flux_test.exs
@@ -85,6 +85,32 @@ defmodule FluxTest do
     assert {:error, :not_asset_module} = Flux.get_asset({Enum, :map})
   end
 
+  test "inspects dependency queries through the public facade" do
+    Application.put_env(:flux, :asset_modules, [SampleAssets, CrossModuleAssets])
+    assert :ok = Flux.Registry.reload()
+    assert :ok = Flux.GraphIndex.reload()
+
+    assert {:ok, upstream_assets} = Flux.upstream_assets({CrossModuleAssets, :publish_orders})
+
+    assert Enum.map(upstream_assets, & &1.ref) == [
+             {SampleAssets, :extract_orders},
+             {SampleAssets, :normalize_orders}
+           ]
+
+    assert {:ok, downstream_assets} =
+             Flux.downstream_assets({SampleAssets, :extract_orders}, transitive: false)
+
+    assert Enum.map(downstream_assets, & &1.ref) == [{SampleAssets, :normalize_orders}]
+
+    assert {:ok, dependency_graph} =
+             Flux.dependency_graph({CrossModuleAssets, :publish_orders}, tags: [:sales])
+
+    assert Map.keys(dependency_graph.assets_by_ref) |> Enum.sort() == [
+             {CrossModuleAssets, :publish_orders},
+             {SampleAssets, :normalize_orders}
+           ]
+  end
+
   test "reports whether a module exposes Flux asset metadata" do
     assert Flux.asset_module?(SampleAssets)
     refute Flux.asset_module?(Enum)

--- a/test/graph_index_test.exs
+++ b/test/graph_index_test.exs
@@ -1,0 +1,214 @@
+defmodule Flux.GraphIndexTest do
+  use ExUnit.Case
+
+  defmodule SourceAssets do
+    use Flux.Assets
+
+    @doc "Raw orders"
+    @asset true
+    def raw_orders, do: [%{id: 1}]
+
+    @doc "Raw customers"
+    @asset true
+    def raw_customers, do: [%{id: 1}]
+  end
+
+  defmodule WarehouseAssets do
+    use Flux.Assets
+
+    alias Flux.GraphIndexTest.SourceAssets
+
+    @doc "Normalize orders"
+    @asset depends_on: [{SourceAssets, :raw_orders}], tags: [:warehouse]
+    def normalize_orders(rows), do: rows
+
+    @doc "Normalize customers"
+    @asset depends_on: [{SourceAssets, :raw_customers}], tags: [:warehouse]
+    def normalize_customers(rows), do: rows
+
+    @doc "Build sales fact"
+    @asset depends_on: [:normalize_orders, :normalize_customers], tags: [:finance]
+    def fact_sales(orders, customers), do: {orders, customers}
+  end
+
+  defmodule ReportingAssets do
+    use Flux.Assets
+
+    alias Flux.GraphIndexTest.WarehouseAssets
+
+    @doc "Build dashboard"
+    @asset depends_on: [{WarehouseAssets, :fact_sales}, {WarehouseAssets, :normalize_orders}]
+    def dashboard(fact_sales, normalize_orders), do: {fact_sales, normalize_orders}
+  end
+
+  setup do
+    previous_modules = Application.get_env(:flux, :asset_modules)
+    previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
+
+    on_exit(fn ->
+      if is_nil(previous_modules) do
+        Application.delete_env(:flux, :asset_modules)
+      else
+        Application.put_env(:flux, :asset_modules, previous_modules)
+      end
+
+      restore_registry(previous_catalog)
+    end)
+
+    :ok
+  end
+
+  test "builds a global DAG index with upstream, downstream, transitive closures, and topological order" do
+    Application.put_env(:flux, :asset_modules, [SourceAssets, WarehouseAssets, ReportingAssets])
+
+    assert :ok = Flux.Registry.reload()
+    assert :ok = Flux.GraphIndex.reload()
+
+    assert {:ok, upstream} = Flux.GraphIndex.upstream_of({WarehouseAssets, :fact_sales})
+
+    assert upstream == [
+             {WarehouseAssets, :normalize_customers},
+             {WarehouseAssets, :normalize_orders}
+           ]
+
+    assert {:ok, downstream} = Flux.GraphIndex.downstream_of({WarehouseAssets, :normalize_orders})
+
+    assert downstream == [
+             {WarehouseAssets, :fact_sales},
+             {ReportingAssets, :dashboard}
+           ]
+
+    assert {:ok, transitive_upstream} =
+             Flux.GraphIndex.transitive_upstream_of({ReportingAssets, :dashboard})
+
+    assert transitive_upstream == [
+             {SourceAssets, :raw_customers},
+             {SourceAssets, :raw_orders},
+             {WarehouseAssets, :normalize_customers},
+             {WarehouseAssets, :normalize_orders},
+             {WarehouseAssets, :fact_sales}
+           ]
+
+    assert {:ok, transitive_downstream} =
+             Flux.GraphIndex.transitive_downstream_of({SourceAssets, :raw_orders})
+
+    assert transitive_downstream == [
+             {WarehouseAssets, :normalize_orders},
+             {WarehouseAssets, :fact_sales},
+             {ReportingAssets, :dashboard}
+           ]
+
+    assert {:ok, topo_order} = Flux.GraphIndex.topological_order()
+
+    assert Enum.find_index(topo_order, &(&1 == {SourceAssets, :raw_orders})) <
+             Enum.find_index(topo_order, &(&1 == {WarehouseAssets, :normalize_orders}))
+
+    assert Enum.find_index(topo_order, &(&1 == {WarehouseAssets, :fact_sales})) <
+             Enum.find_index(topo_order, &(&1 == {ReportingAssets, :dashboard}))
+  end
+
+  test "selects related assets with filters and direct traversal options" do
+    Application.put_env(:flux, :asset_modules, [SourceAssets, WarehouseAssets, ReportingAssets])
+
+    assert :ok = Flux.Registry.reload()
+    assert :ok = Flux.GraphIndex.reload()
+
+    assert {:ok, assets} =
+             Flux.GraphIndex.related_assets({ReportingAssets, :dashboard},
+               direction: :upstream,
+               tags: [:warehouse]
+             )
+
+    assert Enum.map(assets, & &1.ref) == [
+             {WarehouseAssets, :normalize_customers},
+             {WarehouseAssets, :normalize_orders}
+           ]
+
+    assert {:ok, both_neighbors} =
+             Flux.GraphIndex.related_assets({WarehouseAssets, :normalize_orders},
+               direction: :both,
+               transitive: false,
+               include_target: false
+             )
+
+    assert Enum.map(both_neighbors, & &1.ref) == [
+             {SourceAssets, :raw_orders},
+             {WarehouseAssets, :fact_sales},
+             {ReportingAssets, :dashboard}
+           ]
+  end
+
+  test "builds filtered subgraphs rooted at a target reference" do
+    Application.put_env(:flux, :asset_modules, [SourceAssets, WarehouseAssets, ReportingAssets])
+
+    assert :ok = Flux.Registry.reload()
+    assert :ok = Flux.GraphIndex.reload()
+
+    assert {:ok, subgraph} =
+             Flux.GraphIndex.subgraph({ReportingAssets, :dashboard},
+               direction: :upstream,
+               tags: [:warehouse]
+             )
+
+    assert Map.keys(subgraph.assets_by_ref) |> Enum.sort() == [
+             {ReportingAssets, :dashboard},
+             {WarehouseAssets, :normalize_customers},
+             {WarehouseAssets, :normalize_orders}
+           ]
+
+    assert Map.fetch!(subgraph.upstream, {ReportingAssets, :dashboard}) ==
+             MapSet.new([{WarehouseAssets, :normalize_orders}])
+
+    assert Map.fetch!(subgraph.downstream, {WarehouseAssets, :normalize_orders}) ==
+             MapSet.new([{ReportingAssets, :dashboard}])
+  end
+
+  test "reports missing dependencies during graph construction" do
+    missing = %Flux.Asset{
+      module: __MODULE__,
+      name: :missing_dependency,
+      ref: {__MODULE__, :missing_dependency},
+      arity: 0,
+      file: "test/graph_index_test.exs",
+      line: 1,
+      depends_on: [{__MODULE__, :does_not_exist}]
+    }
+
+    assert {:error,
+            {:missing_dependency, {__MODULE__, :missing_dependency},
+             {__MODULE__, :does_not_exist}}} =
+             Flux.GraphIndex.build_index([missing])
+  end
+
+  test "rejects cycles during graph construction" do
+    a = %Flux.Asset{
+      module: __MODULE__,
+      name: :a,
+      ref: {__MODULE__, :a},
+      arity: 0,
+      file: "test/graph_index_test.exs",
+      line: 1,
+      depends_on: [{__MODULE__, :b}]
+    }
+
+    b = %Flux.Asset{
+      module: __MODULE__,
+      name: :b,
+      ref: {__MODULE__, :b},
+      arity: 0,
+      file: "test/graph_index_test.exs",
+      line: 2,
+      depends_on: [{__MODULE__, :a}]
+    }
+
+    assert {:error, {:cycle, cycle}} = Flux.GraphIndex.build_index([a, b])
+    assert cycle == [{__MODULE__, :a}, {__MODULE__, :b}, {__MODULE__, :a}]
+  end
+
+  defp restore_registry({:ok, _catalog}) do
+    :ok = Flux.Registry.reload()
+    :ok = Flux.GraphIndex.reload()
+  end
+
+  defp restore_registry({:error, _reason}), do: :ok
+end


### PR DESCRIPTION
### Motivation

- Provide a startup-built, read-only dependency graph (DAG) for configured assets so dependency queries and validation are fast and deterministic.  
- Support inspection and traversal operations (upstream/downstream/transitive), cycle detection, and deterministic topological ordering for future execution planning.  
- Expose a small public facade to query the graph from `Flux` so operator tooling can inspect dependencies without embedding graph logic in the facade.  

### Description

- Add a new module `Flux.GraphIndex` that builds a global DAG from the canonical asset catalog and caches it in `:persistent_term`; it supports `load/0`, `reload/0`, `get/0`, `upstream_of/1`, `downstream_of/1`, `transitive_upstream_of/1`, `transitive_downstream_of/1`, `related_assets/2`, `subgraph/2`, and `topological_order/0` and implements cycle detection, topological sort, transitive closures, filtering, and deterministic ranking.  
- Wire graph loading into application startup by calling `Flux.GraphIndex.load()` from `Flux.Application.start/2`.  
- Extend the public `Flux` facade with types and new inspection APIs: `dependency_graph/2`, `upstream_assets/2`, and `downstream_assets/2`, which delegate to `Flux.GraphIndex`.  
- Update module docs and roadmap in `lib/flux.ex` to describe the DAG model, graph index, and related API responsibilities.  
- Add comprehensive tests in `test/graph_index_test.exs` covering index construction, adjacency, transitive closures, topological order, filtering, subgraph projection, missing-dependency errors, and cycle detection, and extend `test/flux_test.exs` with facade-level graph inspection tests.  

### Testing

- Ran the test suite with `mix test`, including the new `Flux.GraphIndex` test module and updated `Flux` facade tests, and all tests passed.  
- New tests exercise graph construction (`build_index/1`) error paths for missing dependencies and cycles and verify traversal, filtering, subgraph projection, and topological ordering.  
- Facade-level tests verify that `Flux.upstream_assets/2`, `Flux.downstream_assets/2`, and `Flux.dependency_graph/2` delegate correctly into the graph index and return expected `Flux.Asset` metadata.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c1855772a083288a4785965bdfdaf3)