### PR TITLE
Add in-memory runner and run model; wire `Flux.run/2` to `Flux.Runner`

### DIFF
--- a/lib/flux.ex
+++ b/lib/flux.ex
@@ -90,16 +90,21 @@ defmodule Flux do
 
         @doc "Extract raw orders from the sales source"
         @asset true
-        def extract_orders do
-          [%{id: 1, total: 100}]
+        def extract_orders(_ctx, _deps) do
+          {:ok, %Flux.Asset.Output{output: [%{id: 1, total: 100}], meta: %{source: :sales}}}
         end
 
         @doc "Normalize extracted orders"
         @asset depends_on: [:extract_orders]
-        def normalize_orders(orders) do
-          Enum.map(orders, fn order ->
-            Map.put(order, :normalized, true)
-          end)
+        def normalize_orders(_ctx, deps) do
+          orders = Map.fetch!(deps, {__MODULE__, :extract_orders})
+
+          normalized =
+            Enum.map(orders, fn order ->
+              Map.put(order, :normalized, true)
+            end)
+
+          {:ok, %Flux.Asset.Output{output: normalized, meta: %{normalized_count: length(normalized)}}}
         end
       end
 
@@ -112,8 +117,9 @@ defmodule Flux do
 
         @doc "Build the fact table for sales"
         @asset depends_on: [{SalesETL, :normalize_orders}]
-        def fact_sales(normalized_orders) do
-          %{rows: normalized_orders}
+        def fact_sales(_ctx, deps) do
+          normalized_orders = Map.fetch!(deps, {SalesETL, :normalize_orders})
+          {:ok, %Flux.Asset.Output{output: %{rows: normalized_orders}}}
         end
       end
 
@@ -622,6 +628,12 @@ defmodule Flux do
 
   By default, a run should include the full upstream dependency chain so that
   asset dependencies automatically form the execution pipeline.
+
+  Asset invocation and return contract for this first runner:
+
+    * assets are invoked as `def asset(ctx, deps)`
+    * success must be `{:ok, %Flux.Asset.Output{}}`
+    * failure must be `{:error, reason}`
 
   ## Examples
 

--- a/lib/flux.ex
+++ b/lib/flux.ex
@@ -299,8 +299,8 @@ defmodule Flux do
     5. startup registry loading and caching - done
     6. dependency resolution and graph construction - in progress
     7. graph inspection queries - in progress
-    8. execution planning - in progress
-    9. run model and in-memory execution
+    8. execution planning - done
+    9. run model and in-memory execution - in progress
     10. run storage and retrieval
     11. live run event subscriptions
 
@@ -351,7 +351,8 @@ defmodule Flux do
   Options for `run/2`.
   """
   @type run_opts :: [
-          dependencies: dependencies_mode()
+          dependencies: dependencies_mode(),
+          params: map()
         ]
 
   @typedoc """
@@ -624,35 +625,31 @@ defmodule Flux do
 
   ## Examples
 
-      iex> Flux.run({MyApp.GoldETL, :fact_sales})
-      ** (RuntimeError) TODO: implement Flux.run/2
-
-      iex> Flux.run({MyApp.GoldETL, :fact_sales}, dependencies: :none)
-      ** (RuntimeError) TODO: implement Flux.run/2
+      iex> Flux.run({Unknown.Module, :fact_sales})
+      {:error, :asset_not_found}
 
   ## Expected implementation flow
 
     1. Resolve the target asset
     2. Build the dependency graph or subgraph
     3. Produce an execution plan
-    4. Create and persist a run record
-    5. Emit run and asset lifecycle events
-    6. Execute the plan
+    4. Execute stage-by-stage in deterministic order
+    5. Return run status, outputs, timings, and errors
 
   ## TODO
 
     * Implement on top of the startup-built DAG index in `Flux.GraphIndex`
     * Delegate to `Flux.Runner.run/2`
-    * Define the return contract, likely `{:ok, run}` or `{:error, reason}`
-    * Support `dependencies: :all | :none` first
-    * Execute the plan built by `plan_run/2`
-    * Add parallel scheduling only after the basic plan format is stable
+    * Keep return contract `{:ok, run}` or `{:error, run | reason}`
+    * Keep `dependencies: :all | :none` as the first execution mode toggle
+    * Keep execution in-memory and synchronous for the first cut
+    * Add run process supervision and stage-level parallelism in follow-up work
     * Add freshness-aware skipping after the planner can reason about materialized assets
   """
-  @spec run(asset_ref(), run_opts()) :: term()
+  @spec run(asset_ref(), run_opts()) :: {:ok, Flux.Run.t()} | {:error, Flux.Run.t() | term()}
   def run({module, name}, opts \\ [])
       when is_atom(module) and is_atom(name) and is_list(opts) do
-    todo!("Flux.run/2")
+    Flux.Runner.run({module, name}, opts)
   end
 
   @doc """

--- a/lib/flux/asset.ex
+++ b/lib/flux/asset.ex
@@ -10,6 +10,7 @@ defmodule Flux.Asset do
   """
 
   alias Flux.Ref
+  alias Flux.Asset.Output
 
   @typedoc """
   Supported asset kinds.
@@ -35,6 +36,11 @@ defmodule Flux.Asset do
           tags: [tag()],
           depends_on: [Ref.t()]
         }
+
+  @typedoc """
+  Canonical return shape expected from asset function execution.
+  """
+  @type return_value :: {:ok, Output.t()} | {:error, term()}
 
   @valid_kinds [:materialized, :view, :ephemeral]
 

--- a/lib/flux/asset/output.ex
+++ b/lib/flux/asset/output.ex
@@ -1,0 +1,18 @@
+defmodule Flux.Asset.Output do
+  @moduledoc """
+  Canonical success envelope returned by Flux assets.
+
+  Assets should return one of:
+
+    * `{:ok, %Flux.Asset.Output{}}`
+    * `{:error, reason}`
+  """
+
+  @enforce_keys [:output]
+  defstruct output: nil, meta: %{}
+
+  @type t :: %__MODULE__{
+          output: term(),
+          meta: map()
+        }
+end

--- a/lib/flux/assets.ex
+++ b/lib/flux/assets.ex
@@ -11,6 +11,11 @@ defmodule Flux.Assets do
     * enforcing authoring rules
     * normalizing DSL-friendly dependency declarations
     * emitting `__flux_assets__/0` for later runtime inspection
+
+  Asset authoring contract:
+
+    * asset functions must have arity 2 and use `def asset(ctx, deps)`
+    * assets should return `{:ok, %Flux.Asset.Output{}}` or `{:error, reason}`
   """
 
   alias Flux.Asset
@@ -38,15 +43,25 @@ defmodule Flux.Assets do
 
         case kind do
           :def ->
-            Module.put_attribute(env.module, :flux_assets_raw, %{
-              module: env.module,
-              name: name,
-              arity: length(args || []),
-              doc: normalize_doc(Module.get_attribute(env.module, :doc)),
-              file: normalize_file(env.file),
-              line: env.line,
-              opts: asset_opts
-            })
+            arity = length(args || [])
+
+            if arity == 2 do
+              Module.put_attribute(env.module, :flux_assets_raw, %{
+                module: env.module,
+                name: name,
+                arity: arity,
+                doc: normalize_doc(Module.get_attribute(env.module, :doc)),
+                file: normalize_file(env.file),
+                line: env.line,
+                opts: asset_opts
+              })
+            else
+              compile_error!(
+                env.file,
+                env.line,
+                "@asset functions must have arity 2 and use signature def asset(ctx, deps)"
+              )
+            end
 
           :defp ->
             compile_error!(env.file, env.line, "@asset can only be used on public functions")

--- a/lib/flux/run.ex
+++ b/lib/flux/run.ex
@@ -1,0 +1,41 @@
+defmodule Flux.Run do
+  @moduledoc """
+  Canonical in-memory representation of one Flux run.
+
+  The first runner stores run state in memory and returns this struct directly
+  to callers. Persistence and subscriptions are intentionally deferred.
+  """
+
+  alias Flux.Ref
+  alias Flux.Run.AssetResult
+
+  @type status :: :running | :ok | :error
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          target_refs: [Ref.t()],
+          plan: Flux.Plan.t(),
+          status: status(),
+          started_at: DateTime.t(),
+          finished_at: DateTime.t() | nil,
+          params: map(),
+          outputs: %{Ref.t() => term()},
+          target_outputs: %{Ref.t() => term()},
+          asset_results: %{Ref.t() => AssetResult.t()},
+          error: term() | nil
+        }
+
+  defstruct [
+    :id,
+    :target_refs,
+    :plan,
+    :started_at,
+    status: :running,
+    finished_at: nil,
+    params: %{},
+    outputs: %{},
+    target_outputs: %{},
+    asset_results: %{},
+    error: nil
+  ]
+end

--- a/lib/flux/run/asset_result.ex
+++ b/lib/flux/run/asset_result.ex
@@ -23,7 +23,8 @@ defmodule Flux.Run.AssetResult do
           started_at: DateTime.t(),
           finished_at: DateTime.t(),
           duration_ms: non_neg_integer(),
-          value: term() | nil,
+          output: term() | nil,
+          meta: map(),
           error: error_details() | nil
         }
 
@@ -34,7 +35,8 @@ defmodule Flux.Run.AssetResult do
     :started_at,
     :finished_at,
     :duration_ms,
-    value: nil,
+    output: nil,
+    meta: %{},
     error: nil
   ]
 end

--- a/lib/flux/run/asset_result.ex
+++ b/lib/flux/run/asset_result.ex
@@ -1,0 +1,40 @@
+defmodule Flux.Run.AssetResult do
+  @moduledoc """
+  Per-asset execution outcome captured during a run.
+  """
+
+  alias Flux.Ref
+
+  @type error_kind :: :error | :exit | :throw
+
+  @type error_details :: %{
+          required(:kind) => error_kind(),
+          required(:reason) => term(),
+          required(:stacktrace) => [term()],
+          optional(:message) => String.t()
+        }
+
+  @type status :: :ok | :error
+
+  @type t :: %__MODULE__{
+          ref: Ref.t(),
+          stage: non_neg_integer(),
+          status: status(),
+          started_at: DateTime.t(),
+          finished_at: DateTime.t(),
+          duration_ms: non_neg_integer(),
+          value: term() | nil,
+          error: error_details() | nil
+        }
+
+  defstruct [
+    :ref,
+    :stage,
+    :status,
+    :started_at,
+    :finished_at,
+    :duration_ms,
+    value: nil,
+    error: nil
+  ]
+end

--- a/lib/flux/run/context.ex
+++ b/lib/flux/run/context.ex
@@ -1,0 +1,25 @@
+defmodule Flux.Run.Context do
+  @moduledoc """
+  Runtime context passed to each asset invocation.
+  """
+
+  alias Flux.Ref
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          target_refs: [Ref.t()],
+          current_ref: Ref.t(),
+          params: map(),
+          run_started_at: DateTime.t(),
+          stage: non_neg_integer()
+        }
+
+  defstruct [
+    :run_id,
+    :target_refs,
+    :current_ref,
+    :params,
+    :run_started_at,
+    :stage
+  ]
+end

--- a/lib/flux/runner.ex
+++ b/lib/flux/runner.ex
@@ -7,6 +7,7 @@ defmodule Flux.Runner do
   """
 
   alias Flux.Run
+  alias Flux.Asset.Output
   alias Flux.Run.AssetResult
   alias Flux.Run.Context
 
@@ -73,11 +74,12 @@ defmodule Flux.Runner do
   defp execute_asset(%Run{} = run, ref, stage) do
     started_at = DateTime.utc_now()
     started_monotonic = System.monotonic_time(:millisecond)
+    node = Map.fetch!(run.plan.nodes, ref)
 
     with {:ok, asset} <- Flux.Registry.get_asset(ref),
-         {:ok, deps} <- dependency_outputs(run, asset.depends_on),
+         {:ok, deps} <- dependency_outputs(run, node.upstream),
          ctx <- build_context(run, ref, stage),
-         {:ok, value} <- invoke_asset(asset, ctx, deps) do
+         {:ok, %Output{} = asset_output} <- invoke_asset(asset, ctx, deps) do
       finished_at = DateTime.utc_now()
 
       result = %AssetResult{
@@ -87,13 +89,14 @@ defmodule Flux.Runner do
         started_at: started_at,
         finished_at: finished_at,
         duration_ms: System.monotonic_time(:millisecond) - started_monotonic,
-        value: value
+        output: asset_output.output,
+        meta: asset_output.meta
       }
 
       {:ok,
        %Run{
          run
-         | outputs: Map.put(run.outputs, ref, value),
+         | outputs: Map.put(run.outputs, ref, asset_output.output),
            asset_results: Map.put(run.asset_results, ref, result)
        }}
     else
@@ -126,9 +129,16 @@ defmodule Flux.Runner do
   defp invoke_asset(asset, %Context{} = ctx, deps) do
     try do
       case apply(asset.module, asset.name, [ctx, deps]) do
-        {:ok, value} -> {:ok, value}
-        {:error, reason} -> {:error, reason}
-        other -> {:error, {:invalid_return_shape, other}}
+        {:ok, %Output{} = asset_output} ->
+          {:ok, asset_output}
+
+        {:error, reason} ->
+          {:error, reason}
+
+        other ->
+          {:error,
+           {:invalid_return_shape, other,
+            expected: "{:ok, %Flux.Asset.Output{}} | {:error, reason}"}}
       end
     rescue
       error ->

--- a/lib/flux/runner.ex
+++ b/lib/flux/runner.ex
@@ -1,0 +1,205 @@
+defmodule Flux.Runner do
+  @moduledoc """
+  In-memory deterministic execution runner.
+
+  The first implementation executes plan stages serially and fails fast on the
+  first asset error.
+  """
+
+  alias Flux.Run
+  alias Flux.Run.AssetResult
+  alias Flux.Run.Context
+
+  @typedoc """
+  Options supported by the in-memory runner.
+  """
+  @type run_opts :: [
+          dependencies: Flux.dependencies_mode(),
+          params: map()
+        ]
+
+  @spec run(Flux.asset_ref(), run_opts()) :: {:ok, Run.t()} | {:error, Run.t() | term()}
+  def run(target_ref, opts \\ []) when is_list(opts) do
+    dependencies = Keyword.get(opts, :dependencies, :all)
+    params = Keyword.get(opts, :params, %{})
+
+    with :ok <- validate_params(params),
+         {:ok, plan} <- Flux.plan_run(target_ref, dependencies: dependencies) do
+      run = %Run{
+        id: new_run_id(),
+        target_refs: plan.target_refs,
+        plan: plan,
+        started_at: DateTime.utc_now(),
+        params: params
+      }
+
+      execute_plan(run)
+    end
+  end
+
+  defp validate_params(params) when is_map(params), do: :ok
+  defp validate_params(_params), do: {:error, :invalid_run_params}
+
+  defp execute_plan(%Run{} = run) do
+    case run.plan.stages |> Enum.with_index() |> Enum.reduce_while(run, &run_stage/2) do
+      %Run{status: :error} = failed ->
+        {:error, failed}
+
+      %Run{} = finished ->
+        {:ok,
+         %Run{
+           finished
+           | status: :ok,
+             finished_at: DateTime.utc_now(),
+             target_outputs: Map.take(finished.outputs, finished.target_refs)
+         }}
+    end
+  end
+
+  defp run_stage({refs, stage}, %Run{} = run) do
+    refs
+    |> Enum.reduce_while(run, fn ref, acc_run ->
+      case execute_asset(acc_run, ref, stage) do
+        {:ok, next_run} -> {:cont, next_run}
+        {:error, failed_run} -> {:halt, failed_run}
+      end
+    end)
+    |> then(fn
+      %Run{status: :error} = failed -> {:halt, failed}
+      %Run{} = next_run -> {:cont, next_run}
+    end)
+  end
+
+  defp execute_asset(%Run{} = run, ref, stage) do
+    started_at = DateTime.utc_now()
+    started_monotonic = System.monotonic_time(:millisecond)
+
+    with {:ok, asset} <- Flux.Registry.get_asset(ref),
+         {:ok, deps} <- dependency_outputs(run, asset.depends_on),
+         ctx <- build_context(run, ref, stage),
+         {:ok, value} <- invoke_asset(asset, ctx, deps) do
+      finished_at = DateTime.utc_now()
+
+      result = %AssetResult{
+        ref: ref,
+        stage: stage,
+        status: :ok,
+        started_at: started_at,
+        finished_at: finished_at,
+        duration_ms: System.monotonic_time(:millisecond) - started_monotonic,
+        value: value
+      }
+
+      {:ok,
+       %Run{
+         run
+         | outputs: Map.put(run.outputs, ref, value),
+           asset_results: Map.put(run.asset_results, ref, result)
+       }}
+    else
+      {:error, reason} ->
+        {:error,
+         fail_run(run, ref, stage, started_at, started_monotonic, normalize_reason(reason))}
+    end
+  end
+
+  defp dependency_outputs(%Run{} = run, depends_on) do
+    Enum.reduce_while(depends_on, {:ok, %{}}, fn dep_ref, {:ok, acc} ->
+      case Map.fetch(run.outputs, dep_ref) do
+        {:ok, value} -> {:cont, {:ok, Map.put(acc, dep_ref, value)}}
+        :error -> {:halt, {:error, {:missing_dependency_output, dep_ref}}}
+      end
+    end)
+  end
+
+  defp build_context(%Run{} = run, ref, stage) do
+    %Context{
+      run_id: run.id,
+      target_refs: run.target_refs,
+      current_ref: ref,
+      params: run.params,
+      run_started_at: run.started_at,
+      stage: stage
+    }
+  end
+
+  defp invoke_asset(asset, %Context{} = ctx, deps) do
+    try do
+      case apply(asset.module, asset.name, [ctx, deps]) do
+        {:ok, value} -> {:ok, value}
+        {:error, reason} -> {:error, reason}
+        other -> {:error, {:invalid_return_shape, other}}
+      end
+    rescue
+      error ->
+        {:error,
+         %{
+           kind: :error,
+           reason: error,
+           stacktrace: __STACKTRACE__,
+           message: Exception.message(error)
+         }}
+    catch
+      :throw, reason -> {:error, %{kind: :throw, reason: reason, stacktrace: __STACKTRACE__}}
+      :exit, reason -> {:error, %{kind: :exit, reason: reason, stacktrace: __STACKTRACE__}}
+    end
+  end
+
+  defp fail_run(run, ref, stage, started_at, started_monotonic, reason) do
+    finished_at = DateTime.utc_now()
+
+    result = %AssetResult{
+      ref: ref,
+      stage: stage,
+      status: :error,
+      started_at: started_at,
+      finished_at: finished_at,
+      duration_ms: System.monotonic_time(:millisecond) - started_monotonic,
+      error: normalize_error(reason)
+    }
+
+    %Run{
+      run
+      | status: :error,
+        finished_at: finished_at,
+        error: %{ref: ref, stage: stage, reason: reason},
+        asset_results: Map.put(run.asset_results, ref, result),
+        target_outputs: Map.take(run.outputs, run.target_refs)
+    }
+  end
+
+  defp normalize_reason(%{kind: _kind, reason: _reason, stacktrace: _stacktrace} = reason),
+    do: reason
+
+  defp normalize_reason(reason), do: reason
+
+  defp normalize_error(%{kind: _kind, reason: _reason, stacktrace: _stacktrace} = error),
+    do: error
+
+  defp normalize_error(reason) do
+    %{
+      kind: :error,
+      reason: reason,
+      stacktrace: []
+    }
+  end
+
+  defp new_run_id do
+    binary = :crypto.strong_rand_bytes(16)
+    <<a::32, b::16, c::16, d::16, e::48>> = binary
+
+    c = Bitwise.bor(Bitwise.band(c, 0x0FFF), 0x4000)
+    d = Bitwise.bor(Bitwise.band(d, 0x3FFF), 0x8000)
+
+    Enum.join(
+      [
+        a |> Integer.to_string(16) |> String.pad_leading(8, "0"),
+        b |> Integer.to_string(16) |> String.pad_leading(4, "0"),
+        c |> Integer.to_string(16) |> String.pad_leading(4, "0"),
+        d |> Integer.to_string(16) |> String.pad_leading(4, "0"),
+        e |> Integer.to_string(16) |> String.pad_leading(12, "0")
+      ],
+      "-"
+    )
+  end
+end

--- a/test/assets_test.exs
+++ b/test/assets_test.exs
@@ -3,7 +3,7 @@ defmodule Flux.AssetsTest.Upstream do
 
   @doc "Load source rows"
   @asset true
-  def source_rows, do: [%{id: 1, total: 100}]
+  def source_rows(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1, total: 100}]}}
 end
 
 defmodule Flux.AssetsTest.Sample do
@@ -13,15 +13,19 @@ defmodule Flux.AssetsTest.Sample do
 
   @doc "Extract raw orders"
   @asset true
-  def extract_orders, do: [%{id: 1, total: 100}]
+  def extract_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1, total: 100}]}}
 
   @doc "Normalize extracted orders"
   @asset depends_on: [:extract_orders], tags: [:sales, "warehouse"]
-  def normalize_orders(orders), do: Enum.map(orders, &Map.put(&1, :normalized, true))
+  def normalize_orders(_ctx, deps) do
+    orders = Map.fetch!(deps, {__MODULE__, :extract_orders})
+    {:ok, %Flux.Asset.Output{output: Enum.map(orders, &Map.put(&1, :normalized, true))}}
+  end
 
   @doc false
   @asset depends_on: [{Upstream, :source_rows}], kind: :view
-  def fact_sales(rows), do: %{rows: rows}
+  def fact_sales(_ctx, deps),
+    do: {:ok, %Flux.Asset.Output{output: %{rows: Map.fetch!(deps, {Upstream, :source_rows})}}}
 end
 
 defmodule Flux.AssetsTest do
@@ -41,7 +45,7 @@ defmodule Flux.AssetsTest do
     assert [%Asset{} = extract, %Asset{} = normalize, %Asset{} = fact] = assets
 
     assert extract.ref == {Flux.AssetsTest.Sample, :extract_orders}
-    assert extract.arity == 0
+    assert extract.arity == 2
     assert extract.doc == "Extract raw orders"
     assert extract.file == "test/assets_test.exs"
     assert is_integer(extract.line)
@@ -67,7 +71,7 @@ defmodule Flux.AssetsTest do
       use Flux.Assets
 
       @asset kind: :invalid
-      def bad_kind, do: :ok
+      def bad_kind(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
       """)
     end
 
@@ -76,7 +80,7 @@ defmodule Flux.AssetsTest do
       use Flux.Assets
 
       @asset tags: :sales
-      def bad_tags, do: :ok
+      def bad_tags(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
       """)
     end
 
@@ -85,7 +89,7 @@ defmodule Flux.AssetsTest do
       use Flux.Assets
 
       @asset tags: [:sales, 1]
-      def bad_tag_entry, do: :ok
+      def bad_tag_entry(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
       """)
     end
 
@@ -94,7 +98,7 @@ defmodule Flux.AssetsTest do
       use Flux.Assets
 
       @asset depends_on: :extract_orders
-      def bad_depends_on_shape, do: :ok
+      def bad_depends_on_shape(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
       """)
     end
 
@@ -103,7 +107,7 @@ defmodule Flux.AssetsTest do
       use Flux.Assets
 
       @asset depends_on: [:ok, "bad"]
-      def bad_depends_on, do: :ok
+      def bad_depends_on(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
       """)
     end
 
@@ -112,10 +116,10 @@ defmodule Flux.AssetsTest do
       use Flux.Assets
 
       @asset true
-      def duplicate, do: :ok
+      def duplicate(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
 
       @asset true
-      def duplicate(value), do: value
+      def duplicate(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
       """)
     end
 
@@ -124,7 +128,7 @@ defmodule Flux.AssetsTest do
       use Flux.Assets
 
       @asset true
-      defp private_asset, do: :ok
+      defp private_asset(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
       """)
     end
 
@@ -133,6 +137,15 @@ defmodule Flux.AssetsTest do
       use Flux.Assets
 
       @asset true
+      """)
+    end
+
+    assert_raise CompileError, ~r/@asset functions must have arity 2/, fn ->
+      compile_test_module("""
+      use Flux.Assets
+
+      @asset true
+      def wrong_arity, do: {:ok, %Flux.Asset.Output{output: :ok}}
       """)
     end
   end

--- a/test/flux_test.exs
+++ b/test/flux_test.exs
@@ -10,11 +10,12 @@ defmodule FluxTest do
 
     @doc "Extract raw orders"
     @asset true
-    def extract_orders, do: [%{id: 1}]
+    def extract_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1}]}}
 
     @doc "Normalize extracted orders"
     @asset depends_on: [:extract_orders], tags: [:sales]
-    def normalize_orders(orders), do: orders
+    def normalize_orders(_ctx, deps),
+      do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {__MODULE__, :extract_orders})}}
   end
 
   defmodule CrossModuleAssets do
@@ -24,7 +25,8 @@ defmodule FluxTest do
 
     @doc "Publish normalized orders"
     @asset depends_on: [{SampleAssets, :normalize_orders}], tags: [:reporting]
-    def publish_orders(orders), do: orders
+    def publish_orders(_ctx, deps),
+      do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {SampleAssets, :normalize_orders})}}
   end
 
   defmodule SpoofedAssets do

--- a/test/graph_index_test.exs
+++ b/test/graph_index_test.exs
@@ -6,11 +6,11 @@ defmodule Flux.GraphIndexTest do
 
     @doc "Raw orders"
     @asset true
-    def raw_orders, do: [%{id: 1}]
+    def raw_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1}]}}
 
     @doc "Raw customers"
     @asset true
-    def raw_customers, do: [%{id: 1}]
+    def raw_customers(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1}]}}
   end
 
   defmodule WarehouseAssets do
@@ -20,15 +20,24 @@ defmodule Flux.GraphIndexTest do
 
     @doc "Normalize orders"
     @asset depends_on: [{SourceAssets, :raw_orders}], tags: [:warehouse]
-    def normalize_orders(rows), do: rows
+    def normalize_orders(_ctx, deps),
+      do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {SourceAssets, :raw_orders})}}
 
     @doc "Normalize customers"
     @asset depends_on: [{SourceAssets, :raw_customers}], tags: [:warehouse]
-    def normalize_customers(rows), do: rows
+    def normalize_customers(_ctx, deps),
+      do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {SourceAssets, :raw_customers})}}
 
     @doc "Build sales fact"
     @asset depends_on: [:normalize_orders, :normalize_customers], tags: [:finance]
-    def fact_sales(orders, customers), do: {orders, customers}
+    def fact_sales(_ctx, deps) do
+      {:ok,
+       %Flux.Asset.Output{
+         output:
+           {Map.fetch!(deps, {__MODULE__, :normalize_orders}),
+            Map.fetch!(deps, {__MODULE__, :normalize_customers})}
+       }}
+    end
   end
 
   defmodule ReportingAssets do
@@ -38,7 +47,14 @@ defmodule Flux.GraphIndexTest do
 
     @doc "Build dashboard"
     @asset depends_on: [{WarehouseAssets, :fact_sales}, {WarehouseAssets, :normalize_orders}]
-    def dashboard(fact_sales, normalize_orders), do: {fact_sales, normalize_orders}
+    def dashboard(_ctx, deps) do
+      {:ok,
+       %Flux.Asset.Output{
+         output:
+           {Map.fetch!(deps, {WarehouseAssets, :fact_sales}),
+            Map.fetch!(deps, {WarehouseAssets, :normalize_orders})}
+       }}
+    end
   end
 
   setup do

--- a/test/planner_test.exs
+++ b/test/planner_test.exs
@@ -5,10 +5,10 @@ defmodule Flux.PlannerTest do
     use Flux.Assets
 
     @asset true
-    def raw_orders, do: :ok
+    def raw_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
 
     @asset true
-    def raw_customers, do: :ok
+    def raw_customers(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
   end
 
   defmodule SilverAssets do
@@ -17,10 +17,10 @@ defmodule Flux.PlannerTest do
     alias Flux.PlannerTest.BronzeAssets
 
     @asset depends_on: [{BronzeAssets, :raw_orders}]
-    def nightly_orders(_orders), do: :ok
+    def nightly_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
 
     @asset depends_on: [{BronzeAssets, :raw_customers}]
-    def monthly_customers(_customers), do: :ok
+    def monthly_customers(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
   end
 
   defmodule GoldAssets do
@@ -29,10 +29,10 @@ defmodule Flux.PlannerTest do
     alias Flux.PlannerTest.SilverAssets
 
     @asset depends_on: [{SilverAssets, :nightly_orders}, {SilverAssets, :monthly_customers}]
-    def gold_sales(_orders, _customers), do: :ok
+    def gold_sales(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
 
     @asset depends_on: [{SilverAssets, :nightly_orders}]
-    def gold_finance(_orders), do: :ok
+    def gold_finance(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
   end
 
   setup do

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -1,0 +1,112 @@
+defmodule Flux.RunnerTest do
+  use ExUnit.Case
+
+  defmodule RunnerAssets do
+    use Flux.Assets
+
+    @asset true
+    def base(ctx, _deps) do
+      {:ok, {:base, ctx.params[:partition]}}
+    end
+
+    @asset depends_on: [:base]
+    def transform(_ctx, deps) do
+      {:ok, {:transform, Map.fetch!(deps, {__MODULE__, :base})}}
+    end
+
+    @asset depends_on: [:base]
+    def invalid_return(_ctx, _deps) do
+      :bad_shape
+    end
+
+    @asset depends_on: [:transform]
+    def final(_ctx, deps) do
+      {:ok, {:final, Map.fetch!(deps, {__MODULE__, :transform})}}
+    end
+
+    @asset depends_on: [:base]
+    def crashes(_ctx, _deps) do
+      raise "boom"
+    end
+  end
+
+  setup do
+    previous_modules = Application.get_env(:flux, :asset_modules)
+    previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
+
+    Application.put_env(:flux, :asset_modules, [RunnerAssets])
+    assert :ok = Flux.Registry.reload()
+    assert :ok = Flux.GraphIndex.reload()
+
+    on_exit(fn ->
+      if is_nil(previous_modules) do
+        Application.delete_env(:flux, :asset_modules)
+      else
+        Application.put_env(:flux, :asset_modules, previous_modules)
+      end
+
+      restore_registry(previous_catalog)
+    end)
+
+    :ok
+  end
+
+  test "runs deterministic stage-by-stage execution with context and deps map" do
+    assert {:ok, run} =
+             Flux.run({RunnerAssets, :final},
+               dependencies: :all,
+               params: %{partition: "2026-03-25"}
+             )
+
+    assert run.status == :ok
+    assert is_binary(run.id)
+    assert %DateTime{} = run.started_at
+    assert %DateTime{} = run.finished_at
+
+    assert run.outputs[{RunnerAssets, :base}] == {:base, "2026-03-25"}
+    assert run.outputs[{RunnerAssets, :transform}] == {:transform, {:base, "2026-03-25"}}
+
+    assert run.target_outputs == %{
+             {RunnerAssets, :final} => {:final, {:transform, {:base, "2026-03-25"}}}
+           }
+
+    assert run.asset_results[{RunnerAssets, :base}].duration_ms >= 0
+    assert run.asset_results[{RunnerAssets, :final}].status == :ok
+  end
+
+  test "supports dependencies: :none target-only runs" do
+    assert {:ok, run} = Flux.run({RunnerAssets, :base}, dependencies: :none)
+
+    assert run.status == :ok
+    assert Map.keys(run.outputs) == [{RunnerAssets, :base}]
+    assert run.target_outputs == %{{RunnerAssets, :base} => {:base, nil}}
+  end
+
+  test "captures invalid return shape as a structured run failure" do
+    assert {:error, run} = Flux.run({RunnerAssets, :invalid_return})
+
+    assert run.status == :error
+    assert %{ref: {RunnerAssets, :invalid_return}} = run.error
+
+    assert run.asset_results[{RunnerAssets, :invalid_return}].error.reason ==
+             {:invalid_return_shape, :bad_shape}
+  end
+
+  test "captures raised exceptions with stacktrace details" do
+    assert {:error, run} = Flux.run({RunnerAssets, :crashes})
+
+    assert run.status == :error
+
+    error = run.asset_results[{RunnerAssets, :crashes}].error
+    assert error.kind == :error
+    assert is_list(error.stacktrace)
+    assert error.message == "boom"
+  end
+
+  defp restore_registry({:ok, _catalog}) do
+    :ok = Flux.Registry.reload()
+    :ok = Flux.GraphIndex.reload()
+  end
+
+  defp restore_registry({:error, _reason}), do: :ok
+end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -33,6 +33,15 @@ defmodule Flux.RunnerTest do
     def crashes(_ctx, _deps) do
       raise "boom"
     end
+
+    @asset true
+    def with_meta(_ctx, _deps) do
+      {:ok,
+       %Flux.Asset.Output{
+         output: {:rows, [1, 2, 3]},
+         meta: %{row_count: 123, source: :test}
+       }}
+    end
   end
 
   setup do
@@ -107,6 +116,18 @@ defmodule Flux.RunnerTest do
     assert error.kind == :error
     assert is_list(error.stacktrace)
     assert error.message == "boom"
+  end
+
+  test "preserves asset metadata in asset_results while keeping outputs as business values" do
+    assert {:ok, run} = Flux.run({RunnerAssets, :with_meta})
+
+    ref = {RunnerAssets, :with_meta}
+    output = {:rows, [1, 2, 3]}
+    meta = %{row_count: 123, source: :test}
+
+    assert run.outputs[ref] == output
+    assert run.asset_results[ref].output == output
+    assert run.asset_results[ref].meta == meta
   end
 
   defp restore_registry({:ok, _catalog}) do

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -6,22 +6,27 @@ defmodule Flux.RunnerTest do
 
     @asset true
     def base(ctx, _deps) do
-      {:ok, {:base, ctx.params[:partition]}}
+      {:ok, %Flux.Asset.Output{output: {:base, ctx.params[:partition]}}}
     end
 
     @asset depends_on: [:base]
     def transform(_ctx, deps) do
-      {:ok, {:transform, Map.fetch!(deps, {__MODULE__, :base})}}
+      {:ok, %Flux.Asset.Output{output: {:transform, Map.fetch!(deps, {__MODULE__, :base})}}}
     end
 
     @asset depends_on: [:base]
     def invalid_return(_ctx, _deps) do
-      :bad_shape
+      {:ok, :bad_shape}
     end
 
     @asset depends_on: [:transform]
     def final(_ctx, deps) do
-      {:ok, {:final, Map.fetch!(deps, {__MODULE__, :transform})}}
+      {:ok, %Flux.Asset.Output{output: {:final, Map.fetch!(deps, {__MODULE__, :transform})}}}
+    end
+
+    @asset depends_on: [:transform]
+    def target_only(_ctx, deps) do
+      {:ok, %Flux.Asset.Output{output: map_size(deps)}}
     end
 
     @asset depends_on: [:base]
@@ -75,11 +80,11 @@ defmodule Flux.RunnerTest do
   end
 
   test "supports dependencies: :none target-only runs" do
-    assert {:ok, run} = Flux.run({RunnerAssets, :base}, dependencies: :none)
+    assert {:ok, run} = Flux.run({RunnerAssets, :target_only}, dependencies: :none)
 
     assert run.status == :ok
-    assert Map.keys(run.outputs) == [{RunnerAssets, :base}]
-    assert run.target_outputs == %{{RunnerAssets, :base} => {:base, nil}}
+    assert Map.keys(run.outputs) == [{RunnerAssets, :target_only}]
+    assert run.target_outputs == %{{RunnerAssets, :target_only} => 0}
   end
 
   test "captures invalid return shape as a structured run failure" do
@@ -89,7 +94,8 @@ defmodule Flux.RunnerTest do
     assert %{ref: {RunnerAssets, :invalid_return}} = run.error
 
     assert run.asset_results[{RunnerAssets, :invalid_return}].error.reason ==
-             {:invalid_return_shape, :bad_shape}
+             {:invalid_return_shape, {:ok, :bad_shape},
+              expected: "{:ok, %Flux.Asset.Output{}} | {:error, reason}"}
   end
 
   test "captures raised exceptions with stacktrace details" do


### PR DESCRIPTION
### Motivation

- Implement an initial in-memory run model and deterministic executor to enable executing asset plans end-to-end. 
- Provide a concrete `Flux.run/2` implementation that can be used by higher-level orchestration and tested in isolation.

### Description

- Added a canonical in-memory run struct `Flux.Run` and per-asset result struct `Flux.Run.AssetResult` to capture run metadata, outputs, timings, and errors. 
- Added runtime context `Flux.Run.Context` used when invoking asset functions. 
- Implemented `Flux.Runner` as a deterministic, stage-by-stage in-memory runner that validates params, builds runs from `Flux.plan_run/2`, executes assets serially, collects outputs, and fails fast on the first error. 
- Updated public API in `Flux` to include `params` in `run_opts`, updated the `@spec` and doc/example for `run/2`, and delegated execution to `Flux.Runner.run/2`. 

### Testing

- Added `test/runner_test.exs` which exercises end-to-end execution including multi-stage runs, `dependencies: :none` target-only runs, invalid return-shape handling, and captured exceptions with stacktraces. 
- Ran the test suite for the new runner file with `mix test test/runner_test.exs` and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c3d8f87a2c832891a43aac67f34962)