### PR TITLE
Namespace asset internals under Favn.Assets (Registry, GraphIndex, Planner)

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -283,6 +283,7 @@ The following decisions are source-of-truth for the first v0.3 pipeline foundati
 - [x] Initial orchestration layer outside function attributes
 - [x] Initial pipeline configuration definition model
 - [x] Make pipeline/config/trigger context available through `ctx`
+- [x] Internal module namespacing for asset internals (`Favn.Assets.Registry`, `Favn.Assets.GraphIndex`, `Favn.Assets.Planner`)
 - [ ] Stable operator actions: run, cancel, rerun
 - [x] Basic partition/runtime-window slot in `ctx` (initially `nil` for manual runs)
 

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -474,7 +474,7 @@ defmodule Favn do
   """
   @spec list_assets() :: {:ok, [asset()]} | {:error, term()}
   def list_assets do
-    with {:ok, assets} <- Favn.Registry.list_assets() do
+    with {:ok, assets} <- Favn.Assets.Registry.list_assets() do
       {:ok, Enum.sort_by(assets, & &1.ref)}
     end
   end
@@ -528,7 +528,7 @@ defmodule Favn do
   @spec get_asset(asset_ref()) :: {:ok, asset()} | {:error, asset_error()}
   def get_asset({module, name}) when is_atom(module) and is_atom(name) do
     if asset_module?(module) do
-      with {:ok, asset} <- Favn.Registry.get_asset({module, name}) do
+      with {:ok, asset} <- Favn.Assets.Registry.get_asset({module, name}) do
         {:ok, asset}
       else
         {:error, {:duplicate_asset, _ref}} -> {:error, :asset_not_found}
@@ -542,7 +542,7 @@ defmodule Favn do
   @typedoc """
   Direction used by dependency graph inspection APIs.
   """
-  @type dependency_direction :: Favn.GraphIndex.direction()
+  @type dependency_direction :: Favn.Assets.GraphIndex.direction()
 
   @typedoc """
   Options for dependency graph inspection APIs.
@@ -575,7 +575,7 @@ defmodule Favn do
 
     * `{:ok, assets}` where each entry is `%Favn.Asset{}`
     * `{:error, :not_asset_module}` for invalid target modules
-    * graph/filter validation errors forwarded from `Favn.GraphIndex`
+    * graph/filter validation errors forwarded from `Favn.Assets.GraphIndex`
 
   ## Examples
 
@@ -587,7 +587,7 @@ defmodule Favn do
   def upstream_assets({module, name}, opts \\ [])
       when is_atom(module) and is_atom(name) and is_list(opts) do
     if asset_module?(module) do
-      Favn.GraphIndex.related_assets(
+      Favn.Assets.GraphIndex.related_assets(
         {module, name},
         opts |> Keyword.put_new(:direction, :upstream) |> Keyword.put_new(:include_target, false)
       )
@@ -614,7 +614,7 @@ defmodule Favn do
 
     * `{:ok, assets}` where each entry is `%Favn.Asset{}`
     * `{:error, :not_asset_module}` for invalid target modules
-    * graph/filter validation errors forwarded from `Favn.GraphIndex`
+    * graph/filter validation errors forwarded from `Favn.Assets.GraphIndex`
 
   ## Examples
 
@@ -626,7 +626,7 @@ defmodule Favn do
   def downstream_assets({module, name}, opts \\ [])
       when is_atom(module) and is_atom(name) and is_list(opts) do
     if asset_module?(module) do
-      Favn.GraphIndex.related_assets(
+      Favn.Assets.GraphIndex.related_assets(
         {module, name},
         Keyword.put_new(opts, :direction, :downstream)
       )
@@ -651,9 +651,9 @@ defmodule Favn do
 
   Returns:
 
-    * `{:ok, %Favn.GraphIndex{}}`
+    * `{:ok, %Favn.Assets.GraphIndex{}}`
     * `{:error, :not_asset_module}` for invalid target modules
-    * graph/filter validation errors forwarded from `Favn.GraphIndex`
+    * graph/filter validation errors forwarded from `Favn.Assets.GraphIndex`
 
   ## Examples
 
@@ -661,11 +661,11 @@ defmodule Favn do
       {:error, :not_asset_module}
   """
   @spec dependency_graph(asset_ref(), graph_opts()) ::
-          {:ok, Favn.GraphIndex.t()} | {:error, asset_error() | term()}
+          {:ok, Favn.Assets.GraphIndex.t()} | {:error, asset_error() | term()}
   def dependency_graph({module, name}, opts \\ [])
       when is_atom(module) and is_atom(name) and is_list(opts) do
     if asset_module?(module) do
-      Favn.GraphIndex.subgraph({module, name}, opts)
+      Favn.Assets.GraphIndex.subgraph({module, name}, opts)
     else
       {:error, :not_asset_module}
     end
@@ -750,7 +750,7 @@ defmodule Favn do
   @spec plan_asset_run(asset_ref() | [asset_ref()], plan_asset_run_opts()) ::
           {:ok, Favn.Plan.t()} | {:error, term()}
   def plan_asset_run(targets, opts \\ []) when is_list(opts) do
-    Favn.Planner.plan(targets, opts)
+    Favn.Assets.Planner.plan(targets, opts)
   end
 
   @doc """

--- a/lib/favn/application.ex
+++ b/lib/favn/application.ex
@@ -23,8 +23,8 @@ defmodule Favn.Application do
     # host-managed mode can reuse the same configurable pubsub_name boundary.
     pubsub_child = {Phoenix.PubSub, name: pubsub_name}
 
-    with :ok <- Favn.Registry.load(),
-         :ok <- Favn.GraphIndex.load(),
+    with :ok <- Favn.Assets.Registry.load(),
+         :ok <- Favn.Assets.GraphIndex.load(),
          :ok <- Favn.Storage.validate_adapter(adapter),
          {:ok, child_specs} <- Favn.Storage.child_specs() do
       runtime_children = [Favn.Runtime.RunSupervisor, Favn.Runtime.Manager]

--- a/lib/favn/assets/graph_index.ex
+++ b/lib/favn/assets/graph_index.ex
@@ -1,9 +1,9 @@
-defmodule Favn.GraphIndex do
+defmodule Favn.Assets.GraphIndex do
   @moduledoc """
   Global dependency graph index for configured Favn assets.
 
-  `Favn.GraphIndex` builds a read-only directed acyclic graph (DAG) from the
-  canonical asset catalog loaded by `Favn.Registry`. The index is computed
+  `Favn.Assets.GraphIndex` builds a read-only directed acyclic graph (DAG) from the
+  canonical asset catalog loaded by `Favn.Assets.Registry`. The index is computed
   during application startup and cached in `:persistent_term` for fast,
   repeated read access.
 
@@ -45,7 +45,7 @@ defmodule Favn.GraphIndex do
           {:missing_dependency, Ref.t(), Ref.t()}
           | {:cycle, [Ref.t()]}
           | :invalid_opts
-          | Favn.Registry.error()
+          | Favn.Assets.Registry.error()
 
   @typedoc """
   Direction used when selecting related assets or subgraphs.
@@ -91,7 +91,7 @@ defmodule Favn.GraphIndex do
   """
   @spec load() :: :ok | {:error, error()}
   def load do
-    with {:ok, assets} <- Favn.Registry.list_assets(),
+    with {:ok, assets} <- Favn.Assets.Registry.list_assets(),
          {:ok, %__MODULE__{} = index} <- build_index(assets) do
       :persistent_term.put(@index_key, index)
       :ok
@@ -172,7 +172,7 @@ defmodule Favn.GraphIndex do
   @doc """
   Return a filtered subgraph rooted at a specific asset reference.
 
-  The returned value is another `%Favn.GraphIndex{}` limited to the selected
+  The returned value is another `%Favn.Assets.GraphIndex{}` limited to the selected
   refs so callers can reuse the same traversal and lookup helpers against a
   target-specific graph view.
   """

--- a/lib/favn/assets/planner.ex
+++ b/lib/favn/assets/planner.ex
@@ -1,4 +1,4 @@
-defmodule Favn.Planner do
+defmodule Favn.Assets.Planner do
   @moduledoc """
   Build deterministic execution plans from the global graph index.
 
@@ -12,7 +12,7 @@ defmodule Favn.Planner do
     * stage number equals topological depth (`0` for source assets)
   """
 
-  alias Favn.GraphIndex
+  alias Favn.Assets.GraphIndex
   alias Favn.Plan
   alias Favn.Ref
 

--- a/lib/favn/assets/registry.ex
+++ b/lib/favn/assets/registry.ex
@@ -1,4 +1,4 @@
-defmodule Favn.Registry do
+defmodule Favn.Assets.Registry do
   @moduledoc """
   Global asset discovery and lookup for configured Favn asset modules.
 

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -189,7 +189,7 @@ defmodule Favn.Runtime.Coordinator do
 
   defp start_step_execution(%State{} = state, ref) do
     with {:ok, state} <- apply_step_transition(state, &StepTransitions.start_step(&1, ref)),
-         {:ok, asset} <- Favn.Registry.get_asset(ref),
+         {:ok, asset} <- Favn.Assets.Registry.get_asset(ref),
          {:ok, handle} <- start_executor_step(state, ref, asset) do
       {:ok, put_execution_handle(state, ref, handle)}
     else

--- a/test/favn_test.exs
+++ b/test/favn_test.exs
@@ -102,7 +102,11 @@ defmodule FavnTest do
 
   test "build_catalog preserves deterministic asset order across module merges" do
     assert {:ok, catalog} =
-             Favn.Registry.build_catalog([SampleAssets, CrossModuleAssets, AdditionalAssets])
+             Favn.Assets.Registry.build_catalog([
+               SampleAssets,
+               CrossModuleAssets,
+               AdditionalAssets
+             ])
 
     assert Enum.map(catalog.assets, & &1.ref) == [
              {SampleAssets, :extract_orders},
@@ -177,14 +181,14 @@ defmodule FavnTest do
     assert {:error, :not_asset_module} = Favn.list_assets(SpoofedAssets)
     Application.put_env(:favn, :asset_modules, [SpoofedAssets])
 
-    assert {:error, {:invalid_asset_module, SpoofedAssets}} = Favn.Registry.reload()
+    assert {:error, {:invalid_asset_module, SpoofedAssets}} = Favn.Assets.Registry.reload()
     assert {:error, :not_asset_module} = Favn.get_asset({SpoofedAssets, :normalize_orders})
   end
 
   test "reports invalid globally configured modules" do
     Application.put_env(:favn, :asset_modules, [SampleAssets, Enum])
 
-    assert {:error, {:invalid_asset_module, Enum}} = Favn.Registry.reload()
+    assert {:error, {:invalid_asset_module, Enum}} = Favn.Assets.Registry.reload()
   end
 
   test "reads from the startup-loaded cache until the registry is reloaded" do
@@ -205,7 +209,7 @@ defmodule FavnTest do
              {SampleAssets, :normalize_orders}
            ]
 
-    assert :ok = Favn.Registry.reload()
+    assert :ok = Favn.Assets.Registry.reload()
     assert {:ok, reloaded_assets} = Favn.list_assets()
 
     assert Enum.map(reloaded_assets, & &1.ref) == [

--- a/test/graph_index_test.exs
+++ b/test/graph_index_test.exs
@@ -1,4 +1,4 @@
-defmodule Favn.GraphIndexTest do
+defmodule Favn.Assets.GraphIndexTest do
   use ExUnit.Case
 
   alias Favn.Test.Fixtures.Assets.Graph.ReportingAssets
@@ -21,14 +21,15 @@ defmodule Favn.GraphIndexTest do
         reload_graph?: true
       )
 
-    assert {:ok, upstream} = Favn.GraphIndex.upstream_of({WarehouseAssets, :fact_sales})
+    assert {:ok, upstream} = Favn.Assets.GraphIndex.upstream_of({WarehouseAssets, :fact_sales})
 
     assert upstream == [
              {WarehouseAssets, :normalize_customers},
              {WarehouseAssets, :normalize_orders}
            ]
 
-    assert {:ok, downstream} = Favn.GraphIndex.downstream_of({WarehouseAssets, :normalize_orders})
+    assert {:ok, downstream} =
+             Favn.Assets.GraphIndex.downstream_of({WarehouseAssets, :normalize_orders})
 
     assert downstream == [
              {WarehouseAssets, :fact_sales},
@@ -36,7 +37,7 @@ defmodule Favn.GraphIndexTest do
            ]
 
     assert {:ok, transitive_upstream} =
-             Favn.GraphIndex.transitive_upstream_of({ReportingAssets, :dashboard})
+             Favn.Assets.GraphIndex.transitive_upstream_of({ReportingAssets, :dashboard})
 
     assert transitive_upstream == [
              {SourceAssets, :raw_customers},
@@ -47,7 +48,7 @@ defmodule Favn.GraphIndexTest do
            ]
 
     assert {:ok, transitive_downstream} =
-             Favn.GraphIndex.transitive_downstream_of({SourceAssets, :raw_orders})
+             Favn.Assets.GraphIndex.transitive_downstream_of({SourceAssets, :raw_orders})
 
     assert transitive_downstream == [
              {WarehouseAssets, :normalize_orders},
@@ -55,7 +56,7 @@ defmodule Favn.GraphIndexTest do
              {ReportingAssets, :dashboard}
            ]
 
-    assert {:ok, topo_order} = Favn.GraphIndex.topological_order()
+    assert {:ok, topo_order} = Favn.Assets.GraphIndex.topological_order()
 
     assert Enum.find_index(topo_order, &(&1 == {SourceAssets, :raw_orders})) <
              Enum.find_index(topo_order, &(&1 == {WarehouseAssets, :normalize_orders}))
@@ -71,7 +72,7 @@ defmodule Favn.GraphIndexTest do
       )
 
     assert {:ok, assets} =
-             Favn.GraphIndex.related_assets({ReportingAssets, :dashboard},
+             Favn.Assets.GraphIndex.related_assets({ReportingAssets, :dashboard},
                direction: :upstream,
                tags: [:warehouse]
              )
@@ -82,7 +83,7 @@ defmodule Favn.GraphIndexTest do
            ]
 
     assert {:ok, both_neighbors} =
-             Favn.GraphIndex.related_assets({WarehouseAssets, :normalize_orders},
+             Favn.Assets.GraphIndex.related_assets({WarehouseAssets, :normalize_orders},
                direction: :both,
                transitive: false,
                include_target: false
@@ -102,7 +103,7 @@ defmodule Favn.GraphIndexTest do
       )
 
     assert {:ok, subgraph} =
-             Favn.GraphIndex.subgraph({ReportingAssets, :dashboard},
+             Favn.Assets.GraphIndex.subgraph({ReportingAssets, :dashboard},
                direction: :upstream,
                tags: [:warehouse]
              )
@@ -127,24 +128,32 @@ defmodule Favn.GraphIndexTest do
       )
 
     assert {:error, :invalid_opts} =
-             Favn.GraphIndex.related_assets({ReportingAssets, :dashboard}, direction: :sideways)
+             Favn.Assets.GraphIndex.related_assets({ReportingAssets, :dashboard},
+               direction: :sideways
+             )
 
     assert {:error, :invalid_opts} =
-             Favn.GraphIndex.related_assets({ReportingAssets, :dashboard}, transitive: :yes)
+             Favn.Assets.GraphIndex.related_assets({ReportingAssets, :dashboard},
+               transitive: :yes
+             )
 
     assert {:error, :invalid_opts} =
-             Favn.GraphIndex.related_assets({ReportingAssets, :dashboard}, include_target: 1)
+             Favn.Assets.GraphIndex.related_assets({ReportingAssets, :dashboard},
+               include_target: 1
+             )
 
     assert {:error, :invalid_opts} =
-             Favn.GraphIndex.related_assets({ReportingAssets, :dashboard}, tags: :warehouse)
+             Favn.Assets.GraphIndex.related_assets({ReportingAssets, :dashboard},
+               tags: :warehouse
+             )
 
     assert {:error, :invalid_opts} =
-             Favn.GraphIndex.related_assets({ReportingAssets, :dashboard},
+             Favn.Assets.GraphIndex.related_assets({ReportingAssets, :dashboard},
                modules: ReportingAssets
              )
 
     assert {:error, :invalid_opts} =
-             Favn.GraphIndex.subgraph({ReportingAssets, :dashboard}, names: :dashboard)
+             Favn.Assets.GraphIndex.subgraph({ReportingAssets, :dashboard}, names: :dashboard)
   end
 
   test "reports missing dependencies during graph construction" do
@@ -161,7 +170,7 @@ defmodule Favn.GraphIndexTest do
     assert {:error,
             {:missing_dependency, {__MODULE__, :missing_dependency},
              {__MODULE__, :does_not_exist}}} =
-             Favn.GraphIndex.build_index([missing])
+             Favn.Assets.GraphIndex.build_index([missing])
   end
 
   test "rejects cycles during graph construction" do
@@ -185,7 +194,7 @@ defmodule Favn.GraphIndexTest do
       depends_on: [{__MODULE__, :a}]
     }
 
-    assert {:error, {:cycle, cycle}} = Favn.GraphIndex.build_index([a, b])
+    assert {:error, {:cycle, cycle}} = Favn.Assets.GraphIndex.build_index([a, b])
     assert cycle == [{__MODULE__, :a}, {__MODULE__, :b}, {__MODULE__, :a}]
   end
 end

--- a/test/planner_test.exs
+++ b/test/planner_test.exs
@@ -1,4 +1,4 @@
-defmodule Favn.PlannerTest do
+defmodule Favn.Assets.PlannerTest do
   use ExUnit.Case
 
   alias Favn.Test.Fixtures.Assets.Graph.BronzeAssets

--- a/test/support/favn_test_setup.ex
+++ b/test/support/favn_test_setup.ex
@@ -3,7 +3,7 @@ defmodule Favn.TestSetup do
 
   @type state :: %{
           previous_modules: list(module()) | nil,
-          previous_catalog: {:ok, Favn.Registry.catalog()} | {:error, term()},
+          previous_catalog: {:ok, Favn.Assets.Registry.catalog()} | {:error, term()},
           previous_storage_adapter: module() | nil,
           previous_storage_adapter_opts: keyword() | nil
         }
@@ -14,7 +14,7 @@ defmodule Favn.TestSetup do
 
     %{
       previous_modules: previous_modules,
-      previous_catalog: Favn.Registry.build_catalog(previous_modules || []),
+      previous_catalog: Favn.Assets.Registry.build_catalog(previous_modules || []),
       previous_storage_adapter: Application.get_env(:favn, :storage_adapter),
       previous_storage_adapter_opts: Application.get_env(:favn, :storage_adapter_opts)
     }
@@ -23,10 +23,10 @@ defmodule Favn.TestSetup do
   @spec setup_asset_modules([module()], keyword()) :: :ok
   def setup_asset_modules(modules, opts \\ []) do
     Application.put_env(:favn, :asset_modules, modules)
-    :ok = Favn.Registry.reload()
+    :ok = Favn.Assets.Registry.reload()
 
     if Keyword.get(opts, :reload_graph?, false) do
-      :ok = Favn.GraphIndex.reload()
+      :ok = Favn.Assets.GraphIndex.reload()
     end
 
     :ok
@@ -68,10 +68,10 @@ defmodule Favn.TestSetup do
   defp restore_asset_modules(modules), do: Application.put_env(:favn, :asset_modules, modules)
 
   defp restore_registry({:ok, _catalog}, opts) do
-    :ok = Favn.Registry.reload()
+    :ok = Favn.Assets.Registry.reload()
 
     if Keyword.get(opts, :reload_graph?, false) do
-      :ok = Favn.GraphIndex.reload()
+      :ok = Favn.Assets.GraphIndex.reload()
     end
 
     :ok


### PR DESCRIPTION
### Motivation

- Establish an internal namespace for asset-related internals to separate public facade code from implementation details and reduce top-level module clutter.
- Make startup, planning, and graph/registry responsibilities explicit under `Favn.Assets.*` for clearer ownership and future extension.
- Update references throughout the codebase and tests so runtime and public APIs delegate to the new internal modules consistently.

### Description

- Rename and relocate core asset modules: `Favn.Registry` -> `Favn.Assets.Registry`, `Favn.GraphIndex` -> `Favn.Assets.GraphIndex`, and `Favn.Planner` -> `Favn.Assets.Planner`, including file moves under `lib/favn/assets/`.
- Update public facade and runtime to call the new namespaced modules (e.g. `Favn.list_assets/0`, `Favn.get_asset/1`, `Favn.plan_asset_run/2`, application startup, and `Favn.Runtime.Coordinator`).
- Update tests and test helpers to reference the renamed modules and reload the assets registry/graph via `Favn.Assets.Registry` and `Favn.Assets.GraphIndex`.
- Mark the new internal namespacing item in `FEATURES.md` to reflect the change.

### Testing

- Ran the test suite with `mix test` after the refactor; all tests passed.
- Verified compilation of moved modules and updated references by running `mix compile` as part of the test run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d38ec7199c83289caf4d0a734f3ea1)