### PR TITLE
Rewrite roadmap/docs to canonical asset-first DSL and ctx contract

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,181 +1,52 @@
-Favn Roadmap & Feature Status
+# Favn Roadmap & Feature Status
 
 ## Current Version
 
 **Current release: v0.1.0**
 
-Favn is in early development.
+Favn is in private pre-v1 development with a refactor-first roadmap.
 
-The product direction is now explicitly locked:
+This document is the canonical source of truth for roadmap scope and milestone order.
 
-- Favn is **asset-first**
-- v1 and v2 focus on excellent **ETL/ELT orchestration**
-- assets are the only public executable node type in v1
-- orchestration concerns (pipelines, schedules, polling, triggers) stay **outside** the function-level DSL
-- assets are expected to **materialize externally**
-- Favn tracks orchestration state, lineage, freshness, runs, and materialization history
-- Favn does **not** pass data directly between assets as a public model
+## Product Direction (Canonical)
 
-This document tracks both **direction** and **progress**.
+Favn is an **asset-first ETL/ELT orchestration** library for Elixir.
 
----
+- Author assets with a compact DSL: `@asset`, `@depends`, `@uses`, `@freshness`, `@meta`
+- Author executable work with a single function contract: `def asset(ctx)`
+- Treat dependencies as **ordering + lineage**, not in-memory value passing
+- Use **external materialization** as the data boundary between assets
+- Keep orchestration config outside function attributes and make it available through `ctx`
 
-## Product Focus
+## Execution order
 
-Favn v1 should be great at:
+Roadmap work is prioritized in this order:
 
-- defining ETL/ELT assets in plain Elixir
-- connecting assets through dependency declarations
-- executing asset graphs deterministically
-- scheduling and polling asset/pipeline execution
-- skipping unnecessary work through freshness rules
-- tracking runs and materializations
-- giving a clear graph and documentation view of the codebase
+1. DSL contract
+2. Runtime alignment
+3. Orchestration config model
+4. v1 triggers/scheduling
 
-Favn v1 is **not** trying to solve:
+## In scope for v1
 
-- AI agent orchestration
-- generic workflow automation
-- human-task orchestration
-- broad connector marketplace
-- reusable external pipeline marketplace
+- Stable asset DSL (`@asset`, `@depends`, `@uses`, `@freshness`, `@meta`)
+- Stable runtime asset contract: `def asset(ctx)`
+- Deterministic dependency-based execution
+- Run/step lifecycle with retry, timeout, cancellation, rerun
+- Freshness-aware skip decisions
+- External materialization model with lineage and run visibility
+- Orchestration config model outside function attributes, accessible via `ctx`
 
-Those may come later, but they are not the product goal of v1.
+## Out of scope for v1 function DSL
 
----
+The following stay out of function attributes in v1:
 
-## Core Design Principles
-
-### 1) Assets first
-
-There is only one public executable node type in v1:
-
-- `@asset`
-
-### 2) Small business-focused function DSL
-
-Function attributes should only describe the asset itself.
-
-### 3) Orchestration config stays outside function attributes
-
-Pipelines, schedules, polling, and other triggers belong to orchestration/configuration, not to the business function DSL.
-
-### 4) Built-in Elixir docs are first-class
-
-Favn should use:
-
-- `@moduledoc`
-- `@doc`
-- `@spec`
-
-as the main documentation source for catalog and UI.
-
-### 5) No direct data passing between assets
-
-Dependencies express graph relationships and execution ordering.
-
-Assets are expected to read from and write to external systems/storage as part of their own business logic.
-
-### 6) Assets use runtime context
-
-Assets use a single function shape:
-
-```elixir
-def my_asset(ctx)
-```
-
-Runtime information (trigger context, pipeline config, execution metadata, etc.) is provided through `ctx`.
-
----
-
-## Function-Level DSL (v1)
-
-These are the function attributes we focus on in v1:
-
-- `@asset`
-- `@depends`
-- `@uses`
-- `@freshness`
-- `@meta`
-
-### `@asset`
-
-Marks a public function as a Favn asset with a name.
-
-### `@depends`
-
-Declares upstream asset dependencies.
-
-Purpose:
-
-- execution ordering
-- lineage
-- documentation
-- freshness reasoning
-
-This does not imply direct value passing between assets.
-
-### `@uses`
-
-Declares which external integrations or Elixir functions an asset uses.
-
-Used for:
-
-- lineage
-- UI mapping
-- documentation
-- impact analysis
-
-### `@freshness`
-
-Declares how fresh the latest successful materialization must be for Favn to skip rerun.
-
-### `@meta`
-
-Holds non-execution metadata for catalog, filtering, ownership, and UI.
-
----
-
-## Explicitly Out of Scope for v1 DSL
-
-The following are intentionally not function attributes in v1:
-
-- jobs
-- schedules
-- polling definitions
-- webhook definitions
-- API trigger definitions
-- event trigger definitions
-- checks
-- observers
-- metrics
-- pipeline installation/config
-- source DSL
-- artifact/ref dependency modes
-- data passing configuration between assets
-
----
-
-## Runtime Contract Direction
-
-The v1 asset function contract should be:
-
-```elixir
-@asset "My Asset"
-def my_asset(ctx) do
-  ...
-end
-```
-
-`ctx` should eventually carry runtime information such as:
-
-- run information
-- trigger information
-- freshness/attempt context
-- pipeline-installed configuration
-- partition/runtime-window context (when applicable)
-
----
+- `schedule`
+- `polling`
+- `polling cursor/state`
+- webhook/api/event trigger definitions
+- pipeline installation/config declarations
+- data-passing configuration between assets
 
 ## Roadmap
 
@@ -183,225 +54,59 @@ end
 
 **Status: Released**
 
-This release proves the core architecture and programming model.
-
-### Features
-
-- [x] Asset DSL (`@asset`) for defining business logic
-- [x] Asset discovery and registry
+- [x] Asset discovery and registry foundation
 - [x] Dependency graph construction (DAG)
-- [x] Deterministic planning from dependencies
-- [x] Local synchronous execution
-- [x] Run model with outputs
-- [x] Storage abstraction (in-memory)
-- [x] Run event emission (PubSub)
-- [x] Public API (`Favn` module)
-- [x] Host application integration (supervision tree)
-- [x] Basic tests across core modules
+- [x] Deterministic planning foundation
+- [x] Run model and event foundation
+- [x] Public API entrypoint (`Favn`)
 
 ---
 
-## v0.2.0 — Runtime Foundation
+## v0.3.0 — DSL + Runtime Contract Refactor
 
 **Status: In Progress**
 
-Turns Favn into a real execution engine with durable runtime state and concurrency.
+This milestone is the single pre-v1 refactor milestone and current focus.
 
-### Features
+### DSL contract
 
-- [x] Asynchronous run execution
-- [x] Parallel execution with bounded concurrency
-- [x] Run + step state machine
-- [x] Retry mechanism
-- [x] Cancellation support
-- [x] Timeout handling
-- [x] SQLite storage adapter
-- [x] Stable event schema (runs + steps)
-- [x] Internal runtime telemetry foundation
-- [x] Coordinator / executor separation
-- [ ] Remove current in-memory-output assumptions from the execution model
-- [ ] Align runtime model with asset-first external materialization direction
-- [ ] Simplify asset execution contract toward `def asset(ctx)`
+- [ ] Canonical DSL: `@asset`, `@depends`, `@uses`, `@freshness`, `@meta`
+- [ ] Remove option-style dependency authoring in docs/examples
+- [ ] Keep dependencies focused on ordering + lineage
+
+### Runtime alignment
+
+- [ ] Canonical asset contract: `def asset(ctx)`
+- [ ] Align execution/runtime APIs to single-arg asset invocation
+- [ ] Align examples/docs to external materialization boundaries
+
+### Orchestration config model
+
+- [ ] Keep orchestration config outside function attributes
+- [ ] Provide orchestration-installed config through `ctx`
+- [ ] Clarify runtime context shape in public docs
 
 ---
 
-## v0.3.0 — Asset DSL Refactor
+## v1.0.0 — Stable Asset-Oriented ETL/ELT Orchestrator
 
 **Status: Planned**
 
-Refines authoring around the locked v1 asset model.
+v1 release gates include scheduling and polling capabilities, implemented in orchestration layers (not function attributes).
 
-### Features
+### v1 release gates
 
-- [ ] Support single asset function shape: `def asset(ctx)`
-- [ ] Remove requirement for arity-2 assets
-- [ ] Remove requirement for `%Favn.Asset.Output{}`
-- [ ] Replace `depends_on` option with repeatable `@depends`
-- [ ] Add `@uses`
-- [ ] Add `@freshness`
-- [ ] Add `@meta`
-- [ ] Remove `kind` from the public authoring DSL
-- [ ] Keep built-in Elixir docs as the primary documentation source
-- [ ] Update graph/catalog extraction from the new DSL
-
----
-
-## v0.4.0 — Triggers and Orchestration Layer
-
-**Status: Planned**
-
-Introduces orchestration config outside the business DSL.
-
-### Features
-
-- [ ] Manual run trigger
-- [ ] API-triggered execution
-- [ ] Cron / schedule trigger
-- [ ] Polling trigger
-- [ ] Polling state / cursor tracking
-- [ ] Freshness-aware skip behavior
-- [ ] Initial orchestration layer outside function attributes
-- [ ] Initial pipeline/configuration definition model
-- [ ] Make pipeline/config available through `ctx`
-- [ ] Stable operator actions: run, cancel, rerun
-
----
-
-## v0.5.0 — Single-Node Asset Production Readiness
-
-**Status: Planned**
-
-Makes Favn production-usable for asset-based orchestration on a single node.
-
-### Features
-
-- [ ] Postgres storage adapter
-- [ ] Queueing and admission control
-- [ ] Concurrency controls
-- [ ] Run deduplication / run keys
-- [ ] Materialization metadata/history tracking
-- [ ] Asset freshness state tracking
-- [ ] Improved failure recovery
-- [ ] Asset catalog foundation
-- [ ] Graph and run inspection foundation
-- [ ] Stronger testing around retries, reruns, and recovery
-
----
-
-## v0.6.0 — Pipeline Composition Foundation
-
-**Status: Planned**
-
-Makes larger asset projects easier to install and configure.
-
-### Features
-
-- [ ] Graph composition across modules
-- [ ] Pipeline-level asset selection
-- [ ] Pipeline-level configuration/bindings
-- [ ] Reusable asset graph installation inside an app
-- [ ] Support accessing pipeline-installed configuration through `ctx`
-- [ ] Keep pipeline model outside the function attribute DSL
-- [ ] Preserve asset graph clarity in UI and docs
-
----
-
-## v1.0.0 — Stable Asset-Oriented Orchestrator
-
-**Status: Planned**
-
-First stable release focused on asset-based ETL/ELT orchestration.
-
-### Features
-
-#### Authoring
-
-- [ ] Stable asset DSL: `@asset`, `@depends`, `@uses`, `@freshness`, `@meta`
-- [ ] Stable single asset function contract: `def asset(ctx)`
-
-#### Execution
-
-- [ ] Deterministic dependency-based execution
-- [ ] Manual/API run initiation
-- [ ] Schedule trigger
-- [ ] Polling trigger
-- [ ] Retry, timeout, cancellation, and rerun support
-- [ ] Freshness-aware skip logic
-- [ ] Stable run and step lifecycle
-
-#### Data / materialization model
-
-- [ ] Asset-first external materialization model
-- [ ] Materialization metadata/history tracking
-- [ ] No direct data passing between assets
-- [ ] Runtime context support for orchestration-installed config
-
-#### Orchestration layer
-
-- [ ] Pipeline/configuration layer outside function DSL
-- [ ] Pipeline/config accessible through `ctx`
-- [ ] Graph composition support for larger applications
-
-#### Operator experience
-
-- [ ] Asset graph/catalog view
-- [ ] Run history
-- [ ] Materialization history
-- [ ] Freshness visibility
-- [ ] Failure/retry visibility
-- [ ] Generated documentation from code + metadata
-
-#### Storage/runtime
-
-- [ ] Built-in storage: memory, SQLite, Postgres
-- [ ] Strong single-node production story
-
----
-
-## v2.0.0 — Asset Platform Expansion
-
-**Status: Planned**
-
-Deepens the asset-first model without changing the product focus.
-
-### Features
-
-- [ ] Multi-asset support
-- [ ] Richer graph composition
-- [ ] Better pipeline installation/reuse model
-- [ ] More advanced orchestration config through pipelines
-- [ ] Webhook trigger
-- [ ] Event trigger
-- [ ] Richer API trigger model
-- [ ] Source/external asset observation model
-- [ ] Asset checks
-- [ ] Better partition/runtime-window support through orchestration context
-- [ ] Distributed multi-node execution
-- [ ] Resource-aware placement and scheduling
-- [ ] Stronger plugin seams for storage, triggers, and execution
-- [ ] `favn_view` more mature operator product
-- [ ] `favn_demo` onboarding project
-
----
-
-## Companion Projects
-
-### `favn_view`
-
-- [ ] Alpha after v1 execution + graph foundations are stable
-- [ ] Usable asset catalog/operator UI during v1.x
-- [ ] More complete operator experience in v2
-
-### `favn_demo`
-
-- [ ] Initial demo project after core v1 direction is stable
-- [ ] Better onboarding/demo project in v2
+- [ ] `schedule`
+- [ ] `polling`
+- [ ] `polling cursor/state`
+- [ ] Manual/API triggers integrated with stable runtime lifecycle
+- [ ] Freshness-aware orchestration decisions on stable asset contract
+- [ ] Stable operator visibility for graph, runs, lineage, and materializations
 
 ---
 
 ## Notes
 
-- This roadmap is intentionally narrower than earlier versions.
-- v1 and v2 are focused on making Favn excellent at asset-based ETL/ELT orchestration.
-- General workflow automation and AI-agent orchestration are not part of the current product goal.
-- Priority remains: correct architecture > fast feature delivery.
+- Favn is intentionally focused on asset-first ETL/ELT orchestration.
+- External materialization is the canonical execution/data boundary.
+- Scheduling and polling are explicit v1 gates, not pre-v1 DSL concerns.

--- a/README.md
+++ b/README.md
@@ -1,76 +1,84 @@
 <div align="center">
   <img src="docs/images/favn-logo-transparent.png" alt="Favn logo" width="300" />
-  <p><strong>Asset-first orchestration for Elixir</strong></p>
-  <p>Define business logic as assets. Let Favn discover dependencies, plan runs, and execute deterministic workflows.</p>
+  <p><strong>Asset-first ETL/ELT orchestration for Elixir</strong></p>
+  <p>Define assets, declare lineage, and run deterministic graphs with orchestration config passed via <code>ctx</code>.</p>
 </div>
 
 <p align="center">
-  <strong>Status:</strong> Not recommended for production. API and DSL may change.
+  <strong>Status:</strong> Pre-v1 and under active refactor. API and DSL may change.
 </p>
 
 <p align="center">
   <a href="#quickstart">Quickstart</a> •
+  <a href="#in-scope-for-v1">In scope for v1</a> •
+  <a href="#out-of-scope-for-v1">Out of scope for v1</a> •
   <a href="#configuration">Configuration</a> •
-  <a href="#current-limitations">Current limitations</a> •
-  <a href="#roadmap-and-release-focus">Roadmap</a> •
+  <a href="#roadmap">Roadmap</a> •
   <a href="#installation">Installation</a> • 
   <a href="/FEATURES.md">Features</a> • 
   <a href="/lib/favn.ex">Docs</a>
-
 </p>
 
 ## Favn at a glance
 
-- Plain Elixir functions become assets with metadata and dependencies.
-- Dependency graphs are discovered automatically from asset definitions.
-- Runs are planned deterministically and executed in dependency order.
-- Runtime state, outputs, and run events are exposed through a small public API.
+- Asset-first execution model for ETL/ELT workloads.
+- Canonical authoring DSL: `@asset`, `@depends`, `@uses`, `@freshness`, `@meta`.
+- Canonical runtime contract: `def asset(ctx)`.
+- Dependencies represent ordering/lineage; assets materialize externally.
+- Orchestration config stays outside function attributes and is accessed through `ctx`.
 
-## Introduction
+## In scope for v1
 
-Favn is an asset-first orchestration library for Elixir.
+- Stable asset DSL and single-argument asset contract.
+- Deterministic dependency-based planning and execution.
+- Retry/timeout/cancellation/rerun lifecycle support.
+- Freshness-aware rerun/skip decisions.
+- Graph/run/lineage visibility for operators.
+- v1 orchestration triggers for `schedule`, `polling`, and `polling cursor/state`.
 
-It helps you define business logic as simple, well-documented functions, automatically discover their relationships, and reliably execute them as deterministic workflows.
+## Out of scope for v1
 
-Favn means to hold or embrace—reflecting its role in keeping your workflows connected and reliable.
-
-Instead of building pipelines manually, you describe your system through assets and their dependencies. Favn takes care of planning, execution, and coordination—ensuring that everything runs in the correct order, at the right time, and on the right machine.
-
-Designed for the BEAM, Favn scales from a single node to distributed systems where work is executed in parallel across available resources.
-
-Favn is built to be:
-- predictable — deterministic runs based on explicit dependencies  
-- reliable — execution you can trust in production  
-- observable — clear insight into runs, state, and flow  
-- ergonomic — simple APIs with strong documentation at the center  
-- agent-friendly — easy for both humans and AI to understand, use, and extend  
-
-Whether you're building ETL pipelines, system integrations, workflows, or AI-driven processes, Favn acts as the layer that holds everything together and ensures it runs as expected.
-
-Favn doesn’t just run your workflows. It takes care of them.
+- Broad non-asset automation platforms beyond ETL/ELT asset orchestration.
+- Multi-domain orchestration messaging outside the asset-first product scope.
+- Function-attribute trigger DSL (`schedule`/`polling` in asset attributes).
+- In-memory data passing contract between assets.
 
 ## Quickstart
 
-Define an asset module:
+Define an asset module with the canonical DSL and `def asset(ctx)` contract:
 
 ```elixir
 defmodule MyApp.SalesAssets do
   use Favn.Assets
 
-  @asset true
-  def extract_orders(_ctx, _deps) do
-    {:ok, %Favn.Asset.Output{output: [%{id: 1, total: 100}]}}
+  @asset :extract_orders
+  @uses [:warehouse_api]
+  @freshness [max_age: :timer.hours(1)]
+  @meta [owner: "data-platform", domain: :sales]
+  def extract_orders(ctx) do
+    source = ctx.config[:source] || :warehouse_api
+    _ = source
+
+    # Materialize externally (for example to object storage or warehouse table)
+    :ok
   end
 
-  @asset depends_on: [:extract_orders]
-  def build_daily_report(_ctx, deps) do
-    orders = Map.fetch!(deps, {__MODULE__, :extract_orders})
-    {:ok, %Favn.Asset.Output{output: %{count: length(orders)}}}
+  @asset :daily_sales_report
+  @depends [:extract_orders]
+  @uses [:warehouse]
+  @freshness [max_age: :timer.hours(2)]
+  @meta [owner: "finance-analytics", tier: :gold]
+  def daily_sales_report(ctx) do
+    report_date = ctx.runtime[:date]
+    _ = report_date
+
+    # Read upstream materializations, compute report, write externally
+    :ok
   end
 end
 ```
 
-Register the module and run a target asset:
+Register modules and run a target asset:
 
 ```elixir
 # config/config.exs
@@ -82,7 +90,7 @@ config :favn,
 
 ```elixir
 # from your app runtime / iex
-{:ok, run_id} = Favn.run({MyApp.SalesAssets, :build_daily_report}, dependencies: :all)
+{:ok, run_id} = Favn.run({MyApp.SalesAssets, :daily_sales_report})
 {:ok, run} = Favn.await_run(run_id)
 ```
 
@@ -107,103 +115,20 @@ Key settings:
 - `:storage_adapter`: run storage adapter module.
 - `:storage_adapter_opts`: options passed to the configured storage adapter.
 
-SQLite durable storage (single-node) can be configured with:
+## Roadmap
 
-```elixir
-import Config
-
-config :favn,
-  storage_adapter: Favn.Storage.Adapter.SQLite,
-  storage_adapter_opts: [
-    database: "/var/lib/my_app/favn.db",
-    busy_timeout: 5_000,
-    pool_size: 1
-  ]
-```
-
-SQLite ordering notes:
-
-- `runs.updated_seq` is allocated from a dedicated `favn_counters` row (`run_write_order`)
-  inside the same transaction that persists the run snapshot.
-- `list_runs` remains ordered by latest persisted write:
-  `updated_seq DESC, updated_at_us DESC, id DESC`.
-
-## Current limitations
-
-- The default run store is node-local in-memory storage.
-- Public run execution is asynchronous by default (`Favn.run/2` returns a run id).
-- Independent ready steps execute in parallel within a run, bounded by `max_concurrency`.
-- Run events are best-effort pubsub notifications.
-
-## Runtime behavior in this release
-
-- **Planning and orchestration**: Favn plans dependency-aware runs with deterministic topological stages and orchestrates execution through a run-scoped coordinator with bounded parallel step dispatch per run.
-- **Run lifecycle**: runtime orchestration now uses explicit internal run and step state machines; public run status includes `:running | :ok | :error | :cancelled | :timed_out`.
-- **Step retries**: failed steps can be retried with deterministic step-level policy (`retry` option on `Favn.run/2`) without restarting the run.
-- **Execution boundary**: one-step asset invocation is isolated behind an asynchronous runtime executor boundary.
-- **Storage facade contract**: run retrieval/listing APIs normalize storage failures to one of:
-  - `:not_found`
-  - `:invalid_opts`
-  - `{:store_error, reason}`
-- **Checkpoint persistence policy**: runtime checkpoints are required; if snapshot persistence fails, `Favn.run/2` returns `{:error, {:storage_persist_failed, reason}}`.
-- **Event delivery**: run events are published as best-effort observability signals and do not affect run correctness.
-- **Internal telemetry**: runtime boundaries emit machine-oriented `:telemetry` events under `[:favn, :runtime, ...]` for operators and future external exporters.
-- **Logger correlation metadata**: runtime coordinator/executor processes attach lightweight metadata (`run_id`, `ref`, `stage`, `attempt`) for human diagnostics without treating logs as telemetry.
-
-## Guarantees in this release
-
-- **Run lifecycle semantics**
-  - `Favn.run/2` returns `{:ok, run_id}` when a run is submitted.
-  - Step admission order is deterministic for equally-ready refs; completion order is naturally non-deterministic under parallel execution.
-  - `Favn.cancel_run/1` requests cancellation and returns a cancellation acknowledgement tuple.
-  - `Favn.await_run/2` returns `{:ok, %Favn.Run{status: :ok}}` on success or `{:error, %Favn.Run{status: :error | :cancelled | :timed_out}}` on non-success terminal outcomes.
-  - Failed runs preserve structured failure context in both `run.error` and `run.asset_results[ref].error`.
-  - `Favn.get_run/1` returns the latest stored run state for an ID.
-- **Storage error contract**
-  - `Favn.get_run/1` and `Favn.list_runs/1` return storage errors only as `:not_found`, `:invalid_opts`, or `{:store_error, reason}`.
-  - Adapter-specific raw errors are wrapped as `{:store_error, reason}`.
-- **Event delivery scope**
-  - `Favn.subscribe_run/1` and `Favn.unsubscribe_run/1` manage PubSub subscriptions for run topics.
-  - Event delivery is best-effort; missing subscribers or publish failures do not change run success/failure outcomes.
-  - Events use a stable envelope schema (`schema_version`, `event_type`, `entity`, `run_id`, `sequence`, `emitted_at`, `status`, `data`, optional `ref`/`stage`).
-  - `status` is the **internal runtime** run/step status at emission time (not `%Favn.Run{}` public status).
-
-## Not guaranteed yet / non-goals
-
-- Durable distributed execution guarantees across nodes.
-- Exactly-once event delivery, replay, or durable event logs.
-- Persistent storage guarantees beyond the configured adapter behavior (default adapter is in-memory and node-local).
-- Global concurrency fairness across runs and retries.
-
-## Roadmap and release focus
-
-- Add durable production-ready storage adapters with stronger operational guarantees.
-- Expand run query capabilities for richer operator UIs.
-- Improve event observability integrations (telemetry/export pipelines).
-- Add release packaging/versioning via Hex.
+`FEATURES.md` is the canonical roadmap and milestone source of truth: [FEATURES.md](/FEATURES.md).
 
 ## Installation
 
 Favn is not published on Hex yet.
 
-Install it from the GitHub repository by adding `favn` to your list of
-dependencies in `mix.exs`:
+Install from GitHub in `mix.exs`:
 
 ```elixir
 def deps do
   [
     {:favn, git: "https://github.com/eirhop/favn.git", tag: "v0.1.1"}
-  ]
-end
-```
-
-Once Favn is published on Hex, the dependency can move to a normal versioned
-package declaration:
-
-```elixir
-def deps do
-  [
-    {:favn, "~> 0.1.1"}
   ]
 end
 ```

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -1,313 +1,65 @@
 defmodule Favn do
   @moduledoc """
-  Favn is a library for defining, inspecting, and orchestrating asset-based workflows in Elixir.
+  Favn is an asset-first ETL/ELT orchestration library for Elixir.
 
-  It is built around the idea that each step in a workflow should be expressed as a normal,
-  business-oriented Elixir function, while Favn adds the metadata and orchestration needed to
-  discover assets, understand their dependencies, and execute them as part of a run.
+  The public authoring model is centered on assets with explicit lineage metadata,
+  deterministic dependency-based execution, and orchestration config provided through runtime context.
 
-  Favn is intended to be the core library behind orchestrator applications, operator dashboards,
-  scheduling systems, and other tools that need a stable API for working with assets and runs.
+  ## Canonical authoring model
+
+  Favn authoring is defined by two canonical contracts:
+
+    * DSL attributes: `@asset`, `@depends`, `@uses`, `@freshness`, `@meta`
+    * Asset function shape: `def asset(ctx)`
+
+  Dependencies are used for **ordering and lineage**. Assets materialize externally as part of
+  business logic and are not modeled as direct in-memory value passing between asset functions.
+
+  Orchestration configuration remains outside function attributes and is accessible from `ctx`.
+
+  ## Example
+
+      defmodule MyApp.SalesAssets do
+        use Favn.Assets
+
+        @asset :extract_orders
+        @uses [:warehouse_api]
+        @freshness [max_age: :timer.hours(1)]
+        @meta [owner: "data-platform", domain: :sales]
+        def extract_orders(ctx) do
+          source = ctx.config[:source] || :warehouse_api
+          _ = source
+
+          # Read source system and materialize externally.
+          :ok
+        end
+
+        @asset :daily_sales_report
+        @depends [:extract_orders]
+        @uses [:warehouse]
+        @freshness [max_age: :timer.hours(2)]
+        @meta [owner: "finance-analytics", tier: :gold]
+        def daily_sales_report(ctx) do
+          report_date = ctx.runtime[:date]
+          _ = report_date
+
+          # Read upstream materializations and write final report externally.
+          :ok
+        end
+      end
 
   ## What Favn provides
 
-  Favn is designed for applications that need to:
-
-    * define assets as plain Elixir functions
-    * attach documentation and metadata directly to those assets through @asset annotations
-    * declare dependencies between assets
-    * inspect assets and their relationships at runtime
-    * execute one asset or a dependency-derived workflow
-    * inspect active and completed runs
-    * subscribe to live events from a run
-
-  ## Core concepts
-
-  ### Assets
-
-  An asset is a function that represents a meaningful unit of work in a workflow, such as
-  extracting data, transforming a dataset, or producing a modeled output.
-
-  Assets are intended to be authored in modules that `use Favn.Assets`. At compile time,
-  Favn will collect metadata such as:
-
-    * asset name
-    * documentation
-    * dependency references
-    * source file and line
-    * kind
-    * tags
-
-  This keeps the workflow definition close to the business logic while still allowing Favn to
-  introspect and orchestrate the workflow later.
-
-  ### Dependencies
-
-  Assets can depend on other assets. Favn uses those dependency declarations to derive the
-  execution graph automatically.
-
-  Favn models those relationships as a directed acyclic graph (DAG), not as a strict tree.
-  Shared upstream assets are therefore allowed, cycles are rejected, and a later runtime
-  planner can ensure an asset runs at most once in a single run even when multiple downstream
-  assets depend on it.
-
-  In practice, this means users generally do not need to manually define pipelines. When an
-  asset is run, Favn can compute the dependency graph for the requested target and form the
-  execution pipeline from that graph.
-
-  ### Runs
-
-  A run is a single execution of a target asset.
-
-  Depending on the runtime options, a run may include:
-
-    * only the requested asset
-    * the requested asset and its upstream dependencies
-
-  Runs are intended to be observable and inspectable so that orchestrator applications can show
-  progress, history, and live operational state.
-
-  ### Live events
-
-  Favn is intended to expose structured run events so that consumers can subscribe to the
-  progress of an active run.
-
-  This is designed for use cases such as:
-
-    * live operator dashboards
-    * streaming logs and status in a web UI
-    * audit trails
-    * hooks into telemetry or other observability systems
-
-  Runtime PubSub events are a UI/live-subscription contract. Internal runtime
-  machine telemetry is emitted separately via `:telemetry` event names under
-  `[:favn, :runtime, ...]`.
-
-  ## Authoring assets
-
-  Assets are defined in normal modules using `Favn.Assets`.
-
-  A simplified example:
-
-      defmodule MyApp.SalesETL do
-        use Favn.Assets
-
-        @doc "Extract raw orders from the sales source"
-        @asset true
-        def extract_orders(_ctx, _deps) do
-          {:ok, %Favn.Asset.Output{output: [%{id: 1, total: 100}], meta: %{source: :sales}}}
-        end
-
-        @doc "Normalize extracted orders"
-        @asset depends_on: [:extract_orders]
-        def normalize_orders(_ctx, deps) do
-          orders = Map.fetch!(deps, {__MODULE__, :extract_orders})
-
-          normalized =
-            Enum.map(orders, fn order ->
-              Map.put(order, :normalized, true)
-            end)
-
-          {:ok, %Favn.Asset.Output{output: normalized, meta: %{normalized_count: length(normalized)}}}
-        end
-      end
-
-  Cross-module dependencies are also expected to be supported:
-
-      defmodule MyApp.GoldETL do
-        use Favn.Assets
-
-        alias MyApp.SalesETL
-
-        @doc "Build the fact table for sales"
-        @asset depends_on: [{SalesETL, :normalize_orders}]
-        def fact_sales(_ctx, deps) do
-          normalized_orders = Map.fetch!(deps, {SalesETL, :normalize_orders})
-          {:ok, %Favn.Asset.Output{output: %{rows: normalized_orders}}}
-        end
-      end
-
-  In this model, workflow structure is derived from the dependencies rather than from a
-  separately maintained pipeline definition.
-
-  ## Using the library
-
-  `Favn` is the main public entrypoint for the library.
-
-  Typical usage from an orchestrator app or operator tool:
-
-      Favn.list_assets()
-
-      Favn.list_assets(MyApp.SalesETL)
-
-      Favn.get_asset({MyApp.SalesETL, :normalize_orders})
-
-      Favn.upstream_assets({MyApp.GoldETL, :fact_sales})
-
-      Favn.dependency_graph({MyApp.GoldETL, :fact_sales}, tags: [:warehouse])
-
-      Favn.run({MyApp.GoldETL, :fact_sales})
-
-      Favn.run({MyApp.GoldETL, :fact_sales}, dependencies: :none)
-
-      Favn.get_run(run_id)
-
-      Favn.list_runs()
-
-      Favn.list_runs(status: :running)
-
-      Favn.subscribe_run(run_id)
-
-  ## Setup in a host application
-
-  Favn is an OTP application, not a standalone server you start with a
-  dedicated `favn` command.
-
-  A consumer application typically sets Favn up in four steps:
-
-    1. add `:favn` as a dependency in `mix.exs`
-    2. define one or more asset modules with `use Favn.Assets`
-    3. register those modules under `config :favn, asset_modules: [...]`
-    4. start the host application normally
-
-  Favn is not published on Hex yet, so it should be installed directly
-  from the repository. A minimal dependency declaration looks like this:
-
-      defp deps do
-        [
-          {:favn, git: "https://github.com/eirhop/favn.git", tag: "v0.1.1"}
-        ]
-      end
-
-  Once Hex publishing exists, the dependency can move to a normal versioned
-  package declaration:
-
-      defp deps do
-        [
-          {:favn, "~> 0.1.1"}
-        ]
-      end
-
-  Asset modules usually live in the host application's normal source tree,
-  for example under `lib/my_app/`.
-
-  Once those modules exist, register them in the host application's config.
-  For most projects that means `config/config.exs`, optionally overridden from
-  environment-specific files such as `config/dev.exs`, `config/test.exs`, or
-  `config/runtime.exs` if the application needs environment-dependent module
-  lists.
-
-      import Config
-
-      config :favn,
-        asset_modules: [
-          MyApp.SalesETL,
-          MyApp.GoldETL
-        ]
-
-  The configured module list is the global discovery scope used by
-  `Favn.list_assets/0` and `Favn.get_asset/1`.
-
-  Run event subscriptions use Phoenix PubSub and default to `Favn.PubSub`.
-  Host applications can override the pubsub server name:
-
-      import Config
-
-      config :favn,
-        pubsub_name: MyApp.PubSub
-
-  Run persistence is configured with `:storage_adapter` and
-  `:storage_adapter_opts`.
-
-  For durable single-node SQLite storage:
-
-      import Config
-
-      config :favn,
-        storage_adapter: Favn.Storage.Adapter.SQLite,
-        storage_adapter_opts: [
-          database: "/var/lib/my_app/favn.db",
-          busy_timeout: 5_000,
-          pool_size: 1
-        ]
-
-  In SQLite mode, run ordering uses a dedicated `favn_counters` row
-  (`run_write_order`) to allocate `runs.updated_seq` transactionally.
-  `Favn.list_runs/1` ordering remains newest-first by
-  `updated_seq DESC, updated_at_us DESC, id DESC`.
-
-  ## Starting Favn
-
-  There is no separate Favn server process that operators start manually.
-
-  When the host application boots, Mix starts the `:favn` application as a
-  dependency, and `Favn.Application` loads the configured asset registry during
-  application startup.
-
-  In practice, that means the right startup command is the normal startup
-  command for the host application:
-
-    * `iex -S mix` for interactive local development
-    * `mix run --no-halt` for a long-running non-interactive OTP process
-    * framework-specific commands such as `mix phx.server` when Favn is used
-      inside a Phoenix application
-
-  If the host application is already running under releases, supervision, or a
-  framework entrypoint, Favn starts automatically as part of that boot process.
-
-  ## Configuration lifecycle
-
-  The global asset registry is loaded from application config during startup and
-  then kept in memory for fast lookups. Favn also builds a global dependency
-  graph index during startup from that same canonical asset catalog.
-
-  The graph index is intended to stay read-only for the lifetime of the booted
-  node and supports DAG validation, upstream and downstream inspection,
-  transitive dependency queries, and deterministic topological ordering for
-  later execution planning.
-
-  That means changes to `config :favn, asset_modules: [...]` are not picked up
-  automatically by an already-running node. In normal usage, update the config
-  and restart the host application so Favn reloads the configured registry and
-  dependency graph during boot.
-
-  ## Public API responsibilities
-
-  The intended user-facing responsibilities of this module are:
-
-    * asset discovery
-    * asset inspection
-    * dependency graph inspection
-    * run execution
-    * run inspection
-    * listing historical runs
-    * subscribing to live run events
-
-  This module should stay a thin public facade. Core implementation details should live in
-  dedicated modules underneath.
-
-  ## Design goals
-
-  Favn aims to keep workflow code close to the business domain while still providing the
-  operational features needed by orchestration and observability tooling.
-
-  In practice, that means:
-
-    * business logic remains plain Elixir
-    * documentation lives close to the asset definition
-    * dependencies are simple and explicit
-    * orchestration is derived from asset metadata
-    * the public API stays small and stable
-    * implementation details are pushed into focused modules
-
-  ## Documentation policy
-
-  Documentation ownership is split intentionally:
-
-    * `README.md` is canonical for release status, roadmap planning, and the
-      feature/limitation matrix.
-    * `Favn` moduledoc is canonical for API behavior, contracts, and examples.
-
+    * asset discovery and registry inspection
+    * dependency and upstream graph inspection
+    * deterministic run planning and execution
+    * run lifecycle APIs (`run`, `await_run`, `cancel_run`, run lookup/listing)
+    * live run-event subscriptions for operator tooling
+
+  ## Scope notes
+
+  Favn targets asset-first orchestration. Scheduling and polling concerns are v1 orchestration
+  features, not function-level authoring attributes.
   """
 
   @typedoc """
@@ -742,9 +494,9 @@ defmodule Favn do
 
   Asset invocation contract:
 
-    * assets are invoked as `def asset(ctx, deps)`
-    * success must be `{:ok, %Favn.Asset.Output{}}`
-    * failure must be `{:error, reason}`
+    * canonical authoring contract is `def asset(ctx)`
+    * dependencies provide ordering/lineage and assets materialize externally
+    * return values are interpreted by runtime/executor boundaries; failures are surfaced as run/step errors
 
   ## Examples
 


### PR DESCRIPTION
### Motivation

- Remove legacy/transition framing from top-level docs and establish a single source of truth for roadmap and public authoring intent. 
- Lock the canonical authoring model to an asset-first DSL and a single runtime contract to simplify authoring and future runtime refactors. 
- Move scheduling/polling and orchestration triggers out of pre-v1 DSL concerns and make orchestration configuration accessible via runtime context (`ctx`).

### Description

- Rewrote `FEATURES.md` into a future-only canonical roadmap and merged pre-v1 work into a single refactor milestone `v0.3.0 — DSL + Runtime Contract Refactor`, defining the canonical DSL attributes (`@asset`, `@depends`, `@uses`, `@freshness`, `@meta`) and the canonical asset contract `def asset(ctx)`, and marking `schedule`/`polling`/`polling cursor/state` as v1 gates. 
- Rewrote `README.md` to position Favn as an asset-first ETL/ELT orchestration library, added concise `In scope for v1` and `Out of scope for v1` sections, updated the quickstart to use the canonical DSL and `def asset(ctx)` examples, and pointed roadmap detail to `FEATURES.md`. 
- Updated `lib/favn.ex` moduledoc to match the new source of truth, replaced legacy authoring examples with `def asset(ctx)` examples, clarified that dependencies are for ordering/lineage and assets materialize externally, and removed guidance that required arity-2 signatures or `%Favn.Asset.Output{}` as the public contract. 
- Performed a consistency pass across the three files to standardize vocabulary (`asset-first`, `external materialization`, `orchestration config via ctx`, `v1 scheduling/polling`) and remove legacy patterns from the public docs.

### Testing

- Ran targeted grep searches to confirm legacy patterns were removed, including `rg -n "depends_on:|def .*\(_ctx, deps\)|%Favn.Asset.Output\{"` against `FEATURES.md`, `README.md`, and `lib/favn.ex`, and these checks passed. 
- Verified `FEATURES.md` contains explicit v1 release gates for `schedule`, `polling`, and `polling cursor/state` using `rg` and confirmed presence. 
- Verified presence of the canonical DSL and contract with `rg -n "@asset|@depends|@uses|@freshness|@meta|def asset\(ctx\)"` across `README.md`, `lib/favn.ex`, and `FEATURES.md` and confirmed presence. 
- Committed the changes (`git commit`) successfully as part of the validation workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d157acf4748328a1314e9b7a935c6d)