### PR TITLE
Add asynchronous parallel step execution with bounded concurrency and executor monitoring

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -58,7 +58,7 @@ Turns Favn into a real execution engine with durable state and concurrency.
 ### Features
 
 - [x] Asynchronous run execution
-- [ ] Parallel execution with bounded concurrency
+- [x] Parallel execution with bounded concurrency
 - [x] Run + step state machine (pending → running → success/failure)
 - [ ] Retry mechanism (configurable)
 - [ ] Cancellation support

--- a/README.md
+++ b/README.md
@@ -111,13 +111,14 @@ Key settings:
 
 - The default run store is node-local in-memory storage.
 - Public run execution is asynchronous by default (`Favn.run/2` returns a run id).
+- Independent ready steps execute in parallel within a run, bounded by `max_concurrency`.
 - Run events are best-effort pubsub notifications.
 
 ## Runtime behavior in this release
 
-- **Planning and orchestration**: Favn plans dependency-aware runs with deterministic topological stages and orchestrates execution through a run-scoped coordinator.
+- **Planning and orchestration**: Favn plans dependency-aware runs with deterministic topological stages and orchestrates execution through a run-scoped coordinator with bounded parallel step dispatch per run.
 - **Run lifecycle**: runtime orchestration now uses explicit internal run and step state machines; the public `%Favn.Run{}` projection remains compatible with `:running | :ok | :error`.
-- **Execution boundary**: one-step asset invocation is isolated behind a runtime executor boundary.
+- **Execution boundary**: one-step asset invocation is isolated behind an asynchronous runtime executor boundary.
 - **Storage facade contract**: run retrieval/listing APIs normalize storage failures to one of:
   - `:not_found`
   - `:invalid_opts`
@@ -129,6 +130,7 @@ Key settings:
 
 - **Run lifecycle semantics**
   - `Favn.run/2` returns `{:ok, run_id}` when a run is submitted.
+  - Step admission order is deterministic for equally-ready refs; completion order is naturally non-deterministic under parallel execution.
   - `Favn.await_run/2` returns `{:ok, %Favn.Run{status: :ok}}` on success or `{:error, %Favn.Run{status: :error}}` on execution failure.
   - Failed runs preserve structured failure context in both `run.error` and `run.asset_results[ref].error`.
   - `Favn.get_run/1` returns the latest stored run state for an ID.
@@ -144,7 +146,7 @@ Key settings:
 - Durable distributed execution guarantees across nodes.
 - Exactly-once event delivery, replay, or durable event logs.
 - Persistent storage guarantees beyond the configured adapter behavior (default adapter is in-memory and node-local).
-- Asynchronous or parallel asset execution beyond the current deterministic stage-by-stage runtime model.
+- Global concurrency fairness across runs, retries, cancellation of already-running work, and timeout enforcement.
 
 ## Roadmap and release focus
 

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -337,7 +337,8 @@ defmodule Favn do
   """
   @type run_opts :: [
           dependencies: dependencies_mode(),
-          params: map()
+          params: map(),
+          max_concurrency: pos_integer()
         ]
 
   @typedoc """
@@ -657,16 +658,18 @@ defmodule Favn do
     * `opts`:
       * `dependencies: :all | :none` (default `:all`)
       * `params: map()` (default `%{}`)
+      * `max_concurrency: pos_integer()` (default from runtime config, fallback `1`)
 
   Deterministic behavior:
 
     * planning and stage ordering are deterministic for identical inputs
-    * runnable refs are selected in canonical ref order
+    * runnable refs are admitted in canonical ref order when multiple refs are ready together
 
   Runtime semantics:
 
     * returns immediately with a generated `run_id`
     * orchestration is owned by supervised runtime processes
+    * independent ready steps may execute in parallel up to `max_concurrency`
     * callers can observe progress through `get_run/1`, `list_runs/1`,
       `await_run/2`, and run events
 

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -17,8 +17,6 @@ defmodule Favn.Runtime.Coordinator do
 
   @executor Application.compile_env(:favn, :runtime_executor, Local)
 
-  @type run_result :: {:ok, Favn.Run.t()} | {:error, Favn.Run.t() | term()}
-
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) when is_list(opts) do
     GenServer.start_link(__MODULE__, opts)
@@ -31,64 +29,95 @@ defmodule Favn.Runtime.Coordinator do
 
   @impl true
   def handle_cast(:start_run, %{state: state} = data) do
-    _result = start_and_execute(state)
-    {:stop, :normal, data}
+    with {:ok, state} <- apply_run_transition(state, :start),
+         {:ok, state} <- emit_step_ready_for_sources(state),
+         {:ok, state} <- dispatch_ready_work(state),
+         {:ok, state} <- maybe_finalize_terminal(state) do
+      {:noreply, %{data | state: state}}
+    else
+      {:error, reason} ->
+        {:stop, reason, data}
+    end
   end
 
   @impl true
-  def handle_info(_msg, data) do
-    {:noreply, data}
-  end
-
-  @spec start_and_execute(State.t()) :: run_result()
-  defp start_and_execute(state) do
-    with {:ok, state} <- apply_run_transition(state, :start),
-         {:ok, state} <- emit_step_ready_for_sources(state),
-         {:ok, state} <- execute_until_terminal(state) do
-      public_run = Projector.to_public_run(state)
-      if public_run.status == :ok, do: {:ok, public_run}, else: {:error, public_run}
+  def handle_info({:executor_step_result, exec_ref, ref, result}, %{state: state} = data) do
+    with {:ok, state} <- handle_step_result(state, exec_ref, ref, result),
+         {:ok, state} <- dispatch_ready_work(state),
+         {:ok, state} <- maybe_finalize_terminal(state) do
+      {:noreply, %{data | state: state}}
     else
       {:error, reason} ->
-        {:error, reason}
+        {:stop, reason, data}
     end
   end
 
-  defp execute_until_terminal(%State{run_status: :running} = state) do
-    case pop_next_ready(state) do
-      {:ok, ref, next_state} ->
-        with {:ok, next_state} <- run_step(next_state, ref) do
-          execute_until_terminal(next_state)
+  @impl true
+  def handle_info({:DOWN, monitor_ref, :process, _pid, reason}, %{state: state} = data) do
+    case Map.fetch(state.exec_refs_by_monitor, monitor_ref) do
+      {:ok, exec_ref} ->
+        if MapSet.member?(state.completed_exec_refs, exec_ref) do
+          {:noreply, %{data | state: clear_monitor(state, exec_ref, monitor_ref)}}
+        else
+          with {:ok, state} <-
+                 handle_step_result(
+                   state,
+                   exec_ref,
+                   nil,
+                   {:error, %{kind: :exit, reason: reason, stacktrace: []}}
+                 ),
+               {:ok, state} <- dispatch_ready_work(state),
+               {:ok, state} <- maybe_finalize_terminal(state) do
+            {:noreply, %{data | state: state}}
+          else
+            {:error, reason} -> {:stop, reason, data}
+          end
         end
 
-      :none ->
-        finalize_terminal(state)
+      :error ->
+        {:noreply, data}
     end
   end
 
-  defp execute_until_terminal(%State{} = state), do: {:ok, state}
+  @impl true
+  def handle_info(_msg, data), do: {:noreply, data}
 
-  defp run_step(%State{} = state, ref) do
+  defp dispatch_ready_work(%State{} = state) do
+    if dispatch_allowed?(state) and capacity(state) > 0 do
+      do_dispatch(state)
+    else
+      {:ok, state}
+    end
+  end
+
+  defp do_dispatch(%State{} = state) do
+    cond do
+      not dispatch_allowed?(state) ->
+        {:ok, state}
+
+      capacity(state) <= 0 ->
+        {:ok, state}
+
+      true ->
+        case pop_next_ready(state) do
+          {:ok, ref, next_state} ->
+            with {:ok, next_state} <- start_step_execution(next_state, ref) do
+              do_dispatch(next_state)
+            end
+
+          :none ->
+            {:ok, state}
+        end
+    end
+  end
+
+  defp start_step_execution(%State{} = state, ref) do
     with {:ok, state} <- apply_step_transition(state, &StepTransitions.start_step(&1, ref)),
          {:ok, asset} <- Favn.Registry.get_asset(ref),
-         {:ok, deps} <- dependency_outputs(state, ref) do
-      ctx = build_context(state, ref)
-
-      case @executor.execute_step(asset, ctx, deps) do
-        {:ok, %{output: output, meta: meta}} ->
-          apply_step_transition(state, &StepTransitions.complete_success(&1, ref, output, meta))
-
-        {:error, error} ->
-          with {:ok, state} <-
-                 apply_step_transition(state, &StepTransitions.complete_failure(&1, ref, error)),
-               {:ok, state} <-
-                 apply_run_transition(
-                   state,
-                   {:mark_failed, %{ref: ref, stage: stage_for(state, ref), reason: error.reason}}
-                 ),
-               {:ok, state} <- apply_finalize_unresolved(state, :skipped) do
-            {:ok, state}
-          end
-      end
+         {:ok, deps} <- dependency_outputs(state, ref),
+         {:ok, handle} <-
+           @executor.start_step(asset, build_context(state, ref), deps, self(), ref) do
+      {:ok, put_execution_handle(state, ref, handle)}
     else
       {:error, reason} ->
         normalized = %{kind: :error, reason: reason, stacktrace: []}
@@ -98,28 +127,131 @@ defmodule Favn.Runtime.Coordinator do
                  state,
                  &StepTransitions.complete_failure(&1, ref, normalized)
                ),
-             {:ok, state} <-
-               apply_run_transition(
-                 state,
-                 {:mark_failed, %{ref: ref, stage: stage_for(state, ref), reason: reason}}
-               ),
-             {:ok, state} <- apply_finalize_unresolved(state, :skipped) do
+             {:ok, state} <- close_admission_with_failure(state, ref, reason) do
           {:ok, state}
         end
     end
   end
 
-  defp finalize_terminal(%State{} = state) do
-    if all_targets_success?(state) do
-      apply_run_transition(state, :mark_success)
-    else
-      reason = state.run_error || %{reason: :run_did_not_reach_targets}
-
-      with {:ok, state} <- apply_run_transition(state, {:mark_failed, reason}),
-           {:ok, state} <- apply_finalize_unresolved(state, :skipped) do
-        {:ok, state}
-      end
+  defp handle_step_result(
+         %State{} = state,
+         exec_ref,
+         maybe_ref,
+         {:ok, %{output: output, meta: meta}}
+       ) do
+    with {:ok, ref, state} <- take_execution(state, exec_ref, maybe_ref) do
+      apply_step_transition(state, &StepTransitions.complete_success(&1, ref, output, meta))
     end
+  end
+
+  defp handle_step_result(%State{} = state, exec_ref, maybe_ref, {:error, error})
+       when is_map(error) do
+    with {:ok, ref, state} <- take_execution(state, exec_ref, maybe_ref),
+         {:ok, state} <-
+           apply_step_transition(state, &StepTransitions.complete_failure(&1, ref, error)),
+         {:ok, state} <- close_admission_with_failure(state, ref, error[:reason]) do
+      {:ok, state}
+    end
+  end
+
+  defp maybe_finalize_terminal(%State{run_status: :running} = state) do
+    cond do
+      map_size(state.inflight_execs) > 0 ->
+        {:ok, state}
+
+      all_targets_success?(state) ->
+        apply_run_transition(state, :mark_success)
+
+      true ->
+        reason = state.run_error || %{reason: :run_did_not_reach_targets}
+
+        with {:ok, state} <- close_admission(state),
+             {:ok, state} <- apply_run_transition(state, {:mark_failed, reason}),
+             {:ok, state} <- maybe_finalize_unresolved(state) do
+          {:ok, state}
+        end
+    end
+  end
+
+  defp maybe_finalize_terminal(%State{run_status: :failed} = state) do
+    if map_size(state.inflight_execs) == 0 do
+      maybe_finalize_unresolved(state)
+    else
+      {:ok, state}
+    end
+  end
+
+  defp maybe_finalize_terminal(%State{} = state), do: {:ok, state}
+
+  defp maybe_finalize_unresolved(%State{} = state) do
+    if unresolved_steps?(state) do
+      apply_finalize_unresolved(state, :skipped)
+    else
+      {:ok, state}
+    end
+  end
+
+  defp close_admission_with_failure(%State{} = state, ref, reason) do
+    with {:ok, state} <- close_admission(state),
+         {:ok, state} <-
+           maybe_mark_run_failed(state, %{ref: ref, stage: stage_for(state, ref), reason: reason}) do
+      {:ok, state}
+    end
+  end
+
+  defp maybe_mark_run_failed(%State{run_status: :running} = state, reason),
+    do: apply_run_transition(state, {:mark_failed, reason})
+
+  defp maybe_mark_run_failed(%State{} = state, _reason), do: {:ok, state}
+
+  defp close_admission(%State{} = state), do: {:ok, %{state | admission_open?: false}}
+
+  defp take_execution(%State{} = state, exec_ref, maybe_ref) do
+    case Map.pop(state.inflight_execs, exec_ref) do
+      {nil, _} ->
+        {:ok, nil,
+         %{state | completed_exec_refs: MapSet.put(state.completed_exec_refs, exec_ref)}}
+
+      {%{ref: tracked_ref, monitor_ref: monitor_ref}, inflight} ->
+        ref = maybe_ref || tracked_ref
+
+        next_state =
+          state
+          |> Map.put(:inflight_execs, inflight)
+          |> Map.put(:exec_refs_by_monitor, Map.delete(state.exec_refs_by_monitor, monitor_ref))
+          |> Map.put(:completed_exec_refs, MapSet.put(state.completed_exec_refs, exec_ref))
+
+        {:ok, ref, next_state}
+    end
+    |> case do
+      {:ok, nil, next_state} ->
+        {:error, {:unknown_execution_result, exec_ref, maybe_ref, next_state.run_id}}
+
+      other ->
+        other
+    end
+  end
+
+  defp clear_monitor(%State{} = state, exec_ref, monitor_ref) do
+    %{
+      state
+      | exec_refs_by_monitor: Map.delete(state.exec_refs_by_monitor, monitor_ref),
+        completed_exec_refs: MapSet.put(state.completed_exec_refs, exec_ref)
+    }
+  end
+
+  defp put_execution_handle(%State{} = state, ref, %{
+         exec_ref: exec_ref,
+         monitor_ref: monitor_ref,
+         pid: pid
+       }) do
+    info = %{ref: ref, monitor_ref: monitor_ref, pid: pid}
+
+    %{
+      state
+      | inflight_execs: Map.put(state.inflight_execs, exec_ref, info),
+        exec_refs_by_monitor: Map.put(state.exec_refs_by_monitor, monitor_ref, exec_ref)
+    }
   end
 
   defp apply_run_transition(%State{} = state, command) do
@@ -228,4 +360,14 @@ defmodule Favn.Runtime.Coordinator do
       state.steps |> Map.fetch!(ref) |> Map.get(:status) == :success
     end)
   end
+
+  defp unresolved_steps?(%State{} = state) do
+    Enum.any?(state.steps, fn {_ref, step} -> step.status in [:pending, :ready] end)
+  end
+
+  defp dispatch_allowed?(%State{} = state),
+    do: state.run_status == :running and state.admission_open?
+
+  defp capacity(%State{} = state),
+    do: max(state.max_concurrency - map_size(state.inflight_execs), 0)
 end

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -10,12 +10,12 @@ defmodule Favn.Runtime.Coordinator do
 
   alias Favn.Run.Context
   alias Favn.Runtime.Executor.Local
+
+  require Logger
   alias Favn.Runtime.Projector
   alias Favn.Runtime.State
   alias Favn.Runtime.Transitions.Run, as: RunTransitions
   alias Favn.Runtime.Transitions.Step, as: StepTransitions
-
-  @executor Application.compile_env(:favn, :runtime_executor, Local)
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts) when is_list(opts) do
@@ -116,7 +116,7 @@ defmodule Favn.Runtime.Coordinator do
          {:ok, asset} <- Favn.Registry.get_asset(ref),
          {:ok, deps} <- dependency_outputs(state, ref),
          {:ok, handle} <-
-           @executor.start_step(asset, build_context(state, ref), deps, self(), ref) do
+           executor_module().start_step(asset, build_context(state, ref), deps, self(), ref) do
       {:ok, put_execution_handle(state, ref, handle)}
     else
       {:error, reason} ->
@@ -139,18 +139,27 @@ defmodule Favn.Runtime.Coordinator do
          maybe_ref,
          {:ok, %{output: output, meta: meta}}
        ) do
-    with {:ok, ref, state} <- take_execution(state, exec_ref, maybe_ref) do
-      apply_step_transition(state, &StepTransitions.complete_success(&1, ref, output, meta))
+    case take_execution(state, exec_ref, maybe_ref) do
+      {:ok, ref, state} ->
+        apply_step_transition(state, &StepTransitions.complete_success(&1, ref, output, meta))
+
+      {:ignore, state} ->
+        {:ok, state}
     end
   end
 
   defp handle_step_result(%State{} = state, exec_ref, maybe_ref, {:error, error})
        when is_map(error) do
-    with {:ok, ref, state} <- take_execution(state, exec_ref, maybe_ref),
-         {:ok, state} <-
-           apply_step_transition(state, &StepTransitions.complete_failure(&1, ref, error)),
-         {:ok, state} <- close_admission_with_failure(state, ref, error[:reason]) do
-      {:ok, state}
+    case take_execution(state, exec_ref, maybe_ref) do
+      {:ok, ref, state} ->
+        with {:ok, state} <-
+               apply_step_transition(state, &StepTransitions.complete_failure(&1, ref, error)),
+             {:ok, state} <- close_admission_with_failure(state, ref, error[:reason]) do
+          {:ok, state}
+        end
+
+      {:ignore, state} ->
+        {:ok, state}
     end
   end
 
@@ -209,11 +218,15 @@ defmodule Favn.Runtime.Coordinator do
   defp take_execution(%State{} = state, exec_ref, maybe_ref) do
     case Map.pop(state.inflight_execs, exec_ref) do
       {nil, _} ->
-        {:ok, nil,
-         %{state | completed_exec_refs: MapSet.put(state.completed_exec_refs, exec_ref)}}
+        Logger.debug("Ignoring stale executor result for unknown exec_ref=#{inspect(exec_ref)}")
+        {:ignore, state}
 
       {%{ref: tracked_ref, monitor_ref: monitor_ref}, inflight} ->
-        ref = maybe_ref || tracked_ref
+        if maybe_ref != nil and maybe_ref != tracked_ref do
+          Logger.warning(
+            "Executor returned mismatched step ref; using tracked ref. exec_ref=#{inspect(exec_ref)} tracked_ref=#{inspect(tracked_ref)} received_ref=#{inspect(maybe_ref)}"
+          )
+        end
 
         next_state =
           state
@@ -221,14 +234,7 @@ defmodule Favn.Runtime.Coordinator do
           |> Map.put(:exec_refs_by_monitor, Map.delete(state.exec_refs_by_monitor, monitor_ref))
           |> Map.put(:completed_exec_refs, MapSet.put(state.completed_exec_refs, exec_ref))
 
-        {:ok, ref, next_state}
-    end
-    |> case do
-      {:ok, nil, next_state} ->
-        {:error, {:unknown_execution_result, exec_ref, maybe_ref, next_state.run_id}}
-
-      other ->
-        other
+        {:ok, tracked_ref, next_state}
     end
   end
 
@@ -370,4 +376,8 @@ defmodule Favn.Runtime.Coordinator do
 
   defp capacity(%State{} = state),
     do: max(state.max_concurrency - map_size(state.inflight_execs), 0)
+
+  defp executor_module do
+    Application.get_env(:favn, :runtime_executor, Local)
+  end
 end

--- a/lib/favn/runtime/executor.ex
+++ b/lib/favn/runtime/executor.ex
@@ -1,6 +1,6 @@
 defmodule Favn.Runtime.Executor do
   @moduledoc """
-  Behaviour boundary for single-step asset invocation.
+  Behaviour boundary for asynchronous single-step asset invocation.
   """
 
   alias Favn.Asset
@@ -17,5 +17,12 @@ defmodule Favn.Runtime.Executor do
           {:ok, %{output: term(), meta: map()}}
           | {:error, error_details()}
 
-  @callback execute_step(Asset.t(), Context.t(), map()) :: execution_result()
+  @type execution_handle :: %{
+          required(:exec_ref) => reference(),
+          required(:monitor_ref) => reference(),
+          required(:pid) => pid()
+        }
+
+  @callback start_step(Asset.t(), Context.t(), map(), pid(), Favn.asset_ref()) ::
+              {:ok, execution_handle()} | {:error, term()}
 end

--- a/lib/favn/runtime/executor/local.ex
+++ b/lib/favn/runtime/executor/local.ex
@@ -1,6 +1,6 @@
 defmodule Favn.Runtime.Executor.Local do
   @moduledoc """
-  Local task-based executor for invoking one asset function.
+  Local asynchronous executor for invoking one asset function.
   """
 
   @behaviour Favn.Runtime.Executor
@@ -10,9 +10,17 @@ defmodule Favn.Runtime.Executor.Local do
   alias Favn.Run.Context
 
   @impl true
-  def execute_step(%Asset{} = asset, %Context{} = ctx, deps) when is_map(deps) do
-    task = Task.async(fn -> invoke(asset, ctx, deps) end)
-    Task.await(task, :infinity)
+  def start_step(%Asset{} = asset, %Context{} = ctx, deps, reply_to, step_ref)
+      when is_map(deps) and is_pid(reply_to) do
+    exec_ref = make_ref()
+
+    {pid, monitor_ref} =
+      spawn_monitor(fn ->
+        result = invoke(asset, ctx, deps)
+        send(reply_to, {:executor_step_result, exec_ref, step_ref, result})
+      end)
+
+    {:ok, %{exec_ref: exec_ref, monitor_ref: monitor_ref, pid: pid}}
   end
 
   defp invoke(asset, %Context{} = ctx, deps) do

--- a/lib/favn/runtime/manager.ex
+++ b/lib/favn/runtime/manager.ex
@@ -28,10 +28,12 @@ defmodule Favn.Runtime.Manager do
   def handle_call({:submit_run, target_ref, opts}, _from, state) do
     dependencies = Keyword.get(opts, :dependencies, :all)
     params = Keyword.get(opts, :params, %{})
+    max_concurrency = resolve_max_concurrency(opts)
 
     with :ok <- validate_params(params),
+         :ok <- validate_max_concurrency(max_concurrency),
          {:ok, plan} <- Favn.plan_run(target_ref, dependencies: dependencies),
-         runtime_state <- build_runtime_state(plan, params),
+         runtime_state <- build_runtime_state(plan, params, max_concurrency),
          {:ok, pid} <- start_run_coordinator(runtime_state),
          :ok <- persist_initial_snapshot(runtime_state),
          :ok <- emit_run_created(runtime_state),
@@ -60,12 +62,13 @@ defmodule Favn.Runtime.Manager do
     {:noreply, %{state | run_monitors: remaining}}
   end
 
-  defp build_runtime_state(plan, params) do
+  defp build_runtime_state(plan, params, max_concurrency) do
     %State{
       run_id: new_run_id(),
       target_refs: plan.target_refs,
       plan: plan,
       params: params,
+      max_concurrency: max_concurrency,
       event_seq: 1,
       steps: build_steps(plan)
     }
@@ -156,6 +159,13 @@ defmodule Favn.Runtime.Manager do
 
   defp validate_params(params) when is_map(params), do: :ok
   defp validate_params(_), do: {:error, :invalid_run_params}
+
+  defp validate_max_concurrency(value) when is_integer(value) and value > 0, do: :ok
+  defp validate_max_concurrency(_), do: {:error, :invalid_max_concurrency}
+
+  defp resolve_max_concurrency(opts) do
+    Keyword.get(opts, :max_concurrency, Application.get_env(:favn, :runtime_max_concurrency, 1))
+  end
 
   defp new_run_id do
     binary = :crypto.strong_rand_bytes(16)

--- a/lib/favn/runtime/state.ex
+++ b/lib/favn/runtime/state.ex
@@ -10,12 +10,16 @@ defmodule Favn.Runtime.State do
   @type run_status ::
           :pending | :running | :cancelling | :cancelled | :success | :failed | :timed_out
 
+  @type exec_info :: %{ref: Ref.t(), monitor_ref: reference(), pid: pid()}
+
   @type t :: %__MODULE__{
           run_id: Favn.run_id(),
           run_status: run_status(),
           target_refs: [Ref.t()],
           plan: Plan.t(),
           params: map(),
+          max_concurrency: pos_integer(),
+          admission_open?: boolean(),
           event_seq: non_neg_integer(),
           started_at: DateTime.t() | nil,
           finished_at: DateTime.t() | nil,
@@ -25,6 +29,9 @@ defmodule Favn.Runtime.State do
           ready_queue: [Ref.t()],
           running_steps: MapSet.t(Ref.t()),
           completed_steps: MapSet.t(Ref.t()),
+          inflight_execs: %{reference() => exec_info()},
+          exec_refs_by_monitor: %{reference() => reference()},
+          completed_exec_refs: MapSet.t(reference()),
           outputs: %{Ref.t() => term()},
           run_error: term() | nil
         }
@@ -35,6 +42,8 @@ defmodule Favn.Runtime.State do
     :plan,
     run_status: :pending,
     params: %{},
+    max_concurrency: 1,
+    admission_open?: true,
     event_seq: 0,
     started_at: nil,
     finished_at: nil,
@@ -44,6 +53,9 @@ defmodule Favn.Runtime.State do
     ready_queue: [],
     running_steps: MapSet.new(),
     completed_steps: MapSet.new(),
+    inflight_execs: %{},
+    exec_refs_by_monitor: %{},
+    completed_exec_refs: MapSet.new(),
     outputs: %{},
     run_error: nil
   ]

--- a/lib/favn/runtime/transitions/step.ex
+++ b/lib/favn/runtime/transitions/step.ex
@@ -164,15 +164,18 @@ defmodule Favn.Runtime.Transitions.Step do
   defp unlock_downstream(%State{} = state, ref) do
     step = Map.fetch!(state.steps, ref)
 
-    Enum.reduce(step.downstream, {state, []}, fn downstream_ref, {acc, events} ->
-      downstream = Map.fetch!(acc.steps, downstream_ref)
+    ready_refs =
+      step.downstream
+      |> Enum.uniq()
+      |> Enum.filter(fn downstream_ref ->
+        downstream = Map.fetch!(state.steps, downstream_ref)
+        downstream.status == :pending and all_upstream_success?(state, downstream.upstream)
+      end)
+      |> Enum.sort()
 
-      if downstream.status == :pending and all_upstream_success?(acc, downstream.upstream) do
-        {:ok, next_acc, next_events} = mark_ready(acc, downstream_ref)
-        {next_acc, events ++ next_events}
-      else
-        {acc, events}
-      end
+    Enum.reduce(ready_refs, {state, []}, fn downstream_ref, {acc, events} ->
+      {:ok, next_acc, next_events} = mark_ready(acc, downstream_ref)
+      {next_acc, events ++ next_events}
     end)
   end
 

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -20,8 +20,90 @@ defmodule Favn.RunnerTest do
     def list_runs(_opts, _adapter_opts), do: {:ok, []}
   end
 
+  defmodule ProtocolTestExecutor do
+    @behaviour Favn.Runtime.Executor
+
+    alias Favn.Asset
+    alias Favn.Asset.Output
+    alias Favn.Run.Context
+
+    @impl true
+    def start_step(%Asset{} = asset, %Context{} = ctx, deps, reply_to, step_ref)
+        when is_map(deps) and is_pid(reply_to) do
+      exec_ref = make_ref()
+
+      {pid, monitor_ref} =
+        spawn_monitor(fn ->
+          mode = ctx.params[:executor_mode]
+          result = invoke(asset, ctx, deps)
+
+          case mode do
+            :mismatch_ref ->
+              send(
+                reply_to,
+                {:executor_step_result, exec_ref, {asset.module, :not_the_step}, result}
+              )
+
+            :duplicate_result ->
+              send(reply_to, {:executor_step_result, exec_ref, step_ref, result})
+              send(reply_to, {:executor_step_result, exec_ref, step_ref, result})
+
+            :late_after_down ->
+              sender =
+                spawn(fn ->
+                  Process.sleep(10)
+                  send(reply_to, {:executor_step_result, exec_ref, step_ref, result})
+                end)
+
+              Process.unlink(sender)
+              exit(:executor_down_before_result)
+
+            _ ->
+              send(reply_to, {:executor_step_result, exec_ref, step_ref, result})
+          end
+        end)
+
+      {:ok, %{exec_ref: exec_ref, monitor_ref: monitor_ref, pid: pid}}
+    end
+
+    defp invoke(asset, %Context{} = ctx, deps) do
+      try do
+        case apply(asset.module, asset.name, [ctx, deps]) do
+          {:ok, %Output{} = asset_output} ->
+            {:ok, %{output: asset_output.output, meta: asset_output.meta}}
+
+          {:error, reason} ->
+            {:error, %{kind: :error, reason: reason, stacktrace: []}}
+
+          other ->
+            {:error,
+             %{
+               kind: :error,
+               reason:
+                 {:invalid_return_shape, other,
+                  expected: "{:ok, %Favn.Asset.Output{}} | {:error, reason}"},
+               stacktrace: []
+             }}
+        end
+      rescue
+        error ->
+          {:error,
+           %{
+             kind: :error,
+             reason: error,
+             stacktrace: __STACKTRACE__,
+             message: Exception.message(error)
+           }}
+      catch
+        :throw, reason -> {:error, %{kind: :throw, reason: reason, stacktrace: __STACKTRACE__}}
+        :exit, reason -> {:error, %{kind: :exit, reason: reason, stacktrace: __STACKTRACE__}}
+      end
+    end
+  end
+
   setup do
     state = Favn.TestSetup.capture_state()
+    previous_runtime_executor = Application.get_env(:favn, :runtime_executor)
 
     :ok = Favn.TestSetup.setup_asset_modules([RunnerAssets], reload_graph?: true)
     :ok = Favn.TestSetup.configure_storage_adapter(Favn.Storage.Adapter.Memory, [])
@@ -29,6 +111,12 @@ defmodule Favn.RunnerTest do
 
     on_exit(fn ->
       Favn.TestSetup.restore_state(state, reload_graph?: true, clear_storage_adapter_env?: true)
+
+      if is_nil(previous_runtime_executor) do
+        Application.delete_env(:favn, :runtime_executor)
+      else
+        Application.put_env(:favn, :runtime_executor, previous_runtime_executor)
+      end
     end)
 
     :ok
@@ -353,6 +441,52 @@ defmodule Favn.RunnerTest do
     assert run.status == :error
     assert run.error == %{ref: {RunnerAssets, :hard_crash}, stage: 1, reason: :killed}
     assert run.asset_results[{RunnerAssets, :hard_crash}].error.kind == :exit
+  end
+
+  test "coordinator ignores mismatched ref in executor result and uses tracked ref" do
+    Application.put_env(:favn, :runtime_executor, ProtocolTestExecutor)
+
+    assert {:ok, run_id} =
+             Favn.run({RunnerAssets, :slow_asset},
+               max_concurrency: 1,
+               params: %{executor_mode: :mismatch_ref}
+             )
+
+    assert {:ok, run} = Favn.await_run(run_id)
+    assert run.status == :ok
+    assert run.outputs[{RunnerAssets, :slow_asset}] == :slow_ok
+  end
+
+  test "duplicate executor result for same exec_ref is ignored and does not crash coordinator" do
+    Application.put_env(:favn, :runtime_executor, ProtocolTestExecutor)
+
+    assert {:ok, run_id} =
+             Favn.run({RunnerAssets, :slow_asset},
+               max_concurrency: 1,
+               params: %{executor_mode: :duplicate_result}
+             )
+
+    assert {:ok, run} = Favn.await_run(run_id)
+    assert run.status == :ok
+  end
+
+  test "late executor result after DOWN handling is ignored and does not crash coordinator" do
+    Application.put_env(:favn, :runtime_executor, ProtocolTestExecutor)
+
+    assert {:ok, run_id} =
+             Favn.run({RunnerAssets, :slow_asset},
+               max_concurrency: 1,
+               params: %{executor_mode: :late_after_down}
+             )
+
+    assert {:error, run} = Favn.await_run(run_id)
+    assert run.status == :error
+
+    assert run.error == %{
+             ref: {RunnerAssets, :slow_asset},
+             stage: 0,
+             reason: :executor_down_before_result
+           }
   end
 
   test "run/2 returns immediately with a run id while execution continues" do

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -255,6 +255,106 @@ defmodule Favn.RunnerTest do
     assert {:error, :invalid_opts} = Favn.list_runs(status: :pending)
   end
 
+  test "executes independent ready steps in parallel with bounded concurrency" do
+    counter = :atomics.new(2, signed: false)
+
+    assert {:ok, run_id} =
+             Favn.run({RunnerAssets, :parallel_join},
+               max_concurrency: 2,
+               params: %{counter: counter}
+             )
+
+    assert {:ok, run} = Favn.await_run(run_id)
+
+    assert run.status == :ok
+    assert run.outputs[{RunnerAssets, :parallel_join}] == [:parallel_a, :parallel_b, :parallel_c]
+    assert :atomics.get(counter, 2) <= 2
+
+    join_started = run.asset_results[{RunnerAssets, :parallel_join}].started_at
+
+    latest_upstream_finish =
+      [:parallel_a, :parallel_b, :parallel_c]
+      |> Enum.map(fn name -> run.asset_results[{RunnerAssets, name}].finished_at end)
+      |> Enum.max(DateTime)
+
+    assert DateTime.compare(join_started, latest_upstream_finish) in [:eq, :gt]
+  end
+
+  test "admits ready steps deterministically while allowing non-deterministic completion" do
+    parent = self()
+
+    assert {:ok, run_id} =
+             Favn.run({RunnerAssets, :parallel_join},
+               max_concurrency: 2,
+               params: %{notify_pid: parent}
+             )
+
+    :ok = Favn.subscribe_run(run_id)
+    assert {:ok, _run} = Favn.await_run(run_id)
+
+    events =
+      Stream.repeatedly(fn ->
+        receive do
+          {:favn_run_event, event} -> event
+        after
+          250 -> :done
+        end
+      end)
+      |> Enum.take_while(&(&1 != :done))
+
+    started_order =
+      events
+      |> Enum.filter(&(&1.event == :step_started))
+      |> Enum.map(& &1.ref)
+      |> Enum.filter(fn {mod, name} ->
+        mod == RunnerAssets and name in [:parallel_a, :parallel_b, :parallel_c]
+      end)
+
+    assert started_order == [
+             {RunnerAssets, :parallel_a},
+             {RunnerAssets, :parallel_b},
+             {RunnerAssets, :parallel_c}
+           ]
+  end
+
+  test "first failure closes admission and unresolved work is skipped after inflight drains" do
+    counter = :atomics.new(2, signed: false)
+
+    assert {:ok, run_id} =
+             Favn.run({RunnerAssets, :parallel_terminal},
+               max_concurrency: 2,
+               params: %{counter: counter}
+             )
+
+    assert {:error, run} = Favn.await_run(run_id)
+
+    assert run.status == :error
+
+    assert run.error == %{
+             ref: {RunnerAssets, :parallel_fail},
+             stage: 1,
+             reason: :parallel_failure
+           }
+
+    case Map.get(run.asset_results, {RunnerAssets, :parallel_slow}) do
+      nil -> :ok
+      result -> assert result.status == :ok
+    end
+
+    refute Map.has_key?(run.asset_results, {RunnerAssets, :parallel_after_slow})
+    refute Map.has_key?(run.asset_results, {RunnerAssets, :parallel_terminal})
+    assert :atomics.get(counter, 2) <= 2
+  end
+
+  test "normalizes hard executor crashes into failed step results" do
+    assert {:ok, run_id} = Favn.run({RunnerAssets, :hard_crash}, max_concurrency: 1)
+    assert {:error, run} = Favn.await_run(run_id)
+
+    assert run.status == :error
+    assert run.error == %{ref: {RunnerAssets, :hard_crash}, stage: 1, reason: :killed}
+    assert run.asset_results[{RunnerAssets, :hard_crash}].error.kind == :exit
+  end
+
   test "run/2 returns immediately with a run id while execution continues" do
     assert {:ok, run_id} = Favn.run({RunnerAssets, :slow_asset})
     assert is_binary(run_id)

--- a/test/support/fixtures/assets/runner_assets.ex
+++ b/test/support/fixtures/assets/runner_assets.ex
@@ -70,6 +70,104 @@ defmodule Favn.Test.Fixtures.Assets.Runner.RunnerAssets do
        meta: %{row_count: 123, source: :test}
      }}
   end
+
+  @asset true
+  def parallel_root(_ctx, _deps), do: {:ok, %Favn.Asset.Output{output: :root}}
+
+  @asset depends_on: [:parallel_root]
+  def parallel_a(ctx, _deps), do: tracked_success(ctx, :parallel_a, 80)
+
+  @asset depends_on: [:parallel_root]
+  def parallel_b(ctx, _deps), do: tracked_success(ctx, :parallel_b, 80)
+
+  @asset depends_on: [:parallel_root]
+  def parallel_c(ctx, _deps), do: tracked_success(ctx, :parallel_c, 80)
+
+  @asset depends_on: [:parallel_a, :parallel_b, :parallel_c]
+  def parallel_join(_ctx, deps) do
+    values =
+      [:parallel_a, :parallel_b, :parallel_c]
+      |> Enum.map(&Map.fetch!(deps, {__MODULE__, &1}))
+      |> Enum.sort()
+
+    {:ok, %Favn.Asset.Output{output: values}}
+  end
+
+  @asset depends_on: [:parallel_root]
+  def parallel_fail(ctx, _deps) do
+    tracked_start(ctx, :parallel_fail)
+    Process.sleep(25)
+    tracked_finish(ctx, :parallel_fail)
+    {:error, :parallel_failure}
+  end
+
+  @asset depends_on: [:parallel_root]
+  def parallel_slow(ctx, _deps), do: tracked_success(ctx, :parallel_slow, 120)
+
+  @asset depends_on: [:parallel_slow]
+  def parallel_after_slow(ctx, _deps), do: tracked_success(ctx, :parallel_after_slow, 20)
+
+  @asset depends_on: [:parallel_fail, :parallel_after_slow]
+  def parallel_terminal(_ctx, _deps), do: {:ok, %Favn.Asset.Output{output: :never}}
+
+  @asset depends_on: [:parallel_root]
+  def hard_crash(_ctx, _deps) do
+    Process.exit(self(), :kill)
+  end
+
+  defp tracked_success(ctx, name, sleep_ms) do
+    tracked_start(ctx, name)
+    Process.sleep(sleep_ms)
+    tracked_finish(ctx, name)
+    {:ok, %Favn.Asset.Output{output: name}}
+  end
+
+  defp tracked_start(ctx, name) do
+    maybe_track_counter(ctx.params[:counter], 1)
+
+    if is_pid(ctx.params[:notify_pid]) do
+      send(ctx.params[:notify_pid], {:asset_started, name, System.monotonic_time(:millisecond)})
+    end
+
+    :ok
+  end
+
+  defp tracked_finish(ctx, name) do
+    maybe_track_counter(ctx.params[:counter], -1)
+
+    if is_pid(ctx.params[:notify_pid]) do
+      send(ctx.params[:notify_pid], {:asset_finished, name, System.monotonic_time(:millisecond)})
+    end
+
+    :ok
+  end
+
+  defp maybe_track_counter(nil, _delta), do: :ok
+
+  defp maybe_track_counter(counter, delta) do
+    current = :atomics.add_get(counter, 1, delta)
+
+    if delta > 0 do
+      update_max(counter, current)
+    end
+
+    :ok
+  end
+
+  defp update_max(counter, current) do
+    max_seen = :atomics.get(counter, 2)
+
+    cond do
+      current <= max_seen ->
+        :ok
+
+      :atomics.compare_exchange(counter, 2, max_seen, current) == :ok ->
+        :ok
+
+      true ->
+        update_max(counter, current)
+    end
+  end
 end
 
 defmodule Favn.Test.Fixtures.Assets.Runner.TerminalFailingStore do


### PR DESCRIPTION
### Motivation

- Enable independent ready steps to execute in parallel within a run while bounding concurrency at the run level via `max_concurrency`.
- Move single-step invocation to an asynchronous executor boundary to isolate crashes and support monitoring and backpressure.
- Ensure deterministic admission ordering for equally-ready refs while allowing nondeterministic completion order under parallel execution.
- Properly close admission and drain inflight work on first failure and normalize hard executor crashes into failed step results.

### Description

- Introduces `max_concurrency` as a `run/2` option and runtime config fallback, validates and wires it into runtime state via `Favn.Runtime.Manager` and `Favn.Runtime.State` (`max_concurrency`, `admission_open?`, `inflight_execs`, `exec_refs_by_monitor`, `completed_exec_refs`).
- Reworks the executor behaviour to asynchronous semantics by replacing `execute_step/3` with `start_step/5` and adding an `execution_handle` return shape, and implements this in `Favn.Runtime.Executor.Local` using `spawn_monitor` and message replies.
- Refactors `Favn.Runtime.Coordinator` to dispatch work up to capacity (`dispatch_ready_work` / `do_dispatch` / `start_step_execution`), handle executor results via `handle_info` messages (`:executor_step_result` and `:DOWN`), track inflight executions, clear monitors, and finalize runs when appropriate; adds helper functions for admission and capacity computation.
- Makes the downstream unlocking deterministic by deduping, sorting, and enqueuing newly-ready refs in `Favn.Runtime.Transitions.Step`.
- Adds test fixtures and unit tests validating parallel execution, deterministic admission, admission closing on first failure and draining, and crash normalization; updates `README.md` and `FEATURES.md` to document parallel execution behavior.

### Testing

- Ran the automated test suite via `mix test`, which completed successfully including new tests for concurrency and failure handling.
- New tests added in `test/runner_test.exs` covering `executes independent ready steps in parallel with bounded concurrency`, `admits ready steps deterministically while allowing non-deterministic completion`, `first failure closes admission and unresolved work is skipped after inflight drains`, and `normalizes hard executor crashes into failed step results`, and they passed.
- Existing unit tests were exercised as part of the full test run and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69c96732ddec83288c4926e0971ca9e6)