### PR TITLE
Refactor tests to use shared fixtures and setup helpers

### DIFF
--- a/test/flux_test.exs
+++ b/test/flux_test.exs
@@ -3,7 +3,6 @@ defmodule FluxTest do
 
   doctest Flux
 
-<<<<<<< HEAD
   defmodule SampleAssets do
     use Flux.Assets
 
@@ -41,14 +40,13 @@ defmodule FluxTest do
       do:
         {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {CrossModuleAssets, :publish_orders})}}
   end
-=======
+
   require Logger
 
   alias Flux.Test.Fixtures.Assets.Basic.AdditionalAssets
   alias Flux.Test.Fixtures.Assets.Basic.CrossModuleAssets
   alias Flux.Test.Fixtures.Assets.Basic.SampleAssets
   alias Flux.Test.Fixtures.Assets.Basic.SpoofedAssets
->>>>>>> 31db450 (Extract shared test fixtures and setup helpers)
 
   setup do
     state = Flux.TestSetup.capture_state()

--- a/test/flux_test.exs
+++ b/test/flux_test.exs
@@ -3,6 +3,7 @@ defmodule FluxTest do
 
   doctest Flux
 
+<<<<<<< HEAD
   defmodule SampleAssets do
     use Flux.Assets
 
@@ -40,27 +41,27 @@ defmodule FluxTest do
       do:
         {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {CrossModuleAssets, :publish_orders})}}
   end
+=======
+  require Logger
+
+  alias Flux.Test.Fixtures.Assets.Basic.AdditionalAssets
+  alias Flux.Test.Fixtures.Assets.Basic.CrossModuleAssets
+  alias Flux.Test.Fixtures.Assets.Basic.SampleAssets
+  alias Flux.Test.Fixtures.Assets.Basic.SpoofedAssets
+>>>>>>> 31db450 (Extract shared test fixtures and setup helpers)
 
   setup do
-    previous_modules = Application.get_env(:flux, :asset_modules)
-    previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
+    state = Flux.TestSetup.capture_state()
 
     on_exit(fn ->
-      if is_nil(previous_modules) do
-        Application.delete_env(:flux, :asset_modules)
-      else
-        Application.put_env(:flux, :asset_modules, previous_modules)
-      end
-
-      restore_registry(previous_catalog)
+      Flux.TestSetup.restore_state(state)
     end)
 
     :ok
   end
 
   test "lists globally configured assets through the registry-backed facade" do
-    Application.put_env(:flux, :asset_modules, [SampleAssets, CrossModuleAssets])
-    assert :ok = Flux.Registry.reload()
+    :ok = Flux.TestSetup.setup_asset_modules([SampleAssets, CrossModuleAssets])
 
     assert {:ok, assets} = Flux.list_assets()
 
@@ -90,8 +91,7 @@ defmodule FluxTest do
   end
 
   test "fetches an asset through the public facade" do
-    Application.put_env(:flux, :asset_modules, [SampleAssets, CrossModuleAssets])
-    assert :ok = Flux.Registry.reload()
+    :ok = Flux.TestSetup.setup_asset_modules([SampleAssets, CrossModuleAssets])
 
     assert {:ok, asset} = Flux.get_asset({SampleAssets, :normalize_orders})
     assert {:ok, cross_module_asset} = Flux.get_asset({CrossModuleAssets, :publish_orders})
@@ -104,9 +104,8 @@ defmodule FluxTest do
   end
 
   test "inspects dependency queries through the public facade" do
-    Application.put_env(:flux, :asset_modules, [SampleAssets, CrossModuleAssets])
-    assert :ok = Flux.Registry.reload()
-    assert :ok = Flux.GraphIndex.reload()
+    :ok =
+      Flux.TestSetup.setup_asset_modules([SampleAssets, CrossModuleAssets], reload_graph?: true)
 
     assert {:ok, upstream_assets} = Flux.upstream_assets({CrossModuleAssets, :publish_orders})
 
@@ -150,8 +149,7 @@ defmodule FluxTest do
   end
 
   test "reads from the startup-loaded cache until the registry is reloaded" do
-    Application.put_env(:flux, :asset_modules, [SampleAssets])
-    assert :ok = Flux.Registry.reload()
+    :ok = Flux.TestSetup.setup_asset_modules([SampleAssets])
     assert {:ok, assets} = Flux.list_assets()
 
     assert Enum.map(assets, & &1.ref) == [
@@ -177,7 +175,4 @@ defmodule FluxTest do
              {CrossModuleAssets, :publish_orders}
            ]
   end
-
-  defp restore_registry({:ok, _catalog}), do: :ok = Flux.Registry.reload()
-  defp restore_registry({:error, _reason}), do: :ok
 end

--- a/test/graph_index_test.exs
+++ b/test/graph_index_test.exs
@@ -1,84 +1,25 @@
 defmodule Flux.GraphIndexTest do
   use ExUnit.Case
 
-  defmodule SourceAssets do
-    use Flux.Assets
-
-    @doc "Raw orders"
-    @asset true
-    def raw_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1}]}}
-
-    @doc "Raw customers"
-    @asset true
-    def raw_customers(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1}]}}
-  end
-
-  defmodule WarehouseAssets do
-    use Flux.Assets
-
-    alias Flux.GraphIndexTest.SourceAssets
-
-    @doc "Normalize orders"
-    @asset depends_on: [{SourceAssets, :raw_orders}], tags: [:warehouse]
-    def normalize_orders(_ctx, deps),
-      do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {SourceAssets, :raw_orders})}}
-
-    @doc "Normalize customers"
-    @asset depends_on: [{SourceAssets, :raw_customers}], tags: [:warehouse]
-    def normalize_customers(_ctx, deps),
-      do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {SourceAssets, :raw_customers})}}
-
-    @doc "Build sales fact"
-    @asset depends_on: [:normalize_orders, :normalize_customers], tags: [:finance]
-    def fact_sales(_ctx, deps) do
-      {:ok,
-       %Flux.Asset.Output{
-         output:
-           {Map.fetch!(deps, {__MODULE__, :normalize_orders}),
-            Map.fetch!(deps, {__MODULE__, :normalize_customers})}
-       }}
-    end
-  end
-
-  defmodule ReportingAssets do
-    use Flux.Assets
-
-    alias Flux.GraphIndexTest.WarehouseAssets
-
-    @doc "Build dashboard"
-    @asset depends_on: [{WarehouseAssets, :fact_sales}, {WarehouseAssets, :normalize_orders}]
-    def dashboard(_ctx, deps) do
-      {:ok,
-       %Flux.Asset.Output{
-         output:
-           {Map.fetch!(deps, {WarehouseAssets, :fact_sales}),
-            Map.fetch!(deps, {WarehouseAssets, :normalize_orders})}
-       }}
-    end
-  end
+  alias Flux.Test.Fixtures.Assets.Graph.ReportingAssets
+  alias Flux.Test.Fixtures.Assets.Graph.SourceAssets
+  alias Flux.Test.Fixtures.Assets.Graph.WarehouseAssets
 
   setup do
-    previous_modules = Application.get_env(:flux, :asset_modules)
-    previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
+    state = Flux.TestSetup.capture_state()
 
     on_exit(fn ->
-      if is_nil(previous_modules) do
-        Application.delete_env(:flux, :asset_modules)
-      else
-        Application.put_env(:flux, :asset_modules, previous_modules)
-      end
-
-      restore_registry(previous_catalog)
+      Flux.TestSetup.restore_state(state, reload_graph?: true)
     end)
 
     :ok
   end
 
   test "builds a global DAG index with upstream, downstream, transitive closures, and topological order" do
-    Application.put_env(:flux, :asset_modules, [SourceAssets, WarehouseAssets, ReportingAssets])
-
-    assert :ok = Flux.Registry.reload()
-    assert :ok = Flux.GraphIndex.reload()
+    :ok =
+      Flux.TestSetup.setup_asset_modules([SourceAssets, WarehouseAssets, ReportingAssets],
+        reload_graph?: true
+      )
 
     assert {:ok, upstream} = Flux.GraphIndex.upstream_of({WarehouseAssets, :fact_sales})
 
@@ -124,10 +65,10 @@ defmodule Flux.GraphIndexTest do
   end
 
   test "selects related assets with filters and direct traversal options" do
-    Application.put_env(:flux, :asset_modules, [SourceAssets, WarehouseAssets, ReportingAssets])
-
-    assert :ok = Flux.Registry.reload()
-    assert :ok = Flux.GraphIndex.reload()
+    :ok =
+      Flux.TestSetup.setup_asset_modules([SourceAssets, WarehouseAssets, ReportingAssets],
+        reload_graph?: true
+      )
 
     assert {:ok, assets} =
              Flux.GraphIndex.related_assets({ReportingAssets, :dashboard},
@@ -155,10 +96,10 @@ defmodule Flux.GraphIndexTest do
   end
 
   test "builds filtered subgraphs rooted at a target reference" do
-    Application.put_env(:flux, :asset_modules, [SourceAssets, WarehouseAssets, ReportingAssets])
-
-    assert :ok = Flux.Registry.reload()
-    assert :ok = Flux.GraphIndex.reload()
+    :ok =
+      Flux.TestSetup.setup_asset_modules([SourceAssets, WarehouseAssets, ReportingAssets],
+        reload_graph?: true
+      )
 
     assert {:ok, subgraph} =
              Flux.GraphIndex.subgraph({ReportingAssets, :dashboard},
@@ -180,10 +121,10 @@ defmodule Flux.GraphIndexTest do
   end
 
   test "returns invalid_opts for invalid graph query options" do
-    Application.put_env(:flux, :asset_modules, [SourceAssets, WarehouseAssets, ReportingAssets])
-
-    assert :ok = Flux.Registry.reload()
-    assert :ok = Flux.GraphIndex.reload()
+    :ok =
+      Flux.TestSetup.setup_asset_modules([SourceAssets, WarehouseAssets, ReportingAssets],
+        reload_graph?: true
+      )
 
     assert {:error, :invalid_opts} =
              Flux.GraphIndex.related_assets({ReportingAssets, :dashboard}, direction: :sideways)
@@ -201,7 +142,9 @@ defmodule Flux.GraphIndexTest do
              Flux.GraphIndex.related_assets({ReportingAssets, :dashboard}, kinds: :table)
 
     assert {:error, :invalid_opts} =
-             Flux.GraphIndex.related_assets({ReportingAssets, :dashboard}, modules: ReportingAssets)
+             Flux.GraphIndex.related_assets({ReportingAssets, :dashboard},
+               modules: ReportingAssets
+             )
 
     assert {:error, :invalid_opts} =
              Flux.GraphIndex.subgraph({ReportingAssets, :dashboard}, names: :dashboard)
@@ -248,11 +191,4 @@ defmodule Flux.GraphIndexTest do
     assert {:error, {:cycle, cycle}} = Flux.GraphIndex.build_index([a, b])
     assert cycle == [{__MODULE__, :a}, {__MODULE__, :b}, {__MODULE__, :a}]
   end
-
-  defp restore_registry({:ok, _catalog}) do
-    :ok = Flux.Registry.reload()
-    :ok = Flux.GraphIndex.reload()
-  end
-
-  defp restore_registry({:error, _reason}), do: :ok
 end

--- a/test/planner_test.exs
+++ b/test/planner_test.exs
@@ -1,56 +1,20 @@
 defmodule Flux.PlannerTest do
   use ExUnit.Case
 
-  defmodule BronzeAssets do
-    use Flux.Assets
-
-    @asset true
-    def raw_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
-
-    @asset true
-    def raw_customers(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
-  end
-
-  defmodule SilverAssets do
-    use Flux.Assets
-
-    alias Flux.PlannerTest.BronzeAssets
-
-    @asset depends_on: [{BronzeAssets, :raw_orders}]
-    def nightly_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
-
-    @asset depends_on: [{BronzeAssets, :raw_customers}]
-    def monthly_customers(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
-  end
-
-  defmodule GoldAssets do
-    use Flux.Assets
-
-    alias Flux.PlannerTest.SilverAssets
-
-    @asset depends_on: [{SilverAssets, :nightly_orders}, {SilverAssets, :monthly_customers}]
-    def gold_sales(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
-
-    @asset depends_on: [{SilverAssets, :nightly_orders}]
-    def gold_finance(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
-  end
+  alias Flux.Test.Fixtures.Assets.Graph.BronzeAssets
+  alias Flux.Test.Fixtures.Assets.Graph.GoldAssets
+  alias Flux.Test.Fixtures.Assets.Graph.SilverAssets
 
   setup do
-    previous_modules = Application.get_env(:flux, :asset_modules)
-    previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
+    state = Flux.TestSetup.capture_state()
 
-    Application.put_env(:flux, :asset_modules, [BronzeAssets, SilverAssets, GoldAssets])
-    assert :ok = Flux.Registry.reload()
-    assert :ok = Flux.GraphIndex.reload()
+    :ok =
+      Flux.TestSetup.setup_asset_modules([BronzeAssets, SilverAssets, GoldAssets],
+        reload_graph?: true
+      )
 
     on_exit(fn ->
-      if is_nil(previous_modules) do
-        Application.delete_env(:flux, :asset_modules)
-      else
-        Application.put_env(:flux, :asset_modules, previous_modules)
-      end
-
-      restore_registry(previous_catalog)
+      Flux.TestSetup.restore_state(state, reload_graph?: true)
     end)
 
     :ok
@@ -115,11 +79,4 @@ defmodule Flux.PlannerTest do
              {GoldAssets, :gold_sales}
            ]
   end
-
-  defp restore_registry({:ok, _catalog}) do
-    :ok = Flux.Registry.reload()
-    :ok = Flux.GraphIndex.reload()
-  end
-
-  defp restore_registry({:error, _reason}), do: :ok
 end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -1,99 +1,18 @@
 defmodule Flux.RunnerTest do
   use ExUnit.Case
 
-  defmodule RunnerAssets do
-    use Flux.Assets
-
-    @asset true
-    def base(ctx, _deps) do
-      {:ok, %Flux.Asset.Output{output: {:base, ctx.params[:partition]}}}
-    end
-
-    @asset depends_on: [:base]
-    def transform(_ctx, deps) do
-      {:ok, %Flux.Asset.Output{output: {:transform, Map.fetch!(deps, {__MODULE__, :base})}}}
-    end
-
-    @asset depends_on: [:base]
-    def invalid_return(_ctx, _deps) do
-      {:ok, :bad_shape}
-    end
-
-    @asset depends_on: [:transform]
-    def final(_ctx, deps) do
-      {:ok, %Flux.Asset.Output{output: {:final, Map.fetch!(deps, {__MODULE__, :transform})}}}
-    end
-
-    @asset depends_on: [:transform]
-    def target_only(_ctx, deps) do
-      {:ok, %Flux.Asset.Output{output: map_size(deps)}}
-    end
-
-    @asset depends_on: [:base]
-    def crashes(_ctx, _deps) do
-      raise "boom"
-    end
-
-    @asset true
-    def with_meta(_ctx, _deps) do
-      {:ok,
-       %Flux.Asset.Output{
-         output: {:rows, [1, 2, 3]},
-         meta: %{row_count: 123, source: :test}
-       }}
-    end
-  end
-
-  defmodule TerminalFailingStore do
-    @behaviour Flux.RunStore
-
-    @counter_key {__MODULE__, :put_count}
-
-    @impl true
-    def child_spec(_opts), do: :none
-
-    @impl true
-    def put_run(_run, _opts) do
-      count = :persistent_term.get(@counter_key, 0)
-      :persistent_term.put(@counter_key, count + 1)
-
-      if count == 0 do
-        :ok
-      else
-        {:error, :terminal_write_failed}
-      end
-    end
-
-    @impl true
-    def get_run(_run_id, _opts), do: {:error, :not_found}
-
-    @impl true
-    def list_runs(_opts, _adapter_opts), do: {:ok, []}
-
-    def reset!, do: :persistent_term.erase(@counter_key)
-  end
+  alias Flux.Test.Fixtures.Assets.Runner.RunnerAssets
+  alias Flux.Test.Fixtures.Assets.Runner.TerminalFailingStore
 
   setup do
-    previous_modules = Application.get_env(:flux, :asset_modules)
-    previous_catalog = Flux.Registry.build_catalog(previous_modules || [])
+    state = Flux.TestSetup.capture_state()
 
-    Application.put_env(:flux, :asset_modules, [RunnerAssets])
-    Application.put_env(:flux, :run_store, Flux.RunStore.Memory)
-    Application.put_env(:flux, :run_store_opts, [])
-    clear_memory_run_store()
-    assert :ok = Flux.Registry.reload()
-    assert :ok = Flux.GraphIndex.reload()
+    :ok = Flux.TestSetup.setup_asset_modules([RunnerAssets], reload_graph?: true)
+    :ok = Flux.TestSetup.configure_run_store(Flux.RunStore.Memory, [])
+    :ok = Flux.TestSetup.clear_memory_run_store()
 
     on_exit(fn ->
-      if is_nil(previous_modules) do
-        Application.delete_env(:flux, :asset_modules)
-      else
-        Application.put_env(:flux, :asset_modules, previous_modules)
-      end
-
-      Application.delete_env(:flux, :run_store)
-      Application.delete_env(:flux, :run_store_opts)
-      restore_registry(previous_catalog)
+      Flux.TestSetup.restore_state(state, reload_graph?: true, clear_run_store_env?: true)
     end)
 
     :ok
@@ -198,7 +117,7 @@ defmodule Flux.RunnerTest do
   end
 
   test "returns execution result even when terminal persistence fails" do
-    Application.put_env(:flux, :run_store, TerminalFailingStore)
+    :ok = Flux.TestSetup.configure_run_store(TerminalFailingStore, [])
     TerminalFailingStore.reset!()
 
     assert {:ok, run} = Flux.run({RunnerAssets, :final})
@@ -208,21 +127,4 @@ defmodule Flux.RunnerTest do
   test "rejects unsupported list_runs status filter values" do
     assert {:error, :invalid_opts} = Flux.list_runs(status: :pending)
   end
-
-  defp clear_memory_run_store do
-    table = Flux.RunStore.Memory.Table
-
-    if :ets.whereis(table) != :undefined do
-      :ets.delete_all_objects(table)
-    end
-
-    :ok
-  end
-
-  defp restore_registry({:ok, _catalog}) do
-    :ok = Flux.Registry.reload()
-    :ok = Flux.GraphIndex.reload()
-  end
-
-  defp restore_registry({:error, _reason}), do: :ok
 end

--- a/test/support/fixtures/assets/basic_assets.ex
+++ b/test/support/fixtures/assets/basic_assets.ex
@@ -1,0 +1,38 @@
+defmodule Flux.Test.Fixtures.Assets.Basic.SampleAssets do
+  use Flux.Assets
+
+  @doc "Extract raw orders"
+  @asset true
+  def extract_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1}]}}
+
+  @doc "Normalize extracted orders"
+  @asset depends_on: [:extract_orders], tags: [:sales]
+  def normalize_orders(_ctx, deps),
+    do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {__MODULE__, :extract_orders})}}
+end
+
+defmodule Flux.Test.Fixtures.Assets.Basic.CrossModuleAssets do
+  use Flux.Assets
+
+  alias Flux.Test.Fixtures.Assets.Basic.SampleAssets
+
+  @doc "Publish normalized orders"
+  @asset depends_on: [{SampleAssets, :normalize_orders}], tags: [:reporting]
+  def publish_orders(_ctx, deps),
+    do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {SampleAssets, :normalize_orders})}}
+end
+
+defmodule Flux.Test.Fixtures.Assets.Basic.SpoofedAssets do
+  def __flux_assets__, do: :oops
+end
+
+defmodule Flux.Test.Fixtures.Assets.Basic.AdditionalAssets do
+  use Flux.Assets
+
+  alias Flux.Test.Fixtures.Assets.Basic.CrossModuleAssets
+
+  @doc "Archive published orders"
+  @asset depends_on: [{CrossModuleAssets, :publish_orders}]
+  def archive_orders(_ctx, deps),
+    do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {CrossModuleAssets, :publish_orders})}}
+end

--- a/test/support/fixtures/assets/graph_assets.ex
+++ b/test/support/fixtures/assets/graph_assets.ex
@@ -1,0 +1,89 @@
+defmodule Flux.Test.Fixtures.Assets.Graph.SourceAssets do
+  use Flux.Assets
+
+  @doc "Raw orders"
+  @asset true
+  def raw_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1}]}}
+
+  @doc "Raw customers"
+  @asset true
+  def raw_customers(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: [%{id: 1}]}}
+end
+
+defmodule Flux.Test.Fixtures.Assets.Graph.WarehouseAssets do
+  use Flux.Assets
+
+  alias Flux.Test.Fixtures.Assets.Graph.SourceAssets
+
+  @doc "Normalize orders"
+  @asset depends_on: [{SourceAssets, :raw_orders}], tags: [:warehouse]
+  def normalize_orders(_ctx, deps),
+    do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {SourceAssets, :raw_orders})}}
+
+  @doc "Normalize customers"
+  @asset depends_on: [{SourceAssets, :raw_customers}], tags: [:warehouse]
+  def normalize_customers(_ctx, deps),
+    do: {:ok, %Flux.Asset.Output{output: Map.fetch!(deps, {SourceAssets, :raw_customers})}}
+
+  @doc "Build sales fact"
+  @asset depends_on: [:normalize_orders, :normalize_customers], tags: [:finance]
+  def fact_sales(_ctx, deps) do
+    {:ok,
+     %Flux.Asset.Output{
+       output:
+         {Map.fetch!(deps, {__MODULE__, :normalize_orders}),
+          Map.fetch!(deps, {__MODULE__, :normalize_customers})}
+     }}
+  end
+end
+
+defmodule Flux.Test.Fixtures.Assets.Graph.ReportingAssets do
+  use Flux.Assets
+
+  alias Flux.Test.Fixtures.Assets.Graph.WarehouseAssets
+
+  @doc "Build dashboard"
+  @asset depends_on: [{WarehouseAssets, :fact_sales}, {WarehouseAssets, :normalize_orders}]
+  def dashboard(_ctx, deps) do
+    {:ok,
+     %Flux.Asset.Output{
+       output:
+         {Map.fetch!(deps, {WarehouseAssets, :fact_sales}),
+          Map.fetch!(deps, {WarehouseAssets, :normalize_orders})}
+     }}
+  end
+end
+
+defmodule Flux.Test.Fixtures.Assets.Graph.BronzeAssets do
+  use Flux.Assets
+
+  @asset true
+  def raw_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
+
+  @asset true
+  def raw_customers(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
+end
+
+defmodule Flux.Test.Fixtures.Assets.Graph.SilverAssets do
+  use Flux.Assets
+
+  alias Flux.Test.Fixtures.Assets.Graph.BronzeAssets
+
+  @asset depends_on: [{BronzeAssets, :raw_orders}]
+  def nightly_orders(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
+
+  @asset depends_on: [{BronzeAssets, :raw_customers}]
+  def monthly_customers(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
+end
+
+defmodule Flux.Test.Fixtures.Assets.Graph.GoldAssets do
+  use Flux.Assets
+
+  alias Flux.Test.Fixtures.Assets.Graph.SilverAssets
+
+  @asset depends_on: [{SilverAssets, :nightly_orders}, {SilverAssets, :monthly_customers}]
+  def gold_sales(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
+
+  @asset depends_on: [{SilverAssets, :nightly_orders}]
+  def gold_finance(_ctx, _deps), do: {:ok, %Flux.Asset.Output{output: :ok}}
+end

--- a/test/support/fixtures/assets/runner_assets.ex
+++ b/test/support/fixtures/assets/runner_assets.ex
@@ -1,0 +1,71 @@
+defmodule Flux.Test.Fixtures.Assets.Runner.RunnerAssets do
+  use Flux.Assets
+
+  @asset true
+  def base(ctx, _deps) do
+    {:ok, %Flux.Asset.Output{output: {:base, ctx.params[:partition]}}}
+  end
+
+  @asset depends_on: [:base]
+  def transform(_ctx, deps) do
+    {:ok, %Flux.Asset.Output{output: {:transform, Map.fetch!(deps, {__MODULE__, :base})}}}
+  end
+
+  @asset depends_on: [:base]
+  def invalid_return(_ctx, _deps) do
+    {:ok, :bad_shape}
+  end
+
+  @asset depends_on: [:transform]
+  def final(_ctx, deps) do
+    {:ok, %Flux.Asset.Output{output: {:final, Map.fetch!(deps, {__MODULE__, :transform})}}}
+  end
+
+  @asset depends_on: [:transform]
+  def target_only(_ctx, deps) do
+    {:ok, %Flux.Asset.Output{output: map_size(deps)}}
+  end
+
+  @asset depends_on: [:base]
+  def crashes(_ctx, _deps) do
+    raise "boom"
+  end
+
+  @asset true
+  def with_meta(_ctx, _deps) do
+    {:ok,
+     %Flux.Asset.Output{
+       output: {:rows, [1, 2, 3]},
+       meta: %{row_count: 123, source: :test}
+     }}
+  end
+end
+
+defmodule Flux.Test.Fixtures.Assets.Runner.TerminalFailingStore do
+  @behaviour Flux.RunStore
+
+  @counter_key {__MODULE__, :put_count}
+
+  @impl true
+  def child_spec(_opts), do: :none
+
+  @impl true
+  def put_run(_run, _opts) do
+    count = :persistent_term.get(@counter_key, 0)
+    :persistent_term.put(@counter_key, count + 1)
+
+    if count == 0 do
+      :ok
+    else
+      {:error, :terminal_write_failed}
+    end
+  end
+
+  @impl true
+  def get_run(_run_id, _opts), do: {:error, :not_found}
+
+  @impl true
+  def list_runs(_opts, _adapter_opts), do: {:ok, []}
+
+  def reset!, do: :persistent_term.erase(@counter_key)
+end

--- a/test/support/flux_test_setup.ex
+++ b/test/support/flux_test_setup.ex
@@ -1,0 +1,74 @@
+defmodule Flux.TestSetup do
+  @moduledoc false
+
+  @type state :: %{
+          previous_modules: list(module()) | nil,
+          previous_catalog: {:ok, Flux.Registry.catalog()} | {:error, term()}
+        }
+
+  @spec capture_state() :: state()
+  def capture_state do
+    previous_modules = Application.get_env(:flux, :asset_modules)
+
+    %{
+      previous_modules: previous_modules,
+      previous_catalog: Flux.Registry.build_catalog(previous_modules || [])
+    }
+  end
+
+  @spec setup_asset_modules([module()], keyword()) :: :ok
+  def setup_asset_modules(modules, opts \\ []) do
+    Application.put_env(:flux, :asset_modules, modules)
+    :ok = Flux.Registry.reload()
+
+    if Keyword.get(opts, :reload_graph?, false) do
+      :ok = Flux.GraphIndex.reload()
+    end
+
+    :ok
+  end
+
+  @spec configure_run_store(module(), keyword()) :: :ok
+  def configure_run_store(store, store_opts \\ []) do
+    Application.put_env(:flux, :run_store, store)
+    Application.put_env(:flux, :run_store_opts, store_opts)
+  end
+
+  @spec clear_memory_run_store() :: :ok
+  def clear_memory_run_store do
+    table = Flux.RunStore.Memory.Table
+
+    if :ets.whereis(table) != :undefined do
+      :ets.delete_all_objects(table)
+    end
+
+    :ok
+  end
+
+  @spec restore_state(state(), keyword()) :: :ok
+  def restore_state(state, opts \\ []) do
+    restore_asset_modules(state.previous_modules)
+
+    if Keyword.get(opts, :clear_run_store_env?, false) do
+      Application.delete_env(:flux, :run_store)
+      Application.delete_env(:flux, :run_store_opts)
+    end
+
+    restore_registry(state.previous_catalog, opts)
+  end
+
+  defp restore_asset_modules(nil), do: Application.delete_env(:flux, :asset_modules)
+  defp restore_asset_modules(modules), do: Application.put_env(:flux, :asset_modules, modules)
+
+  defp restore_registry({:ok, _catalog}, opts) do
+    :ok = Flux.Registry.reload()
+
+    if Keyword.get(opts, :reload_graph?, false) do
+      :ok = Flux.GraphIndex.reload()
+    end
+
+    :ok
+  end
+
+  defp restore_registry({:error, _reason}, _opts), do: :ok
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,13 @@
+<<<<<<< HEAD
+=======
+require Logger
+
+Code.require_file("support/fixtures/assets/basic_assets.ex", __DIR__)
+Code.require_file("support/fixtures/assets/graph_assets.ex", __DIR__)
+Code.require_file("support/fixtures/assets/runner_assets.ex", __DIR__)
+Code.require_file("support/flux_test_setup.ex", __DIR__)
+
+>>>>>>> 31db450 (Extract shared test fixtures and setup helpers)
 trace? = "--trace" in System.argv()
 
 ExUnit.start(capture_log: !trace?)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,13 +1,8 @@
-<<<<<<< HEAD
-=======
-require Logger
-
 Code.require_file("support/fixtures/assets/basic_assets.ex", __DIR__)
 Code.require_file("support/fixtures/assets/graph_assets.ex", __DIR__)
 Code.require_file("support/fixtures/assets/runner_assets.ex", __DIR__)
 Code.require_file("support/flux_test_setup.ex", __DIR__)
 
->>>>>>> 31db450 (Extract shared test fixtures and setup helpers)
 trace? = "--trace" in System.argv()
 
 ExUnit.start(capture_log: !trace?)


### PR DESCRIPTION
### Motivation
- Remove duplicated test-local asset modules and repeated setup/teardown code by centralizing fixtures and environment management to make tests easier to maintain and reason about.
- Provide reusable helpers for configuring `:asset_modules`, reloading the registry/graph, run-store configuration, and memory cleanup to reduce boilerplate and avoid fragile copy/paste logic.

### Description
- Added shared fixture modules under `test/support/fixtures/assets/` for basic, graph/planner, and runner scenarios (`basic_assets.ex`, `graph_assets.ex`, `runner_assets.ex`) and updated test files to alias those modules.
- Added `Flux.TestSetup` in `test/support/flux_test_setup.ex` exposing `capture_state/0`, `setup_asset_modules/2`, `configure_run_store/2`, `clear_memory_run_store/0`, and `restore_state/2` to encapsulate env capture/restore, registry/graph reloads, run-store configuration, and ETS cleanup.
- Updated `test/flux_test.exs`, `test/graph_index_test.exs`, `test/planner_test.exs`, and `test/runner_test.exs` to consume the shared fixtures and use `Flux.TestSetup` helpers instead of inline module definitions and duplicated setup/restore code, preserving existing assertions and behavior.
- Updated `test/test_helper.exs` to require the new support files so fixtures and helpers are loaded for the test suite; no changes were made to code under `lib/`.

### Testing
- Ran `mix format` on modified test/support and test files, which completed successfully.
- Attempted `mix test` for the modified test files, but execution was blocked because dependencies were not available locally and `mix deps.get` could not fully bootstrap due to an external Hex install error (HTTP 503), so the test run did not complete.
- Attempted `mix deps.get`, which fetched the Git dependency but failed while installing Hex metadata due to an upstream HTTP 503, preventing full test execution.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c57af6b1b48328ba9d28c7d39a40fc)