### PR TITLE
docs: define canonical documentation ownership and maintenance checklist

### DIFF
--- a/lib/flux.ex
+++ b/lib/flux.ex
@@ -276,6 +276,14 @@ defmodule Flux do
     * the public API stays small and stable
     * implementation details are pushed into focused modules
 
+  ## Documentation policy
+
+  Documentation ownership is split intentionally:
+
+    * `README.md` is canonical for release status, roadmap planning, and the
+      feature/limitation matrix.
+    * `Flux` moduledoc is canonical for API behavior, contracts, and examples.
+
   ## Status
 
   Flux is currently being rebuilt from the asset authoring layer upward.

--- a/tmp_project_state.md
+++ b/tmp_project_state.md
@@ -2,6 +2,10 @@ Dev review feedback:
 - Duplicate type from asset.ex -> @valid_kinds [:materialized, :view, :ephemeral]. please reuse type from asset.ex
 - In tests add logging of what test and results so that i can see results when running tests. 
 
+Maintenance checklist (required on every API or roadmap change):
+- Update `README.md` as the canonical source for release status, roadmap, and feature/limitation matrix changes.
+- Update `lib/flux.ex` moduledoc as the canonical source for API behavior/contracts and usage examples.
+
 
 
 Natural next steps:


### PR DESCRIPTION
### Motivation
- Clarify which project documents are the canonical sources of truth for release/roadmap information versus API behavior to avoid documentation drift.
- Ensure maintenance practices require updating both the public README and the `Flux` moduledoc when API or roadmap changes occur.

### Description
- Add a `Documentation policy` subsection to the `Flux` moduledoc stating that `README.md` is canonical for release status, roadmap planning, and the feature/limitation matrix while the `Flux` moduledoc is canonical for API behavior, contracts, and examples (`lib/flux.ex`).
- Add a maintenance checklist to `tmp_project_state.md` that explicitly requires updating `README.md` and `lib/flux.ex` moduledoc on every API or roadmap change (`tmp_project_state.md`).
- This PR modifies only documentation files and does not change any functional code or tests.

### Testing
- No automated tests were executed because the changes are documentation-only; no test or runtime behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c56edcc44883289358fa8e5bc790f8)