### PR TITLE
Add Flux.Planner and Flux.Plan with `Flux.plan_run/2` API

### DIFF
--- a/lib/flux.ex
+++ b/lib/flux.ex
@@ -299,7 +299,7 @@ defmodule Flux do
     5. startup registry loading and caching - done
     6. dependency resolution and graph construction - in progress
     7. graph inspection queries - in progress
-    8. execution planning
+    8. execution planning - in progress
     9. run model and in-memory execution
     10. run storage and retrieval
     11. live run event subscriptions
@@ -353,6 +353,11 @@ defmodule Flux do
   @type run_opts :: [
           dependencies: dependencies_mode()
         ]
+
+  @typedoc """
+  Options for `plan_run/2`.
+  """
+  @type plan_run_opts :: run_opts()
 
   @doc """
   List all registered assets.
@@ -553,6 +558,32 @@ defmodule Flux do
   end
 
   @doc """
+  Build a deterministic execution plan for one or more targets.
+
+  This API returns a run-once plan shape where nodes are deduplicated by
+  canonical ref and grouped into topological stages for parallel execution.
+
+  ## Examples
+
+      iex> Flux.plan_run({Unknown.Module, :fact_sales})
+      {:error, {:asset_not_found, {Unknown.Module, :fact_sales}}}
+
+      iex> Flux.plan_run([])
+      {:error, :empty_targets}
+
+  ## TODO
+
+    * Keep this planner deterministic and graph-derived
+    * Keep plan nodes deduplicated by canonical ref
+    * Add freshness-aware actions after run storage exists
+  """
+  @spec plan_run(asset_ref() | [asset_ref()], plan_run_opts()) ::
+          {:ok, Flux.Plan.t()} | {:error, term()}
+  def plan_run(targets, opts \\ []) when is_list(opts) do
+    Flux.Planner.plan(targets, opts)
+  end
+
+  @doc """
   Start a run for the given asset.
 
   By default, a run should include the full upstream dependency chain so that
@@ -581,7 +612,7 @@ defmodule Flux do
     * Delegate to `Flux.Runner.run/2`
     * Define the return contract, likely `{:ok, run}` or `{:error, reason}`
     * Support `dependencies: :all | :none` first
-    * Plan execution from a target subgraph with run-once semantics
+    * Execute the plan built by `plan_run/2`
     * Add parallel scheduling only after the basic plan format is stable
     * Add freshness-aware skipping after the planner can reason about materialized assets
   """

--- a/lib/flux.ex
+++ b/lib/flux.ex
@@ -357,7 +357,9 @@ defmodule Flux do
   @typedoc """
   Options for `plan_run/2`.
   """
-  @type plan_run_opts :: run_opts()
+  @type plan_run_opts :: [
+          dependencies: dependencies_mode()
+        ]
 
   @doc """
   List all registered assets.
@@ -562,14 +564,45 @@ defmodule Flux do
 
   This API returns a run-once plan shape where nodes are deduplicated by
   canonical ref and grouped into topological stages for parallel execution.
+  Planning is deterministic:
+
+    * target refs are normalized, deduplicated, and sorted
+    * node refs inside each stage are sorted
+    * stage number is computed as topological depth from source assets
 
   ## Examples
 
       iex> Flux.plan_run({Unknown.Module, :fact_sales})
-      {:error, {:asset_not_found, {Unknown.Module, :fact_sales}}}
+      {:error, :asset_not_found}
 
       iex> Flux.plan_run([])
       {:error, :empty_targets}
+
+  ## Output shape
+
+      %Flux.Plan{
+        target_refs: [{MyApp.GoldETL, :fact_sales}],
+        dependencies: :all,
+        topo_order: [
+          {MyApp.SourceETL, :raw_orders},
+          {MyApp.WarehouseETL, :normalize_orders},
+          {MyApp.GoldETL, :fact_sales}
+        ],
+        stages: [
+          [{MyApp.SourceETL, :raw_orders}],
+          [{MyApp.WarehouseETL, :normalize_orders}],
+          [{MyApp.GoldETL, :fact_sales}]
+        ],
+        nodes: %{
+          {MyApp.WarehouseETL, :normalize_orders} => %{
+            ref: {MyApp.WarehouseETL, :normalize_orders},
+            upstream: [{MyApp.SourceETL, :raw_orders}],
+            downstream: [{MyApp.GoldETL, :fact_sales}],
+            stage: 1,
+            action: :run
+          }
+        }
+      }
 
   ## TODO
 

--- a/lib/flux/plan.ex
+++ b/lib/flux/plan.ex
@@ -5,7 +5,7 @@ defmodule Flux.Plan do
   Plans are built from a target set and a dependency mode. Nodes are deduplicated
   by canonical asset reference so shared dependencies execute at most once.
 
-  `stages` groups refs by topological rank so each stage can run in parallel
+  `stages` groups refs by topological depth so each stage can run in parallel
   after all refs in previous stages are satisfied.
   """
 

--- a/lib/flux/plan.ex
+++ b/lib/flux/plan.ex
@@ -1,0 +1,48 @@
+defmodule Flux.Plan do
+  @moduledoc """
+  Deterministic execution plan for one logical run request.
+
+  Plans are built from a target set and a dependency mode. Nodes are deduplicated
+  by canonical asset reference so shared dependencies execute at most once.
+
+  `stages` groups refs by topological rank so each stage can run in parallel
+  after all refs in previous stages are satisfied.
+  """
+
+  alias Flux.Ref
+
+  @typedoc """
+  Execution action for one planned node.
+  """
+  @type action :: :run
+
+  @typedoc """
+  One planned node keyed by canonical ref.
+  """
+  @type plan_node :: %{
+          ref: Ref.t(),
+          upstream: [Ref.t()],
+          downstream: [Ref.t()],
+          stage: non_neg_integer(),
+          action: action()
+        }
+
+  @typedoc """
+  Topologically ordered plan stages.
+  """
+  @type stage :: [Ref.t()]
+
+  @type t :: %__MODULE__{
+          target_refs: [Ref.t()],
+          dependencies: Flux.dependencies_mode(),
+          nodes: %{required(Ref.t()) => plan_node()},
+          topo_order: [Ref.t()],
+          stages: [stage()]
+        }
+
+  defstruct target_refs: [],
+            dependencies: :all,
+            nodes: %{},
+            topo_order: [],
+            stages: []
+end

--- a/lib/flux/planner.ex
+++ b/lib/flux/planner.ex
@@ -4,6 +4,12 @@ defmodule Flux.Planner do
 
   The planner produces a deduplicated run graph for one or more targets and
   groups plan nodes into topological stages for parallel execution.
+
+  Determinism guarantees:
+
+    * target refs are normalized, deduplicated, and sorted
+    * `stages` contain refs sorted by canonical ref order
+    * stage number equals topological depth (`0` for source assets)
   """
 
   alias Flux.GraphIndex
@@ -44,18 +50,21 @@ defmodule Flux.Planner do
   defp normalize_targets({module, name}) when is_atom(module) and is_atom(name),
     do: {:ok, [{module, name}]}
 
-  defp normalize_targets(targets) when is_list(targets) do
-    cond do
-      targets == [] -> {:error, :empty_targets}
-      Enum.all?(targets, &valid_ref?/1) -> {:ok, targets |> Enum.uniq() |> Enum.sort()}
-      true -> {:error, :invalid_target_ref}
-    end
-  end
+  defp normalize_targets([]), do: {:error, :empty_targets}
+
+  defp normalize_targets(targets) when is_list(targets),
+    do: normalize_target_list(targets, [])
 
   defp normalize_targets(_targets), do: {:error, :invalid_target_ref}
 
-  defp valid_ref?({module, name}) when is_atom(module) and is_atom(name), do: true
-  defp valid_ref?(_other), do: false
+  defp normalize_target_list([], refs), do: {:ok, refs |> Enum.uniq() |> Enum.sort()}
+
+  defp normalize_target_list([{module, name} | rest], refs)
+       when is_atom(module) and is_atom(name) do
+    normalize_target_list(rest, [{module, name} | refs])
+  end
+
+  defp normalize_target_list([_invalid | _rest], _refs), do: {:error, :invalid_target_ref}
 
   defp validate_dependencies_mode(:all), do: :ok
   defp validate_dependencies_mode(:none), do: :ok
@@ -64,7 +73,7 @@ defmodule Flux.Planner do
   defp validate_target_refs(index, refs) do
     case Enum.find(refs, &(not Map.has_key?(index.assets_by_ref, &1))) do
       nil -> :ok
-      ref -> {:error, {:asset_not_found, ref}}
+      _ref -> {:error, :asset_not_found}
     end
   end
 

--- a/lib/flux/planner.ex
+++ b/lib/flux/planner.ex
@@ -1,0 +1,134 @@
+defmodule Flux.Planner do
+  @moduledoc """
+  Build deterministic execution plans from the global graph index.
+
+  The planner produces a deduplicated run graph for one or more targets and
+  groups plan nodes into topological stages for parallel execution.
+  """
+
+  alias Flux.GraphIndex
+  alias Flux.Plan
+  alias Flux.Ref
+
+  @typedoc """
+  Planner options.
+
+    * `:dependencies` - `:all` includes transitive upstream dependencies;
+      `:none` includes target refs only.
+  """
+  @type plan_opts :: [dependencies: Flux.dependencies_mode()]
+
+  @spec plan(Ref.t() | [Ref.t()], plan_opts()) :: {:ok, Plan.t()} | {:error, term()}
+  def plan(targets, opts \\ []) when is_list(opts) do
+    dependencies = Keyword.get(opts, :dependencies, :all)
+
+    with {:ok, target_refs} <- normalize_targets(targets),
+         :ok <- validate_dependencies_mode(dependencies),
+         {:ok, index} <- GraphIndex.get(),
+         :ok <- validate_target_refs(index, target_refs),
+         {:ok, refs} <- selected_refs(index, target_refs, dependencies),
+         {:ok, projected_index} <- projected_index(index, refs) do
+      stage_map = build_stage_map(projected_index)
+
+      {:ok,
+       %Plan{
+         target_refs: target_refs,
+         dependencies: dependencies,
+         nodes: build_nodes(projected_index, stage_map),
+         topo_order: projected_index.topo_order,
+         stages: build_stages(projected_index, stage_map)
+       }}
+    end
+  end
+
+  defp normalize_targets({module, name}) when is_atom(module) and is_atom(name),
+    do: {:ok, [{module, name}]}
+
+  defp normalize_targets(targets) when is_list(targets) do
+    cond do
+      targets == [] -> {:error, :empty_targets}
+      Enum.all?(targets, &valid_ref?/1) -> {:ok, targets |> Enum.uniq() |> Enum.sort()}
+      true -> {:error, :invalid_target_ref}
+    end
+  end
+
+  defp normalize_targets(_targets), do: {:error, :invalid_target_ref}
+
+  defp valid_ref?({module, name}) when is_atom(module) and is_atom(name), do: true
+  defp valid_ref?(_other), do: false
+
+  defp validate_dependencies_mode(:all), do: :ok
+  defp validate_dependencies_mode(:none), do: :ok
+  defp validate_dependencies_mode(other), do: {:error, {:invalid_dependencies_mode, other}}
+
+  defp validate_target_refs(index, refs) do
+    case Enum.find(refs, &(not Map.has_key?(index.assets_by_ref, &1))) do
+      nil -> :ok
+      ref -> {:error, {:asset_not_found, ref}}
+    end
+  end
+
+  defp selected_refs(_index, target_refs, :none), do: {:ok, MapSet.new(target_refs)}
+
+  defp selected_refs(index, target_refs, :all) do
+    refs =
+      Enum.reduce(target_refs, MapSet.new(), fn ref, acc ->
+        upstream_refs = Map.fetch!(index.transitive_upstream, ref)
+
+        acc
+        |> MapSet.union(upstream_refs)
+        |> MapSet.put(ref)
+      end)
+
+    {:ok, refs}
+  end
+
+  defp projected_index(index, refs) do
+    refs
+    |> Enum.map(&Map.fetch!(index.assets_by_ref, &1))
+    |> project_assets(refs)
+    |> GraphIndex.build_index()
+  end
+
+  defp project_assets(assets, refs) do
+    Enum.map(assets, fn asset ->
+      %{asset | depends_on: Enum.filter(asset.depends_on, &MapSet.member?(refs, &1))}
+    end)
+  end
+
+  defp build_stage_map(index) do
+    Enum.reduce(index.topo_order, %{}, fn ref, acc ->
+      stage =
+        index.upstream
+        |> Map.fetch!(ref)
+        |> Enum.map(&Map.fetch!(acc, &1))
+        |> case do
+          [] -> 0
+          stages -> Enum.max(stages) + 1
+        end
+
+      Map.put(acc, ref, stage)
+    end)
+  end
+
+  defp build_nodes(index, stage_map) do
+    Enum.reduce(index.topo_order, %{}, fn ref, acc ->
+      node = %{
+        ref: ref,
+        upstream: index.upstream |> Map.fetch!(ref) |> Enum.sort(),
+        downstream: index.downstream |> Map.fetch!(ref) |> Enum.sort(),
+        stage: Map.fetch!(stage_map, ref),
+        action: :run
+      }
+
+      Map.put(acc, ref, node)
+    end)
+  end
+
+  defp build_stages(index, stage_map) do
+    index.topo_order
+    |> Enum.group_by(&Map.fetch!(stage_map, &1))
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map(fn {_rank, refs} -> Enum.sort(refs) end)
+  end
+end

--- a/test/planner_test.exs
+++ b/test/planner_test.exs
@@ -99,8 +99,21 @@ defmodule Flux.PlannerTest do
     assert {:error, {:invalid_dependencies_mode, :invalid}} =
              Flux.plan_run({GoldAssets, :gold_sales}, dependencies: :invalid)
 
-    assert {:error, {:asset_not_found, {GoldAssets, :missing}}} =
-             Flux.plan_run({GoldAssets, :missing})
+    assert {:error, :asset_not_found} = Flux.plan_run({GoldAssets, :missing})
+  end
+
+  test "normalizes duplicate targets into deterministic sorted order" do
+    assert {:ok, plan} =
+             Flux.plan_run([
+               {GoldAssets, :gold_sales},
+               {GoldAssets, :gold_finance},
+               {GoldAssets, :gold_sales}
+             ])
+
+    assert plan.target_refs == [
+             {GoldAssets, :gold_finance},
+             {GoldAssets, :gold_sales}
+           ]
   end
 
   defp restore_registry({:ok, _catalog}) do

--- a/test/planner_test.exs
+++ b/test/planner_test.exs
@@ -1,0 +1,112 @@
+defmodule Flux.PlannerTest do
+  use ExUnit.Case
+
+  defmodule BronzeAssets do
+    use Flux.Assets
+
+    @asset true
+    def raw_orders, do: :ok
+
+    @asset true
+    def raw_customers, do: :ok
+  end
+
+  defmodule SilverAssets do
+    use Flux.Assets
+
+    alias Flux.PlannerTest.BronzeAssets
+
+    @asset depends_on: [{BronzeAssets, :raw_orders}]
+    def nightly_orders(_orders), do: :ok
+
+    @asset depends_on: [{BronzeAssets, :raw_customers}]
+    def monthly_customers(_customers), do: :ok
+  end
+
+  defmodule GoldAssets do
+    use Flux.Assets
+
+    alias Flux.PlannerTest.SilverAssets
+
+    @asset depends_on: [{SilverAssets, :nightly_orders}, {SilverAssets, :monthly_customers}]
+    def gold_sales(_orders, _customers), do: :ok
+
+    @asset depends_on: [{SilverAssets, :nightly_orders}]
+    def gold_finance(_orders), do: :ok
+  end
+
+  setup do
+    previous_modules = Application.get_env(:flux, :asset_modules)
+    previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
+
+    Application.put_env(:flux, :asset_modules, [BronzeAssets, SilverAssets, GoldAssets])
+    assert :ok = Flux.Registry.reload()
+    assert :ok = Flux.GraphIndex.reload()
+
+    on_exit(fn ->
+      if is_nil(previous_modules) do
+        Application.delete_env(:flux, :asset_modules)
+      else
+        Application.put_env(:flux, :asset_modules, previous_modules)
+      end
+
+      restore_registry(previous_catalog)
+    end)
+
+    :ok
+  end
+
+  test "builds multi-target plans with shared dependency dedup and stage grouping" do
+    assert {:ok, plan} =
+             Flux.plan_run([
+               {GoldAssets, :gold_sales},
+               {GoldAssets, :gold_finance}
+             ])
+
+    assert Map.keys(plan.nodes) |> MapSet.new() ==
+             MapSet.new([
+               {BronzeAssets, :raw_customers},
+               {BronzeAssets, :raw_orders},
+               {SilverAssets, :monthly_customers},
+               {SilverAssets, :nightly_orders},
+               {GoldAssets, :gold_finance},
+               {GoldAssets, :gold_sales}
+             ])
+
+    assert plan.stages == [
+             [{BronzeAssets, :raw_customers}, {BronzeAssets, :raw_orders}],
+             [{SilverAssets, :monthly_customers}, {SilverAssets, :nightly_orders}],
+             [{GoldAssets, :gold_finance}, {GoldAssets, :gold_sales}]
+           ]
+
+    assert plan.nodes[{SilverAssets, :nightly_orders}].downstream == [
+             {GoldAssets, :gold_finance},
+             {GoldAssets, :gold_sales}
+           ]
+  end
+
+  test "supports dependencies: :none for target-only planning" do
+    assert {:ok, plan} = Flux.plan_run({GoldAssets, :gold_sales}, dependencies: :none)
+
+    assert plan.topo_order == [{GoldAssets, :gold_sales}]
+    assert plan.stages == [[{GoldAssets, :gold_sales}]]
+    assert plan.nodes[{GoldAssets, :gold_sales}].upstream == []
+  end
+
+  test "returns errors for invalid planner input" do
+    assert {:error, :empty_targets} = Flux.plan_run([])
+
+    assert {:error, {:invalid_dependencies_mode, :invalid}} =
+             Flux.plan_run({GoldAssets, :gold_sales}, dependencies: :invalid)
+
+    assert {:error, {:asset_not_found, {GoldAssets, :missing}}} =
+             Flux.plan_run({GoldAssets, :missing})
+  end
+
+  defp restore_registry({:ok, _catalog}) do
+    :ok = Flux.Registry.reload()
+    :ok = Flux.GraphIndex.reload()
+  end
+
+  defp restore_registry({:error, _reason}), do: :ok
+end


### PR DESCRIPTION
### Motivation

- Introduce a deterministic, read-only planning layer to produce execution plans from the global graph index so runs can be planned before execution. 
- Provide a stable plan shape that deduplicates shared dependencies and groups nodes into topological stages for parallel execution.
- Surface a public API `Flux.plan_run/2` to make planning available through the main `Flux` facade.

### Description

- Add `Flux.Plan` as the canonical plan shape with `target_refs`, `dependencies`, `nodes`, `topo_order`, and `stages` fields. 
- Implement `Flux.Planner` which builds deduplicated plans from the startup `Flux.GraphIndex`, including target normalization, dependency selection, projected index construction, stage mapping, node construction, and stage grouping. 
- Add `Flux.plan_run/2` to the public `Flux` module that delegates to `Flux.Planner.plan/2` and add the `plan_run_opts` type alias. 
- Add comprehensive unit tests in `test/planner_test.exs` that exercise multi-target planning with shared dependency deduplication, `dependencies: :none` behavior, and invalid input error paths.

### Testing

- Compiled the code and ran the planner unit tests with `mix test test/planner_test.exs`, and the tests completed successfully. 
- The new tests cover multi-target plan composition, stage grouping, downstream/upstream relationships, `dependencies: :none` mode, and invalid input handling and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c2e6f386748328b1a634c80c446455)