### PR TITLE
SQLite: use favn_counters monotonic counter for run updated_seq allocation

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -64,7 +64,7 @@ Turns Favn into a real execution engine with durable state and concurrency.
 - [x] Cancellation support
 - [x] Timeout handling
 - [x] SQLite storage adapter
-- [ ] SQLite `run_write_orders` growth management (prune/compact strategy)
+- [x] SQLite monotonic `updated_seq` allocation via `favn_counters` (replaces `run_write_orders` growth path)
 - [ ] Stable event schema (runs + steps)
 - [ ] Telemetry integration
 - [ ] Initial materialization/artifact model (replace in-memory-only outputs)

--- a/README.md
+++ b/README.md
@@ -121,6 +121,13 @@ config :favn,
   ]
 ```
 
+SQLite ordering notes:
+
+- `runs.updated_seq` is allocated from a dedicated `favn_counters` row (`run_write_order`)
+  inside the same transaction that persists the run snapshot.
+- `list_runs` remains ordered by latest persisted write:
+  `updated_seq DESC, updated_at_us DESC, id DESC`.
+
 ## Current limitations
 
 - The default run store is node-local in-memory storage.

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -227,6 +227,11 @@ defmodule Favn do
           pool_size: 5
         ]
 
+  In SQLite mode, run ordering uses a dedicated `favn_counters` row
+  (`run_write_order`) to allocate `runs.updated_seq` transactionally.
+  `Favn.list_runs/1` ordering remains newest-first by
+  `updated_seq DESC, updated_at_us DESC, id DESC`.
+
   ## Starting Favn
 
   There is no separate Favn server process that operators start manually.

--- a/lib/favn/storage/adapter/sqlite.ex
+++ b/lib/favn/storage/adapter/sqlite.ex
@@ -62,30 +62,34 @@ defmodule Favn.Storage.Adapter.SQLite do
         run_blob = excluded.run_blob
       """
 
-      case Repo.transact(fn ->
-             with {:ok, _} <-
-                    Ecto.Adapters.SQL.query(
-                      Repo,
-                      "INSERT INTO run_write_orders DEFAULT VALUES",
-                      []
-                    ),
-                  {:ok, %{rows: [[updated_seq]]}} <-
-                    Ecto.Adapters.SQL.query(Repo, "SELECT last_insert_rowid()", []),
-                  params <- [
-                    run.id,
-                    Atom.to_string(run.status),
-                    datetime_to_iso(run.started_at),
-                    datetime_to_iso(run.finished_at),
-                    now_us,
-                    updated_seq,
-                    :erlang.term_to_binary(run)
-                  ],
-                  {:ok, _} <- Ecto.Adapters.SQL.query(Repo, sql, params) do
-               {:ok, :ok}
-             else
-               {:error, reason} -> Repo.rollback(reason)
-             end
-           end) do
+      updated_seq_sql = """
+      INSERT INTO favn_counters (name, value)
+      VALUES (?1, 1)
+      ON CONFLICT(name) DO UPDATE SET value = value + 1
+      RETURNING value
+      """
+
+      case Repo.transact(
+             fn ->
+               with {:ok, %{rows: [[updated_seq]]}} <-
+                      Ecto.Adapters.SQL.query(Repo, updated_seq_sql, ["run_write_order"]),
+                    params <- [
+                      run.id,
+                      Atom.to_string(run.status),
+                      datetime_to_iso(run.started_at),
+                      datetime_to_iso(run.finished_at),
+                      now_us,
+                      updated_seq,
+                      :erlang.term_to_binary(run)
+                    ],
+                    {:ok, _} <- Ecto.Adapters.SQL.query(Repo, sql, params) do
+                 {:ok, :ok}
+               else
+                 {:error, reason} -> Repo.rollback(reason)
+               end
+             end,
+             mode: :immediate
+           ) do
         {:ok, :ok} -> :ok
         {:error, reason} -> {:error, reason}
       end

--- a/priv/favn/storage/sqlite/migrations/20260330000000_create_runs.exs
+++ b/priv/favn/storage/sqlite/migrations/20260330000000_create_runs.exs
@@ -2,9 +2,6 @@ defmodule Favn.Storage.SQLite.Migrations.CreateRuns do
   use Ecto.Migration
 
   def change do
-    create table(:run_write_orders) do
-    end
-
     create table(:runs, primary_key: false) do
       add :id, :text, primary_key: true
       add :status, :text, null: false
@@ -18,5 +15,16 @@ defmodule Favn.Storage.SQLite.Migrations.CreateRuns do
 
     create index(:runs, [:status])
     create index(:runs, [:updated_seq, :updated_at_us, :id])
+
+    create table(:favn_counters, primary_key: false) do
+      add :name, :text, primary_key: true
+      add :value, :bigint, null: false
+    end
+
+    execute("""
+    INSERT INTO favn_counters (name, value)
+    VALUES ('run_write_order', 0)
+    ON CONFLICT(name) DO NOTHING
+    """)
   end
 end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -248,9 +248,9 @@ defmodule Favn.RunnerTest do
 
   test "lists runs with status filter and limit in newest-first order" do
     assert {:ok, ok_run_id} = Favn.run({RunnerAssets, :final})
-    assert {:ok, error_run_id} = Favn.run({RunnerAssets, :crashes})
-
     assert {:ok, ok_run} = Favn.await_run(ok_run_id)
+
+    assert {:ok, error_run_id} = Favn.run({RunnerAssets, :crashes})
     assert {:error, error_run} = Favn.await_run(error_run_id)
 
     assert {:ok, all_runs} = Favn.list_runs()

--- a/test/sqlite_storage_test.exs
+++ b/test/sqlite_storage_test.exs
@@ -58,6 +58,15 @@ defmodule Favn.SQLiteStorageTest do
     assert {:error, :not_found} = Storage.get_run("missing-sqlite-run")
   end
 
+  test "does not keep run_write_orders helper table after migrations" do
+    assert {:ok, %{rows: [[0]]}} =
+             Ecto.Adapters.SQL.query(
+               Repo,
+               "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'run_write_orders'",
+               []
+             )
+  end
+
   test "concurrent writes preserve adapter ordering in list_runs/1" do
     base_started_at = DateTime.utc_now() |> DateTime.truncate(:second)
 
@@ -90,6 +99,33 @@ defmodule Favn.SQLiteStorageTest do
              )
 
     assert listed_ids == Enum.map(rows, &hd/1)
+
+    assert {:ok, %{rows: [[counter_value]]}} =
+             Ecto.Adapters.SQL.query(
+               Repo,
+               "SELECT value FROM favn_counters WHERE name = 'run_write_order'",
+               []
+             )
+
+    assert counter_value >= 12
+  end
+
+  test "updating the same run id advances sequence and moves run to front" do
+    base_started_at = DateTime.utc_now() |> DateTime.truncate(:second)
+    first = sample_run("run-a", :running, base_started_at)
+    second = sample_run("run-b", :running, base_started_at)
+
+    assert :ok = Storage.put_run(first)
+    assert :ok = Storage.put_run(second)
+
+    assert {:ok, initial_runs} = Storage.list_runs()
+    assert Enum.map(initial_runs, & &1.id) == ["run-b", "run-a"]
+
+    updated_first = %{first | status: :ok, finished_at: base_started_at}
+    assert :ok = Storage.put_run(updated_first)
+
+    assert {:ok, reordered_runs} = Storage.list_runs()
+    assert Enum.map(reordered_runs, & &1.id) == ["run-a", "run-b"]
   end
 
   defp sample_run(id, status, started_at \\ DateTime.utc_now()) do


### PR DESCRIPTION
### Motivation

- Replace the growing helper table approach (`run_write_orders`) with a durable, monotonic counter to transactionally allocate `runs.updated_seq` and prevent unbounded table growth.

### Description

- Swap the adapter allocation logic in `Favn.Storage.Adapter.SQLite` to UPSERT into a new `favn_counters` table and `RETURNING value` to obtain `updated_seq` inside the same transaction and use `mode: :immediate` for the transaction. 
- Update the migration to remove `run_write_orders` and create `favn_counters` with an initial `run_write_order` row seeded to `0`.
- Add documentation notes in `README.md`, `FEATURES.md`, and `lib/favn.ex` describing the new SQLite ordering/counter semantics and that `Favn.list_runs/1` remains ordered by `updated_seq DESC, updated_at_us DESC, id DESC`.
- Adjust and extend tests: reorder a run creation in `runner_test.exs` for stable expectations and add new assertions in `sqlite_storage_test.exs` to verify the absence of `run_write_orders`, that concurrent writes increment the counter, and that updating an existing run advances its sequence and moves it to the front.

### Testing

- Ran the test suite with `mix test` and verified `Favn.SQLiteStorageTest` and `Favn.RunnerTest` (including the new SQLite counter assertions) pass successfully. 
- The new SQLite-specific tests assert table migration state, concurrent write ordering, counter increment behavior, and run-order updates, and they all succeeded under the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cae3097da0832886cb8f8dc094d447)