### PR TITLE
Validate GraphIndex query options before traversal

### DIFF
--- a/lib/flux/graph_index.ex
+++ b/lib/flux/graph_index.ex
@@ -44,6 +44,7 @@ defmodule Flux.GraphIndex do
   @type error ::
           {:missing_dependency, Ref.t(), Ref.t()}
           | {:cycle, [Ref.t()]}
+          | :invalid_opts
           | Flux.Registry.error()
 
   @typedoc """
@@ -227,32 +228,68 @@ defmodule Flux.GraphIndex do
   end
 
   defp selected_refs(index, ref, opts) do
-    transitive? = Keyword.get(opts, :transitive, true)
+    with :ok <- validate_opts(opts) do
+      transitive? = Keyword.get(opts, :transitive, true)
 
-    case {Keyword.get(opts, :direction, :upstream), transitive?} do
-      {:upstream, false} ->
-        fetch_set(index.upstream, ref)
+      case {Keyword.get(opts, :direction, :upstream), transitive?} do
+        {:upstream, false} ->
+          fetch_set(index.upstream, ref)
 
-      {:downstream, false} ->
-        fetch_set(index.downstream, ref)
+        {:downstream, false} ->
+          fetch_set(index.downstream, ref)
 
-      {:upstream, true} ->
-        fetch_set(index.transitive_upstream, ref)
+        {:upstream, true} ->
+          fetch_set(index.transitive_upstream, ref)
 
-      {:downstream, true} ->
-        fetch_set(index.transitive_downstream, ref)
+        {:downstream, true} ->
+          fetch_set(index.transitive_downstream, ref)
 
-      {:both, false} ->
-        with {:ok, upstream} <- fetch_set(index.upstream, ref),
-             {:ok, downstream} <- fetch_set(index.downstream, ref) do
-          {:ok, MapSet.union(upstream, downstream)}
-        end
+        {:both, false} ->
+          with {:ok, upstream} <- fetch_set(index.upstream, ref),
+               {:ok, downstream} <- fetch_set(index.downstream, ref) do
+            {:ok, MapSet.union(upstream, downstream)}
+          end
 
-      {:both, true} ->
-        with {:ok, upstream} <- fetch_set(index.transitive_upstream, ref),
-             {:ok, downstream} <- fetch_set(index.transitive_downstream, ref) do
-          {:ok, MapSet.union(upstream, downstream)}
-        end
+        {:both, true} ->
+          with {:ok, upstream} <- fetch_set(index.transitive_upstream, ref),
+               {:ok, downstream} <- fetch_set(index.transitive_downstream, ref) do
+            {:ok, MapSet.union(upstream, downstream)}
+          end
+      end
+    end
+  end
+
+  defp validate_opts(opts) do
+    direction = Keyword.get(opts, :direction, :upstream)
+
+    with :ok <- validate_inclusion(direction, [:upstream, :downstream, :both]),
+         :ok <- validate_boolean_opt(opts, :transitive),
+         :ok <- validate_boolean_opt(opts, :include_target),
+         :ok <- validate_list_opt(opts, :tags),
+         :ok <- validate_list_opt(opts, :kinds),
+         :ok <- validate_list_opt(opts, :modules),
+         :ok <- validate_list_opt(opts, :names) do
+      :ok
+    end
+  end
+
+  defp validate_inclusion(value, allowed) do
+    if value in allowed, do: :ok, else: {:error, :invalid_opts}
+  end
+
+  defp validate_boolean_opt(opts, key) do
+    case Keyword.fetch(opts, key) do
+      :error -> :ok
+      {:ok, value} when is_boolean(value) -> :ok
+      {:ok, _invalid} -> {:error, :invalid_opts}
+    end
+  end
+
+  defp validate_list_opt(opts, key) do
+    case Keyword.fetch(opts, key) do
+      :error -> :ok
+      {:ok, value} when is_list(value) -> :ok
+      {:ok, _invalid} -> {:error, :invalid_opts}
     end
   end
 

--- a/test/graph_index_test.exs
+++ b/test/graph_index_test.exs
@@ -179,6 +179,34 @@ defmodule Flux.GraphIndexTest do
              MapSet.new([{ReportingAssets, :dashboard}])
   end
 
+  test "returns invalid_opts for invalid graph query options" do
+    Application.put_env(:flux, :asset_modules, [SourceAssets, WarehouseAssets, ReportingAssets])
+
+    assert :ok = Flux.Registry.reload()
+    assert :ok = Flux.GraphIndex.reload()
+
+    assert {:error, :invalid_opts} =
+             Flux.GraphIndex.related_assets({ReportingAssets, :dashboard}, direction: :sideways)
+
+    assert {:error, :invalid_opts} =
+             Flux.GraphIndex.related_assets({ReportingAssets, :dashboard}, transitive: :yes)
+
+    assert {:error, :invalid_opts} =
+             Flux.GraphIndex.related_assets({ReportingAssets, :dashboard}, include_target: 1)
+
+    assert {:error, :invalid_opts} =
+             Flux.GraphIndex.related_assets({ReportingAssets, :dashboard}, tags: :warehouse)
+
+    assert {:error, :invalid_opts} =
+             Flux.GraphIndex.related_assets({ReportingAssets, :dashboard}, kinds: :table)
+
+    assert {:error, :invalid_opts} =
+             Flux.GraphIndex.related_assets({ReportingAssets, :dashboard}, modules: ReportingAssets)
+
+    assert {:error, :invalid_opts} =
+             Flux.GraphIndex.subgraph({ReportingAssets, :dashboard}, names: :dashboard)
+  end
+
   test "reports missing dependencies during graph construction" do
     missing = %Flux.Asset{
       module: __MODULE__,


### PR DESCRIPTION
### Motivation
- Prevent runtime crashes from unexpected filter shapes by validating graph-query options before selecting refs. 
- Ensure callers receive an explicit `{:error, :invalid_opts}` for malformed options rather than letting pattern-match gaps or case mismatches raise. 
- Make the error shape part of the module's declared `error()` type so callers can handle it explicitly. 

### Description
- Add `validate_opts/1` and helpers (`validate_inclusion/2`, `validate_boolean_opt/2`, `validate_list_opt/2`) and invoke them at the start of `selected_refs/3` to enforce option shapes. 
- Enforce `direction` ∈ `[:upstream, :downstream, :both]`, ensure `transitive` and `include_target` are booleans when present, and ensure `tags`, `kinds`, `modules`, and `names` are lists when present. 
- Add `:invalid_opts` to the `@type error` union and return `{:error, :invalid_opts}` on validation failures. 
- Add a new test `returns invalid_opts for invalid graph query options` in `test/graph_index_test.exs` that asserts `{:error, :invalid_opts}` for a variety of malformed inputs to `related_assets/2` and `subgraph/2`. 

### Testing
- Ran `mix test test/graph_index_test.exs` against the modified code and the new test, which completed successfully with `6 tests, 0 failures`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c56ee01208832896fa2d960a8a3bfd)