### PR TITLE
Add storage facade and in-memory run store; persist runs and wire storage into application

### DIFF
--- a/lib/flux.ex
+++ b/lib/flux.ex
@@ -374,7 +374,7 @@ defmodule Flux do
   Filter options for `list_runs/1`.
   """
   @type list_runs_opts :: [
-          status: :pending | :running | :ok | :error,
+          status: :running | :ok | :error,
           limit: pos_integer()
         ]
 

--- a/lib/flux.ex
+++ b/lib/flux.ex
@@ -307,8 +307,33 @@ defmodule Flux do
     7. graph inspection queries - in progress
     8. execution planning - done
     9. run model and in-memory execution - in progress
-    10. run storage and retrieval
+    10. run storage and retrieval - in progress
     11. live run event subscriptions
+    12. pre-release refactor pass for shared helpers and consistent module patterns
+    13. pre-release documentation and test hardening for v0.1
+    14. storage adapter boundary for memory/SQLite/Postgres and third-party plugins
+
+  ## v0.1 release focus
+
+  In addition to finishing the remaining runtime APIs, the first release should include a
+  deliberate quality pass over internals, docs, and tests so the public facade stays small and
+  predictable as usage grows.
+
+  The v0.1 closeout checklist is:
+
+    * finish run lifecycle APIs (`get_run/1`, `list_runs/1`, `subscribe_run/1`, `unsubscribe_run/1`)
+    * refactor reusable logic into small shared helpers where duplication exists across modules
+    * align coding patterns across modules (naming, return shapes, and error conventions)
+    * tighten and refresh user-facing docs in this module and related public interfaces
+    * consolidate test fixtures so one canonical test asset module set is reused across suites
+    * keep tests deterministic and focused on public contracts
+
+  Production deployment note:
+
+  Flux is expected to run on multiple BEAM nodes in clustered environments (for example
+  Kubernetes). The in-memory run store is intentionally node-local and non-durable for
+  development. Production and multi-node consistency are expected to use durable shared
+  adapters (Postgres first, with SQLite and third-party adapters as follow-up options).
 
   """
 
@@ -352,6 +377,11 @@ defmodule Flux do
           status: :pending | :running | :ok | :error,
           limit: pos_integer()
         ]
+
+  @typedoc """
+  Run retrieval/listing errors returned by storage-backed APIs.
+  """
+  @type run_error :: :not_found | :invalid_opts | {:store_error, term()}
 
   @typedoc """
   Options for `run/2`.
@@ -616,6 +646,7 @@ defmodule Flux do
     * Keep this planner deterministic and graph-derived
     * Keep plan nodes deduplicated by canonical ref
     * Add freshness-aware actions after run storage exists
+    * Reuse planner normalization and sorting helpers from one shared internal module
   """
   @spec plan_run(asset_ref() | [asset_ref()], plan_run_opts()) ::
           {:ok, Flux.Plan.t()} | {:error, term()}
@@ -657,6 +688,7 @@ defmodule Flux do
     * Keep execution in-memory and synchronous for the first cut
     * Add run process supervision and stage-level parallelism in follow-up work
     * Add freshness-aware skipping after the planner can reason about materialized assets
+    * Share common execution result-shaping helpers with planner and storage layers
   """
   @spec run(asset_ref(), run_opts()) :: {:ok, Flux.Run.t()} | {:error, Flux.Run.t() | term()}
   def run({module, name}, opts \\ [])
@@ -673,19 +705,17 @@ defmodule Flux do
   ## Examples
 
       iex> Flux.get_run("run_123")
-      ** (RuntimeError) TODO: implement Flux.get_run/1
+      {:error, :not_found}
 
   ## TODO
 
-    * Implement after the run model and runner exist
-    * Delegate to `Flux.Storage` or a dedicated run store
-    * Define the canonical run shape
-    * Decide how much execution detail belongs in the run record itself
+    * Delegate to `Flux.Storage`
+    * Keep return contract stable across storage adapters
+    * Preserve the canonical `%Flux.Run{}` shape in storage
   """
-  @spec get_run(run_id()) :: term()
+  @spec get_run(run_id()) :: {:ok, Flux.Run.t()} | {:error, run_error()}
   def get_run(run_id) do
-    _ = run_id
-    todo!("Flux.get_run/1")
+    Flux.Storage.get_run(run_id)
   end
 
   @doc """
@@ -697,21 +727,21 @@ defmodule Flux do
   ## Examples
 
       iex> Flux.list_runs()
-      ** (RuntimeError) TODO: implement Flux.list_runs/1
+      {:ok, []}
 
       iex> Flux.list_runs(status: :running)
-      ** (RuntimeError) TODO: implement Flux.list_runs/1
+      {:ok, []}
 
   ## TODO
 
-    * Implement after the run model and storage layer exist
     * Delegate to `Flux.Storage`
-    * Define default ordering, likely newest first
+    * Keep default ordering newest-first
+    * Keep filter semantics stable across storage adapters
     * Consider pagination rather than large unbounded lists
   """
-  @spec list_runs(list_runs_opts()) :: [term()]
+  @spec list_runs(list_runs_opts()) :: {:ok, [Flux.Run.t()]} | {:error, run_error()}
   def list_runs(opts \\ []) when is_list(opts) do
-    todo!("Flux.list_runs/1")
+    Flux.Storage.list_runs(opts)
   end
 
   @doc """

--- a/lib/flux/application.ex
+++ b/lib/flux/application.ex
@@ -9,8 +9,9 @@ defmodule Flux.Application do
 
     with :ok <- Flux.Registry.load(),
          :ok <- Flux.GraphIndex.load(),
-         :ok <- Flux.Storage.validate_adapter(adapter) do
-      Supervisor.start_link(Flux.Storage.child_specs(),
+         :ok <- Flux.Storage.validate_adapter(adapter),
+         {:ok, child_specs} <- Flux.Storage.child_specs() do
+      Supervisor.start_link(child_specs,
         strategy: :one_for_one,
         name: Flux.Supervisor
       )

--- a/lib/flux/application.ex
+++ b/lib/flux/application.ex
@@ -5,9 +5,15 @@ defmodule Flux.Application do
 
   @impl true
   def start(_type, _args) do
+    adapter = Flux.Storage.adapter_module()
+
     with :ok <- Flux.Registry.load(),
-         :ok <- Flux.GraphIndex.load() do
-      Supervisor.start_link([], strategy: :one_for_one, name: Flux.Supervisor)
+         :ok <- Flux.GraphIndex.load(),
+         :ok <- Flux.Storage.validate_adapter(adapter) do
+      Supervisor.start_link(Flux.Storage.child_specs(),
+        strategy: :one_for_one,
+        name: Flux.Supervisor
+      )
     end
   end
 end

--- a/lib/flux/run_store.ex
+++ b/lib/flux/run_store.ex
@@ -1,0 +1,45 @@
+defmodule Flux.RunStore do
+  @moduledoc """
+  Behaviour for run persistence adapters.
+
+  Run store adapters are the boundary between Flux runtime orchestration and
+  concrete persistence backends.
+
+  The default adapter in v0.1 is `Flux.RunStore.Memory`, which is node-local
+  and non-durable. Future adapters (for example Postgres or SQLite) should
+  implement this behaviour without changing the `Flux` public API.
+
+  ## Required invariants
+
+    * Run IDs are treated as globally unique identifiers.
+    * `put_run/2` is idempotent for the same run ID.
+    * `list_runs/2` returns deterministic newest-first ordering.
+    * Adapters should return `{:error, :not_found}` for missing run IDs.
+
+  ## Lifecycle
+
+  Adapters may expose a `child_spec/1` function and return either:
+
+    * `{:ok, child_spec}` when supervision is required
+    * `:none` when no process lifecycle is needed
+  """
+
+  alias Flux.Run
+
+  @typedoc "Runtime options passed to a concrete run-store adapter."
+  @type adapter_opts :: keyword()
+
+  @typedoc "Filter options accepted by `list_runs/2`."
+  @type list_opts :: Flux.list_runs_opts()
+
+  @typedoc "Run store errors normalized by the storage facade."
+  @type error :: :not_found | :invalid_opts | term()
+
+  @callback child_spec(adapter_opts()) :: {:ok, Supervisor.child_spec()} | :none
+
+  @callback put_run(Run.t(), adapter_opts()) :: :ok | {:error, error()}
+
+  @callback get_run(Flux.run_id(), adapter_opts()) :: {:ok, Run.t()} | {:error, error()}
+
+  @callback list_runs(list_opts(), adapter_opts()) :: {:ok, [Run.t()]} | {:error, error()}
+end

--- a/lib/flux/run_store/memory.ex
+++ b/lib/flux/run_store/memory.ex
@@ -1,0 +1,96 @@
+defmodule Flux.RunStore.Memory do
+  @moduledoc """
+  In-memory run store adapter.
+
+  This adapter is intended for development and testing:
+
+    * node-local
+    * non-durable (data is lost on restart)
+    * deterministic listing for predictable assertions
+  """
+
+  use GenServer
+
+  alias Flux.Run
+
+  @table_name __MODULE__.Table
+
+  @spec child_spec(keyword()) :: {:ok, Supervisor.child_spec()} | :none
+  def child_spec(opts \\ []) do
+    {:ok,
+     %{
+       id: __MODULE__,
+       start: {__MODULE__, :start_link, [opts]},
+       type: :worker,
+       restart: :permanent,
+       shutdown: 5000
+     }}
+  end
+
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(_opts) do
+    GenServer.start_link(__MODULE__, %{}, name: __MODULE__)
+  end
+
+  @impl true
+  def init(state) do
+    _table = :ets.new(@table_name, [:set, :named_table, :public, read_concurrency: true])
+    {:ok, state}
+  end
+
+  @spec put_run(Run.t(), keyword()) :: :ok | {:error, term()}
+  def put_run(%Run{} = run, _opts) do
+    inserted_seq =
+      case :ets.lookup(@table_name, run.id) do
+        [{_id, _stored_run, existing_inserted_seq}] -> existing_inserted_seq
+        [] -> System.unique_integer([:monotonic, :positive])
+      end
+
+    true = :ets.insert(@table_name, {run.id, run, inserted_seq})
+    :ok
+  rescue
+    error -> {:error, error}
+  end
+
+  @spec get_run(Flux.run_id(), keyword()) :: {:ok, Run.t()} | {:error, :not_found | term()}
+  def get_run(run_id, _opts) do
+    case :ets.lookup(@table_name, run_id) do
+      [{^run_id, run, _inserted_seq}] -> {:ok, run}
+      [] -> {:error, :not_found}
+    end
+  rescue
+    error -> {:error, error}
+  end
+
+  @spec list_runs(Flux.list_runs_opts(), keyword()) :: {:ok, [Run.t()]} | {:error, term()}
+  def list_runs(opts, _adapter_opts) when is_list(opts) do
+    status = Keyword.get(opts, :status)
+    limit = Keyword.get(opts, :limit)
+
+    runs =
+      @table_name
+      |> :ets.tab2list()
+      |> Enum.map(fn {_id, run, inserted_seq} -> {run, inserted_seq} end)
+      |> maybe_filter_status(status)
+      |> Enum.sort_by(&sort_key/1, :desc)
+      |> Enum.map(&elem(&1, 0))
+      |> maybe_limit(limit)
+
+    {:ok, runs}
+  rescue
+    error -> {:error, error}
+  end
+
+  defp maybe_filter_status(runs, nil), do: runs
+
+  defp maybe_filter_status(runs, status) do
+    Enum.filter(runs, fn {run, _seq} -> run.status == status end)
+  end
+
+  defp maybe_limit(runs, nil), do: runs
+  defp maybe_limit(runs, limit), do: Enum.take(runs, limit)
+
+  defp sort_key({run, inserted_seq}) do
+    {run.started_at, inserted_seq, run.id}
+  end
+end

--- a/lib/flux/runner.ex
+++ b/lib/flux/runner.ex
@@ -34,9 +34,9 @@ defmodule Flux.Runner do
         params: params
       }
 
-      with :ok <- Flux.Storage.put_run(run),
-           result <- execute_plan(run),
-           :ok <- persist_terminal_result(result) do
+      with :ok <- Flux.Storage.put_run(run) do
+        result = execute_plan(run)
+        _ = persist_terminal_result(result)
         result
       end
     end

--- a/lib/flux/runner.ex
+++ b/lib/flux/runner.ex
@@ -34,12 +34,26 @@ defmodule Flux.Runner do
         params: params
       }
 
-      execute_plan(run)
+      with :ok <- Flux.Storage.put_run(run),
+           result <- execute_plan(run),
+           :ok <- persist_terminal_result(result) do
+        result
+      end
     end
   end
 
   defp validate_params(params) when is_map(params), do: :ok
   defp validate_params(_params), do: {:error, :invalid_run_params}
+
+  defp persist_terminal_result({:ok, %Run{} = run}) do
+    Flux.Storage.put_run(run)
+  end
+
+  defp persist_terminal_result({:error, %Run{} = run}) do
+    Flux.Storage.put_run(run)
+  end
+
+  defp persist_terminal_result(_result), do: :ok
 
   defp execute_plan(%Run{} = run) do
     case run.plan.stages |> Enum.with_index() |> Enum.reduce_while(run, &run_stage/2) do

--- a/lib/flux/storage.ex
+++ b/lib/flux/storage.ex
@@ -1,0 +1,106 @@
+defmodule Flux.Storage do
+  @moduledoc """
+  Storage facade that delegates run persistence to the configured run-store adapter.
+
+  This module is the only storage entrypoint used by `Flux` and `Flux.Runner`.
+  """
+
+  alias Flux.Run
+
+  @default_adapter Flux.RunStore.Memory
+
+  @type error :: :not_found | :invalid_opts | {:store_error, term()}
+
+  @spec child_specs() :: [Supervisor.child_spec()]
+  def child_specs do
+    adapter = adapter_module()
+
+    with :ok <- validate_adapter(adapter),
+         {:ok, child_spec} <- adapter.child_spec(adapter_opts()) do
+      [child_spec]
+    else
+      :none -> []
+      {:error, _reason} -> []
+    end
+  end
+
+  @spec put_run(Run.t()) :: :ok | {:error, error()}
+  def put_run(%Run{} = run) do
+    adapter_call(fn adapter, opts -> adapter.put_run(run, opts) end)
+  end
+
+  @spec get_run(Flux.run_id()) :: {:ok, Run.t()} | {:error, error()}
+  def get_run(run_id) do
+    adapter_call(fn adapter, opts -> adapter.get_run(run_id, opts) end)
+  end
+
+  @spec list_runs(Flux.list_runs_opts()) :: {:ok, [Run.t()]} | {:error, error()}
+  def list_runs(opts \\ []) when is_list(opts) do
+    with :ok <- validate_list_opts(opts) do
+      adapter_call(fn adapter, adapter_opts -> adapter.list_runs(opts, adapter_opts) end)
+    end
+  end
+
+  @spec adapter_module() :: module()
+  def adapter_module do
+    Application.get_env(:flux, :run_store, @default_adapter)
+  end
+
+  @spec adapter_opts() :: keyword()
+  def adapter_opts do
+    Application.get_env(:flux, :run_store_opts, [])
+  end
+
+  @spec validate_adapter(module()) :: :ok | {:error, error()}
+  def validate_adapter(adapter) when is_atom(adapter) do
+    required_callbacks = [
+      {:child_spec, 1},
+      {:put_run, 2},
+      {:get_run, 2},
+      {:list_runs, 2}
+    ]
+
+    with {:module, ^adapter} <- Code.ensure_loaded(adapter),
+         true <-
+           Enum.all?(required_callbacks, fn {name, arity} ->
+             function_exported?(adapter, name, arity)
+           end) do
+      :ok
+    else
+      _ -> {:error, {:store_error, {:invalid_run_store_adapter, adapter}}}
+    end
+  end
+
+  defp validate_list_opts(opts) do
+    status = Keyword.get(opts, :status)
+    limit = Keyword.get(opts, :limit)
+
+    cond do
+      not is_nil(status) and status not in [:pending, :running, :ok, :error] ->
+        {:error, :invalid_opts}
+
+      not is_nil(limit) and (not is_integer(limit) or limit <= 0) ->
+        {:error, :invalid_opts}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp adapter_call(fun) do
+    adapter = adapter_module()
+
+    with :ok <- validate_adapter(adapter) do
+      adapter
+      |> fun.(adapter_opts())
+      |> normalize_result()
+    end
+  end
+
+  defp normalize_result(:ok), do: :ok
+  defp normalize_result({:ok, _value} = ok), do: ok
+  defp normalize_result({:error, :not_found}), do: {:error, :not_found}
+  defp normalize_result({:error, :invalid_opts}), do: {:error, :invalid_opts}
+  defp normalize_result({:error, {:store_error, _reason}} = error), do: error
+  defp normalize_result({:error, reason}), do: {:error, {:store_error, reason}}
+end

--- a/lib/flux/storage.ex
+++ b/lib/flux/storage.ex
@@ -11,16 +11,16 @@ defmodule Flux.Storage do
 
   @type error :: :not_found | :invalid_opts | {:store_error, term()}
 
-  @spec child_specs() :: [Supervisor.child_spec()]
+  @spec child_specs() :: {:ok, [Supervisor.child_spec()]} | {:error, error()}
   def child_specs do
     adapter = adapter_module()
 
     with :ok <- validate_adapter(adapter),
          {:ok, child_spec} <- adapter.child_spec(adapter_opts()) do
-      [child_spec]
+      {:ok, [child_spec]}
     else
-      :none -> []
-      {:error, _reason} -> []
+      :none -> {:ok, []}
+      {:error, reason} -> {:error, {:store_error, reason}}
     end
   end
 
@@ -76,7 +76,7 @@ defmodule Flux.Storage do
     limit = Keyword.get(opts, :limit)
 
     cond do
-      not is_nil(status) and status not in [:pending, :running, :ok, :error] ->
+      not is_nil(status) and status not in [:running, :ok, :error] ->
         {:error, :invalid_opts}
 
       not is_nil(limit) and (not is_integer(limit) or limit <= 0) ->

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -44,6 +44,35 @@ defmodule Flux.RunnerTest do
     end
   end
 
+  defmodule TerminalFailingStore do
+    @behaviour Flux.RunStore
+
+    @counter_key {__MODULE__, :put_count}
+
+    @impl true
+    def child_spec(_opts), do: :none
+
+    @impl true
+    def put_run(_run, _opts) do
+      count = :persistent_term.get(@counter_key, 0)
+      :persistent_term.put(@counter_key, count + 1)
+
+      if count == 0 do
+        :ok
+      else
+        {:error, :terminal_write_failed}
+      end
+    end
+
+    @impl true
+    def get_run(_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
+    def list_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    def reset!, do: :persistent_term.erase(@counter_key)
+  end
+
   setup do
     previous_modules = Application.get_env(:flux, :asset_modules)
     previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
@@ -163,6 +192,18 @@ defmodule Flux.RunnerTest do
 
   test "returns :not_found for missing runs" do
     assert {:error, :not_found} = Flux.get_run("missing-run-id")
+  end
+
+  test "returns execution result even when terminal persistence fails" do
+    Application.put_env(:flux, :run_store, TerminalFailingStore)
+    TerminalFailingStore.reset!()
+
+    assert {:ok, run} = Flux.run({RunnerAssets, :final})
+    assert run.status == :ok
+  end
+
+  test "rejects unsupported list_runs status filter values" do
+    assert {:error, :invalid_opts} = Flux.list_runs(status: :pending)
   end
 
   defp clear_memory_run_store do

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -49,6 +49,9 @@ defmodule Flux.RunnerTest do
     previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
 
     Application.put_env(:flux, :asset_modules, [RunnerAssets])
+    Application.put_env(:flux, :run_store, Flux.RunStore.Memory)
+    Application.put_env(:flux, :run_store_opts, [])
+    clear_memory_run_store()
     assert :ok = Flux.Registry.reload()
     assert :ok = Flux.GraphIndex.reload()
 
@@ -59,6 +62,8 @@ defmodule Flux.RunnerTest do
         Application.put_env(:flux, :asset_modules, previous_modules)
       end
 
+      Application.delete_env(:flux, :run_store)
+      Application.delete_env(:flux, :run_store_opts)
       restore_registry(previous_catalog)
     end)
 
@@ -128,6 +133,46 @@ defmodule Flux.RunnerTest do
     assert run.outputs[ref] == output
     assert run.asset_results[ref].output == output
     assert run.asset_results[ref].meta == meta
+  end
+
+  test "persists run records for get_run/1" do
+    assert {:ok, run} = Flux.run({RunnerAssets, :final})
+
+    assert {:ok, fetched} = Flux.get_run(run.id)
+    assert fetched.id == run.id
+    assert fetched.status == :ok
+    assert fetched.target_refs == run.target_refs
+  end
+
+  test "lists runs with status filter and limit in newest-first order" do
+    assert {:ok, ok_run} = Flux.run({RunnerAssets, :final})
+    assert {:error, error_run} = Flux.run({RunnerAssets, :crashes})
+
+    assert {:ok, all_runs} = Flux.list_runs()
+    assert Enum.map(all_runs, & &1.id) == [error_run.id, ok_run.id]
+
+    assert {:ok, running_runs} = Flux.list_runs(status: :running)
+    assert running_runs == []
+
+    assert {:ok, failed_runs} = Flux.list_runs(status: :error)
+    assert Enum.map(failed_runs, & &1.id) == [error_run.id]
+
+    assert {:ok, limited_runs} = Flux.list_runs(limit: 1)
+    assert Enum.map(limited_runs, & &1.id) == [error_run.id]
+  end
+
+  test "returns :not_found for missing runs" do
+    assert {:error, :not_found} = Flux.get_run("missing-run-id")
+  end
+
+  defp clear_memory_run_store do
+    table = Flux.RunStore.Memory.Table
+
+    if :ets.whereis(table) != :undefined do
+      :ets.delete_all_objects(table)
+    end
+
+    :ok
   end
 
   defp restore_registry({:ok, _catalog}) do


### PR DESCRIPTION
### Motivation

- Provide a pluggable storage boundary for run persistence so runs can be stored, listed, and retrieved across adapters instead of remaining purely in-memory.
- Persist run lifecycle state during execution to support `get_run/1` and `list_runs/1` and to enable future durable adapters for production usage.

### Description

- Introduces a `Flux.Storage` facade that delegates persistence calls to a configurable adapter and normalizes adapter results, plus new types and validation for adapter options and listing filters. 
- Adds a `Flux.RunStore` behaviour and an in-memory adapter `Flux.RunStore.Memory` implementing `child_spec/1`, `put_run/2`, `get_run/2`, and `list_runs/2` using ETS for deterministic newest-first ordering. 
- Updates `Flux.Runner` to persist the run before execution (`put_run/1`) and again for terminal results, with a helper `persist_terminal_result/1` to save success or failure. 
- Wires storage into application startup by validating the configured adapter in `Flux.Application.start/2` and starting adapter child specs from `Flux.Storage.child_specs/0`, and updates public API in `Flux` to delegate `get_run/1` and `list_runs/1` to `Flux.Storage`. 
- Adds `run_error` types and short documentation notes and expands tests to cover storage behaviour and API expectations. 

### Testing

- Ran the test suite with `mix test`, including `Flux.RunnerTest` which was extended to configure the in-memory adapter and clear the ETS table, and all tests passed. 
- Exercised persistence-related scenarios in tests: `get_run/1` returns persisted runs and `:not_found` for missing IDs, `list_runs/1` honors `status` and `limit` and returns newest-first ordering, and these assertions succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c425091ac4832883ea738bc2f59b78)