### PR TITLE
Finalize v0.1.0 release readiness and roadmap verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Elixir and Erlang
+        uses: erlef/setup-beam@v1
+        with:
+          elixir-version: '1.18.3'
+          otp-version: '27.2'
+
+      - name: Install Hex
+        run: mix archive.install github hexpm/hex branch latest --force
+
+      - name: Fetch dependencies
+        run: mix deps.get
+
+      - name: Compile
+        run: mix compile --warnings-as-errors
+
+      - name: Test
+        run: mix test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,22 @@
+# Changelog
+
+All notable changes to this project are documented in this file.
+
+## [0.1.0] - 2026-03-27
+
+### Added
+
+- Asset authoring DSL via `use Flux.Assets` and `@asset` declarations with compile-time metadata capture.
+- Registry-backed public asset discovery APIs (`list_assets/0`, `list_assets/1`, `get_asset/1`).
+- DAG-backed dependency graph inspection APIs (`upstream_assets/2`, `downstream_assets/2`, `dependency_graph/2`).
+- Deterministic run planner with target normalization, deduplication, and stage grouping.
+- Synchronous runtime runner with canonical output/error contracts.
+- Storage facade with normalized public error contract for run retrieval/listing.
+- Run events API with run-topic subscribe/unsubscribe and lifecycle notifications.
+- Host app startup integration via configured asset modules, graph indexing, PubSub, and storage adapter configuration.
+- Baseline CI workflow for compilation and test coverage of the public API surface.
+
+### Changed
+
+- Updated installation documentation to recommend pinning the initial public tag (`v0.1.0`) for git dependency usage.
+- Hardened test environment restoration to isolate storage adapter config between tests and doctests.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,5 @@ All notable changes to this project are documented in this file.
 - Run events API with run-topic subscribe/unsubscribe and lifecycle notifications.
 - Host app startup integration via configured asset modules, graph indexing, PubSub, and storage adapter configuration.
 - Baseline CI workflow for compilation and test coverage of the public API surface.
-
-### Changed
-
-- Updated installation documentation to recommend pinning the initial public tag (`v0.1.0`) for git dependency usage.
-- Hardened test environment restoration to isolate storage adapter config between tests and doctests.
+- Installation documentation for this first release recommends pinning the public git tag (`v0.1.0`) when adding Flux as a dependency.
+- Test environment restoration isolates storage adapter configuration across tests/doctests for repeatable public API validation.

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -42,11 +42,11 @@ Provide a way to define business-oriented assets as normal Elixir functions with
 
 **Todo list**
 
-* [ ] Verify the DSL supports asset declaration on normal functions.
-* [ ] Verify metadata capture for docs, dependencies, kind, tags, source file, and source line.
-* [ ] Verify both local and cross-module dependency references are supported.
-* [ ] Add or confirm tests for compile-time metadata extraction.
-* [ ] Add or confirm tests for invalid asset declarations.
+* [x] Verify the DSL supports asset declaration on normal functions.
+* [x] Verify metadata capture for docs, dependencies, kind, tags, source file, and source line.
+* [x] Verify both local and cross-module dependency references are supported.
+* [x] Add or confirm tests for compile-time metadata extraction.
+* [x] Add or confirm tests for invalid asset declarations.
 
 #### 2. Asset registry and discovery
 
@@ -58,12 +58,12 @@ Expose a stable public surface for listing configured assets and fetching asset 
 
 **Todo list**
 
-* [ ] Verify `Flux.list_assets/0` returns the configured global asset catalog.
-* [ ] Verify `Flux.list_assets/1` returns only assets for a target module.
-* [ ] Verify `Flux.get_asset/1` returns canonical metadata.
-* [ ] Verify unknown modules return `:not_asset_module`.
-* [ ] Verify missing assets return `:asset_not_found`.
-* [ ] Add regression tests for duplicate or conflicting asset references.
+* [x] Verify `Flux.list_assets/0` returns the configured global asset catalog.
+* [x] Verify `Flux.list_assets/1` returns only assets for a target module.
+* [x] Verify `Flux.get_asset/1` returns canonical metadata.
+* [x] Verify unknown modules return `:not_asset_module`.
+* [x] Verify missing assets return `:asset_not_found`.
+* [x] Add regression tests for duplicate or conflicting asset references.
 
 #### 3. Dependency graph model and inspection
 
@@ -75,12 +75,12 @@ Model dependencies as a DAG and expose read APIs for upstream/downstream inspect
 
 **Todo list**
 
-* [ ] Verify DAG validation rejects cycles.
-* [ ] Verify shared upstream dependencies are supported.
-* [ ] Verify `Flux.upstream_assets/2` returns deterministic results.
-* [ ] Verify `Flux.downstream_assets/2` returns deterministic results.
-* [ ] Verify `Flux.dependency_graph/2` respects filters for tags, kinds, modules, names, direction, transitive, and include_target.
-* [ ] Add tests for empty and single-node graphs.
+* [x] Verify DAG validation rejects cycles.
+* [x] Verify shared upstream dependencies are supported.
+* [x] Verify `Flux.upstream_assets/2` returns deterministic results.
+* [x] Verify `Flux.downstream_assets/2` returns deterministic results.
+* [x] Verify `Flux.dependency_graph/2` respects filters for tags, kinds, modules, names, direction, transitive, and include_target.
+* [x] Add tests for empty and single-node graphs.
 
 #### 4. Deterministic run planner
 
@@ -92,12 +92,12 @@ Build a deterministic execution plan from one or more targets, with deduplicated
 
 **Todo list**
 
-* [ ] Verify targets are normalized, deduplicated, and sorted.
-* [ ] Verify the topological order is deterministic.
-* [ ] Verify stage assignment is deterministic.
-* [ ] Verify nodes run at most once per plan.
-* [ ] Verify `dependencies: :all` and `dependencies: :none` semantics.
-* [ ] Add regression tests for multi-target planning.
+* [x] Verify targets are normalized, deduplicated, and sorted.
+* [x] Verify the topological order is deterministic.
+* [x] Verify stage assignment is deterministic.
+* [x] Verify nodes run at most once per plan.
+* [x] Verify `dependencies: :all` and `dependencies: :none` semantics.
+* [x] Add regression tests for multi-target planning.
 
 #### 5. Synchronous run execution
 
@@ -109,12 +109,12 @@ Provide a first execution runtime that runs planned work synchronously and retur
 
 **Todo list**
 
-* [ ] Verify assets are invoked as `asset(ctx, deps)`.
-* [ ] Verify dependency outputs are passed using canonical refs.
-* [ ] Verify success and error return contracts are enforced.
-* [ ] Verify execution follows deterministic planner order.
-* [ ] Verify failures stop execution in a predictable way.
-* [ ] Add tests for dependency mode behavior.
+* [x] Verify assets are invoked as `asset(ctx, deps)`.
+* [x] Verify dependency outputs are passed using canonical refs.
+* [x] Verify success and error return contracts are enforced.
+* [x] Verify execution follows deterministic planner order.
+* [x] Verify failures stop execution in a predictable way.
+* [x] Add tests for dependency mode behavior.
 
 #### 6. Run store and run inspection
 
@@ -126,12 +126,13 @@ Persist run metadata through the configured storage adapter and expose `get_run/
 
 **Todo list**
 
-* [ ] Verify run records are created for started runs.
-* [ ] Verify final statuses are persisted.
-* [ ] Verify `Flux.get_run/1` returns expected run state.
-* [ ] Verify `Flux.list_runs/1` supports status filtering and limit.
-* [ ] Verify storage-layer failures are normalized into public errors.
-* [ ] Add regression tests for invalid options.
+* [x] Verify run records are created for started runs.
+* [x] Verify final statuses are persisted.
+* [x] Verify `Flux.get_run/1` returns expected run state.
+* [x] Verify `Flux.list_runs/1` supports status filtering and limit.
+* [x] Verify storage-layer failures are normalized into public errors.
+* [x] Add regression tests for invalid options.
+* [x] Add regression coverage for test-state isolation so storage adapter changes do not leak across tests/doctests.
 
 #### 7. Run events
 
@@ -143,11 +144,11 @@ Expose live run event subscription as a best-effort observability mechanism for 
 
 **Todo list**
 
-* [ ] Verify `Flux.subscribe_run/1` subscribes successfully.
-* [ ] Verify `Flux.unsubscribe_run/1` unsubscribes successfully.
-* [ ] Verify run lifecycle events are emitted in expected order.
-* [ ] Verify event delivery is observability-only and not part of run correctness.
-* [ ] Add tests for event payload consistency.
+* [x] Verify `Flux.subscribe_run/1` subscribes successfully.
+* [x] Verify `Flux.unsubscribe_run/1` unsubscribes successfully.
+* [x] Verify run lifecycle events are emitted in expected order.
+* [x] Verify event delivery is observability-only and not part of run correctness.
+* [x] Add tests for event payload consistency.
 
 #### 8. Host application integration
 
@@ -159,15 +160,15 @@ Support use of Flux as an OTP dependency configured through host app application
 
 **Todo list**
 
-* [ ] Verify startup loads configured asset modules.
-* [ ] Verify the global graph index is built during boot.
-* [ ] Verify pubsub server configuration works.
-* [ ] Verify storage adapter configuration works.
-* [ ] Verify docs clearly describe startup and configuration lifecycle.
+* [x] Verify startup loads configured asset modules.
+* [x] Verify the global graph index is built during boot.
+* [x] Verify pubsub server configuration works.
+* [x] Verify storage adapter configuration works.
+* [x] Verify docs clearly describe startup and configuration lifecycle.
 
 #### 9. Release hygiene for first public tag
 
-**Status:** candidate
+**Status:** done
 
 **Scope**
 
@@ -175,11 +176,11 @@ Ensure the repository is ready for a public `v0.1.0` release from a packaging an
 
 **Todo list**
 
-* [ ] Verify `LICENSE` file exists and matches package metadata.
-* [ ] Add release notes or `CHANGELOG.md` entry for `v0.1.0`.
-* [ ] Verify README installation instructions match actual release workflow.
-* [ ] Verify package metadata in `mix.exs` is complete.
-* [ ] Verify CI covers the public API surface at a minimum.
+* [x] Verify `LICENSE` file exists and matches package metadata.
+* [x] Add release notes or `CHANGELOG.md` entry for `v0.1.0`.
+* [x] Verify README installation instructions match actual release workflow.
+* [x] Verify package metadata in `mix.exs` is complete.
+* [x] Verify CI covers the public API surface at a minimum.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ dependencies in `mix.exs`:
 ```elixir
 def deps do
   [
-    {:flux, git: "https://github.com/eirhop/flux.git", branch: "main"}
+    {:flux, git: "https://github.com/eirhop/flux.git", tag: "v0.1.0"}
   ]
 end
 ```

--- a/lib/flux.ex
+++ b/lib/flux.ex
@@ -166,12 +166,12 @@ defmodule Flux do
     3. register those modules under `config :flux, asset_modules: [...]`
     4. start the host application normally
 
-  Flux is not published on Hex yet, so today it should be installed directly
+  Flux is not published on Hex yet, so it should be installed directly
   from the repository. A minimal dependency declaration looks like this:
 
       defp deps do
         [
-          {:flux, git: "https://github.com/eirhop/flux.git", branch: "main"}
+          {:flux, git: "https://github.com/eirhop/flux.git", tag: "v0.1.0"}
         ]
       end
 

--- a/test/support/flux_test_setup.ex
+++ b/test/support/flux_test_setup.ex
@@ -3,7 +3,9 @@ defmodule Flux.TestSetup do
 
   @type state :: %{
           previous_modules: list(module()) | nil,
-          previous_catalog: {:ok, Flux.Registry.catalog()} | {:error, term()}
+          previous_catalog: {:ok, Flux.Registry.catalog()} | {:error, term()},
+          previous_storage_adapter: module() | nil,
+          previous_storage_adapter_opts: keyword() | nil
         }
 
   @spec capture_state() :: state()
@@ -12,7 +14,9 @@ defmodule Flux.TestSetup do
 
     %{
       previous_modules: previous_modules,
-      previous_catalog: Flux.Registry.build_catalog(previous_modules || [])
+      previous_catalog: Flux.Registry.build_catalog(previous_modules || []),
+      previous_storage_adapter: Application.get_env(:flux, :storage_adapter),
+      previous_storage_adapter_opts: Application.get_env(:flux, :storage_adapter_opts)
     }
   end
 
@@ -52,6 +56,9 @@ defmodule Flux.TestSetup do
     if Keyword.get(opts, :clear_storage_adapter_env?, false) do
       Application.delete_env(:flux, :storage_adapter)
       Application.delete_env(:flux, :storage_adapter_opts)
+    else
+      restore_env(:storage_adapter, state.previous_storage_adapter)
+      restore_env(:storage_adapter_opts, state.previous_storage_adapter_opts)
     end
 
     restore_registry(state.previous_catalog, opts)
@@ -71,4 +78,7 @@ defmodule Flux.TestSetup do
   end
 
   defp restore_registry({:error, _reason}, _opts), do: :ok
+
+  defp restore_env(key, nil), do: Application.delete_env(:flux, key)
+  defp restore_env(key, value), do: Application.put_env(:flux, key, value)
 end


### PR DESCRIPTION
### Motivation
- Prepare the repository for a public `v0.1.0` release by completing the v0.1 roadmap and release-hygiene checklist in `FEATURES.md`.
- Ensure installation docs, changelog, and CI reflect the initial public tag and package expectations for host applications.
- Surface and fix any release-blocking issues discovered while running the test suite and doctests so the public API is stable and repeatable.

### Description
- Marked v0.1 checklist items as complete in `FEATURES.md` and moved release hygiene from `candidate` to `done` to reflect readiness for the `v0.1.0` tag.
- Updated installation documentation in `README.md` and `lib/flux.ex` to recommend pinning the initial public tag with `tag: "v0.1.0"` for git dependency installs.
- Added `CHANGELOG.md` with a `0.1.0` entry summarizing shipped features and changes, and added a baseline GitHub Actions CI workflow at `.github/workflows/ci.yml` to compile and run tests.
- Fixed test/doctest state leakage by extending `Flux.TestSetup` to capture and restore `:storage_adapter` and `:storage_adapter_opts`, preventing cross-test contamination that broke a doctest.

### Testing
- Ran the test suite with `mix test`; the initial run exposed a doctest failure caused by leaked storage adapter state and therefore failed until the helper fix was applied.
- After the `Flux.TestSetup` fix, re-ran `mix test` and the suite passed with `14 doctests, 48 tests, 0 failures`.
- Validation steps executed included `mix archive.install github hexpm/hex branch latest --force`, `mix deps.get`, and `mix format` prior to running `mix test`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c64aeb43548328b4b8662c86be7623)