### PR TITLE
test: remove non-essential Logger calls from unit tests

### DIFF
--- a/test/asset_test.exs
+++ b/test/asset_test.exs
@@ -4,8 +4,6 @@ defmodule Flux.AssetTest do
   alias Flux.Asset
   alias Flux.Ref
 
-  require Logger
-
   test "defaults optional fields" do
     asset = %Asset{
       module: Example.Assets,
@@ -15,8 +13,6 @@ defmodule Flux.AssetTest do
       file: "lib/example/assets.ex",
       line: 12
     }
-
-    Logger.debug("default asset metadata: #{inspect(asset, pretty: true)}")
 
     assert asset.kind == :materialized
     assert asset.tags == []
@@ -37,8 +33,6 @@ defmodule Flux.AssetTest do
       tags: [:warehouse, "finance"],
       depends_on: [Ref.new(Example.Assets, :normalize_orders)]
     }
-
-    Logger.debug("canonical asset metadata: #{inspect(asset, pretty: true)}")
 
     assert asset.module == Example.Assets
     assert asset.name == :fact_sales

--- a/test/assets_test.exs
+++ b/test/assets_test.exs
@@ -33,12 +33,8 @@ defmodule Flux.AssetsTest do
 
   alias Flux.Asset
 
-  require Logger
-
   test "captures canonical asset metadata in source order" do
     assets = Flux.AssetsTest.Sample.__flux_assets__()
-
-    Logger.debug("module assets: #{inspect(assets, pretty: true)}")
 
     assert Enum.map(assets, & &1.name) == [:extract_orders, :normalize_orders, :fact_sales]
 
@@ -64,8 +60,6 @@ defmodule Flux.AssetsTest do
   end
 
   test "rejects invalid asset declarations at compile time" do
-    Logger.info("compiling invalid asset declarations to verify compile-time validation")
-
     assert_raise CompileError, ~r/invalid asset kind/, fn ->
       compile_test_module("""
       use Flux.Assets

--- a/test/flux_test.exs
+++ b/test/flux_test.exs
@@ -3,8 +3,6 @@ defmodule FluxTest do
 
   doctest Flux
 
-  require Logger
-
   defmodule SampleAssets do
     use Flux.Assets
 
@@ -88,8 +86,6 @@ defmodule FluxTest do
   test "lists assets for a module through the public facade" do
     assert {:ok, assets} = Flux.list_assets(SampleAssets)
 
-    Logger.debug("facade asset list: #{inspect(assets, pretty: true)}")
-
     assert Enum.map(assets, & &1.name) == [:extract_orders, :normalize_orders]
   end
 
@@ -99,8 +95,6 @@ defmodule FluxTest do
 
     assert {:ok, asset} = Flux.get_asset({SampleAssets, :normalize_orders})
     assert {:ok, cross_module_asset} = Flux.get_asset({CrossModuleAssets, :publish_orders})
-
-    Logger.debug("facade asset lookup: #{inspect(asset, pretty: true)}")
 
     assert asset.depends_on == [{SampleAssets, :extract_orders}]
     assert cross_module_asset.depends_on == [{SampleAssets, :normalize_orders}]

--- a/test/ref_test.exs
+++ b/test/ref_test.exs
@@ -3,12 +3,8 @@ defmodule Flux.RefTest do
 
   alias Flux.Ref
 
-  require Logger
-
   test "builds a canonical ref" do
     ref = Ref.new(Example.Assets, :normalize_orders)
-
-    Logger.debug("built ref: #{inspect(ref)}")
 
     assert ref == {Example.Assets, :normalize_orders}
   end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,5 +1,3 @@
-require Logger
-
 trace? = "--trace" in System.argv()
 
 ExUnit.start(capture_log: !trace?)


### PR DESCRIPTION
### Motivation

- Reduce test noise by removing unneeded `Logger` requires and diagnostic `Logger.debug/info` calls that do not affect assertions.
- Keep tests deterministic and focused on behavior and assertions only.
- Simplify test helper by avoiding an unnecessary `require Logger` while preserving runtime logging configuration.

### Description

- Removed `require Logger` and non-essential `Logger.debug/1` calls from `test/asset_test.exs`.
- Removed `require Logger` and diagnostic logging from `test/assets_test.exs` while preserving compile-time validation checks and assertions.
- Removed `require Logger` and debug logging from `test/flux_test.exs` and `test/ref_test.exs`.
- Removed an unnecessary `require Logger` from `test/test_helper.exs` while keeping `ExUnit.start/1` and `Logger.configure/1` intact.

### Testing

- Attempted to run `mix test test/asset_test.exs test/assets_test.exs test/flux_test.exs test/ref_test.exs`, but execution was blocked due to missing dependencies and could not complete.
- Attempted `mix deps.get` to fetch dependencies, which failed because Hex metadata download returned HTTP 503 in this environment.
- Attempted `mix local.hex --force` to install Hex, which also failed due to the same Hex endpoint error; no test suite results could be produced here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c57afa13c48328856b0afaae246df6)