### PR TITLE
Rewrite README with core Flux overview and onboarding sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,89 @@
 # Flux
 
-**TODO: Add description**
+Flux is an Elixir library for defining business-oriented data assets, discovering their dependencies, and orchestrating deterministic runs from those dependency relationships. It is designed as a core runtime that host applications can use to power workflow execution, inspection, and operator-facing tooling.
+
+## Features
+
+- **Asset DSL** via `use Flux.Assets` and `@asset` annotations on normal Elixir functions.
+- **Registry** for loading configured asset modules and exposing a stable discovery surface.
+- **Graph inspection** for upstream/downstream traversal and dependency-aware introspection.
+- **Planner** for deriving an executable order from a target asset and its transitive dependencies.
+- **Runner** for executing planned asset steps for a run target.
+- **Run store** for recording run metadata and statuses.
+- **Run events** for publishing run lifecycle updates to subscribers.
+
+## Quickstart
+
+Define an asset module:
+
+```elixir
+defmodule MyApp.SalesAssets do
+  use Flux.Assets
+
+  @asset true
+  def extract_orders(_ctx, _deps) do
+    {:ok, %Flux.Asset.Output{output: [%{id: 1, total: 100}]}}
+  end
+
+  @asset depends_on: [:extract_orders]
+  def build_daily_report(_ctx, deps) do
+    orders = Map.fetch!(deps, {__MODULE__, :extract_orders})
+    {:ok, %Flux.Asset.Output{output: %{count: length(orders)}}}
+  end
+end
+```
+
+Register the module and run a target asset:
+
+```elixir
+# config/config.exs
+import Config
+
+config :flux,
+  asset_modules: [MyApp.SalesAssets]
+```
+
+```elixir
+# from your app runtime / iex
+{:ok, run} = Flux.run({MyApp.SalesAssets, :build_daily_report}, dependencies: :all)
+```
+
+## Configuration
+
+Flux is configured through the `:flux` application environment:
+
+```elixir
+import Config
+
+config :flux,
+  asset_modules: [MyApp.SalesAssets],
+  pubsub_name: MyApp.PubSub,
+  run_store: Flux.RunStore.Memory,
+  run_store_opts: []
+```
+
+Key settings:
+
+- `asset_modules`: modules that define assets with `use Flux.Assets`.
+- `:pubsub_name`: PubSub server name used for run event broadcasting.
+- `:run_store`: run store implementation module.
+- `:run_store_opts`: options passed to the configured run store.
+
+## Current limitations
+
+- The default run store is node-local in-memory storage.
+- Execution is currently synchronous.
+- Run events are best-effort pubsub notifications.
+
+## Roadmap and release focus
+
+Current development is focused on stabilizing the core API and runtime behavior:
+
+- Harden the public API for asset inspection and run orchestration.
+- Improve planner/runner ergonomics and error reporting.
+- Add stronger durability and query capabilities for run storage.
+- Expand event delivery semantics and observability integrations.
+- Prepare Hex packaging and versioned release practices for broader adoption.
 
 ## Installation
 
@@ -27,8 +110,3 @@ def deps do
   ]
 end
 ```
-
-Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_doc)
-and published on [HexDocs](https://hexdocs.pm). Once published, the docs can
-be found at <https://hexdocs.pm/flux>.
-


### PR DESCRIPTION
### Motivation

- Replace the placeholder README with a concise overview so new users immediately understand what Flux is and when to use it. 
- Provide a clear, documentation-first quickstart that demonstrates authoring assets with `use Flux.Assets` and running targets with `Flux.run/2`. 
- Surface configuration keys and current limitations to set expectations for integration and short-term behavior.

### Description

- Replaced the top-level README paragraph with a short summary describing Flux as an Elixir library for defining business-oriented data assets and orchestrating dependency-driven runs. 
- Added a `Features` section listing the core runtime surfaces including the asset DSL, registry, graph inspection, planner, runner, run store, and run events. 
- Added a `Quickstart` section with an example asset module that uses `use Flux.Assets` and a sample invocation of `Flux.run/2`. 
- Added a `Configuration` section documenting `config :flux, asset_modules: [...]`, `:pubsub_name`, `:run_store`, and `:run_store_opts`, plus brief descriptions and sample config. 
- Added `Current limitations` noting the node-local memory run store, synchronous execution, and best-effort events, and a `Roadmap and release focus` section describing upcoming stabilization and packaging work.

### Testing

- No automated tests were run because this change is documentation-only. 
- Existing test suite and code were not modified by this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c56ed919ec8328a19036cc30cc0692)