### PR TITLE
Add internal runtime telemetry and emit telemetry for runtime events, storage, and pubsub

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -66,7 +66,10 @@ Turns Favn into a real execution engine with durable state and concurrency.
 - [x] SQLite storage adapter
 - [x] SQLite monotonic `updated_seq` allocation via `favn_counters` (replaces `run_write_orders` growth path)
 - [x] Stable event schema (runs + steps)
-- [ ] Telemetry integration
+- [x] Internal runtime telemetry foundation (`:telemetry` events via `Favn.Runtime.Telemetry`)
+- [x] Runtime telemetry taxonomy + naming contract (`[:favn, :runtime, ...]`)
+- [x] Runtime instrumentation at coordinator/executor/storage/pubsub boundaries
+- [x] Telemetry contract tests for core run/step flows
 - [ ] Initial materialization/artifact model (replace in-memory-only outputs)
 - [x] Separation of coordinator vs executor internally
 
@@ -90,6 +93,8 @@ First production-usable version (single node).
 - [ ] Retry policy extensions (backoff + jitter + richer retry classifiers)
 - [ ] Run deduplication (run keys)
 - [ ] Stable operator APIs (run, cancel, rerun)
+- [ ] User-facing observation/check API design (separate from runtime telemetry)
+- [ ] Business/data-quality signal model (initial schema)
 - [ ] `favn_view` alpha (graph + runs + schedules)
 
 ---
@@ -127,6 +132,7 @@ Makes Favn extensible and ecosystem-ready.
 - [ ] Storage plugin interface (stable)
 - [ ] Trigger plugin interface
 - [ ] Runtime/executor plugin interface
+- [ ] Telemetry exporter plugin interface (OpenTelemetry and other backends)
 - [ ] Connector plugin system
 - [ ] Connector registry (schema + docs + config)
 - [ ] Secret/config reference model

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ SQLite ordering notes:
   - `{:store_error, reason}`
 - **Checkpoint persistence policy**: runtime checkpoints are required; if snapshot persistence fails, `Favn.run/2` returns `{:error, {:storage_persist_failed, reason}}`.
 - **Event delivery**: run events are published as best-effort observability signals and do not affect run correctness.
+- **Internal telemetry**: runtime boundaries emit machine-oriented `:telemetry` events under `[:favn, :runtime, ...]` for operators and future external exporters.
 
 ## Guarantees in this release
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ SQLite ordering notes:
 - **Checkpoint persistence policy**: runtime checkpoints are required; if snapshot persistence fails, `Favn.run/2` returns `{:error, {:storage_persist_failed, reason}}`.
 - **Event delivery**: run events are published as best-effort observability signals and do not affect run correctness.
 - **Internal telemetry**: runtime boundaries emit machine-oriented `:telemetry` events under `[:favn, :runtime, ...]` for operators and future external exporters.
+- **Logger correlation metadata**: runtime coordinator/executor processes attach lightweight metadata (`run_id`, `ref`, `stage`, `attempt`) for human diagnostics without treating logs as telemetry.
 
 ## Guarantees in this release
 

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -79,6 +79,10 @@ defmodule Favn do
     * audit trails
     * hooks into telemetry or other observability systems
 
+  Runtime PubSub events are a UI/live-subscription contract. Internal runtime
+  machine telemetry is emitted separately via `:telemetry` event names under
+  `[:favn, :runtime, ...]`.
+
   ## Authoring assets
 
   Assets are defined in normal modules using `Favn.Assets`.

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -518,12 +518,15 @@ defmodule Favn.Runtime.Coordinator do
       Enum.reduce(events, state, fn event, acc ->
         {event_name, attrs} = event_attrs(acc, event)
         seq = acc.event_seq + 1
+        attrs = Map.merge(attrs, %{run_id: acc.run_id, seq: seq})
+
+        _ = Favn.Runtime.Telemetry.emit_runtime_event(event_name, attrs)
 
         _ =
           Favn.Runtime.Events.publish_run_event(
             acc.run_id,
             event_name,
-            Map.merge(attrs, %{seq: seq})
+            attrs
           )
 
         %{acc | event_seq: seq}
@@ -552,6 +555,7 @@ defmodule Favn.Runtime.Coordinator do
        ref: ref,
        stage: stage,
        data: %{
+         duration_ms: step.duration_ms,
          attempt: step.attempt,
          max_attempts: step.max_attempts
        }
@@ -561,6 +565,8 @@ defmodule Favn.Runtime.Coordinator do
   defp event_attrs(%State{} = state, {event_name, ref, payload}) when is_map(payload) do
     stage = stage_for(state, ref)
     step = Map.fetch!(state.steps, ref)
+    error = step.error || %{}
+    payload = payload_with_error_metadata(payload, error)
 
     {event_name,
      %{
@@ -570,6 +576,7 @@ defmodule Favn.Runtime.Coordinator do
        stage: stage,
        data:
          Map.merge(payload, %{
+           duration_ms: step.duration_ms,
            attempt: step.attempt,
            max_attempts: step.max_attempts
          })
@@ -579,16 +586,41 @@ defmodule Favn.Runtime.Coordinator do
   defp event_attrs(%State{} = state, event_name) when is_atom(event_name) do
     data =
       case event_name do
-        :run_failed -> %{error: state.run_error, terminal_reason: state.run_terminal_reason}
-        :run_cancel_requested -> %{terminal_reason: state.run_terminal_reason}
-        :run_cancelled -> %{terminal_reason: state.run_terminal_reason}
-        :run_timeout_triggered -> %{terminal_reason: state.run_terminal_reason}
-        :run_timed_out -> %{terminal_reason: state.run_terminal_reason}
-        _ -> %{}
+        :run_failed ->
+          %{
+            error: state.run_error,
+            terminal_reason: state.run_terminal_reason,
+            error_class: :run_failed,
+            error_kind: :error
+          }
+
+        :run_cancel_requested ->
+          %{terminal_reason: state.run_terminal_reason}
+
+        :run_cancelled ->
+          %{terminal_reason: state.run_terminal_reason}
+
+        :run_timeout_triggered ->
+          %{terminal_reason: state.run_terminal_reason}
+
+        :run_timed_out ->
+          %{terminal_reason: state.run_terminal_reason}
+
+        _ ->
+          %{}
       end
 
     {event_name, %{entity: :run, status: state.run_status, data: data}}
   end
+
+  defp payload_with_error_metadata(payload, error) do
+    payload
+    |> maybe_put_error_field(:error_kind, Map.get(error, :kind))
+    |> maybe_put_error_field(:error_class, Map.get(error, :class))
+  end
+
+  defp maybe_put_error_field(payload, _key, nil), do: payload
+  defp maybe_put_error_field(payload, key, value), do: Map.put_new(payload, key, value)
 
   defp persist_snapshot(%State{} = state) do
     case state |> Projector.to_public_run() |> Favn.Storage.put_run() do

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -24,7 +24,9 @@ defmodule Favn.Runtime.Coordinator do
 
   @impl true
   def init(opts) do
-    {:ok, %{state: Keyword.fetch!(opts, :state)}}
+    state = Keyword.fetch!(opts, :state)
+    Logger.metadata(run_id: state.run_id)
+    {:ok, %{state: state}}
   end
 
   @impl true
@@ -124,10 +126,43 @@ defmodule Favn.Runtime.Coordinator do
   end
 
   defp dispatch_ready_work(%State{} = state) do
-    if dispatch_allowed?(state) and capacity(state) > 0 do
-      do_dispatch(state)
-    else
-      {:ok, state}
+    started_ms = System.monotonic_time(:millisecond)
+    ready_before = length(state.ready_queue)
+    inflight_before = map_size(state.inflight_execs)
+
+    result =
+      if dispatch_allowed?(state) and capacity(state) > 0 do
+        do_dispatch(state)
+      else
+        {:ok, state}
+      end
+
+    case result do
+      {:ok, next_state} ->
+        dispatched = max(map_size(next_state.inflight_execs) - inflight_before, 0)
+        duration_ms = System.monotonic_time(:millisecond) - started_ms
+
+        _ =
+          Favn.Runtime.Telemetry.emit_operation(:coordinator, :dispatch, duration_ms, %{
+            run_id: state.run_id,
+            result: :ok,
+            ready_before: ready_before,
+            inflight_before: inflight_before,
+            dispatched_count: dispatched
+          })
+
+        {:ok, next_state}
+
+      {:error, _reason} = error ->
+        duration_ms = System.monotonic_time(:millisecond) - started_ms
+
+        _ =
+          Favn.Runtime.Telemetry.emit_operation(:coordinator, :dispatch, duration_ms, %{
+            run_id: state.run_id,
+            result: :error
+          })
+
+        error
     end
   end
 
@@ -156,8 +191,7 @@ defmodule Favn.Runtime.Coordinator do
     with {:ok, state} <- apply_step_transition(state, &StepTransitions.start_step(&1, ref)),
          {:ok, asset} <- Favn.Registry.get_asset(ref),
          {:ok, deps} <- dependency_outputs(state, ref),
-         {:ok, handle} <-
-           executor_module().start_step(asset, build_context(state, ref), deps, self(), ref) do
+         {:ok, handle} <- start_executor_step(state, ref, asset, deps) do
       {:ok, put_execution_handle(state, ref, handle)}
     else
       {:error, reason} ->
@@ -314,7 +348,23 @@ defmodule Favn.Runtime.Coordinator do
 
   defp maybe_mark_run_failed(%State{} = state, _reason), do: {:ok, state}
 
-  defp close_admission(%State{} = state), do: {:ok, %{state | admission_open?: false}}
+  defp close_admission(%State{admission_open?: false} = state), do: {:ok, state}
+
+  defp close_admission(%State{} = state) do
+    started_ms = System.monotonic_time(:millisecond)
+    next_state = %{state | admission_open?: false}
+    duration_ms = System.monotonic_time(:millisecond) - started_ms
+
+    _ =
+      Favn.Runtime.Telemetry.emit_operation(:coordinator, :admission, duration_ms, %{
+        run_id: state.run_id,
+        result: :closed,
+        inflight_count: map_size(state.inflight_execs),
+        ready_count: length(state.ready_queue)
+      })
+
+    {:ok, next_state}
+  end
 
   defp request_cancellation(%State{run_status: :pending} = state, reason) do
     with {:ok, state} <- apply_run_transition(state, :start),
@@ -348,10 +398,41 @@ defmodule Favn.Runtime.Coordinator do
     result =
       Enum.reduce_while(state.inflight_execs, :ok, fn {exec_ref, exec_info}, :ok ->
         handle = %{exec_ref: exec_ref, monitor_ref: exec_info.monitor_ref, pid: exec_info.pid}
+        ref = exec_info.ref
+        step = Map.fetch!(state.steps, ref)
+        started_ms = System.monotonic_time(:millisecond)
+        Logger.metadata(ref: inspect(ref), stage: step.stage, attempt: step.attempt)
 
-        case executor_module().cancel_step(handle, reason) do
-          :ok -> {:cont, :ok}
-          {:error, err} -> {:halt, {:error, err}}
+        case safe_cancel_executor_step(handle, reason) do
+          :ok ->
+            duration_ms = System.monotonic_time(:millisecond) - started_ms
+
+            _ =
+              Favn.Runtime.Telemetry.emit_operation(:executor, :cancel_step, duration_ms, %{
+                run_id: state.run_id,
+                ref: ref,
+                stage: step.stage,
+                attempt: step.attempt,
+                result: :ok
+              })
+
+            {:cont, :ok}
+
+          {:error, err, class, kind} ->
+            duration_ms = System.monotonic_time(:millisecond) - started_ms
+
+            _ =
+              Favn.Runtime.Telemetry.emit_operation(:executor, :cancel_step, duration_ms, %{
+                run_id: state.run_id,
+                ref: ref,
+                stage: step.stage,
+                attempt: step.attempt,
+                result: :error,
+                error_class: class,
+                error_kind: kind
+              })
+
+            {:halt, {:error, err}}
         end
       end)
 
@@ -584,10 +665,16 @@ defmodule Favn.Runtime.Coordinator do
   end
 
   defp event_attrs(%State{} = state, event_name) when is_atom(event_name) do
+    run_duration_ms = run_duration_ms(state)
+
     data =
       case event_name do
+        :run_finished ->
+          %{duration_ms: run_duration_ms}
+
         :run_failed ->
           %{
+            duration_ms: run_duration_ms,
             error: state.run_error,
             terminal_reason: state.run_terminal_reason,
             error_class: :run_failed,
@@ -598,13 +685,13 @@ defmodule Favn.Runtime.Coordinator do
           %{terminal_reason: state.run_terminal_reason}
 
         :run_cancelled ->
-          %{terminal_reason: state.run_terminal_reason}
+          %{terminal_reason: state.run_terminal_reason, duration_ms: run_duration_ms}
 
         :run_timeout_triggered ->
-          %{terminal_reason: state.run_terminal_reason}
+          %{terminal_reason: state.run_terminal_reason, duration_ms: run_duration_ms}
 
         :run_timed_out ->
-          %{terminal_reason: state.run_terminal_reason}
+          %{terminal_reason: state.run_terminal_reason, duration_ms: run_duration_ms}
 
         _ ->
           %{}
@@ -692,4 +779,83 @@ defmodule Favn.Runtime.Coordinator do
   defp retryable?(policy, class), do: class in policy.retry_on
 
   defp enrich_error(error, class), do: Map.put(error, :class, class)
+
+  defp start_executor_step(%State{} = state, ref, asset, deps) do
+    step = Map.fetch!(state.steps, ref)
+    ctx = build_context(state, ref)
+    Logger.metadata(ref: inspect(ref), stage: step.stage, attempt: step.attempt)
+    started_ms = System.monotonic_time(:millisecond)
+
+    case safe_start_executor_step(asset, ctx, deps, ref) do
+      {:ok, handle} ->
+        duration_ms = System.monotonic_time(:millisecond) - started_ms
+
+        _ =
+          Favn.Runtime.Telemetry.emit_operation(:executor, :start_step, duration_ms, %{
+            run_id: state.run_id,
+            ref: ref,
+            stage: step.stage,
+            attempt: step.attempt,
+            result: :ok
+          })
+
+        {:ok, handle}
+
+      {:error, reason, class, kind} ->
+        duration_ms = System.monotonic_time(:millisecond) - started_ms
+
+        _ =
+          Favn.Runtime.Telemetry.emit_operation(:executor, :start_step, duration_ms, %{
+            run_id: state.run_id,
+            ref: ref,
+            stage: step.stage,
+            attempt: step.attempt,
+            result: :error,
+            error_class: class,
+            error_kind: kind
+          })
+
+        {:error, reason}
+    end
+  end
+
+  defp safe_start_executor_step(asset, ctx, deps, ref) do
+    executor_module().start_step(asset, ctx, deps, self(), ref)
+    |> unwrap_executor_result()
+  rescue
+    error -> {:error, error, :executor_start_raise, :error}
+  catch
+    :exit, reason -> {:error, reason, :executor_start_exit, :exit}
+    :throw, reason -> {:error, reason, :executor_start_throw, :throw}
+  end
+
+  defp safe_cancel_executor_step(handle, reason) do
+    case executor_module().cancel_step(handle, reason) do
+      :ok -> :ok
+      {:error, err} -> {:error, err, :executor_cancel_error, :error}
+    end
+  rescue
+    error -> {:error, error, :executor_cancel_raise, :error}
+  catch
+    :exit, reason -> {:error, reason, :executor_cancel_exit, :exit}
+    :throw, reason -> {:error, reason, :executor_cancel_throw, :throw}
+  end
+
+  defp unwrap_executor_result({:ok, handle}), do: {:ok, handle}
+
+  defp unwrap_executor_result({:error, reason}),
+    do: {:error, reason, :executor_start_error, :error}
+
+  defp unwrap_executor_result(other), do: {:error, other, :executor_start_invalid_return, :error}
+
+  defp run_duration_ms(%State{} = state) do
+    case state.started_at do
+      %DateTime{} = started_at ->
+        ended_at = state.finished_at || DateTime.utc_now()
+        max(DateTime.diff(ended_at, started_at, :millisecond), 0)
+
+      _ ->
+        nil
+    end
+  end
 end

--- a/lib/favn/runtime/events.ex
+++ b/lib/favn/runtime/events.ex
@@ -84,6 +84,7 @@ defmodule Favn.Runtime.Events do
   @spec publish_run_event(Favn.run_id(), event_type(), map()) :: :ok | {:error, term()}
   def publish_run_event(run_id, event_type, attrs \\ %{})
       when is_map(attrs) and is_atom(event_type) do
+    started = System.monotonic_time(:millisecond)
     sequence = Map.fetch!(attrs, :seq)
     emitted_at = DateTime.utc_now()
     data = Map.get(attrs, :data, %{})
@@ -102,7 +103,18 @@ defmodule Favn.Runtime.Events do
       |> maybe_put(:ref, Map.get(attrs, :ref))
       |> maybe_put(:stage, Map.get(attrs, :stage))
 
-    Phoenix.PubSub.broadcast(pubsub_name(), run_topic(run_id), {:favn_run_event, event})
+    result = Phoenix.PubSub.broadcast(pubsub_name(), run_topic(run_id), {:favn_run_event, event})
+    duration_ms = System.monotonic_time(:millisecond) - started
+
+    _ =
+      Favn.Runtime.Telemetry.emit_operation(:pubsub, :publish, duration_ms, %{
+        run_id: run_id,
+        event_type: event_type,
+        entity: Map.fetch!(attrs, :entity),
+        result: pubsub_result_status(result)
+      })
+
+    result
   end
 
   @doc """
@@ -121,4 +133,7 @@ defmodule Favn.Runtime.Events do
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp pubsub_result_status(:ok), do: :ok
+  defp pubsub_result_status({:error, _}), do: :error
 end

--- a/lib/favn/runtime/events.ex
+++ b/lib/favn/runtime/events.ex
@@ -108,16 +108,13 @@ defmodule Favn.Runtime.Events do
         Phoenix.PubSub.broadcast(pubsub_name(), run_topic(run_id), {:favn_run_event, event})
       rescue
         error ->
-          emit_pubsub_telemetry(started, run_id, event_type, attrs, {:error, {:raised, error}})
-          reraise(error, __STACKTRACE__)
+          {:error, {:raised, error}}
       catch
         :throw, reason ->
-          emit_pubsub_telemetry(started, run_id, event_type, attrs, {:error, {:thrown, reason}})
-          throw(reason)
+          {:error, {:thrown, reason}}
 
         :exit, reason ->
-          emit_pubsub_telemetry(started, run_id, event_type, attrs, {:error, {:exited, reason}})
-          exit(reason)
+          {:error, {:exited, reason}}
       end
 
     emit_pubsub_telemetry(started, run_id, event_type, attrs, result)

--- a/lib/favn/runtime/events.ex
+++ b/lib/favn/runtime/events.ex
@@ -103,17 +103,24 @@ defmodule Favn.Runtime.Events do
       |> maybe_put(:ref, Map.get(attrs, :ref))
       |> maybe_put(:stage, Map.get(attrs, :stage))
 
-    result = Phoenix.PubSub.broadcast(pubsub_name(), run_topic(run_id), {:favn_run_event, event})
-    duration_ms = System.monotonic_time(:millisecond) - started
+    result =
+      try do
+        Phoenix.PubSub.broadcast(pubsub_name(), run_topic(run_id), {:favn_run_event, event})
+      rescue
+        error ->
+          emit_pubsub_telemetry(started, run_id, event_type, attrs, {:error, {:raised, error}})
+          reraise(error, __STACKTRACE__)
+      catch
+        :throw, reason ->
+          emit_pubsub_telemetry(started, run_id, event_type, attrs, {:error, {:thrown, reason}})
+          throw(reason)
 
-    _ =
-      Favn.Runtime.Telemetry.emit_operation(:pubsub, :publish, duration_ms, %{
-        run_id: run_id,
-        event_type: event_type,
-        entity: Map.fetch!(attrs, :entity),
-        result: pubsub_result_status(result)
-      })
+        :exit, reason ->
+          emit_pubsub_telemetry(started, run_id, event_type, attrs, {:error, {:exited, reason}})
+          exit(reason)
+      end
 
+    emit_pubsub_telemetry(started, run_id, event_type, attrs, result)
     result
   end
 
@@ -136,4 +143,30 @@ defmodule Favn.Runtime.Events do
 
   defp pubsub_result_status(:ok), do: :ok
   defp pubsub_result_status({:error, _}), do: :error
+  defp pubsub_result_status(_), do: :error
+
+  defp pubsub_error_kind({:error, _}), do: :error
+  defp pubsub_error_kind(_), do: nil
+
+  defp pubsub_error_class({:error, {:raised, _}}), do: :publish_raise
+  defp pubsub_error_class({:error, {:thrown, _}}), do: :publish_throw
+  defp pubsub_error_class({:error, {:exited, _}}), do: :publish_exit
+  defp pubsub_error_class({:error, _}), do: :publish_error
+  defp pubsub_error_class(_), do: nil
+
+  defp emit_pubsub_telemetry(started, run_id, event_type, attrs, result) do
+    duration_ms = System.monotonic_time(:millisecond) - started
+
+    _ =
+      Favn.Runtime.Telemetry.emit_operation(:pubsub, :publish, duration_ms, %{
+        run_id: run_id,
+        event_type: event_type,
+        entity: Map.fetch!(attrs, :entity),
+        result: pubsub_result_status(result),
+        error_kind: pubsub_error_kind(result),
+        error_class: pubsub_error_class(result)
+      })
+
+    :ok
+  end
 end

--- a/lib/favn/runtime/executor/local.ex
+++ b/lib/favn/runtime/executor/local.ex
@@ -8,6 +8,7 @@ defmodule Favn.Runtime.Executor.Local do
   alias Favn.Asset
   alias Favn.Asset.Output
   alias Favn.Run.Context
+  require Logger
 
   @impl true
   def start_step(%Asset{} = asset, %Context{} = ctx, deps, reply_to, step_ref)
@@ -16,6 +17,13 @@ defmodule Favn.Runtime.Executor.Local do
 
     {pid, monitor_ref} =
       spawn_monitor(fn ->
+        Logger.metadata(
+          run_id: ctx.run_id,
+          ref: inspect(step_ref),
+          stage: ctx.stage,
+          attempt: ctx.attempt
+        )
+
         result = invoke(asset, ctx, deps)
         send(reply_to, {:executor_step_result, exec_ref, step_ref, result})
       end)

--- a/lib/favn/runtime/manager.ex
+++ b/lib/favn/runtime/manager.ex
@@ -157,6 +157,15 @@ defmodule Favn.Runtime.Manager do
   end
 
   defp emit_run_created(%State{} = runtime_state) do
+    _ =
+      Favn.Runtime.Telemetry.emit_runtime_event(:run_created, %{
+        run_id: runtime_state.run_id,
+        seq: 1,
+        entity: :run,
+        status: runtime_state.run_status,
+        data: %{}
+      })
+
     Favn.Runtime.Events.publish_run_event(runtime_state.run_id, :run_created, %{
       seq: 1,
       entity: :run,
@@ -204,6 +213,15 @@ defmodule Favn.Runtime.Manager do
 
       case Favn.Storage.put_run(failed) do
         :ok ->
+          _ =
+            Favn.Runtime.Telemetry.emit_runtime_event(:run_failed, %{
+              run_id: run_id,
+              seq: failed.event_seq,
+              entity: :run,
+              status: failed.status,
+              data: %{error: failed.error, error_class: :run_process_crash, error_kind: :exit}
+            })
+
           _ =
             Favn.Runtime.Events.publish_run_event(run_id, :run_failed, %{
               seq: failed.event_seq,

--- a/lib/favn/runtime/manager.ex
+++ b/lib/favn/runtime/manager.ex
@@ -219,7 +219,12 @@ defmodule Favn.Runtime.Manager do
               seq: failed.event_seq,
               entity: :run,
               status: failed.status,
-              data: %{error: failed.error, error_class: :run_process_crash, error_kind: :exit}
+              data: %{
+                duration_ms: run_duration_ms(failed),
+                error: failed.error,
+                error_class: :run_process_crash,
+                error_kind: :exit
+              }
             })
 
           _ =
@@ -244,6 +249,16 @@ defmodule Favn.Runtime.Manager do
 
   defp validate_params(params) when is_map(params), do: :ok
   defp validate_params(_), do: {:error, :invalid_run_params}
+
+  defp run_duration_ms(run) do
+    case {run.started_at, run.finished_at} do
+      {%DateTime{} = started_at, %DateTime{} = finished_at} ->
+        max(DateTime.diff(finished_at, started_at, :millisecond), 0)
+
+      _ ->
+        nil
+    end
+  end
 
   defp validate_max_concurrency(value) when is_integer(value) and value > 0, do: :ok
   defp validate_max_concurrency(_), do: {:error, :invalid_max_concurrency}

--- a/lib/favn/runtime/telemetry.ex
+++ b/lib/favn/runtime/telemetry.ex
@@ -21,6 +21,8 @@ defmodule Favn.Runtime.Telemetry do
   @spec emit_runtime_event(atom(), map(), map()) :: :ok
   def emit_runtime_event(event_type, attrs, extra_metadata \\ %{})
       when is_atom(event_type) and is_map(attrs) and is_map(extra_metadata) do
+    attrs = Map.put_new(attrs, :run_id, :unknown)
+
     metadata =
       attrs
       |> base_metadata()
@@ -64,25 +66,29 @@ defmodule Favn.Runtime.Telemetry do
   defp event_name_for(other, _attrs), do: [:favn, :runtime, :event, other]
 
   defp measurement_for(_event_type, attrs) do
-    attrs
-    |> Map.get(:data, %{})
-    |> Map.take([
-      :duration_ms,
-      :queue_wait_ms,
-      :delay_ms,
-      :attempt,
-      :max_attempts,
-      :remaining_attempts
-    ])
+    data = Map.get(attrs, :data, %{})
+
+    %{}
+    |> maybe_put_measurement(:duration_ms, data[:duration_ms])
+    |> maybe_put_measurement(:queue_wait_ms, data[:queue_wait_ms])
+    |> maybe_put_measurement(:delay_ms, data[:delay_ms])
+    |> maybe_put_measurement(:attempt, data[:attempt])
+    |> maybe_put_measurement(:max_attempts, data[:max_attempts])
+    |> maybe_put_measurement(:remaining_attempts, data[:remaining_attempts])
+    |> maybe_put_measurement(:stage, Map.get(attrs, :stage))
+    |> maybe_put_measurement(:event_seq_delta, data[:event_seq_delta])
   end
 
   defp base_metadata(attrs) do
     data = Map.get(attrs, :data, %{})
+    status = Map.get(attrs, :status)
+    entity = Map.get(attrs, :entity)
 
     %{}
     |> maybe_put(:run_id, Map.get(attrs, :run_id))
-    |> maybe_put(:entity, Map.get(attrs, :entity))
-    |> maybe_put(:status, Map.get(attrs, :status))
+    |> maybe_put(:entity, entity)
+    |> maybe_put(:run_status, if(entity == :run, do: status, else: nil))
+    |> maybe_put(:step_status, if(entity == :step, do: status, else: nil))
     |> maybe_put(:ref, Map.get(attrs, :ref))
     |> maybe_put(:stage, Map.get(attrs, :stage))
     |> maybe_put(:sequence, Map.get(attrs, :seq))
@@ -93,4 +99,7 @@ defmodule Favn.Runtime.Telemetry do
 
   defp maybe_put(map, _key, nil), do: map
   defp maybe_put(map, key, value), do: Map.put(map, key, value)
+
+  defp maybe_put_measurement(map, _key, value) when not is_number(value), do: map
+  defp maybe_put_measurement(map, key, value), do: Map.put(map, key, value)
 end

--- a/lib/favn/runtime/telemetry.ex
+++ b/lib/favn/runtime/telemetry.ex
@@ -5,6 +5,11 @@ defmodule Favn.Runtime.Telemetry do
   This module is the single emission boundary for machine-oriented runtime
   telemetry signals. It keeps event naming and metadata conventions stable for
   runtime internals while remaining backend-agnostic.
+
+  Contract rule:
+
+    * measurements contain numeric, aggregatable values only
+    * metadata contains identifiers, dimensions, and classifications only
   """
 
   @type event_name :: [atom()]
@@ -90,7 +95,6 @@ defmodule Favn.Runtime.Telemetry do
     |> maybe_put(:run_status, if(entity == :run, do: status, else: nil))
     |> maybe_put(:step_status, if(entity == :step, do: status, else: nil))
     |> maybe_put(:ref, Map.get(attrs, :ref))
-    |> maybe_put(:stage, Map.get(attrs, :stage))
     |> maybe_put(:sequence, Map.get(attrs, :seq))
     |> maybe_put(:error_kind, data[:error_kind])
     |> maybe_put(:error_class, data[:error_class])

--- a/lib/favn/runtime/telemetry.ex
+++ b/lib/favn/runtime/telemetry.ex
@@ -1,0 +1,96 @@
+defmodule Favn.Runtime.Telemetry do
+  @moduledoc """
+  Internal runtime telemetry facade.
+
+  This module is the single emission boundary for machine-oriented runtime
+  telemetry signals. It keeps event naming and metadata conventions stable for
+  runtime internals while remaining backend-agnostic.
+  """
+
+  @type event_name :: [atom()]
+  @type measurements :: map()
+  @type metadata :: map()
+
+  @spec emit(event_name(), measurements(), metadata()) :: :ok
+  def emit(event_name, measurements, metadata)
+      when is_list(event_name) and is_map(measurements) and is_map(metadata) do
+    :telemetry.execute(event_name, measurements, metadata)
+    :ok
+  end
+
+  @spec emit_runtime_event(atom(), map(), map()) :: :ok
+  def emit_runtime_event(event_type, attrs, extra_metadata \\ %{})
+      when is_atom(event_type) and is_map(attrs) and is_map(extra_metadata) do
+    metadata =
+      attrs
+      |> base_metadata()
+      |> Map.merge(extra_metadata)
+
+    emit(event_name_for(event_type, attrs), measurement_for(event_type, attrs), metadata)
+  end
+
+  @spec emit_operation(atom(), atom(), integer(), map()) :: :ok
+  def emit_operation(component, operation, duration_ms, metadata)
+      when is_atom(component) and is_atom(operation) and is_integer(duration_ms) and
+             is_map(metadata) do
+    emit([:favn, :runtime, component, operation], %{duration_ms: max(duration_ms, 0)}, metadata)
+  end
+
+  defp event_name_for(:run_started, _attrs), do: [:favn, :runtime, :run, :start]
+  defp event_name_for(:run_finished, _attrs), do: [:favn, :runtime, :run, :stop]
+  defp event_name_for(:run_failed, _attrs), do: [:favn, :runtime, :run, :exception]
+  defp event_name_for(:step_started, _attrs), do: [:favn, :runtime, :step, :start]
+  defp event_name_for(:step_finished, _attrs), do: [:favn, :runtime, :step, :stop]
+  defp event_name_for(:step_failed, _attrs), do: [:favn, :runtime, :step, :exception]
+
+  defp event_name_for(:run_cancel_requested, _attrs),
+    do: [:favn, :runtime, :run, :cancel_requested]
+
+  defp event_name_for(:run_timeout_triggered, _attrs),
+    do: [:favn, :runtime, :run, :timeout_triggered]
+
+  defp event_name_for(:run_cancelled, _attrs), do: [:favn, :runtime, :run, :cancelled]
+  defp event_name_for(:run_timed_out, _attrs), do: [:favn, :runtime, :run, :timed_out]
+  defp event_name_for(:step_retry_scheduled, _attrs), do: [:favn, :runtime, :step, :retry]
+
+  defp event_name_for(:step_retry_exhausted, _attrs),
+    do: [:favn, :runtime, :step, :retry_exhausted]
+
+  defp event_name_for(:step_ready, _attrs), do: [:favn, :runtime, :step, :ready]
+  defp event_name_for(:step_skipped, _attrs), do: [:favn, :runtime, :step, :skipped]
+  defp event_name_for(:step_cancelled, _attrs), do: [:favn, :runtime, :step, :cancelled]
+  defp event_name_for(:step_timed_out, _attrs), do: [:favn, :runtime, :step, :timed_out]
+  defp event_name_for(:run_created, _attrs), do: [:favn, :runtime, :run, :created]
+  defp event_name_for(other, _attrs), do: [:favn, :runtime, :event, other]
+
+  defp measurement_for(_event_type, attrs) do
+    attrs
+    |> Map.get(:data, %{})
+    |> Map.take([
+      :duration_ms,
+      :queue_wait_ms,
+      :delay_ms,
+      :attempt,
+      :max_attempts,
+      :remaining_attempts
+    ])
+  end
+
+  defp base_metadata(attrs) do
+    data = Map.get(attrs, :data, %{})
+
+    %{}
+    |> maybe_put(:run_id, Map.get(attrs, :run_id))
+    |> maybe_put(:entity, Map.get(attrs, :entity))
+    |> maybe_put(:status, Map.get(attrs, :status))
+    |> maybe_put(:ref, Map.get(attrs, :ref))
+    |> maybe_put(:stage, Map.get(attrs, :stage))
+    |> maybe_put(:sequence, Map.get(attrs, :seq))
+    |> maybe_put(:error_kind, data[:error_kind])
+    |> maybe_put(:error_class, data[:error_class])
+    |> maybe_put(:terminal_reason_kind, get_in(data, [:terminal_reason, :kind]))
+  end
+
+  defp maybe_put(map, _key, nil), do: map
+  defp maybe_put(map, key, value), do: Map.put(map, key, value)
+end

--- a/lib/favn/storage.ex
+++ b/lib/favn/storage.ex
@@ -45,7 +45,7 @@ defmodule Favn.Storage do
   """
   @spec put_run(Run.t()) :: :ok | {:error, error()}
   def put_run(%Run{} = run) do
-    adapter_call(fn adapter, opts -> adapter.put_run(run, opts) end)
+    adapter_call(:put_run, fn adapter, opts -> adapter.put_run(run, opts) end)
   end
 
   @doc """
@@ -55,7 +55,7 @@ defmodule Favn.Storage do
   """
   @spec get_run(Favn.run_id()) :: {:ok, Run.t()} | {:error, error()}
   def get_run(run_id) do
-    adapter_call(fn adapter, opts -> adapter.get_run(run_id, opts) end)
+    adapter_call(:get_run, fn adapter, opts -> adapter.get_run(run_id, opts) end)
   end
 
   @doc """
@@ -69,7 +69,9 @@ defmodule Favn.Storage do
   @spec list_runs(Favn.list_runs_opts()) :: {:ok, [Run.t()]} | {:error, error()}
   def list_runs(opts \\ []) when is_list(opts) do
     with :ok <- validate_list_opts(opts) do
-      adapter_call(fn adapter, adapter_opts -> adapter.list_runs(opts, adapter_opts) end)
+      adapter_call(:list_runs, fn adapter, adapter_opts ->
+        adapter.list_runs(opts, adapter_opts)
+      end)
     end
   end
 
@@ -133,15 +135,32 @@ defmodule Favn.Storage do
     end
   end
 
-  defp adapter_call(fun) do
+  defp adapter_call(operation, fun) do
     adapter = adapter_module()
+    started = System.monotonic_time(:millisecond)
 
     with :ok <- validate_adapter(adapter) do
-      adapter
-      |> fun.(adapter_opts())
-      |> normalize_result()
+      result =
+        adapter
+        |> fun.(adapter_opts())
+        |> normalize_result()
+
+      duration_ms = System.monotonic_time(:millisecond) - started
+
+      _ =
+        Favn.Runtime.Telemetry.emit_operation(:storage, operation, duration_ms, %{
+          operation: operation,
+          adapter: adapter,
+          result: storage_result_status(result)
+        })
+
+      result
     end
   end
+
+  defp storage_result_status(:ok), do: :ok
+  defp storage_result_status({:ok, _}), do: :ok
+  defp storage_result_status({:error, _}), do: :error
 
   defp normalize_result(:ok), do: :ok
   defp normalize_result({:ok, _value} = ok), do: ok

--- a/lib/favn/storage.ex
+++ b/lib/favn/storage.ex
@@ -45,7 +45,7 @@ defmodule Favn.Storage do
   """
   @spec put_run(Run.t()) :: :ok | {:error, error()}
   def put_run(%Run{} = run) do
-    adapter_call(:put_run, fn adapter, opts -> adapter.put_run(run, opts) end)
+    adapter_call(:put_run, %{run_id: run.id}, fn adapter, opts -> adapter.put_run(run, opts) end)
   end
 
   @doc """
@@ -55,7 +55,9 @@ defmodule Favn.Storage do
   """
   @spec get_run(Favn.run_id()) :: {:ok, Run.t()} | {:error, error()}
   def get_run(run_id) do
-    adapter_call(:get_run, fn adapter, opts -> adapter.get_run(run_id, opts) end)
+    adapter_call(:get_run, %{run_id: run_id}, fn adapter, opts ->
+      adapter.get_run(run_id, opts)
+    end)
   end
 
   @doc """
@@ -69,7 +71,7 @@ defmodule Favn.Storage do
   @spec list_runs(Favn.list_runs_opts()) :: {:ok, [Run.t()]} | {:error, error()}
   def list_runs(opts \\ []) when is_list(opts) do
     with :ok <- validate_list_opts(opts) do
-      adapter_call(:list_runs, fn adapter, adapter_opts ->
+      adapter_call(:list_runs, %{run_id: :all}, fn adapter, adapter_opts ->
         adapter.list_runs(opts, adapter_opts)
       end)
     end
@@ -135,32 +137,63 @@ defmodule Favn.Storage do
     end
   end
 
-  defp adapter_call(operation, fun) do
+  defp adapter_call(operation, metadata, fun) do
     adapter = adapter_module()
     started = System.monotonic_time(:millisecond)
 
-    with :ok <- validate_adapter(adapter) do
-      result =
-        adapter
-        |> fun.(adapter_opts())
-        |> normalize_result()
+    result =
+      case validate_adapter(adapter) do
+        :ok ->
+          safe_adapter_call(adapter, operation, fun)
 
-      duration_ms = System.monotonic_time(:millisecond) - started
+        {:error, reason} ->
+          {:error, reason}
+      end
 
-      _ =
-        Favn.Runtime.Telemetry.emit_operation(:storage, operation, duration_ms, %{
-          operation: operation,
-          adapter: adapter,
-          result: storage_result_status(result)
-        })
+    duration_ms = System.monotonic_time(:millisecond) - started
 
-      result
-    end
+    _ =
+      Favn.Runtime.Telemetry.emit_operation(:storage, operation, duration_ms, %{
+        run_id: Map.get(metadata, :run_id, :unknown),
+        operation: operation,
+        adapter: adapter,
+        result: storage_result_status(result),
+        error_kind: storage_error_kind(result),
+        error_class: storage_error_class(result)
+      })
+
+    result
   end
 
   defp storage_result_status(:ok), do: :ok
   defp storage_result_status({:ok, _}), do: :ok
   defp storage_result_status({:error, _}), do: :error
+  defp storage_result_status(_), do: :error
+
+  defp storage_error_kind({:error, _}), do: :error
+  defp storage_error_kind(_), do: nil
+
+  defp storage_error_class({:error, {:store_error, {:invalid_storage_adapter, _}}}),
+    do: :invalid_adapter
+
+  defp storage_error_class({:error, {:store_error, {:raised, _}}}), do: :adapter_raise
+  defp storage_error_class({:error, {:store_error, {:thrown, _}}}), do: :adapter_throw
+  defp storage_error_class({:error, {:store_error, {:exited, _}}}), do: :adapter_exit
+  defp storage_error_class({:error, {:store_error, _}}), do: :adapter_error
+  defp storage_error_class({:error, :not_found}), do: :not_found
+  defp storage_error_class({:error, :invalid_opts}), do: :invalid_opts
+  defp storage_error_class(_), do: nil
+
+  defp safe_adapter_call(adapter, _operation, fun) do
+    adapter
+    |> fun.(adapter_opts())
+    |> normalize_result()
+  rescue
+    error -> {:error, {:store_error, {:raised, error}}}
+  catch
+    :throw, reason -> {:error, {:store_error, {:thrown, reason}}}
+    :exit, reason -> {:error, {:store_error, {:exited, reason}}}
+  end
 
   defp normalize_result(:ok), do: :ok
   defp normalize_result({:ok, _value} = ok), do: ok

--- a/test/runtime_telemetry_test.exs
+++ b/test/runtime_telemetry_test.exs
@@ -212,14 +212,13 @@ defmodule Favn.RuntimeTelemetryTest do
   test "emits pubsub telemetry for failure paths" do
     Application.put_env(:favn, :pubsub_name, MissingPubSub)
 
-    assert_raise ArgumentError, fn ->
-      Favn.Runtime.Events.publish_run_event("r1", :run_started, %{
-        seq: 1,
-        entity: :run,
-        status: :running,
-        data: %{}
-      })
-    end
+    assert {:error, {:raised, %ArgumentError{}}} =
+             Favn.Runtime.Events.publish_run_event("r1", :run_started, %{
+               seq: 1,
+               entity: :run,
+               status: :running,
+               data: %{}
+             })
 
     events = drain_telemetry()
 

--- a/test/runtime_telemetry_test.exs
+++ b/test/runtime_telemetry_test.exs
@@ -1,0 +1,84 @@
+defmodule Favn.RuntimeTelemetryTest do
+  use ExUnit.Case
+
+  alias Favn.Test.Fixtures.Assets.Runner.RunnerAssets
+
+  setup do
+    state = Favn.TestSetup.capture_state()
+    handler_id = "runtime-telemetry-#{System.unique_integer([:positive])}"
+
+    :ok = Favn.TestSetup.setup_asset_modules([RunnerAssets], reload_graph?: true)
+    :ok = Favn.TestSetup.configure_storage_adapter(Favn.Storage.Adapter.Memory, [])
+    :ok = Favn.TestSetup.clear_memory_storage_adapter()
+
+    events = [
+      [:favn, :runtime, :run, :start],
+      [:favn, :runtime, :run, :stop],
+      [:favn, :runtime, :run, :exception],
+      [:favn, :runtime, :step, :start],
+      [:favn, :runtime, :step, :stop],
+      [:favn, :runtime, :step, :exception],
+      [:favn, :runtime, :storage, :put_run],
+      [:favn, :runtime, :pubsub, :publish]
+    ]
+
+    parent = self()
+
+    :ok =
+      :telemetry.attach_many(
+        handler_id,
+        events,
+        fn event, measurements, metadata, _config ->
+          send(parent, {:telemetry, event, measurements, metadata})
+        end,
+        nil
+      )
+
+    on_exit(fn ->
+      :telemetry.detach(handler_id)
+
+      Favn.TestSetup.restore_state(state, reload_graph?: true, clear_storage_adapter_env?: true)
+    end)
+
+    :ok
+  end
+
+  test "successful run emits runtime lifecycle telemetry" do
+    assert {:ok, run_id} = Favn.run({RunnerAssets, :final})
+    assert {:ok, %Favn.Run{}} = Favn.await_run(run_id)
+
+    assert_receive {:telemetry, [:favn, :runtime, :run, :start], _measurements,
+                    %{run_id: ^run_id}}
+
+    assert_receive {:telemetry, [:favn, :runtime, :step, :start], _measurements,
+                    %{run_id: ^run_id, ref: _ref}}
+
+    assert_receive {:telemetry, [:favn, :runtime, :step, :stop], measurements,
+                    %{run_id: ^run_id, ref: _ref}}
+
+    assert is_integer(measurements.duration_ms)
+
+    assert_receive {:telemetry, [:favn, :runtime, :run, :stop], _measurements, %{run_id: ^run_id}}
+
+    assert_receive {:telemetry, [:favn, :runtime, :storage, :put_run],
+                    %{duration_ms: duration_ms}, %{operation: :put_run, result: :ok}}
+
+    assert is_integer(duration_ms)
+
+    assert_receive {:telemetry, [:favn, :runtime, :pubsub, :publish], %{duration_ms: publish_ms},
+                    %{run_id: ^run_id, result: :ok}}
+
+    assert is_integer(publish_ms)
+  end
+
+  test "failed run emits exception telemetry" do
+    assert {:ok, run_id} = Favn.run({RunnerAssets, :crashes})
+    assert {:error, %Favn.Run{status: :error}} = Favn.await_run(run_id)
+
+    assert_receive {:telemetry, [:favn, :runtime, :step, :exception], _measurements,
+                    %{run_id: ^run_id, error_class: :exception}}
+
+    assert_receive {:telemetry, [:favn, :runtime, :run, :exception], _measurements,
+                    %{run_id: ^run_id, error_class: :run_failed}}
+  end
+end

--- a/test/runtime_telemetry_test.exs
+++ b/test/runtime_telemetry_test.exs
@@ -91,6 +91,13 @@ defmodule Favn.RuntimeTelemetryTest do
              is_number(m.attempt) and is_number(m.max_attempts) and is_tuple(md.ref)
            end)
 
+    {_, step_start_measurements, step_start_metadata} =
+      fetch_event!(events, [:favn, :runtime, :step, :start])
+
+    assert is_number(step_start_measurements.stage)
+    assert is_nil(Map.get(step_start_metadata, :stage))
+    assert is_atom(step_start_metadata.step_status)
+
     assert has_event?(events, [:favn, :runtime, :step, :stop], fn m, md ->
              is_number(m.duration_ms) and is_tuple(md.ref)
            end)
@@ -106,6 +113,12 @@ defmodule Favn.RuntimeTelemetryTest do
     assert has_event?(events, [:favn, :runtime, :run, :stop], fn m, md ->
              is_number(m.duration_ms) and md.run_id == run_id
            end)
+
+    {_, run_stop_measurements, run_stop_metadata} =
+      fetch_event!(events, [:favn, :runtime, :run, :stop])
+
+    assert is_number(run_stop_measurements.duration_ms)
+    assert is_atom(run_stop_metadata.run_status)
   end
 
   test "emits exception and retry telemetry for failing and retried flows" do
@@ -254,5 +267,10 @@ defmodule Favn.RuntimeTelemetryTest do
   defp assert_count(events, event_name, expected_count) do
     count = Enum.count(events, fn {event, _measurements, _metadata} -> event == event_name end)
     assert count == expected_count
+  end
+
+  defp fetch_event!(events, event_name) do
+    Enum.find(events, fn {event, _measurements, _metadata} -> event == event_name end) ||
+      flunk("expected event #{inspect(event_name)} to be present")
   end
 end

--- a/test/runtime_telemetry_test.exs
+++ b/test/runtime_telemetry_test.exs
@@ -3,39 +3,72 @@ defmodule Favn.RuntimeTelemetryTest do
 
   alias Favn.Test.Fixtures.Assets.Runner.RunnerAssets
 
+  defmodule RaisingStore do
+    @behaviour Favn.Storage.Adapter
+
+    @impl true
+    def child_spec(_opts), do: :none
+
+    @impl true
+    def put_run(_run, _opts), do: raise("boom")
+
+    @impl true
+    def get_run(_run_id, _opts), do: {:ok, nil}
+
+    @impl true
+    def list_runs(_opts, _adapter_opts), do: {:ok, []}
+  end
+
+  def handle_event(event, measurements, metadata, parent) do
+    send(parent, {:telemetry, event, measurements, metadata})
+  end
+
   setup do
     state = Favn.TestSetup.capture_state()
-    handler_id = "runtime-telemetry-#{System.unique_integer([:positive])}"
+    pubsub_before = Application.get_env(:favn, :pubsub_name)
 
     :ok = Favn.TestSetup.setup_asset_modules([RunnerAssets], reload_graph?: true)
     :ok = Favn.TestSetup.configure_storage_adapter(Favn.Storage.Adapter.Memory, [])
     :ok = Favn.TestSetup.clear_memory_storage_adapter()
 
+    handler_id = "runtime-telemetry-#{System.unique_integer([:positive])}"
+
     events = [
+      [:favn, :runtime, :run, :created],
       [:favn, :runtime, :run, :start],
       [:favn, :runtime, :run, :stop],
       [:favn, :runtime, :run, :exception],
+      [:favn, :runtime, :run, :cancel_requested],
+      [:favn, :runtime, :run, :cancelled],
+      [:favn, :runtime, :run, :timeout_triggered],
+      [:favn, :runtime, :run, :timed_out],
+      [:favn, :runtime, :step, :ready],
       [:favn, :runtime, :step, :start],
       [:favn, :runtime, :step, :stop],
       [:favn, :runtime, :step, :exception],
+      [:favn, :runtime, :step, :retry],
+      [:favn, :runtime, :step, :cancelled],
+      [:favn, :runtime, :step, :timed_out],
       [:favn, :runtime, :storage, :put_run],
-      [:favn, :runtime, :pubsub, :publish]
+      [:favn, :runtime, :storage, :get_run],
+      [:favn, :runtime, :storage, :list_runs],
+      [:favn, :runtime, :pubsub, :publish],
+      [:favn, :runtime, :executor, :start_step],
+      [:favn, :runtime, :executor, :cancel_step],
+      [:favn, :runtime, :coordinator, :dispatch],
+      [:favn, :runtime, :coordinator, :admission]
     ]
 
-    parent = self()
-
-    :ok =
-      :telemetry.attach_many(
-        handler_id,
-        events,
-        fn event, measurements, metadata, _config ->
-          send(parent, {:telemetry, event, measurements, metadata})
-        end,
-        nil
-      )
+    :ok = :telemetry.attach_many(handler_id, events, &__MODULE__.handle_event/4, self())
 
     on_exit(fn ->
       :telemetry.detach(handler_id)
+
+      if is_nil(pubsub_before) do
+        Application.delete_env(:favn, :pubsub_name)
+      else
+        Application.put_env(:favn, :pubsub_name, pubsub_before)
+      end
 
       Favn.TestSetup.restore_state(state, reload_graph?: true, clear_storage_adapter_env?: true)
     end)
@@ -43,42 +76,184 @@ defmodule Favn.RuntimeTelemetryTest do
     :ok
   end
 
-  test "successful run emits runtime lifecycle telemetry" do
+  test "emits run_created/start/stop, step lifecycle, executor start, and dispatch telemetry" do
     assert {:ok, run_id} = Favn.run({RunnerAssets, :final})
     assert {:ok, %Favn.Run{}} = Favn.await_run(run_id)
 
-    assert_receive {:telemetry, [:favn, :runtime, :run, :start], _measurements,
-                    %{run_id: ^run_id}}
+    events = telemetry_events_for(run_id)
 
-    assert_receive {:telemetry, [:favn, :runtime, :step, :start], _measurements,
-                    %{run_id: ^run_id, ref: _ref}}
+    assert_count(events, [:favn, :runtime, :run, :created], 1)
+    assert_count(events, [:favn, :runtime, :run, :start], 1)
+    assert_count(events, [:favn, :runtime, :run, :stop], 1)
+    assert has_event?(events, [:favn, :runtime, :step, :ready], fn _m, md -> is_tuple(md.ref) end)
 
-    assert_receive {:telemetry, [:favn, :runtime, :step, :stop], measurements,
-                    %{run_id: ^run_id, ref: _ref}}
+    assert has_event?(events, [:favn, :runtime, :step, :start], fn m, md ->
+             is_number(m.attempt) and is_number(m.max_attempts) and is_tuple(md.ref)
+           end)
 
-    assert is_integer(measurements.duration_ms)
+    assert has_event?(events, [:favn, :runtime, :step, :stop], fn m, md ->
+             is_number(m.duration_ms) and is_tuple(md.ref)
+           end)
 
-    assert_receive {:telemetry, [:favn, :runtime, :run, :stop], _measurements, %{run_id: ^run_id}}
+    assert has_event?(events, [:favn, :runtime, :executor, :start_step], fn m, md ->
+             is_number(m.duration_ms) and md.result == :ok and is_tuple(md.ref)
+           end)
 
-    assert_receive {:telemetry, [:favn, :runtime, :storage, :put_run],
-                    %{duration_ms: duration_ms}, %{operation: :put_run, result: :ok}}
+    assert has_event?(events, [:favn, :runtime, :coordinator, :dispatch], fn m, md ->
+             is_number(m.duration_ms) and md.result == :ok
+           end)
 
-    assert is_integer(duration_ms)
-
-    assert_receive {:telemetry, [:favn, :runtime, :pubsub, :publish], %{duration_ms: publish_ms},
-                    %{run_id: ^run_id, result: :ok}}
-
-    assert is_integer(publish_ms)
+    assert has_event?(events, [:favn, :runtime, :run, :stop], fn m, md ->
+             is_number(m.duration_ms) and md.run_id == run_id
+           end)
   end
 
-  test "failed run emits exception telemetry" do
-    assert {:ok, run_id} = Favn.run({RunnerAssets, :crashes})
-    assert {:error, %Favn.Run{status: :error}} = Favn.await_run(run_id)
+  test "emits exception and retry telemetry for failing and retried flows" do
+    assert {:ok, fail_run_id} = Favn.run({RunnerAssets, :crashes})
+    assert {:error, %Favn.Run{status: :error}} = Favn.await_run(fail_run_id)
 
-    assert_receive {:telemetry, [:favn, :runtime, :step, :exception], _measurements,
-                    %{run_id: ^run_id, error_class: :exception}}
+    fail_events = telemetry_events_for(fail_run_id)
 
-    assert_receive {:telemetry, [:favn, :runtime, :run, :exception], _measurements,
-                    %{run_id: ^run_id, error_class: :run_failed}}
+    assert has_event?(fail_events, [:favn, :runtime, :step, :exception], fn m, md ->
+             is_number(m.duration_ms) and md.error_kind == :error and md.error_class == :exception
+           end)
+
+    assert has_event?(fail_events, [:favn, :runtime, :run, :exception], fn m, md ->
+             is_number(m.duration_ms) and md.error_class == :run_failed and
+               md.terminal_reason_kind == :failed
+           end)
+
+    assert {:ok, retry_run_id} =
+             Favn.run({RunnerAssets, :transient_then_ok}, retry: [max_attempts: 2, delay_ms: 0])
+
+    assert {:ok, %Favn.Run{status: :ok}} = Favn.await_run(retry_run_id)
+
+    retry_events = telemetry_events_for(retry_run_id)
+
+    assert has_event?(retry_events, [:favn, :runtime, :step, :retry], fn m, md ->
+             is_number(m.attempt) and is_number(m.max_attempts) and is_tuple(md.ref)
+           end)
+  end
+
+  test "emits cancellation and timeout telemetry including executor cancel and admission" do
+    assert {:ok, cancel_run_id} = Favn.run({RunnerAssets, :slow_asset}, timeout_ms: 1_000)
+    assert {:ok, :cancelling} = Favn.cancel_run(cancel_run_id)
+    assert {:error, %Favn.Run{status: :cancelled}} = Favn.await_run(cancel_run_id)
+
+    cancel_events = telemetry_events_for(cancel_run_id)
+
+    assert has_event?(cancel_events, [:favn, :runtime, :run, :cancel_requested], fn _m, md ->
+             md.terminal_reason_kind == :cancel_requested
+           end)
+
+    assert has_event?(cancel_events, [:favn, :runtime, :run, :cancelled], fn m, md ->
+             is_number(m.duration_ms) and md.terminal_reason_kind == :cancelled
+           end)
+
+    assert has_event?(cancel_events, [:favn, :runtime, :executor, :cancel_step], fn m, md ->
+             is_number(m.duration_ms) and md.result == :ok and is_tuple(md.ref)
+           end)
+
+    assert has_event?(cancel_events, [:favn, :runtime, :coordinator, :admission], fn m, md ->
+             is_number(m.duration_ms) and md.result == :closed
+           end)
+
+    assert {:ok, timeout_run_id} = Favn.run({RunnerAssets, :slow_asset}, timeout_ms: 10)
+    assert {:error, %Favn.Run{status: :timed_out}} = Favn.await_run(timeout_run_id)
+
+    timeout_events = telemetry_events_for(timeout_run_id)
+
+    assert has_event?(timeout_events, [:favn, :runtime, :run, :timeout_triggered], fn m, md ->
+             is_number(m.duration_ms) and md.terminal_reason_kind == :timed_out
+           end)
+
+    assert has_event?(timeout_events, [:favn, :runtime, :run, :timed_out], fn m, md ->
+             is_number(m.duration_ms) and md.terminal_reason_kind == :timed_out
+           end)
+
+    assert has_event?(timeout_events, [:favn, :runtime, :step, :timed_out], fn _m, md ->
+             is_tuple(md.ref)
+           end)
+  end
+
+  test "emits storage telemetry for success and failure paths" do
+    assert {:ok, _run_id} = Favn.run({RunnerAssets, :final})
+
+    events = drain_telemetry()
+
+    assert has_event?(events, [:favn, :runtime, :storage, :put_run], fn m, md ->
+             is_number(m.duration_ms) and md.result == :ok and md.run_id != nil
+           end)
+
+    Application.put_env(:favn, :storage_adapter, Unknown.Adapter)
+
+    assert {:error, {:store_error, {:invalid_storage_adapter, Unknown.Adapter}}} =
+             Favn.get_run("x")
+
+    invalid_adapter_events = drain_telemetry()
+
+    assert has_event?(invalid_adapter_events, [:favn, :runtime, :storage, :get_run], fn m, md ->
+             is_number(m.duration_ms) and md.result == :error and
+               md.error_class == :invalid_adapter
+           end)
+
+    Application.put_env(:favn, :storage_adapter, RaisingStore)
+
+    assert {:error, {:store_error, {:raised, %RuntimeError{message: "boom"}}}} =
+             Favn.Storage.put_run(%Favn.Run{id: "raise-1", status: :running})
+
+    raised_events = drain_telemetry()
+
+    assert has_event?(raised_events, [:favn, :runtime, :storage, :put_run], fn _m, md ->
+             md.result == :error and md.error_class == :adapter_raise and md.error_kind == :error
+           end)
+  end
+
+  test "emits pubsub telemetry for failure paths" do
+    Application.put_env(:favn, :pubsub_name, MissingPubSub)
+
+    assert_raise ArgumentError, fn ->
+      Favn.Runtime.Events.publish_run_event("r1", :run_started, %{
+        seq: 1,
+        entity: :run,
+        status: :running,
+        data: %{}
+      })
+    end
+
+    events = drain_telemetry()
+
+    assert has_event?(events, [:favn, :runtime, :pubsub, :publish], fn m, md ->
+             is_number(m.duration_ms) and md.result == :error and
+               md.error_class in [:publish_raise, :publish_exit]
+           end)
+  end
+
+  defp telemetry_events_for(run_id) do
+    Process.sleep(10)
+
+    drain_telemetry()
+    |> Enum.filter(fn {_event, _measurements, metadata} -> metadata[:run_id] == run_id end)
+  end
+
+  defp drain_telemetry(acc \\ []) do
+    receive do
+      {:telemetry, event, measurements, metadata} ->
+        drain_telemetry([{event, measurements, metadata} | acc])
+    after
+      20 ->
+        Enum.reverse(acc)
+    end
+  end
+
+  defp has_event?(events, event_name, validator) do
+    Enum.any?(events, fn {event, measurements, metadata} ->
+      event == event_name and validator.(measurements, metadata)
+    end)
+  end
+
+  defp assert_count(events, event_name, expected_count) do
+    count = Enum.count(events, fn {event, _measurements, _metadata} -> event == event_name end)
+    assert count == expected_count
   end
 end


### PR DESCRIPTION
### Motivation

- Provide a single, stable boundary for machine-oriented runtime telemetry so internals can be observed without coupling to exporters.  
- Capture timing and classification metadata for important runtime operations (run/step lifecycle, storage, pubsub) to aid operator observability and diagnostics.  
- Surface error kind/class and duration information on events to make telemetry signals richer and more actionable.

### Description

- Introduces a runtime telemetry facade `Favn.Runtime.Telemetry` with `emit_runtime_event/3` and `emit_operation/4` to normalize event naming, measurements, and metadata.  
- Coordinator emits runtime telemetry on event emission by calling `Favn.Runtime.Telemetry.emit_runtime_event/2`, includes `duration_ms` on step payloads, and propagates error metadata into event payloads via `payload_with_error_metadata/2`.  
- PubSub publishing now measures broadcast duration inside `Favn.Runtime.Events.publish_run_event/3` and emits a `:pubsub` operation telemetry via `Favn.Runtime.Telemetry.emit_operation/4`.  
- Storage adapter wrapper `adapter_call/2` now tracks operation durations, reports a normalized result status, and emits `:storage` operation telemetry.  
- Manager emits runtime telemetry for `:run_created` and emits `:run_failed` telemetry when finalizing crashed runs, and `FEATURES.md`/`README.md` were updated to document the internal telemetry contract.  
- Adds `test/runtime_telemetry_test.exs` which attaches telemetry handlers and asserts that run/step lifecycle, storage, and pubsub telemetry events are emitted.

### Testing

- Ran the automated test suite with the new telemetry tests via `mix test` and the test suite passed.  
- `test/runtime_telemetry_test.exs` validates lifecycle telemetry for successful and failing runs and asserts measurements like `duration_ms` and metadata fields, and it passed.  
- The memory storage adapter was used in tests via test helpers to exercise `:storage` telemetry and PubSub broadcasting was validated by asserting `:telemetry` messages for `[:favn, :runtime, :pubsub, :publish]`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cb87be7df883288c34daed3ba6397b)