### PR TITLE
Add run cancellation and timeout support (engine, coordinator, executor, storage, docs, tests)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -61,8 +61,8 @@ Turns Favn into a real execution engine with durable state and concurrency.
 - [x] Parallel execution with bounded concurrency
 - [x] Run + step state machine (pending → running → success/failure)
 - [ ] Retry mechanism (configurable)
-- [ ] Cancellation support
-- [ ] Timeout handling
+- [x] Cancellation support
+- [x] Timeout handling
 - [ ] SQLite storage adapter
 - [ ] Stable event schema (runs + steps)
 - [ ] Telemetry integration

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Key settings:
   - `Favn.run/2` returns `{:ok, run_id}` when a run is submitted.
   - Step admission order is deterministic for equally-ready refs; completion order is naturally non-deterministic under parallel execution.
   - `Favn.cancel_run/1` requests cancellation and returns a cancellation acknowledgement tuple.
-  - `Favn.await_run/2` returns `{:ok, %Favn.Run{status: :ok}}` on success, `{:ok, %Favn.Run{status: :cancelled}}` on cancellation, or `{:error, %Favn.Run{status: :error | :timed_out}}` on failure/timeout.
+  - `Favn.await_run/2` returns `{:ok, %Favn.Run{status: :ok}}` on success or `{:error, %Favn.Run{status: :error | :cancelled | :timed_out}}` on non-success terminal outcomes.
   - Failed runs preserve structured failure context in both `run.error` and `run.asset_results[ref].error`.
   - `Favn.get_run/1` returns the latest stored run state for an ID.
 - **Storage error contract**

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Key settings:
 ## Runtime behavior in this release
 
 - **Planning and orchestration**: Favn plans dependency-aware runs with deterministic topological stages and orchestrates execution through a run-scoped coordinator with bounded parallel step dispatch per run.
-- **Run lifecycle**: runtime orchestration now uses explicit internal run and step state machines; the public `%Favn.Run{}` projection remains compatible with `:running | :ok | :error`.
+- **Run lifecycle**: runtime orchestration now uses explicit internal run and step state machines; public run status includes `:running | :ok | :error | :cancelled | :timed_out`.
 - **Execution boundary**: one-step asset invocation is isolated behind an asynchronous runtime executor boundary.
 - **Storage facade contract**: run retrieval/listing APIs normalize storage failures to one of:
   - `:not_found`
@@ -131,7 +131,8 @@ Key settings:
 - **Run lifecycle semantics**
   - `Favn.run/2` returns `{:ok, run_id}` when a run is submitted.
   - Step admission order is deterministic for equally-ready refs; completion order is naturally non-deterministic under parallel execution.
-  - `Favn.await_run/2` returns `{:ok, %Favn.Run{status: :ok}}` on success or `{:error, %Favn.Run{status: :error}}` on execution failure.
+  - `Favn.cancel_run/1` requests cancellation and returns a cancellation acknowledgement tuple.
+  - `Favn.await_run/2` returns `{:ok, %Favn.Run{status: :ok}}` on success, `{:ok, %Favn.Run{status: :cancelled}}` on cancellation, or `{:error, %Favn.Run{status: :error | :timed_out}}` on failure/timeout.
   - Failed runs preserve structured failure context in both `run.error` and `run.asset_results[ref].error`.
   - `Favn.get_run/1` returns the latest stored run state for an ID.
 - **Storage error contract**
@@ -146,7 +147,7 @@ Key settings:
 - Durable distributed execution guarantees across nodes.
 - Exactly-once event delivery, replay, or durable event logs.
 - Persistent storage guarantees beyond the configured adapter behavior (default adapter is in-memory and node-local).
-- Global concurrency fairness across runs, retries, cancellation of already-running work, and timeout enforcement.
+- Global concurrency fairness across runs and retries.
 
 ## Roadmap and release focus
 

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -706,10 +706,17 @@ defmodule Favn do
     * `{:ok, :cancelled}` when run is already cancelled
     * `{:ok, :already_terminal}` when run already reached a non-cancel terminal status
     * `{:error, :not_found}` when run ID does not exist
+    * `{:error, :coordinator_unavailable}` when run appears running but no live coordinator is available
+    * `{:error, :timeout_in_progress}` when timeout terminalization is already in progress
   """
   @spec cancel_run(run_id()) ::
           {:ok, :cancelling | :cancelled | :already_terminal}
-          | {:error, :not_found | :invalid_run_id | term()}
+          | {:error,
+             :not_found
+             | :invalid_run_id
+             | :coordinator_unavailable
+             | :timeout_in_progress
+             | term()}
   def cancel_run(run_id) do
     Favn.Runtime.Engine.cancel_run(run_id)
   end
@@ -725,7 +732,7 @@ defmodule Favn do
   Returns:
 
     * `{:ok, %Favn.Run{status: :ok}}` on successful completion
-    * `{:ok, %Favn.Run{status: :cancelled}}` when cancellation completes
+    * `{:error, %Favn.Run{status: :cancelled}}` when cancellation completes
     * `{:error, %Favn.Run{status: :error}}` when the run fails
     * `{:error, %Favn.Run{status: :timed_out}}` when the run times out
     * `{:error, :not_found}` when the run ID does not exist

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -323,7 +323,7 @@ defmodule Favn do
   Filter options for `list_runs/1`.
   """
   @type list_runs_opts :: [
-          status: :running | :ok | :error,
+          status: :running | :ok | :error | :cancelled | :timed_out,
           limit: pos_integer()
         ]
 
@@ -338,7 +338,8 @@ defmodule Favn do
   @type run_opts :: [
           dependencies: dependencies_mode(),
           params: map(),
-          max_concurrency: pos_integer()
+          max_concurrency: pos_integer(),
+          timeout_ms: pos_integer()
         ]
 
   @typedoc """
@@ -659,6 +660,7 @@ defmodule Favn do
       * `dependencies: :all | :none` (default `:all`)
       * `params: map()` (default `%{}`)
       * `max_concurrency: pos_integer()` (default from runtime config, fallback `1`)
+      * `timeout_ms: pos_integer()` timeout counted from run start
 
   Deterministic behavior:
 
@@ -696,6 +698,23 @@ defmodule Favn do
   end
 
   @doc """
+  Request cancellation of a submitted run.
+
+  Returns:
+
+    * `{:ok, :cancelling}` when cancellation request is accepted
+    * `{:ok, :cancelled}` when run is already cancelled
+    * `{:ok, :already_terminal}` when run already reached a non-cancel terminal status
+    * `{:error, :not_found}` when run ID does not exist
+  """
+  @spec cancel_run(run_id()) ::
+          {:ok, :cancelling | :cancelled | :already_terminal}
+          | {:error, :not_found | :invalid_run_id | term()}
+  def cancel_run(run_id) do
+    Favn.Runtime.Engine.cancel_run(run_id)
+  end
+
+  @doc """
   Block until one submitted run reaches a terminal state.
 
   Accepted options:
@@ -706,7 +725,9 @@ defmodule Favn do
   Returns:
 
     * `{:ok, %Favn.Run{status: :ok}}` on successful completion
+    * `{:ok, %Favn.Run{status: :cancelled}}` when cancellation completes
     * `{:error, %Favn.Run{status: :error}}` when the run fails
+    * `{:error, %Favn.Run{status: :timed_out}}` when the run times out
     * `{:error, :not_found}` when the run ID does not exist
     * `{:error, :timeout}` when timeout elapses before terminal state
     * `{:error, reason}` for storage retrieval failures
@@ -746,7 +767,7 @@ defmodule Favn do
 
   Accepted options:
 
-    * `status: :running | :ok | :error`
+    * `status: :running | :ok | :error | :cancelled | :timed_out`
     * `limit: positive_integer()`
 
   Deterministic behavior:

--- a/lib/favn/run.ex
+++ b/lib/favn/run.ex
@@ -9,7 +9,7 @@ defmodule Favn.Run do
   alias Favn.Ref
   alias Favn.Run.AssetResult
 
-  @type status :: :running | :ok | :error
+  @type status :: :running | :ok | :error | :cancelled | :timed_out
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -23,7 +23,8 @@ defmodule Favn.Run do
           outputs: %{Ref.t() => term()},
           target_outputs: %{Ref.t() => term()},
           asset_results: %{Ref.t() => AssetResult.t()},
-          error: term() | nil
+          error: term() | nil,
+          terminal_reason: map() | nil
         }
 
   defstruct [
@@ -38,6 +39,7 @@ defmodule Favn.Run do
     outputs: %{},
     target_outputs: %{},
     asset_results: %{},
-    error: nil
+    error: nil,
+    terminal_reason: nil
   ]
 end

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -30,6 +30,7 @@ defmodule Favn.Runtime.Coordinator do
   @impl true
   def handle_cast(:start_run, %{state: state} = data) do
     with {:ok, state} <- apply_run_transition(state, :start),
+         {:ok, state} <- maybe_schedule_timeout(state),
          {:ok, state} <- emit_step_ready_for_sources(state),
          {:ok, state} <- dispatch_ready_work(state),
          {:ok, state} <- maybe_finalize_terminal(state) do
@@ -37,6 +38,16 @@ defmodule Favn.Runtime.Coordinator do
     else
       {:error, reason} ->
         {:stop, reason, data}
+    end
+  end
+
+  @impl true
+  def handle_cast({:cancel_run, reason}, %{state: state} = data) when is_map(reason) do
+    with {:ok, state} <- request_cancellation(state, reason),
+         {:ok, state} <- maybe_finalize_terminal(state) do
+      {:noreply, %{data | state: state}}
+    else
+      {:error, reason} -> {:stop, reason, data}
     end
   end
 
@@ -49,6 +60,16 @@ defmodule Favn.Runtime.Coordinator do
     else
       {:error, reason} ->
         {:stop, reason, data}
+    end
+  end
+
+  @impl true
+  def handle_info(:run_deadline_reached, %{state: state} = data) do
+    with {:ok, state} <- request_timeout(state),
+         {:ok, state} <- maybe_finalize_terminal(state) do
+      {:noreply, %{data | state: state}}
+    else
+      {:error, reason} -> {:stop, reason, data}
     end
   end
 
@@ -152,14 +173,32 @@ defmodule Favn.Runtime.Coordinator do
        when is_map(error) do
     case take_execution(state, exec_ref, maybe_ref) do
       {:ok, ref, state} ->
-        with {:ok, state} <-
-               apply_step_transition(state, &StepTransitions.complete_failure(&1, ref, error)),
-             {:ok, state} <- close_admission_with_failure(state, ref, error[:reason]) do
-          {:ok, state}
-        end
+        handle_terminal_step_error(state, ref, error)
 
       {:ignore, state} ->
         {:ok, state}
+    end
+  end
+
+  defp handle_terminal_step_error(%State{run_status: :cancelling} = state, ref, _error) do
+    apply_step_transition(
+      state,
+      &StepTransitions.complete_cancelled(&1, ref, %{kind: :run_cancelled})
+    )
+  end
+
+  defp handle_terminal_step_error(%State{run_status: :timing_out} = state, ref, _error) do
+    apply_step_transition(
+      state,
+      &StepTransitions.complete_timed_out(&1, ref, %{kind: :run_timed_out})
+    )
+  end
+
+  defp handle_terminal_step_error(%State{} = state, ref, error) do
+    with {:ok, state} <-
+           apply_step_transition(state, &StepTransitions.complete_failure(&1, ref, error)),
+         {:ok, state} <- close_admission_with_failure(state, ref, error[:reason]) do
+      {:ok, state}
     end
   end
 
@@ -190,11 +229,33 @@ defmodule Favn.Runtime.Coordinator do
     end
   end
 
+  defp maybe_finalize_terminal(%State{run_status: :cancelling} = state) do
+    if map_size(state.inflight_execs) == 0 do
+      with {:ok, state} <- maybe_finalize_unresolved(state, :cancelled),
+           {:ok, state} <- apply_run_transition(state, :mark_cancelled) do
+        {:ok, state}
+      end
+    else
+      {:ok, state}
+    end
+  end
+
+  defp maybe_finalize_terminal(%State{run_status: :timing_out} = state) do
+    if map_size(state.inflight_execs) == 0 do
+      with {:ok, state} <- maybe_finalize_unresolved(state, :timed_out),
+           {:ok, state} <- apply_run_transition(state, :mark_timed_out) do
+        {:ok, state}
+      end
+    else
+      {:ok, state}
+    end
+  end
+
   defp maybe_finalize_terminal(%State{} = state), do: {:ok, state}
 
-  defp maybe_finalize_unresolved(%State{} = state) do
+  defp maybe_finalize_unresolved(%State{} = state, replacement_status \\ :skipped) do
     if unresolved_steps?(state) do
-      apply_finalize_unresolved(state, :skipped)
+      apply_finalize_unresolved(state, replacement_status)
     else
       {:ok, state}
     end
@@ -214,6 +275,51 @@ defmodule Favn.Runtime.Coordinator do
   defp maybe_mark_run_failed(%State{} = state, _reason), do: {:ok, state}
 
   defp close_admission(%State{} = state), do: {:ok, %{state | admission_open?: false}}
+
+  defp request_cancellation(%State{run_status: :pending} = state, reason) do
+    with {:ok, state} <- apply_run_transition(state, :start),
+         {:ok, state} <- request_cancellation(state, reason) do
+      {:ok, state}
+    end
+  end
+
+  defp request_cancellation(%State{run_status: :running} = state, reason) do
+    with {:ok, state} <- apply_run_transition(state, :request_cancel),
+         {:ok, state} <- close_admission(state),
+         {:ok, state} <- interrupt_inflight(state, Map.put(reason, :kind, :run_cancelled)) do
+      {:ok, state}
+    end
+  end
+
+  defp request_cancellation(%State{run_status: :cancelling} = state, _reason), do: {:ok, state}
+  defp request_cancellation(%State{} = state, _reason), do: {:ok, state}
+
+  defp request_timeout(%State{run_status: :running} = state) do
+    with {:ok, state} <- apply_run_transition(state, :request_timeout),
+         {:ok, state} <- close_admission(state),
+         {:ok, state} <- interrupt_inflight(state, %{kind: :run_timed_out}) do
+      {:ok, state}
+    end
+  end
+
+  defp request_timeout(%State{} = state), do: {:ok, state}
+
+  defp interrupt_inflight(%State{} = state, reason) do
+    result =
+      Enum.reduce_while(state.inflight_execs, :ok, fn {exec_ref, exec_info}, :ok ->
+        handle = %{exec_ref: exec_ref, monitor_ref: exec_info.monitor_ref, pid: exec_info.pid}
+
+        case executor_module().cancel_step(handle, reason) do
+          :ok -> {:cont, :ok}
+          {:error, err} -> {:halt, {:error, err}}
+        end
+      end)
+
+    case result do
+      :ok -> {:ok, state}
+      {:error, reason} -> {:error, {:executor_cancel_failed, reason}}
+    end
+  end
 
   defp take_execution(%State{} = state, exec_ref, maybe_ref) do
     case Map.pop(state.inflight_execs, exec_ref) do
@@ -315,13 +421,31 @@ defmodule Favn.Runtime.Coordinator do
     {:ok, state}
   end
 
+  defp maybe_schedule_timeout(%State{timeout_ms: nil} = state), do: {:ok, state}
+
+  defp maybe_schedule_timeout(%State{timeout_ms: timeout_ms} = state)
+       when is_integer(timeout_ms) and timeout_ms > 0 do
+    timer_ref = Process.send_after(self(), :run_deadline_reached, timeout_ms)
+    deadline_at = DateTime.add(state.started_at || DateTime.utc_now(), timeout_ms, :millisecond)
+    {:ok, %{state | timeout_timer_ref: timer_ref, deadline_at: deadline_at}}
+  end
+
   defp event_attrs(%State{} = state, {event_name, ref}) do
     stage = stage_for(state, ref)
     {event_name, %{ref: ref, stage: stage}}
   end
 
   defp event_attrs(%State{} = state, event_name) when is_atom(event_name) do
-    payload = if event_name == :run_failed, do: %{error: state.run_error}, else: %{}
+    payload =
+      case event_name do
+        :run_failed -> %{error: state.run_error, terminal_reason: state.run_terminal_reason}
+        :run_cancel_requested -> %{terminal_reason: state.run_terminal_reason}
+        :run_cancelled -> %{terminal_reason: state.run_terminal_reason}
+        :run_timeout_triggered -> %{terminal_reason: state.run_terminal_reason}
+        :run_timed_out -> %{terminal_reason: state.run_terminal_reason}
+        _ -> %{}
+      end
+
     {event_name, %{payload: payload}}
   end
 

--- a/lib/favn/runtime/engine.ex
+++ b/lib/favn/runtime/engine.ex
@@ -12,7 +12,12 @@ defmodule Favn.Runtime.Engine do
 
   @spec cancel_run(Favn.run_id()) ::
           {:ok, :cancelling | :cancelled | :already_terminal}
-          | {:error, :not_found | :invalid_run_id | term()}
+          | {:error,
+             :not_found
+             | :invalid_run_id
+             | :coordinator_unavailable
+             | :timeout_in_progress
+             | term()}
   def cancel_run(run_id) do
     Favn.Runtime.Manager.cancel_run(run_id)
   end
@@ -37,7 +42,7 @@ defmodule Favn.Runtime.Engine do
         end
 
       {:ok, %Favn.Run{} = run} ->
-        if run.status in [:ok, :cancelled], do: {:ok, run}, else: {:error, run}
+        if run.status == :ok, do: {:ok, run}, else: {:error, run}
 
       {:error, :not_found} ->
         {:error, :not_found}

--- a/lib/favn/runtime/engine.ex
+++ b/lib/favn/runtime/engine.ex
@@ -10,6 +10,13 @@ defmodule Favn.Runtime.Engine do
     Favn.Runtime.Manager.submit_run(target_ref, opts)
   end
 
+  @spec cancel_run(Favn.run_id()) ::
+          {:ok, :cancelling | :cancelled | :already_terminal}
+          | {:error, :not_found | :invalid_run_id | term()}
+  def cancel_run(run_id) do
+    Favn.Runtime.Manager.cancel_run(run_id)
+  end
+
   @spec await_run(Favn.run_id(), keyword()) :: {:ok, Favn.Run.t()} | {:error, term()}
   def await_run(run_id, opts \\ []) when is_list(opts) do
     timeout = Keyword.get(opts, :timeout, :infinity)
@@ -30,7 +37,7 @@ defmodule Favn.Runtime.Engine do
         end
 
       {:ok, %Favn.Run{} = run} ->
-        if run.status == :ok, do: {:ok, run}, else: {:error, run}
+        if run.status in [:ok, :cancelled], do: {:ok, run}, else: {:error, run}
 
       {:error, :not_found} ->
         {:error, :not_found}

--- a/lib/favn/runtime/events.ex
+++ b/lib/favn/runtime/events.ex
@@ -12,6 +12,7 @@ defmodule Favn.Runtime.Events do
           | :run_started
           | :run_cancel_requested
           | :run_cancelled
+          | :run_timeout_triggered
           | :run_failed
           | :run_finished
           | :run_timed_out

--- a/lib/favn/runtime/executor.ex
+++ b/lib/favn/runtime/executor.ex
@@ -25,4 +25,6 @@ defmodule Favn.Runtime.Executor do
 
   @callback start_step(Asset.t(), Context.t(), map(), pid(), Favn.asset_ref()) ::
               {:ok, execution_handle()} | {:error, term()}
+
+  @callback cancel_step(execution_handle(), map()) :: :ok | {:error, term()}
 end

--- a/lib/favn/runtime/executor/local.ex
+++ b/lib/favn/runtime/executor/local.ex
@@ -23,6 +23,14 @@ defmodule Favn.Runtime.Executor.Local do
     {:ok, %{exec_ref: exec_ref, monitor_ref: monitor_ref, pid: pid}}
   end
 
+  @impl true
+  def cancel_step(%{pid: pid}, _reason) when is_pid(pid) do
+    Process.exit(pid, :kill)
+    :ok
+  rescue
+    error -> {:error, error}
+  end
+
   defp invoke(asset, %Context{} = ctx, deps) do
     try do
       case apply(asset.module, asset.name, [ctx, deps]) do

--- a/lib/favn/runtime/manager.ex
+++ b/lib/favn/runtime/manager.ex
@@ -21,25 +21,41 @@ defmodule Favn.Runtime.Manager do
     GenServer.call(__MODULE__, {:submit_run, target_ref, opts}, :infinity)
   end
 
+  @spec cancel_run(Favn.run_id()) ::
+          {:ok, :cancelling | :cancelled | :already_terminal}
+          | {:error, :not_found | :invalid_run_id | term()}
+  def cancel_run(run_id) when is_binary(run_id) do
+    GenServer.call(__MODULE__, {:cancel_run, run_id}, :infinity)
+  end
+
+  def cancel_run(_run_id), do: {:error, :invalid_run_id}
+
   @impl true
-  def init(_opts), do: {:ok, %{run_monitors: %{}}}
+  def init(_opts), do: {:ok, %{run_monitors: %{}, run_pids: %{}}}
 
   @impl true
   def handle_call({:submit_run, target_ref, opts}, _from, state) do
     dependencies = Keyword.get(opts, :dependencies, :all)
     params = Keyword.get(opts, :params, %{})
     max_concurrency = resolve_max_concurrency(opts)
+    timeout_ms = Keyword.get(opts, :timeout_ms)
 
     with :ok <- validate_params(params),
          :ok <- validate_max_concurrency(max_concurrency),
+         :ok <- validate_timeout_ms(timeout_ms),
          {:ok, plan} <- Favn.plan_run(target_ref, dependencies: dependencies),
-         runtime_state <- build_runtime_state(plan, params, max_concurrency),
+         runtime_state <- build_runtime_state(plan, params, max_concurrency, timeout_ms),
          {:ok, pid} <- start_run_coordinator(runtime_state),
          :ok <- persist_initial_snapshot(runtime_state),
          :ok <- emit_run_created(runtime_state),
          :ok <- kickoff_run(pid) do
       ref = Process.monitor(pid)
-      next_state = put_in(state, [:run_monitors, ref], runtime_state.run_id)
+
+      next_state =
+        state
+        |> put_in([:run_monitors, ref], runtime_state.run_id)
+        |> put_in([:run_pids, runtime_state.run_id], pid)
+
       {:reply, {:ok, runtime_state.run_id}, next_state}
     else
       {:start_failed_after_spawn, pid, reason} ->
@@ -52,23 +68,55 @@ defmodule Favn.Runtime.Manager do
   end
 
   @impl true
+  def handle_call({:cancel_run, run_id}, _from, state) do
+    reply =
+      case Favn.Storage.get_run(run_id) do
+        {:ok, %{status: :cancelled}} ->
+          {:ok, :cancelled}
+
+        {:ok, %{status: :running}} ->
+          case Map.fetch(state.run_pids, run_id) do
+            {:ok, pid} ->
+              GenServer.cast(pid, {:cancel_run, %{requested_by: :api}})
+              {:ok, :cancelling}
+
+            :error ->
+              {:ok, :cancelling}
+          end
+
+        {:ok, _run} ->
+          {:ok, :already_terminal}
+
+        {:error, :not_found} ->
+          {:error, :not_found}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+
+    {:reply, reply, state}
+  end
+
+  @impl true
   def handle_info({:DOWN, ref, :process, _pid, reason}, state) do
     {run_id, remaining} = Map.pop(state.run_monitors, ref)
+    run_pids = if run_id, do: Map.delete(state.run_pids, run_id), else: state.run_pids
 
     if run_id do
       maybe_finalize_crashed_run(run_id, reason)
     end
 
-    {:noreply, %{state | run_monitors: remaining}}
+    {:noreply, %{state | run_monitors: remaining, run_pids: run_pids}}
   end
 
-  defp build_runtime_state(plan, params, max_concurrency) do
+  defp build_runtime_state(plan, params, max_concurrency, timeout_ms) do
     %State{
       run_id: new_run_id(),
       target_refs: plan.target_refs,
       plan: plan,
       params: params,
       max_concurrency: max_concurrency,
+      timeout_ms: timeout_ms,
       event_seq: 1,
       steps: build_steps(plan)
     }
@@ -127,7 +175,7 @@ defmodule Favn.Runtime.Manager do
 
   defp maybe_finalize_crashed_run(run_id, reason) do
     with {:ok, run} <- Favn.Storage.get_run(run_id),
-         true <- run.status == :running do
+         true <- run.status in [:running] do
       failed =
         %{
           run
@@ -162,6 +210,10 @@ defmodule Favn.Runtime.Manager do
 
   defp validate_max_concurrency(value) when is_integer(value) and value > 0, do: :ok
   defp validate_max_concurrency(_), do: {:error, :invalid_max_concurrency}
+
+  defp validate_timeout_ms(nil), do: :ok
+  defp validate_timeout_ms(value) when is_integer(value) and value > 0, do: :ok
+  defp validate_timeout_ms(_), do: {:error, :invalid_timeout_ms}
 
   defp resolve_max_concurrency(opts) do
     Keyword.get(opts, :max_concurrency, Application.get_env(:favn, :runtime_max_concurrency, 1))

--- a/lib/favn/runtime/manager.ex
+++ b/lib/favn/runtime/manager.ex
@@ -23,7 +23,12 @@ defmodule Favn.Runtime.Manager do
 
   @spec cancel_run(Favn.run_id()) ::
           {:ok, :cancelling | :cancelled | :already_terminal}
-          | {:error, :not_found | :invalid_run_id | term()}
+          | {:error,
+             :not_found
+             | :invalid_run_id
+             | :coordinator_unavailable
+             | :timeout_in_progress
+             | term()}
   def cancel_run(run_id) when is_binary(run_id) do
     GenServer.call(__MODULE__, {:cancel_run, run_id}, :infinity)
   end
@@ -74,14 +79,15 @@ defmodule Favn.Runtime.Manager do
         {:ok, %{status: :cancelled}} ->
           {:ok, :cancelled}
 
-        {:ok, %{status: :running}} ->
-          case Map.fetch(state.run_pids, run_id) do
-            {:ok, pid} ->
-              GenServer.cast(pid, {:cancel_run, %{requested_by: :api}})
-              {:ok, :cancelling}
+        {:ok, %{status: :running, terminal_reason: %{kind: :timed_out}}} ->
+          {:error, :timeout_in_progress}
 
-            :error ->
-              {:ok, :cancelling}
+        {:ok, %{status: :running}} ->
+          with {:ok, pid} <- Map.fetch(state.run_pids, run_id) do
+            GenServer.cast(pid, {:cancel_run, %{requested_by: :api}})
+            {:ok, :cancelling}
+          else
+            :error -> {:error, :coordinator_unavailable}
           end
 
         {:ok, _run} ->

--- a/lib/favn/runtime/projector.ex
+++ b/lib/favn/runtime/projector.ex
@@ -23,13 +23,16 @@ defmodule Favn.Runtime.Projector do
       outputs: state.outputs,
       target_outputs: target_outputs,
       asset_results: build_asset_results(state),
-      error: state.run_error
+      error: state.run_error,
+      terminal_reason: state.run_terminal_reason
     }
   end
 
   defp public_status(:pending), do: :running
-  defp public_status(status) when status in [:running, :cancelling], do: :running
+  defp public_status(status) when status in [:running, :cancelling, :timing_out], do: :running
   defp public_status(:success), do: :ok
+  defp public_status(:cancelled), do: :cancelled
+  defp public_status(:timed_out), do: :timed_out
   defp public_status(_status), do: :error
 
   defp build_asset_results(%State{} = state) do

--- a/lib/favn/runtime/state.ex
+++ b/lib/favn/runtime/state.ex
@@ -8,7 +8,14 @@ defmodule Favn.Runtime.State do
   alias Favn.Runtime.StepState
 
   @type run_status ::
-          :pending | :running | :cancelling | :cancelled | :success | :failed | :timed_out
+          :pending
+          | :running
+          | :cancelling
+          | :cancelled
+          | :timing_out
+          | :success
+          | :failed
+          | :timed_out
 
   @type exec_info :: %{ref: Ref.t(), monitor_ref: reference(), pid: pid()}
 
@@ -24,7 +31,9 @@ defmodule Favn.Runtime.State do
           started_at: DateTime.t() | nil,
           finished_at: DateTime.t() | nil,
           cancel_requested_at: DateTime.t() | nil,
+          timeout_ms: pos_integer() | nil,
           deadline_at: DateTime.t() | nil,
+          timeout_timer_ref: reference() | nil,
           steps: %{Ref.t() => StepState.t()},
           ready_queue: [Ref.t()],
           running_steps: MapSet.t(Ref.t()),
@@ -33,7 +42,8 @@ defmodule Favn.Runtime.State do
           exec_refs_by_monitor: %{reference() => reference()},
           completed_exec_refs: MapSet.t(reference()),
           outputs: %{Ref.t() => term()},
-          run_error: term() | nil
+          run_error: term() | nil,
+          run_terminal_reason: map() | nil
         }
 
   defstruct [
@@ -48,7 +58,9 @@ defmodule Favn.Runtime.State do
     started_at: nil,
     finished_at: nil,
     cancel_requested_at: nil,
+    timeout_ms: nil,
     deadline_at: nil,
+    timeout_timer_ref: nil,
     steps: %{},
     ready_queue: [],
     running_steps: MapSet.new(),
@@ -57,6 +69,7 @@ defmodule Favn.Runtime.State do
     exec_refs_by_monitor: %{},
     completed_exec_refs: MapSet.new(),
     outputs: %{},
-    run_error: nil
+    run_error: nil,
+    run_terminal_reason: nil
   ]
 end

--- a/lib/favn/runtime/step_state.ex
+++ b/lib/favn/runtime/step_state.ex
@@ -19,7 +19,8 @@ defmodule Favn.Runtime.StepState do
           duration_ms: non_neg_integer() | nil,
           output: term() | nil,
           meta: map(),
-          error: map() | nil
+          error: map() | nil,
+          terminal_reason: term() | nil
         }
 
   defstruct [
@@ -33,6 +34,7 @@ defmodule Favn.Runtime.StepState do
     duration_ms: nil,
     output: nil,
     meta: %{},
-    error: nil
+    error: nil,
+    terminal_reason: nil
   ]
 end

--- a/lib/favn/runtime/transitions/run.ex
+++ b/lib/favn/runtime/transitions/run.ex
@@ -9,7 +9,13 @@ defmodule Favn.Runtime.Transitions.Run do
 
   @spec apply(
           State.t(),
-          :start | :mark_success | {:mark_failed, term()} | :request_cancel | :mark_cancelled
+          :start
+          | :mark_success
+          | {:mark_failed, term()}
+          | :request_cancel
+          | :mark_cancelled
+          | :request_timeout
+          | :mark_timed_out
         ) ::
           {:ok, State.t(), [atom()]} | {:error, transition_error()}
   def apply(%State{run_status: :pending} = state, :start) do
@@ -24,17 +30,71 @@ defmodule Favn.Runtime.Transitions.Run do
 
   def apply(%State{run_status: :running} = state, {:mark_failed, reason}) do
     now = DateTime.utc_now()
-    {:ok, %{state | run_status: :failed, finished_at: now, run_error: reason}, [:run_failed]}
+
+    {:ok,
+     %{
+       state
+       | run_status: :failed,
+         finished_at: now,
+         run_error: reason,
+         run_terminal_reason: %{kind: :failed, reason: reason}
+     }, [:run_failed]}
   end
 
   def apply(%State{run_status: :running} = state, :request_cancel) do
-    {:ok, %{state | run_status: :cancelling, cancel_requested_at: DateTime.utc_now()},
-     [:run_cancel_requested]}
+    requested_at = DateTime.utc_now()
+
+    {:ok,
+     %{
+       state
+       | run_status: :cancelling,
+         cancel_requested_at: requested_at,
+         run_terminal_reason: %{kind: :cancel_requested, requested_at: requested_at}
+     }, [:run_cancel_requested]}
   end
 
   def apply(%State{run_status: :cancelling} = state, :mark_cancelled) do
     now = DateTime.utc_now()
-    {:ok, %{state | run_status: :cancelled, finished_at: now}, [:run_cancelled]}
+
+    {:ok,
+     %{
+       state
+       | run_status: :cancelled,
+         finished_at: now,
+         run_terminal_reason: %{
+           kind: :cancelled,
+           requested_at: state.cancel_requested_at,
+           finished_at: now
+         }
+     }, [:run_cancelled]}
+  end
+
+  def apply(%State{run_status: :running} = state, :request_timeout) do
+    triggered_at = DateTime.utc_now()
+
+    {:ok,
+     %{
+       state
+       | run_status: :timing_out,
+         run_terminal_reason: %{
+           kind: :timed_out,
+           deadline_at: state.deadline_at,
+           triggered_at: triggered_at
+         }
+     }, [:run_timeout_triggered]}
+  end
+
+  def apply(%State{run_status: :timing_out} = state, :mark_timed_out) do
+    now = DateTime.utc_now()
+
+    {:ok,
+     %{
+       state
+       | run_status: :timed_out,
+         finished_at: now,
+         run_terminal_reason:
+           Map.merge(state.run_terminal_reason || %{kind: :timed_out}, %{finished_at: now})
+     }, [:run_timed_out]}
   end
 
   def apply(%State{run_status: status}, action) do

--- a/lib/favn/runtime/transitions/step.ex
+++ b/lib/favn/runtime/transitions/step.ex
@@ -102,19 +102,77 @@ defmodule Favn.Runtime.Transitions.Step do
     end
   end
 
+  @spec complete_cancelled(State.t(), Favn.asset_ref(), map()) ::
+          {:ok, State.t(), [event()]} | {:error, transition_error()}
+  def complete_cancelled(%State{} = state, ref, reason) when is_map(reason) do
+    with {:ok, step} <- fetch_step(state, ref),
+         :ok <- require_status(step, :running, :complete_cancelled) do
+      now = DateTime.utc_now()
+      duration_ms = DateTime.diff(now, step.started_at || now, :millisecond)
+
+      next_step = %{
+        step
+        | status: :cancelled,
+          finished_at: now,
+          duration_ms: max(duration_ms, 0),
+          output: nil,
+          error: nil,
+          terminal_reason: reason
+      }
+
+      next_state =
+        state
+        |> put_step(next_step)
+        |> clear_running(ref)
+        |> put_completed(ref)
+
+      {:ok, next_state, [{:step_cancelled, ref}]}
+    end
+  end
+
+  @spec complete_timed_out(State.t(), Favn.asset_ref(), map()) ::
+          {:ok, State.t(), [event()]} | {:error, transition_error()}
+  def complete_timed_out(%State{} = state, ref, reason) when is_map(reason) do
+    with {:ok, step} <- fetch_step(state, ref),
+         :ok <- require_status(step, :running, :complete_timed_out) do
+      now = DateTime.utc_now()
+      duration_ms = DateTime.diff(now, step.started_at || now, :millisecond)
+
+      next_step = %{
+        step
+        | status: :timed_out,
+          finished_at: now,
+          duration_ms: max(duration_ms, 0),
+          output: nil,
+          error: nil,
+          terminal_reason: reason
+      }
+
+      next_state =
+        state
+        |> put_step(next_step)
+        |> clear_running(ref)
+        |> put_completed(ref)
+
+      {:ok, next_state, [{:step_timed_out, ref}]}
+    end
+  end
+
   @doc """
   Finalize unresolved steps deterministically after run failure/cancellation.
   """
-  @spec finalize_unresolved(State.t(), :skipped | :cancelled) :: {State.t(), [event()]}
+  @spec finalize_unresolved(State.t(), :skipped | :cancelled | :timed_out) ::
+          {State.t(), [event()]}
   def finalize_unresolved(%State{} = state, replacement_status)
-      when replacement_status in [:skipped, :cancelled] do
+      when replacement_status in [:skipped, :cancelled, :timed_out] do
     {next_steps, events} =
       Enum.reduce(state.steps, {%{}, []}, fn {ref, step}, {acc_steps, acc_events} ->
         case step.status do
           status when status in [:pending, :ready] ->
             event = event_for(replacement_status)
+            reason = terminal_reason_for(replacement_status)
 
-            {Map.put(acc_steps, ref, %{step | status: replacement_status}),
+            {Map.put(acc_steps, ref, %{step | status: replacement_status, terminal_reason: reason}),
              [{event, ref} | acc_events]}
 
           _ ->
@@ -127,6 +185,10 @@ defmodule Favn.Runtime.Transitions.Step do
 
   defp event_for(:skipped), do: :step_skipped
   defp event_for(:cancelled), do: :step_cancelled
+  defp event_for(:timed_out), do: :step_timed_out
+  defp terminal_reason_for(:skipped), do: %{kind: :skipped}
+  defp terminal_reason_for(:cancelled), do: %{kind: :cancelled}
+  defp terminal_reason_for(:timed_out), do: %{kind: :timed_out}
 
   defp fetch_step(%State{steps: steps}, ref) do
     case Map.fetch(steps, ref) do

--- a/lib/favn/storage.ex
+++ b/lib/favn/storage.ex
@@ -63,7 +63,7 @@ defmodule Favn.Storage do
 
   Supported filters:
 
-    * `:status` - one of `:running | :ok | :error`
+    * `:status` - one of `:running | :ok | :error | :cancelled | :timed_out`
     * `:limit` - positive integer max result count
   """
   @spec list_runs(Favn.list_runs_opts()) :: {:ok, [Run.t()]} | {:error, error()}
@@ -122,7 +122,7 @@ defmodule Favn.Storage do
     limit = Keyword.get(opts, :limit)
 
     cond do
-      not is_nil(status) and status not in [:running, :ok, :error] ->
+      not is_nil(status) and status not in [:running, :ok, :error, :cancelled, :timed_out] ->
         {:error, :invalid_opts}
 
       not is_nil(limit) and (not is_integer(limit) or limit <= 0) ->

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -66,6 +66,12 @@ defmodule Favn.RunnerTest do
       {:ok, %{exec_ref: exec_ref, monitor_ref: monitor_ref, pid: pid}}
     end
 
+    @impl true
+    def cancel_step(%{pid: pid}, _reason) do
+      Process.exit(pid, :kill)
+      :ok
+    end
+
     defp invoke(asset, %Context{} = ctx, deps) do
       try do
         case apply(asset.module, asset.name, [ctx, deps]) do
@@ -498,5 +504,45 @@ defmodule Favn.RunnerTest do
 
     assert {:ok, done} = Favn.await_run(run_id)
     assert done.status == :ok
+  end
+
+  test "cancel_run/1 cancels a running run and await_run returns cancelled as ok" do
+    assert {:ok, run_id} = Favn.run({RunnerAssets, :slow_asset})
+    assert {:ok, :cancelling} = Favn.cancel_run(run_id)
+    assert {:ok, run} = Favn.await_run(run_id)
+    assert run.status == :cancelled
+    assert run.terminal_reason[:kind] == :cancelled
+  end
+
+  test "cancel_run/1 returns already_terminal for completed run" do
+    assert {:ok, run_id} = Favn.run({RunnerAssets, :slow_asset})
+    assert {:ok, _run} = Favn.await_run(run_id)
+    assert {:ok, :already_terminal} = Favn.cancel_run(run_id)
+  end
+
+  test "cancel_run/1 returns not_found for unknown run id" do
+    assert {:error, :not_found} = Favn.cancel_run("missing-run-id")
+  end
+
+  test "run timeout marks run as timed_out" do
+    assert {:ok, run_id} = Favn.run({RunnerAssets, :slow_asset}, timeout_ms: 10)
+    assert {:error, run} = Favn.await_run(run_id)
+    assert run.status == :timed_out
+    assert run.terminal_reason[:kind] == :timed_out
+  end
+
+  test "list_runs supports cancelled and timed_out status filters" do
+    assert {:ok, cancelled_run_id} = Favn.run({RunnerAssets, :slow_asset})
+    assert {:ok, :cancelling} = Favn.cancel_run(cancelled_run_id)
+    assert {:ok, cancelled_run} = Favn.await_run(cancelled_run_id)
+
+    assert {:ok, timed_out_run_id} = Favn.run({RunnerAssets, :slow_asset}, timeout_ms: 10)
+    assert {:error, timed_out_run} = Favn.await_run(timed_out_run_id)
+
+    assert {:ok, cancelled_runs} = Favn.list_runs(status: :cancelled)
+    assert Enum.map(cancelled_runs, & &1.id) == [cancelled_run.id]
+
+    assert {:ok, timed_out_runs} = Favn.list_runs(status: :timed_out)
+    assert Enum.map(timed_out_runs, & &1.id) == [timed_out_run.id]
   end
 end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -506,10 +506,10 @@ defmodule Favn.RunnerTest do
     assert done.status == :ok
   end
 
-  test "cancel_run/1 cancels a running run and await_run returns cancelled as ok" do
+  test "cancel_run/1 cancels a running run and await_run returns cancelled as error terminal" do
     assert {:ok, run_id} = Favn.run({RunnerAssets, :slow_asset})
     assert {:ok, :cancelling} = Favn.cancel_run(run_id)
-    assert {:ok, run} = Favn.await_run(run_id)
+    assert {:error, run} = Favn.await_run(run_id)
     assert run.status == :cancelled
     assert run.terminal_reason[:kind] == :cancelled
   end
@@ -524,6 +524,33 @@ defmodule Favn.RunnerTest do
     assert {:error, :not_found} = Favn.cancel_run("missing-run-id")
   end
 
+  test "cancel_run/1 returns coordinator_unavailable when run is persisted as running but manager has no pid" do
+    run = %Favn.Run{
+      id: "orphan-running-run",
+      status: :running,
+      started_at: DateTime.utc_now(),
+      target_refs: [],
+      plan: %Favn.Plan{}
+    }
+
+    assert :ok = Favn.Storage.put_run(run)
+    assert {:error, :coordinator_unavailable} = Favn.cancel_run(run.id)
+  end
+
+  test "cancel_run/1 returns timeout_in_progress when timeout handling has already started" do
+    run = %Favn.Run{
+      id: "timing-out-run",
+      status: :running,
+      started_at: DateTime.utc_now(),
+      target_refs: [],
+      plan: %Favn.Plan{},
+      terminal_reason: %{kind: :timed_out, triggered_at: DateTime.utc_now()}
+    }
+
+    assert :ok = Favn.Storage.put_run(run)
+    assert {:error, :timeout_in_progress} = Favn.cancel_run(run.id)
+  end
+
   test "run timeout marks run as timed_out" do
     assert {:ok, run_id} = Favn.run({RunnerAssets, :slow_asset}, timeout_ms: 10)
     assert {:error, run} = Favn.await_run(run_id)
@@ -534,7 +561,7 @@ defmodule Favn.RunnerTest do
   test "list_runs supports cancelled and timed_out status filters" do
     assert {:ok, cancelled_run_id} = Favn.run({RunnerAssets, :slow_asset})
     assert {:ok, :cancelling} = Favn.cancel_run(cancelled_run_id)
-    assert {:ok, cancelled_run} = Favn.await_run(cancelled_run_id)
+    assert {:error, cancelled_run} = Favn.await_run(cancelled_run_id)
 
     assert {:ok, timed_out_run_id} = Favn.run({RunnerAssets, :slow_asset}, timeout_ms: 10)
     assert {:error, timed_out_run} = Favn.await_run(timed_out_run_id)

--- a/test/runtime_transitions_test.exs
+++ b/test/runtime_transitions_test.exs
@@ -19,6 +19,15 @@ defmodule Favn.RuntimeTransitionsTest do
              RunTransitions.apply(terminal, :start)
   end
 
+  test "run timeout transitions validate lifecycle" do
+    state = %State{run_status: :pending}
+    assert {:ok, state, [:run_started]} = RunTransitions.apply(state, :start)
+    assert {:ok, state, [:run_timeout_triggered]} = RunTransitions.apply(state, :request_timeout)
+    assert state.run_status == :timing_out
+    assert {:ok, state, [:run_timed_out]} = RunTransitions.apply(state, :mark_timed_out)
+    assert state.run_status == :timed_out
+  end
+
   test "step transitions unlock downstream only after upstream success" do
     ref_a = {__MODULE__, :a}
     ref_b = {__MODULE__, :b}
@@ -64,5 +73,19 @@ defmodule Favn.RuntimeTransitionsTest do
     assert state.steps[ref_done].status == :success
     assert state.ready_queue == []
     assert Enum.count(events, &(elem(&1, 0) == :step_skipped)) == 2
+  end
+
+  test "finalize unresolved can mark timed_out deterministically" do
+    ref_pending = {__MODULE__, :pending_step}
+
+    state = %State{
+      steps: %{
+        ref_pending => %StepState{ref: ref_pending, status: :pending}
+      }
+    }
+
+    {state, events} = StepTransitions.finalize_unresolved(state, :timed_out)
+    assert state.steps[ref_pending].status == :timed_out
+    assert events == [{:step_timed_out, ref_pending}]
   end
 end


### PR DESCRIPTION
### Motivation
- Provide operator controls to cancel running runs and enforce per-run timeouts so runs can be terminated deterministically.
- Surface cancellation/timeout terminal reasons in public projections and storage so UIs and consumers can observe why runs ended.
- Integrate cancellation/timeout across runtime components (manager, coordinator, executor) and update public APIs and docs accordingly.

### Description
- Added public API `Favn.cancel_run/1` and extended `Favn.run/2` to accept `timeout_ms` in `run_opts`, and updated `await_run/2` and `list_runs/1` semantics to include `:cancelled` and `:timed_out` statuses.
- Introduced run lifecycle states and terminal reason tracking: internal `State` now has `run_terminal_reason` and `timeout_ms`/`deadline_at` fields, public `%Favn.Run{}` adds `terminal_reason`, and status mapping includes `:cancelled` and `:timed_out`.
- Coordinator improvements: schedule run deadline timers, handle `:run_deadline_reached`, support `:cancel_run` casts, request cancellation/timeouts that interrupt inflight executions, and finalize runs deterministically when inflight work completes.
- Executor behaviour extended with `cancel_step/2` callback and `Favn.Runtime.Executor.Local` implements cancellation by sending `Process.exit(pid, :kill)` to the worker.
- Manager tracks run PIDs, validates and forwards cancellation requests to coordinators, stores `timeout_ms` in runtime state, and persists initial snapshots unchanged.
- Transition and step changes: run transitions include `:request_timeout`/`:mark_timed_out` and set run terminal reasons, step transitions support `complete_cancelled/3` and `complete_timed_out/3`, and `finalize_unresolved/2` can now mark unresolved steps as `:timed_out` with terminal reasons.
- Storage and API validation updated to accept `:cancelled` and `:timed_out` as valid `list_runs` filters and to expose the new fields in persisted runs.
- Documentation updates: `FEATURES.md` and `README.md` reflect the new lifecycle states, timeouts, and cancellation behavior.
- Tests: added and updated test cases to cover cancellation, timeout flow, listing by new statuses, and transition semantics.

### Testing
- Ran the full unit test suite with `mix test` which includes new runner tests exercising `cancel_run/1`, timeout handling, and `list_runs` filters, and runtime transition tests for timeout flows; all tests passed.
- New/updated tests include `test/runner_test.exs` additions for cancellation and timeout scenarios and `test/runtime_transitions_test.exs` additions for timeout transition and finalize behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca24db3b388328912754746e509350)