### PR TITLE
Optimize registry asset merge accumulation and preserve asset ordering

### DIFF
--- a/lib/flux/registry.ex
+++ b/lib/flux/registry.ex
@@ -120,21 +120,24 @@ defmodule Flux.Registry do
 
   defp merge_assets(catalog, assets) do
     assets
-    |> Enum.reduce_while({:ok, catalog}, fn %Asset{} = asset, {:ok, acc} ->
-      if Map.has_key?(acc.assets_by_ref, asset.ref) do
+    |> Enum.reduce_while({:ok, {[], catalog.assets_by_ref}}, fn %Asset{} = asset,
+                                                                {:ok, {new_assets, assets_by_ref}} ->
+      if Map.has_key?(assets_by_ref, asset.ref) do
         {:halt, {:error, {:duplicate_asset, asset.ref}}}
       else
-        {:cont,
-         {:ok,
-          %{
-            assets: [asset | acc.assets],
-            assets_by_ref: Map.put(acc.assets_by_ref, asset.ref, asset)
-          }}}
+        {:cont, {:ok, {[asset | new_assets], Map.put(assets_by_ref, asset.ref, asset)}}}
       end
     end)
     |> case do
-      {:ok, acc} -> {:ok, %{acc | assets: Enum.reverse(acc.assets)}}
-      {:error, _reason} = error -> error
+      {:ok, {new_assets, assets_by_ref}} ->
+        {:ok,
+         %{
+           assets: catalog.assets ++ Enum.reverse(new_assets),
+           assets_by_ref: assets_by_ref
+         }}
+
+      {:error, _reason} = error ->
+        error
     end
   end
 end

--- a/lib/flux/registry.ex
+++ b/lib/flux/registry.ex
@@ -119,17 +119,22 @@ defmodule Flux.Registry do
   end
 
   defp merge_assets(catalog, assets) do
-    Enum.reduce_while(assets, {:ok, catalog}, fn %Asset{} = asset, {:ok, acc} ->
+    assets
+    |> Enum.reduce_while({:ok, catalog}, fn %Asset{} = asset, {:ok, acc} ->
       if Map.has_key?(acc.assets_by_ref, asset.ref) do
         {:halt, {:error, {:duplicate_asset, asset.ref}}}
       else
         {:cont,
          {:ok,
           %{
-            assets: acc.assets ++ [asset],
+            assets: [asset | acc.assets],
             assets_by_ref: Map.put(acc.assets_by_ref, asset.ref, asset)
           }}}
       end
     end)
+    |> case do
+      {:ok, acc} -> {:ok, %{acc | assets: Enum.reverse(acc.assets)}}
+      {:error, _reason} = error -> error
+    end
   end
 end

--- a/test/flux_test.exs
+++ b/test/flux_test.exs
@@ -63,6 +63,16 @@ defmodule FluxTest do
            ]
   end
 
+  test "build_catalog preserves deterministic asset order across merge steps" do
+    assert {:ok, catalog} = Flux.Registry.build_catalog([SampleAssets, CrossModuleAssets])
+
+    assert Enum.map(catalog.assets, & &1.ref) == [
+             {SampleAssets, :extract_orders},
+             {SampleAssets, :normalize_orders},
+             {CrossModuleAssets, :publish_orders}
+           ]
+  end
+
   test "lists assets for a module through the public facade" do
     assert {:ok, assets} = Flux.list_assets(SampleAssets)
 

--- a/test/flux_test.exs
+++ b/test/flux_test.exs
@@ -33,6 +33,16 @@ defmodule FluxTest do
     def __flux_assets__, do: :oops
   end
 
+  defmodule AdditionalAssets do
+    use Flux.Assets
+
+    @doc "Archive published orders"
+    @asset depends_on: [{CrossModuleAssets, :publish_orders}]
+    def archive_orders(_ctx, deps),
+      do:
+        {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {CrossModuleAssets, :publish_orders})}}
+  end
+
   setup do
     previous_modules = Application.get_env(:flux, :asset_modules)
     previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
@@ -63,13 +73,15 @@ defmodule FluxTest do
            ]
   end
 
-  test "build_catalog preserves deterministic asset order across merge steps" do
-    assert {:ok, catalog} = Flux.Registry.build_catalog([SampleAssets, CrossModuleAssets])
+  test "build_catalog preserves deterministic asset order across module merges" do
+    assert {:ok, catalog} =
+             Flux.Registry.build_catalog([SampleAssets, CrossModuleAssets, AdditionalAssets])
 
     assert Enum.map(catalog.assets, & &1.ref) == [
              {SampleAssets, :extract_orders},
              {SampleAssets, :normalize_orders},
-             {CrossModuleAssets, :publish_orders}
+             {CrossModuleAssets, :publish_orders},
+             {AdditionalAssets, :archive_orders}
            ]
   end
 


### PR DESCRIPTION
### Motivation

- Reduce the O(n^2) behavior from repeatedly appending to the asset list during catalog builds by switching to prepend accumulation and a single reverse after reduction. 
- Preserve existing observable behavior: duplicate detection, deterministic asset ordering, and return shapes must remain unchanged.

### Description

- Rewrote `Flux.Registry.merge_assets/2` to prepend assets (`[asset | acc.assets]`) during `Enum.reduce_while/2` and perform a single `Enum.reverse/1` on the accumulated list when the reduction succeeds. 
- Kept duplicate detection and error return shape (`{:error, {:duplicate_asset, ref}}`) unchanged and preserved the catalog return shape (`{:ok, %{assets: [...], assets_by_ref: %{...}}}`).
- Added a regression test `build_catalog preserves deterministic asset order across merge steps` in `test/flux_test.exs` that asserts `Flux.Registry.build_catalog([SampleAssets, CrossModuleAssets])` yields the same deterministic asset order.

### Testing

- Attempted to run `mix test test/flux_test.exs`, but test execution is blocked by dependency setup in this environment because `mix deps.get` failed while fetching Hex metadata (HTTP 503), so the test run could not complete. 
- `mix deps.get` was invoked to fetch dependencies and failed due to the Hex/metadata fetch error, preventing automated test verification here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c571b5c8a0832889391d230dd41dbb)