### PR TITLE
Docs: expand v0.4 orchestration roadmap, remove v0.6 section, add README roadmap note

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -250,7 +250,7 @@ Refines authoring around the locked v1 asset model.
 
 **Status: Planned**
 
-Introduces orchestration config outside the business DSL.
+Introduces orchestration config outside the business DSL and includes initial pipeline composition/install concerns.
 
 ### Features
 
@@ -264,6 +264,13 @@ Introduces orchestration config outside the business DSL.
 - [ ] Initial pipeline/configuration definition model
 - [ ] Make pipeline/config available through `ctx`
 - [ ] Stable operator actions: run, cancel, rerun
+- [ ] Graph composition across modules
+- [ ] Pipeline-level asset selection
+- [ ] Pipeline-level configuration/bindings
+- [ ] Reusable asset graph installation inside an app
+- [ ] Support accessing pipeline-installed configuration through `ctx`
+- [ ] Keep pipeline model outside the function attribute DSL
+- [ ] Preserve asset graph clarity in UI and docs
 
 ---
 
@@ -285,24 +292,6 @@ Makes Favn production-usable for asset-based orchestration on a single node.
 - [ ] Asset catalog foundation
 - [ ] Graph and run inspection foundation
 - [ ] Stronger testing around retries, reruns, and recovery
-
----
-
-## v0.6.0 — Pipeline Composition Foundation
-
-**Status: Planned**
-
-Makes larger asset projects easier to install and configure.
-
-### Features
-
-- [ ] Graph composition across modules
-- [ ] Pipeline-level asset selection
-- [ ] Pipeline-level configuration/bindings
-- [ ] Reusable asset graph installation inside an app
-- [ ] Support accessing pipeline-installed configuration through `ctx`
-- [ ] Keep pipeline model outside the function attribute DSL
-- [ ] Preserve asset graph clarity in UI and docs
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ SQLite ordering notes:
 - Add durable production-ready storage adapters with stronger operational guarantees.
 - Expand run query capabilities for richer operator UIs.
 - Improve event observability integrations (telemetry/export pipelines).
+- Land orchestration-layer fundamentals for v1 (manual/API triggers, schedule, polling, freshness-aware skips, and pipeline-installed runtime config via `ctx`).
 - Add release packaging/versioning via Hex.
 
 ## Installation


### PR DESCRIPTION
### Motivation
- Clarify and consolidate orchestration responsibilities and pipeline composition/install concerns into the v0.4 roadmap and surface pipeline-installed runtime configuration access via `ctx`.
- Remove a redundant v0.6.0 section to keep the public roadmap focused and avoid duplication.

### Description
- Expanded `FEATURES.md` v0.4.0 entry to include pipeline composition across modules, pipeline-level asset selection, pipeline-level configuration/bindings, reusable asset graph installation, and access to pipeline-installed configuration through `ctx`.
- Removed the redundant `v0.6.0 — Pipeline Composition Foundation` section from `FEATURES.md`.
- Updated `README.md` to add a roadmap bullet highlighting landing orchestration-layer fundamentals for v1, including manual/API triggers, schedule and polling triggers, freshness-aware skips, and pipeline-installed runtime config via `ctx`.
- Applied minor formatting adjustments and a trailing newline normalization.

### Testing
- This is a documentation-only change and no automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d159ff9be48328a864251bef3c8a46)