### PR TITLE
Add SQLite durable storage adapter (Ecto) with migrations, docs, and tests

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -63,7 +63,7 @@ Turns Favn into a real execution engine with durable state and concurrency.
 - [x] Retry mechanism (configurable, step-level fixed delay + max attempts + retry classes)
 - [x] Cancellation support
 - [x] Timeout handling
-- [ ] SQLite storage adapter
+- [x] SQLite storage adapter
 - [ ] Stable event schema (runs + steps)
 - [ ] Telemetry integration
 - [ ] Initial materialization/artifact model (replace in-memory-only outputs)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -64,6 +64,7 @@ Turns Favn into a real execution engine with durable state and concurrency.
 - [x] Cancellation support
 - [x] Timeout handling
 - [x] SQLite storage adapter
+- [ ] SQLite `run_write_orders` growth management (prune/compact strategy)
 - [ ] Stable event schema (runs + steps)
 - [ ] Telemetry integration
 - [ ] Initial materialization/artifact model (replace in-memory-only outputs)

--- a/README.md
+++ b/README.md
@@ -107,6 +107,20 @@ Key settings:
 - `:storage_adapter`: run storage adapter module.
 - `:storage_adapter_opts`: options passed to the configured storage adapter.
 
+SQLite durable storage (single-node) can be configured with:
+
+```elixir
+import Config
+
+config :favn,
+  storage_adapter: Favn.Storage.Adapter.SQLite,
+  storage_adapter_opts: [
+    database: "/var/lib/my_app/favn.db",
+    busy_timeout: 5_000,
+    pool_size: 5
+  ]
+```
+
 ## Current limitations
 
 - The default run store is node-local in-memory storage.

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -212,6 +212,21 @@ defmodule Favn do
       config :favn,
         pubsub_name: MyApp.PubSub
 
+  Run persistence is configured with `:storage_adapter` and
+  `:storage_adapter_opts`.
+
+  For durable single-node SQLite storage:
+
+      import Config
+
+      config :favn,
+        storage_adapter: Favn.Storage.Adapter.SQLite,
+        storage_adapter_opts: [
+          database: "/var/lib/my_app/favn.db",
+          busy_timeout: 5_000,
+          pool_size: 5
+        ]
+
   ## Starting Favn
 
   There is no separate Favn server process that operators start manually.

--- a/lib/favn/storage/adapter.ex
+++ b/lib/favn/storage/adapter.ex
@@ -13,7 +13,7 @@ defmodule Favn.Storage.Adapter do
 
     * Run IDs are treated as globally unique identifiers.
     * `put_run/2` is idempotent for the same run ID.
-    * `list_runs/2` returns deterministic newest-first ordering.
+    * `list_runs/2` returns deterministic newest-first ordering by latest persisted write.
     * Adapters should return `{:error, :not_found}` for missing run IDs.
 
   ## Lifecycle

--- a/lib/favn/storage/adapter/memory.ex
+++ b/lib/favn/storage/adapter/memory.ex
@@ -42,11 +42,15 @@ defmodule Favn.Storage.Adapter.Memory do
   def put_run(%Run{} = run, _opts) do
     inserted_seq =
       case :ets.lookup(@table_name, run.id) do
-        [{_id, _stored_run, existing_inserted_seq}] -> existing_inserted_seq
-        [] -> System.unique_integer([:monotonic, :positive])
+        [{_id, _stored_run, existing_inserted_seq, _existing_updated_seq}] ->
+          existing_inserted_seq
+
+        [] ->
+          System.unique_integer([:monotonic, :positive])
       end
 
-    true = :ets.insert(@table_name, {run.id, run, inserted_seq})
+    updated_seq = System.unique_integer([:monotonic, :positive])
+    true = :ets.insert(@table_name, {run.id, run, inserted_seq, updated_seq})
     :ok
   rescue
     error -> {:error, error}
@@ -55,7 +59,7 @@ defmodule Favn.Storage.Adapter.Memory do
   @spec get_run(Favn.run_id(), keyword()) :: {:ok, Run.t()} | {:error, :not_found | term()}
   def get_run(run_id, _opts) do
     case :ets.lookup(@table_name, run_id) do
-      [{^run_id, run, _inserted_seq}] -> {:ok, run}
+      [{^run_id, run, _inserted_seq, _updated_seq}] -> {:ok, run}
       [] -> {:error, :not_found}
     end
   rescue
@@ -70,7 +74,7 @@ defmodule Favn.Storage.Adapter.Memory do
     runs =
       @table_name
       |> :ets.tab2list()
-      |> Enum.map(fn {_id, run, inserted_seq} -> {run, inserted_seq} end)
+      |> Enum.map(fn {_id, run, _inserted_seq, updated_seq} -> {run, updated_seq} end)
       |> maybe_filter_status(status)
       |> Enum.sort_by(&sort_key/1, :desc)
       |> Enum.map(&elem(&1, 0))
@@ -90,7 +94,7 @@ defmodule Favn.Storage.Adapter.Memory do
   defp maybe_limit(runs, nil), do: runs
   defp maybe_limit(runs, limit), do: Enum.take(runs, limit)
 
-  defp sort_key({run, inserted_seq}) do
-    {run.started_at, inserted_seq, run.id}
+  defp sort_key({run, updated_seq}) do
+    {updated_seq, run.id}
   end
 end

--- a/lib/favn/storage/adapter/sqlite.ex
+++ b/lib/favn/storage/adapter/sqlite.ex
@@ -16,19 +16,19 @@ defmodule Favn.Storage.Adapter.SQLite do
   @behaviour Favn.Storage.Adapter
 
   alias Favn.Run
-  alias Favn.Storage.SQLite.Migrations
   alias Favn.Storage.SQLite.Repo
+  alias Favn.Storage.SQLite.Supervisor, as: SQLiteSupervisor
 
   @impl true
   def child_spec(opts) when is_list(opts) do
     with {:ok, repo_config} <- repo_config(opts) do
       child =
         Supervisor.child_spec(
-          {Repo, repo_config},
-          id: Repo,
+          {SQLiteSupervisor, repo_config},
+          id: SQLiteSupervisor,
           restart: :permanent,
           shutdown: 5_000,
-          type: :worker
+          type: :supervisor
         )
 
       {:ok, child}
@@ -38,17 +38,28 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def put_run(%Run{} = run, opts) do
     with {:ok, _repo_config} <- repo_config(opts),
-         :ok <- ensure_migrated() do
-      now = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+         :ok <- ensure_repo_started() do
+      now_us = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
+      updated_seq = System.unique_integer([:monotonic, :positive])
 
       sql = """
-      INSERT INTO runs (id, status, started_at, finished_at, inserted_at, updated_at, run_blob)
-      VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6)
+      INSERT INTO runs (
+        id,
+        status,
+        started_at,
+        finished_at,
+        inserted_at_us,
+        updated_at_us,
+        updated_seq,
+        run_blob
+      )
+      VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6, ?7)
       ON CONFLICT(id) DO UPDATE SET
         status = excluded.status,
         started_at = excluded.started_at,
         finished_at = excluded.finished_at,
-        updated_at = excluded.updated_at,
+        updated_at_us = excluded.updated_at_us,
+        updated_seq = excluded.updated_seq,
         run_blob = excluded.run_blob
       """
 
@@ -57,7 +68,8 @@ defmodule Favn.Storage.Adapter.SQLite do
         Atom.to_string(run.status),
         datetime_to_iso(run.started_at),
         datetime_to_iso(run.finished_at),
-        now,
+        now_us,
+        updated_seq,
         :erlang.term_to_binary(run)
       ]
 
@@ -71,11 +83,11 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def get_run(run_id, opts) when is_binary(run_id) and is_list(opts) do
     with {:ok, _repo_config} <- repo_config(opts),
-         :ok <- ensure_migrated() do
+         :ok <- ensure_repo_started() do
       sql = "SELECT run_blob FROM runs WHERE id = ?1 LIMIT 1"
 
       case Ecto.Adapters.SQL.query(Repo, sql, [run_id]) do
-        {:ok, %{rows: [[blob]]}} -> {:ok, :erlang.binary_to_term(blob)}
+        {:ok, %{rows: [[blob]]}} -> deserialize_run(blob)
         {:ok, %{rows: []}} -> {:error, :not_found}
         {:error, reason} -> {:error, reason}
       end
@@ -85,7 +97,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def list_runs(opts, adapter_opts) when is_list(opts) and is_list(adapter_opts) do
     with {:ok, _repo_config} <- repo_config(adapter_opts),
-         :ok <- ensure_migrated() do
+         :ok <- ensure_repo_started() do
       status = Keyword.get(opts, :status)
       limit = Keyword.get(opts, :limit)
 
@@ -93,8 +105,17 @@ defmodule Favn.Storage.Adapter.SQLite do
 
       case Ecto.Adapters.SQL.query(Repo, sql, params) do
         {:ok, %{rows: rows}} ->
-          runs = Enum.map(rows, fn [blob] -> :erlang.binary_to_term(blob) end)
-          {:ok, runs}
+          rows
+          |> Enum.reduce_while({:ok, []}, fn [blob], {:ok, acc} ->
+            case deserialize_run(blob) do
+              {:ok, run} -> {:cont, {:ok, [run | acc]}}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+          |> case do
+            {:ok, runs} -> {:ok, Enum.reverse(runs)}
+            {:error, reason} -> {:error, reason}
+          end
 
         {:error, reason} ->
           {:error, reason}
@@ -104,41 +125,38 @@ defmodule Favn.Storage.Adapter.SQLite do
 
   defp build_list_query(nil, nil) do
     {
-      "SELECT run_blob FROM runs ORDER BY updated_at DESC, inserted_at DESC, id DESC",
+      "SELECT run_blob FROM runs ORDER BY updated_seq DESC, updated_at_us DESC, id DESC",
       []
     }
   end
 
   defp build_list_query(status, nil) do
     {
-      "SELECT run_blob FROM runs WHERE status = ?1 ORDER BY updated_at DESC, inserted_at DESC, id DESC",
+      "SELECT run_blob FROM runs WHERE status = ?1 ORDER BY updated_seq DESC, updated_at_us DESC, id DESC",
       [Atom.to_string(status)]
     }
   end
 
   defp build_list_query(nil, limit) do
     {
-      "SELECT run_blob FROM runs ORDER BY updated_at DESC, inserted_at DESC, id DESC LIMIT ?1",
+      "SELECT run_blob FROM runs ORDER BY updated_seq DESC, updated_at_us DESC, id DESC LIMIT ?1",
       [limit]
     }
   end
 
   defp build_list_query(status, limit) do
     {
-      "SELECT run_blob FROM runs WHERE status = ?1 ORDER BY updated_at DESC, inserted_at DESC, id DESC LIMIT ?2",
+      "SELECT run_blob FROM runs WHERE status = ?1 ORDER BY updated_seq DESC, updated_at_us DESC, id DESC LIMIT ?2",
       [Atom.to_string(status), limit]
     }
   end
 
-  defp ensure_migrated do
+  defp ensure_repo_started do
     if Process.whereis(Repo) == nil do
       {:error, :sqlite_repo_not_started}
     else
-      Migrations.migrate!(Repo)
       :ok
     end
-  rescue
-    error -> {:error, error}
   end
 
   defp repo_config(opts) do
@@ -163,6 +181,13 @@ defmodule Favn.Storage.Adapter.SQLite do
 
   defp datetime_to_iso(nil), do: nil
 
-  defp datetime_to_iso(%DateTime{} = dt),
-    do: DateTime.truncate(dt, :second) |> DateTime.to_iso8601()
+  defp datetime_to_iso(%DateTime{} = dt), do: DateTime.to_iso8601(dt)
+
+  defp deserialize_run(blob) when is_binary(blob) do
+    try do
+      {:ok, :erlang.binary_to_term(blob, [:safe])}
+    rescue
+      error -> {:error, {:invalid_run_blob, error}}
+    end
+  end
 end

--- a/lib/favn/storage/adapter/sqlite.ex
+++ b/lib/favn/storage/adapter/sqlite.ex
@@ -1,0 +1,168 @@
+defmodule Favn.Storage.Adapter.SQLite do
+  @moduledoc """
+  Durable SQLite storage adapter backed by Ecto.
+
+  ## Options
+
+    * `:database` - SQLite database path (required)
+    * `:pool_size` - Ecto pool size (default: `5`)
+    * `:busy_timeout` - sqlite busy timeout in milliseconds (default: `5_000`)
+
+  The adapter stores full `%Favn.Run{}` snapshots as Erlang binaries while also
+  indexing common run list fields (`id`, `status`, timestamps) for deterministic
+  querying.
+  """
+
+  @behaviour Favn.Storage.Adapter
+
+  alias Favn.Run
+  alias Favn.Storage.SQLite.Migrations
+  alias Favn.Storage.SQLite.Repo
+
+  @impl true
+  def child_spec(opts) when is_list(opts) do
+    with {:ok, repo_config} <- repo_config(opts) do
+      child =
+        Supervisor.child_spec(
+          {Repo, repo_config},
+          id: Repo,
+          restart: :permanent,
+          shutdown: 5_000,
+          type: :worker
+        )
+
+      {:ok, child}
+    end
+  end
+
+  @impl true
+  def put_run(%Run{} = run, opts) do
+    with {:ok, _repo_config} <- repo_config(opts),
+         :ok <- ensure_migrated() do
+      now = DateTime.utc_now() |> DateTime.truncate(:second) |> DateTime.to_iso8601()
+
+      sql = """
+      INSERT INTO runs (id, status, started_at, finished_at, inserted_at, updated_at, run_blob)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?5, ?6)
+      ON CONFLICT(id) DO UPDATE SET
+        status = excluded.status,
+        started_at = excluded.started_at,
+        finished_at = excluded.finished_at,
+        updated_at = excluded.updated_at,
+        run_blob = excluded.run_blob
+      """
+
+      params = [
+        run.id,
+        Atom.to_string(run.status),
+        datetime_to_iso(run.started_at),
+        datetime_to_iso(run.finished_at),
+        now,
+        :erlang.term_to_binary(run)
+      ]
+
+      case Ecto.Adapters.SQL.query(Repo, sql, params) do
+        {:ok, _} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def get_run(run_id, opts) when is_binary(run_id) and is_list(opts) do
+    with {:ok, _repo_config} <- repo_config(opts),
+         :ok <- ensure_migrated() do
+      sql = "SELECT run_blob FROM runs WHERE id = ?1 LIMIT 1"
+
+      case Ecto.Adapters.SQL.query(Repo, sql, [run_id]) do
+        {:ok, %{rows: [[blob]]}} -> {:ok, :erlang.binary_to_term(blob)}
+        {:ok, %{rows: []}} -> {:error, :not_found}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_runs(opts, adapter_opts) when is_list(opts) and is_list(adapter_opts) do
+    with {:ok, _repo_config} <- repo_config(adapter_opts),
+         :ok <- ensure_migrated() do
+      status = Keyword.get(opts, :status)
+      limit = Keyword.get(opts, :limit)
+
+      {sql, params} = build_list_query(status, limit)
+
+      case Ecto.Adapters.SQL.query(Repo, sql, params) do
+        {:ok, %{rows: rows}} ->
+          runs = Enum.map(rows, fn [blob] -> :erlang.binary_to_term(blob) end)
+          {:ok, runs}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp build_list_query(nil, nil) do
+    {
+      "SELECT run_blob FROM runs ORDER BY updated_at DESC, inserted_at DESC, id DESC",
+      []
+    }
+  end
+
+  defp build_list_query(status, nil) do
+    {
+      "SELECT run_blob FROM runs WHERE status = ?1 ORDER BY updated_at DESC, inserted_at DESC, id DESC",
+      [Atom.to_string(status)]
+    }
+  end
+
+  defp build_list_query(nil, limit) do
+    {
+      "SELECT run_blob FROM runs ORDER BY updated_at DESC, inserted_at DESC, id DESC LIMIT ?1",
+      [limit]
+    }
+  end
+
+  defp build_list_query(status, limit) do
+    {
+      "SELECT run_blob FROM runs WHERE status = ?1 ORDER BY updated_at DESC, inserted_at DESC, id DESC LIMIT ?2",
+      [Atom.to_string(status), limit]
+    }
+  end
+
+  defp ensure_migrated do
+    if Process.whereis(Repo) == nil do
+      {:error, :sqlite_repo_not_started}
+    else
+      Migrations.migrate!(Repo)
+      :ok
+    end
+  rescue
+    error -> {:error, error}
+  end
+
+  defp repo_config(opts) do
+    database = Keyword.get(opts, :database)
+
+    cond do
+      is_nil(database) ->
+        {:error, :sqlite_database_required}
+
+      not is_binary(database) ->
+        {:error, :sqlite_database_invalid}
+
+      true ->
+        {:ok,
+         [
+           database: database,
+           pool_size: Keyword.get(opts, :pool_size, 5),
+           busy_timeout: Keyword.get(opts, :busy_timeout, 5_000)
+         ]}
+    end
+  end
+
+  defp datetime_to_iso(nil), do: nil
+
+  defp datetime_to_iso(%DateTime{} = dt),
+    do: DateTime.truncate(dt, :second) |> DateTime.to_iso8601()
+end

--- a/lib/favn/storage/adapter/sqlite.ex
+++ b/lib/favn/storage/adapter/sqlite.ex
@@ -40,7 +40,6 @@ defmodule Favn.Storage.Adapter.SQLite do
     with {:ok, _repo_config} <- repo_config(opts),
          :ok <- ensure_repo_started() do
       now_us = DateTime.utc_now() |> DateTime.to_unix(:microsecond)
-      updated_seq = System.unique_integer([:monotonic, :positive])
 
       sql = """
       INSERT INTO runs (
@@ -63,18 +62,31 @@ defmodule Favn.Storage.Adapter.SQLite do
         run_blob = excluded.run_blob
       """
 
-      params = [
-        run.id,
-        Atom.to_string(run.status),
-        datetime_to_iso(run.started_at),
-        datetime_to_iso(run.finished_at),
-        now_us,
-        updated_seq,
-        :erlang.term_to_binary(run)
-      ]
-
-      case Ecto.Adapters.SQL.query(Repo, sql, params) do
-        {:ok, _} -> :ok
+      case Repo.transaction(fn ->
+             with {:ok, _} <-
+                    Ecto.Adapters.SQL.query(
+                      Repo,
+                      "INSERT INTO run_write_orders DEFAULT VALUES",
+                      []
+                    ),
+                  {:ok, %{rows: [[updated_seq]]}} <-
+                    Ecto.Adapters.SQL.query(Repo, "SELECT last_insert_rowid()", []),
+                  params <- [
+                    run.id,
+                    Atom.to_string(run.status),
+                    datetime_to_iso(run.started_at),
+                    datetime_to_iso(run.finished_at),
+                    now_us,
+                    updated_seq,
+                    :erlang.term_to_binary(run)
+                  ],
+                  {:ok, _} <- Ecto.Adapters.SQL.query(Repo, sql, params) do
+               :ok
+             else
+               {:error, reason} -> Repo.rollback(reason)
+             end
+           end) do
+        {:ok, :ok} -> :ok
         {:error, reason} -> {:error, reason}
       end
     end

--- a/lib/favn/storage/adapter/sqlite.ex
+++ b/lib/favn/storage/adapter/sqlite.ex
@@ -62,7 +62,7 @@ defmodule Favn.Storage.Adapter.SQLite do
         run_blob = excluded.run_blob
       """
 
-      case Repo.transaction(fn ->
+      case Repo.transact(fn ->
              with {:ok, _} <-
                     Ecto.Adapters.SQL.query(
                       Repo,
@@ -81,12 +81,14 @@ defmodule Favn.Storage.Adapter.SQLite do
                     :erlang.term_to_binary(run)
                   ],
                   {:ok, _} <- Ecto.Adapters.SQL.query(Repo, sql, params) do
-               :ok
+               {:ok, :ok}
              else
-               {:error, reason} -> Repo.rollback(reason)
+               {:error, reason} -> {:error, reason}
              end
            end) do
         {:ok, :ok} -> :ok
+        {:ok, {:ok, :ok}} -> :ok
+        {:ok, {:error, reason}} -> {:error, reason}
         {:error, reason} -> {:error, reason}
       end
     end

--- a/lib/favn/storage/adapter/sqlite.ex
+++ b/lib/favn/storage/adapter/sqlite.ex
@@ -83,12 +83,10 @@ defmodule Favn.Storage.Adapter.SQLite do
                   {:ok, _} <- Ecto.Adapters.SQL.query(Repo, sql, params) do
                {:ok, :ok}
              else
-               {:error, reason} -> {:error, reason}
+               {:error, reason} -> Repo.rollback(reason)
              end
            end) do
         {:ok, :ok} -> :ok
-        {:ok, {:ok, :ok}} -> :ok
-        {:ok, {:error, reason}} -> {:error, reason}
         {:error, reason} -> {:error, reason}
       end
     end

--- a/lib/favn/storage/sqlite/migrations.ex
+++ b/lib/favn/storage/sqlite/migrations.ex
@@ -1,0 +1,17 @@
+defmodule Favn.Storage.SQLite.Migrations do
+  @moduledoc """
+  Runs SQLite migrations for the durable storage adapter.
+  """
+
+  @spec migrate!(module()) :: :ok
+  def migrate!(repo) do
+    path = Application.app_dir(:favn, "priv/favn/storage/sqlite/migrations")
+
+    {:ok, _migrated, _apps} =
+      Ecto.Migrator.with_repo(repo, fn migrator_repo ->
+        Ecto.Migrator.run(migrator_repo, path, :up, all: true)
+      end)
+
+    :ok
+  end
+end

--- a/lib/favn/storage/sqlite/repo.ex
+++ b/lib/favn/storage/sqlite/repo.ex
@@ -5,5 +5,6 @@ defmodule Favn.Storage.SQLite.Repo do
 
   use Ecto.Repo,
     otp_app: :favn,
+    priv: "priv/favn/storage/sqlite",
     adapter: Ecto.Adapters.SQLite3
 end

--- a/lib/favn/storage/sqlite/repo.ex
+++ b/lib/favn/storage/sqlite/repo.ex
@@ -1,0 +1,9 @@
+defmodule Favn.Storage.SQLite.Repo do
+  @moduledoc """
+  Ecto repository used by `Favn.Storage.Adapter.SQLite`.
+  """
+
+  use Ecto.Repo,
+    otp_app: :favn,
+    adapter: Ecto.Adapters.SQLite3
+end

--- a/lib/favn/storage/sqlite/supervisor.ex
+++ b/lib/favn/storage/sqlite/supervisor.ex
@@ -1,6 +1,10 @@
 defmodule Favn.Storage.SQLite.Supervisor do
   @moduledoc """
   Supervises the SQLite repo after running adapter migrations once at startup.
+
+  NOTE: this bootstrap path currently uses a small custom migration step.
+  Follow-up: evaluate replacing with an `Ecto.Migrator.start_link/1` child-based
+  startup flow if it stays equally small and explicit for Favn.
   """
 
   use Supervisor

--- a/lib/favn/storage/sqlite/supervisor.ex
+++ b/lib/favn/storage/sqlite/supervisor.ex
@@ -1,10 +1,9 @@
 defmodule Favn.Storage.SQLite.Supervisor do
   @moduledoc """
-  Supervises the SQLite repo after running adapter migrations once at startup.
+  Supervises the SQLite repo after running migrations once at startup.
 
-  NOTE: this bootstrap path currently uses a small custom migration step.
-  Follow-up: evaluate replacing with an `Ecto.Migrator.start_link/1` child-based
-  startup flow if it stays equally small and explicit for Favn.
+  Migrations are run against the runtime-configured SQLite path before the
+  long-lived repo child starts.
   """
 
   use Supervisor

--- a/lib/favn/storage/sqlite/supervisor.ex
+++ b/lib/favn/storage/sqlite/supervisor.ex
@@ -1,0 +1,38 @@
+defmodule Favn.Storage.SQLite.Supervisor do
+  @moduledoc """
+  Supervises the SQLite repo after running adapter migrations once at startup.
+  """
+
+  use Supervisor
+
+  alias Favn.Storage.SQLite.Migrations
+  alias Favn.Storage.SQLite.Repo
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    Supervisor.start_link(__MODULE__, opts, name: __MODULE__)
+  end
+
+  @impl true
+  def init(opts) do
+    :ok = run_bootstrap_migrations(opts)
+
+    children = [
+      {Repo, opts}
+    ]
+
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp run_bootstrap_migrations(opts) do
+    {:ok, pid} = Repo.start_link(opts)
+
+    try do
+      Migrations.migrate!(Repo)
+    after
+      GenServer.stop(pid)
+    end
+
+    :ok
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Favn.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger, :phoenix_pubsub],
+      extra_applications: [:logger, :phoenix_pubsub, :ecto_sql],
       mod: {Favn.Application, []}
     ]
   end
@@ -30,6 +30,21 @@ defmodule Favn.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      {:decimal, git: "https://github.com/ericmj/decimal.git", tag: "v2.3.0", override: true},
+      {:telemetry,
+       git: "https://github.com/beam-telemetry/telemetry.git", tag: "v1.3.0", override: true},
+      {:db_connection,
+       git: "https://github.com/elixir-ecto/db_connection.git", tag: "v2.8.1", override: true},
+      {:elixir_make,
+       git: "https://github.com/elixir-lang/elixir_make.git", tag: "v0.9.0", override: true},
+      {:cc_precompiler,
+       git: "https://github.com/cocoa-xu/cc_precompiler.git", tag: "v0.1.11", override: true},
+      {:exqlite,
+       git: "https://github.com/elixir-sqlite/exqlite.git", tag: "v0.22.0", override: true},
+      {:ecto, git: "https://github.com/elixir-ecto/ecto.git", tag: "v3.13.5", override: true},
+      {:ecto_sql,
+       git: "https://github.com/elixir-ecto/ecto_sql.git", tag: "v3.13.4", override: true},
+      {:ecto_sqlite3, git: "https://github.com/elixir-sqlite/ecto_sqlite3.git", tag: "v0.22.0"},
       {:phoenix_pubsub,
        git: "https://github.com/phoenixframework/phoenix_pubsub.git", tag: "v2.2.0"}
     ]

--- a/mix.exs
+++ b/mix.exs
@@ -30,6 +30,10 @@ defmodule Favn.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
+      # NOTE:
+      # This project runs in environments where Hex registry access may be blocked
+      # behind a proxy. We pin the Ecto/SQLite dependency chain to git sources and
+      # use overrides so dependency resolution does not require hex.pm metadata.
       {:decimal, git: "https://github.com/ericmj/decimal.git", tag: "v2.3.0", override: true},
       {:telemetry,
        git: "https://github.com/beam-telemetry/telemetry.git", tag: "v1.3.0", override: true},

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,12 @@
 %{
+  "cc_precompiler": {:git, "https://github.com/cocoa-xu/cc_precompiler.git", "c07f72380a2600d2582ae03c3ea88a400d84c647", [tag: "v0.1.11"]},
+  "db_connection": {:git, "https://github.com/elixir-ecto/db_connection.git", "d572b07b853565c117d68ea11ea4ae9141c8af2b", [tag: "v2.8.1"]},
+  "decimal": {:git, "https://github.com/ericmj/decimal.git", "592d59ac4474933f91cdc3e8e037f137f7e008b0", [tag: "v2.3.0"]},
+  "ecto": {:git, "https://github.com/elixir-ecto/ecto.git", "0bc7948ee9fbca21872ef5502f4d4c2c2f3e51f1", [tag: "v3.13.5"]},
+  "ecto_sql": {:git, "https://github.com/elixir-ecto/ecto_sql.git", "ed07cf27a49109be3b2558574ff03d9499f79557", [tag: "v3.13.4"]},
+  "ecto_sqlite3": {:git, "https://github.com/elixir-sqlite/ecto_sqlite3.git", "2f9a6ffed4ea8dec9010b72173da8e62de3e8672", [tag: "v0.22.0"]},
+  "elixir_make": {:git, "https://github.com/elixir-lang/elixir_make.git", "12f5bcd40a7b87d00d67185d5af3b6f0496abd54", [tag: "v0.9.0"]},
+  "exqlite": {:git, "https://github.com/elixir-sqlite/exqlite.git", "c63c4faf2dc3a9a23e3f83cdb611baa248b7ac6a", [tag: "v0.22.0"]},
   "phoenix_pubsub": {:git, "https://github.com/phoenixframework/phoenix_pubsub.git", "086e0af0af9306580ee59025c85931936a849ab5", [tag: "v2.2.0"]},
+  "telemetry": {:git, "https://github.com/beam-telemetry/telemetry.git", "8d8af76720856bcf26641ee1307658ad8f25e466", [tag: "v1.3.0"]},
 }

--- a/priv/favn/storage/sqlite/migrations/20260330000000_create_runs.exs
+++ b/priv/favn/storage/sqlite/migrations/20260330000000_create_runs.exs
@@ -2,6 +2,9 @@ defmodule Favn.Storage.SQLite.Migrations.CreateRuns do
   use Ecto.Migration
 
   def change do
+    create table(:run_write_orders) do
+    end
+
     create table(:runs, primary_key: false) do
       add :id, :text, primary_key: true
       add :status, :text, null: false

--- a/priv/favn/storage/sqlite/migrations/20260330000000_create_runs.exs
+++ b/priv/favn/storage/sqlite/migrations/20260330000000_create_runs.exs
@@ -7,12 +7,13 @@ defmodule Favn.Storage.SQLite.Migrations.CreateRuns do
       add :status, :text, null: false
       add :started_at, :utc_datetime
       add :finished_at, :utc_datetime
-      add :inserted_at, :utc_datetime, null: false
-      add :updated_at, :utc_datetime, null: false
+      add :inserted_at_us, :bigint, null: false
+      add :updated_at_us, :bigint, null: false
+      add :updated_seq, :bigint, null: false
       add :run_blob, :binary, null: false
     end
 
     create index(:runs, [:status])
-    create index(:runs, [:updated_at, :inserted_at, :id])
+    create index(:runs, [:updated_seq, :updated_at_us, :id])
   end
 end

--- a/priv/favn/storage/sqlite/migrations/20260330000000_create_runs.exs
+++ b/priv/favn/storage/sqlite/migrations/20260330000000_create_runs.exs
@@ -1,0 +1,18 @@
+defmodule Favn.Storage.SQLite.Migrations.CreateRuns do
+  use Ecto.Migration
+
+  def change do
+    create table(:runs, primary_key: false) do
+      add :id, :text, primary_key: true
+      add :status, :text, null: false
+      add :started_at, :utc_datetime
+      add :finished_at, :utc_datetime
+      add :inserted_at, :utc_datetime, null: false
+      add :updated_at, :utc_datetime, null: false
+      add :run_blob, :binary, null: false
+    end
+
+    create index(:runs, [:status])
+    create index(:runs, [:updated_at, :inserted_at, :id])
+  end
+end

--- a/test/sqlite_storage_bootstrap_test.exs
+++ b/test/sqlite_storage_bootstrap_test.exs
@@ -1,0 +1,50 @@
+defmodule Favn.SQLiteStorageBootstrapTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Run
+  alias Favn.Storage
+  alias Favn.Storage.Adapter.SQLite
+
+  setup do
+    state = Favn.TestSetup.capture_state()
+
+    on_exit(fn ->
+      Favn.TestSetup.restore_state(state, clear_storage_adapter_env?: true)
+    end)
+
+    :ok
+  end
+
+  test "adapter child_spec boots repo and migrations for runtime use" do
+    db_path =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_sqlite_bootstrap_#{System.unique_integer([:positive, :monotonic])}.db"
+      )
+
+    on_exit(fn -> File.rm(db_path) end)
+
+    :ok = Favn.TestSetup.configure_storage_adapter(SQLite, database: db_path)
+    {:ok, child_spec} = SQLite.child_spec(database: db_path)
+    start_supervised!(child_spec)
+
+    run = sample_run("bootstrap-run", :running)
+    assert :ok = Storage.put_run(run)
+    assert {:ok, stored} = Storage.get_run("bootstrap-run")
+    assert stored.id == "bootstrap-run"
+  end
+
+  defp sample_run(id, status) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %Run{
+      id: id,
+      target_refs: [],
+      plan: nil,
+      status: status,
+      event_seq: 0,
+      started_at: now,
+      finished_at: if(status in [:ok, :error, :cancelled, :timed_out], do: now, else: nil)
+    }
+  end
+end

--- a/test/sqlite_storage_test.exs
+++ b/test/sqlite_storage_test.exs
@@ -3,6 +3,7 @@ defmodule Favn.SQLiteStorageTest do
 
   alias Favn.Run
   alias Favn.Storage
+  alias Favn.Storage.SQLite.Migrations
   alias Favn.Storage.SQLite.Repo
 
   setup do
@@ -16,6 +17,7 @@ defmodule Favn.SQLiteStorageTest do
 
     :ok = Favn.TestSetup.configure_storage_adapter(Favn.Storage.Adapter.SQLite, database: db_path)
     start_supervised!({Repo, database: db_path, pool_size: 1, busy_timeout: 5_000})
+    :ok = Migrations.migrate!(Repo)
 
     on_exit(fn ->
       Favn.TestSetup.restore_state(state, clear_storage_adapter_env?: true)
@@ -34,30 +36,30 @@ defmodule Favn.SQLiteStorageTest do
     assert fetched.status == :running
   end
 
-  test "lists runs newest first with filters and limit" do
-    first = sample_run("sqlite-run-1", :ok)
-    second = sample_run("sqlite-run-2", :error)
+  test "lists runs newest first by latest persisted write, not by id" do
+    same_started_at = DateTime.utc_now() |> DateTime.truncate(:second)
+    first = sample_run("zzz-first-id", :ok, same_started_at)
+    second = sample_run("aaa-second-id", :error, same_started_at)
 
     assert :ok = Storage.put_run(first)
-    Process.sleep(5)
     assert :ok = Storage.put_run(second)
 
     assert {:ok, all_runs} = Storage.list_runs()
-    assert Enum.map(all_runs, & &1.id) == ["sqlite-run-2", "sqlite-run-1"]
+    assert Enum.map(all_runs, & &1.id) == ["aaa-second-id", "zzz-first-id"]
 
     assert {:ok, errored} = Storage.list_runs(status: :error)
-    assert Enum.map(errored, & &1.id) == ["sqlite-run-2"]
+    assert Enum.map(errored, & &1.id) == ["aaa-second-id"]
 
     assert {:ok, limited} = Storage.list_runs(limit: 1)
-    assert Enum.map(limited, & &1.id) == ["sqlite-run-2"]
+    assert Enum.map(limited, & &1.id) == ["aaa-second-id"]
   end
 
   test "returns :not_found for missing run id" do
     assert {:error, :not_found} = Storage.get_run("missing-sqlite-run")
   end
 
-  defp sample_run(id, status) do
-    now = DateTime.utc_now() |> DateTime.truncate(:second)
+  defp sample_run(id, status, started_at \\ DateTime.utc_now()) do
+    now = DateTime.truncate(started_at, :second)
 
     %Run{
       id: id,

--- a/test/sqlite_storage_test.exs
+++ b/test/sqlite_storage_test.exs
@@ -58,6 +58,40 @@ defmodule Favn.SQLiteStorageTest do
     assert {:error, :not_found} = Storage.get_run("missing-sqlite-run")
   end
 
+  test "concurrent writes preserve adapter ordering in list_runs/1" do
+    base_started_at = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    tasks =
+      for index <- 1..12 do
+        Task.async(fn ->
+          run_id = "concurrent-run-#{index}"
+          run = sample_run(run_id, :ok, base_started_at)
+          assert :ok = Storage.put_run(run)
+          run_id
+        end)
+      end
+
+    _ids = Enum.map(tasks, &Task.await(&1, 5_000))
+
+    assert {:ok, runs} = Storage.list_runs()
+
+    listed_ids =
+      runs
+      |> Enum.map(& &1.id)
+      |> Enum.filter(&String.starts_with?(&1, "concurrent-run-"))
+
+    assert length(listed_ids) == 12
+
+    assert {:ok, %{rows: rows}} =
+             Ecto.Adapters.SQL.query(
+               Repo,
+               "SELECT id FROM runs WHERE id LIKE 'concurrent-run-%' ORDER BY updated_seq DESC, updated_at_us DESC, id DESC",
+               []
+             )
+
+    assert listed_ids == Enum.map(rows, &hd/1)
+  end
+
   defp sample_run(id, status, started_at \\ DateTime.utc_now()) do
     now = DateTime.truncate(started_at, :second)
 

--- a/test/sqlite_storage_test.exs
+++ b/test/sqlite_storage_test.exs
@@ -1,0 +1,72 @@
+defmodule Favn.SQLiteStorageTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Run
+  alias Favn.Storage
+  alias Favn.Storage.SQLite.Repo
+
+  setup do
+    state = Favn.TestSetup.capture_state()
+
+    db_path =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_sqlite_#{System.unique_integer([:positive, :monotonic])}.db"
+      )
+
+    :ok = Favn.TestSetup.configure_storage_adapter(Favn.Storage.Adapter.SQLite, database: db_path)
+    start_supervised!({Repo, database: db_path, pool_size: 1, busy_timeout: 5_000})
+
+    on_exit(fn ->
+      Favn.TestSetup.restore_state(state, clear_storage_adapter_env?: true)
+      File.rm(db_path)
+    end)
+
+    :ok
+  end
+
+  test "persists and fetches runs" do
+    run = sample_run("sqlite-run-1", :running)
+
+    assert :ok = Storage.put_run(run)
+    assert {:ok, fetched} = Storage.get_run("sqlite-run-1")
+    assert fetched.id == run.id
+    assert fetched.status == :running
+  end
+
+  test "lists runs newest first with filters and limit" do
+    first = sample_run("sqlite-run-1", :ok)
+    second = sample_run("sqlite-run-2", :error)
+
+    assert :ok = Storage.put_run(first)
+    Process.sleep(5)
+    assert :ok = Storage.put_run(second)
+
+    assert {:ok, all_runs} = Storage.list_runs()
+    assert Enum.map(all_runs, & &1.id) == ["sqlite-run-2", "sqlite-run-1"]
+
+    assert {:ok, errored} = Storage.list_runs(status: :error)
+    assert Enum.map(errored, & &1.id) == ["sqlite-run-2"]
+
+    assert {:ok, limited} = Storage.list_runs(limit: 1)
+    assert Enum.map(limited, & &1.id) == ["sqlite-run-2"]
+  end
+
+  test "returns :not_found for missing run id" do
+    assert {:error, :not_found} = Storage.get_run("missing-sqlite-run")
+  end
+
+  defp sample_run(id, status) do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    %Run{
+      id: id,
+      target_refs: [],
+      plan: nil,
+      status: status,
+      event_seq: 0,
+      started_at: now,
+      finished_at: if(status in [:ok, :error, :cancelled, :timed_out], do: now, else: nil)
+    }
+  end
+end


### PR DESCRIPTION
### Motivation

- Provide durable single-node run persistence for Favn using SQLite to move beyond in-memory storage.
- Expose a configurable `:storage_adapter` option to allow host apps to select SQLite-backed storage with connection options.
- Enable deterministic querying and indexing of runs for production single-node usage.

### Description

- Add `Favn.Storage.Adapter.SQLite` implementing the `Favn.Storage.Adapter` behaviour with `child_spec/1`, `put_run/2`, `get_run/2`, and `list_runs/2`, storing full `%Favn.Run{}` snapshots as `run_blob` via `:erlang.term_to_binary` and indexed fields for queries.
- Add `Favn.Storage.SQLite.Repo` and `Favn.Storage.SQLite.Migrations` plus the migration `priv/favn/storage/sqlite/migrations/20260330000000_create_runs.exs` to create the `runs` table and indexes.
- Update `mix.exs` to include `:ecto_sql`, `:ecto`, `:ecto_sqlite3`, `:exqlite` and supporting deps and add `:ecto_sql` to `extra_applications`, and update `mix.lock` accordingly.
- Update docs and examples in `README.md`, `lib/favn.ex`, and `FEATURES.md` to document SQLite configuration and mark the SQLite adapter as implemented.

### Testing

- Added `test/sqlite_storage_test.exs` which runs `Favn.SQLiteStorageTest` covering `put_run/2`, `get_run/2`, `list_runs/2` ordering/filters/limits, and missing-run behavior, and those tests were executed and passed.
- Tests use a temporary SQLite file and start `Favn.Storage.SQLite.Repo` under test supervision to validate migrations and runtime behavior, and no test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69ca5a82be688328b793650ae84a805b)