### PR TITLE
Use prepend accumulation in registry merge to avoid repeated appends while preserving order

### DIFF
--- a/lib/flux/registry.ex
+++ b/lib/flux/registry.ex
@@ -89,10 +89,10 @@ defmodule Flux.Registry do
           | {:error, error()}
   def build_catalog(modules) when is_list(modules) do
     modules
-    |> Enum.reduce_while(%{assets: [], assets_by_ref: %{}}, fn module, catalog ->
+    |> Enum.reduce_while({:ok, %{assets: [], assets_by_ref: %{}}}, fn module, {:ok, catalog} ->
       if Flux.asset_module?(module) do
         case merge_assets(catalog, module.__flux_assets__()) do
-          {:ok, updated_catalog} -> {:cont, updated_catalog}
+          {:ok, updated_catalog} -> {:cont, {:ok, updated_catalog}}
           {:error, _reason} = error -> {:halt, error}
         end
       else
@@ -100,8 +100,8 @@ defmodule Flux.Registry do
       end
     end)
     |> case do
+      {:ok, catalog} -> {:ok, %{catalog | assets: Enum.reverse(catalog.assets)}}
       {:error, _reason} = error -> error
-      catalog -> {:ok, catalog}
     end
   end
 
@@ -120,24 +120,17 @@ defmodule Flux.Registry do
 
   defp merge_assets(catalog, assets) do
     assets
-    |> Enum.reduce_while({:ok, {[], catalog.assets_by_ref}}, fn %Asset{} = asset,
-                                                                {:ok, {new_assets, assets_by_ref}} ->
-      if Map.has_key?(assets_by_ref, asset.ref) do
+    |> Enum.reduce_while({:ok, catalog}, fn %Asset{} = asset, {:ok, acc} ->
+      if Map.has_key?(acc.assets_by_ref, asset.ref) do
         {:halt, {:error, {:duplicate_asset, asset.ref}}}
       else
-        {:cont, {:ok, {[asset | new_assets], Map.put(assets_by_ref, asset.ref, asset)}}}
+        {:cont,
+         {:ok,
+          %{
+            assets: [asset | acc.assets],
+            assets_by_ref: Map.put(acc.assets_by_ref, asset.ref, asset)
+          }}}
       end
     end)
-    |> case do
-      {:ok, {new_assets, assets_by_ref}} ->
-        {:ok,
-         %{
-           assets: catalog.assets ++ Enum.reverse(new_assets),
-           assets_by_ref: assets_by_ref
-         }}
-
-      {:error, _reason} = error ->
-        error
-    end
   end
 end

--- a/test/flux_test.exs
+++ b/test/flux_test.exs
@@ -80,6 +80,17 @@ defmodule FluxTest do
              {CrossModuleAssets, :publish_orders},
              {AdditionalAssets, :archive_orders}
            ]
+
+    :ok = Flux.TestSetup.setup_asset_modules([SampleAssets, CrossModuleAssets, AdditionalAssets])
+
+    assert {:ok, listed_assets} = Flux.list_assets()
+
+    assert Enum.map(listed_assets, & &1.ref) == [
+             {SampleAssets, :extract_orders},
+             {SampleAssets, :normalize_orders},
+             {CrossModuleAssets, :publish_orders},
+             {AdditionalAssets, :archive_orders}
+           ]
   end
 
   test "lists assets for a module through the public facade" do


### PR DESCRIPTION
### Motivation
- Improve performance of asset merging by avoiding repeated list appends when building the global asset catalog. 
- Keep deterministic asset ordering and duplicate-detection semantics unchanged while reducing allocation overhead. 
- Ensure public-facing APIs retain their existing return shapes (`{:ok, catalog}` / `{:error, reason}`) and behavior.

### Description
- Reworked `Flux.Registry.build_catalog/1` to carry an `{:ok, catalog}` accumulator through module reduction and perform a single `Enum.reverse/1` on `catalog.assets` after reduction completes. 
- Rewrote `merge_assets/2` to prepend each `asset` into `acc.assets` (`[asset | acc.assets]`) and update `assets_by_ref` on the accumulator, preserving duplicate detection via `assets_by_ref`. 
- Preserved all existing error return shapes and duplicate collision behavior (`{:error, {:duplicate_asset, ref}}`). 
- Strengthened the deterministic-order regression test in `test/flux_test.exs` to also assert that `Flux.list_assets/0` returns the same stable order after registry setup.

### Testing
- Ran the focused test file with `mix test test/flux_test.exs`, which completed successfully with `14 doctests, 9 tests, 0 failures`. 
- Project dependencies and formatting commands used during validation (`mix archive.install` / `mix deps.get` / `mix format`) completed without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c590fbaab08328acae434fe2ca5453)