### PR TITLE
Add schedule trigger DSL and normalize pipeline schedules with default timezone

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -281,6 +281,11 @@ The following decisions are source-of-truth for the first v0.3 pipeline foundati
 - [x] Deterministic pipeline selector resolution (ref/module/tag/category)
 - [x] Initial orchestration layer outside function attributes
 - [x] Initial pipeline configuration definition model
+- [x] Reusable schedule trigger DSL (`Favn.Triggers.Schedules`) with repeated top-level `schedule` declarations
+- [x] Pipeline schedule clause supports explicit schedule refs (`{Module, :name}`) and inline schedule keywords
+- [x] Remove temporary atom-only schedule references from pipeline DSL
+- [x] Resolve pipeline schedules into normalized trigger schedule structs in `ctx.pipeline.schedule`
+- [x] Configurable scheduler default timezone (`config :favn, scheduler: [default_timezone: ...]`)
 - [x] Make pipeline/config/trigger context available through `ctx`
 - [x] Internal module namespacing for asset internals (`Favn.Assets.Registry`, `Favn.Assets.GraphIndex`, `Favn.Assets.Planner`)
 - [x] Stable operator actions: run, cancel, rerun
@@ -290,6 +295,10 @@ The following decisions are source-of-truth for the first v0.3 pipeline foundati
 
 - [ ] API-triggered execution
 - [ ] Cron/schedule runtime engine
+- [ ] Cron parser/runtime validation hardening (strict expression + timezone validation)
+- [ ] Schedule missed-run runtime semantics (`missed: :one | :all`)
+- [ ] Schedule overlap runtime semantics (`overlap: :allow | :queue_one`)
+- [ ] Schedule `catchup_limit` option
 - [ ] Polling trigger runtime
 - [ ] Polling state/cursor tracking
 - [ ] Backfills

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -286,6 +286,7 @@ The following decisions are source-of-truth for the first v0.3 pipeline foundati
 - [x] Remove temporary atom-only schedule references from pipeline DSL
 - [x] Resolve pipeline schedules into normalized trigger schedule structs in `ctx.pipeline.schedule`
 - [x] Configurable scheduler default timezone (`config :favn, scheduler: [default_timezone: ...]`)
+- [x] Validate cron expressions and timezone identifiers during schedule authoring
 - [x] Make pipeline/config/trigger context available through `ctx`
 - [x] Internal module namespacing for asset internals (`Favn.Assets.Registry`, `Favn.Assets.GraphIndex`, `Favn.Assets.Planner`)
 - [x] Stable operator actions: run, cancel, rerun
@@ -295,7 +296,6 @@ The following decisions are source-of-truth for the first v0.3 pipeline foundati
 
 - [ ] API-triggered execution
 - [ ] Cron/schedule runtime engine
-- [ ] Cron parser/runtime validation hardening (strict expression + timezone validation)
 - [ ] Schedule missed-run runtime semantics (`missed: :one | :all`)
 - [ ] Schedule overlap runtime semantics (`overlap: :allow | :queue_one`)
 - [ ] Schedule `catchup_limit` option

--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ import Config
 config :favn,
   asset_modules: [MyApp.SalesAssets],
   pubsub_name: MyApp.PubSub,
+  scheduler: [default_timezone: "Etc/UTC"],
   storage_adapter: Favn.Storage.Adapter.Memory,
   storage_adapter_opts: []
 ```
@@ -121,6 +122,7 @@ Key settings:
 
 - `asset_modules`: modules that define assets with `use Favn.Assets`.
 - `:pubsub_name`: PubSub server name used for run event broadcasting.
+- `:scheduler`: trigger scheduler configuration (`default_timezone` for schedule trigger resolution).
 - `:storage_adapter`: run storage adapter module.
 - `:storage_adapter_opts`: options passed to the configured storage adapter.
 
@@ -217,6 +219,16 @@ Inside `select do ... end`, selectors are additive (union-based), not intersecti
 That means each selector contributes refs to one combined target set before dedupe/sort.
 
 A pipeline definition should use either shorthand selection or `select`, but not both in the same definition.
+
+Schedule authoring now supports both:
+
+- reusable named schedules in modules that `use Favn.Triggers.Schedules`
+- inline schedule definitions directly inside `pipeline ... do`
+
+Pipeline schedule references use explicit refs:
+
+- `schedule {MyApp.Schedules, :daily_oslo}`
+- `schedule cron: "0 2 * * *", timezone: "Europe/Oslo", missed: :skip, overlap: :forbid`
 
 Deferred from the first v0.3 pipeline foundation PR:
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,11 @@ Pipeline schedule references use explicit refs:
 - `schedule {MyApp.Schedules, :daily_oslo}`
 - `schedule cron: "0 2 * * *", timezone: "Europe/Oslo", missed: :skip, overlap: :forbid`
 
+Schedule DSL validation is strict at authoring time:
+
+- cron must be a valid 5-field cron expression
+- timezone must be a known zoneinfo identifier
+
 Deferred from the first v0.3 pipeline foundation PR:
 
 - schedule/polling runtime engines

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -229,7 +229,8 @@ defmodule Favn do
         asset_modules: [
           MyApp.SalesETL,
           MyApp.GoldETL
-        ]
+        ],
+        scheduler: [default_timezone: "Etc/UTC"]
 
   The configured module list is the global discovery scope used by
   `Favn.list_assets/0` and `Favn.get_asset/1`.

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -793,6 +793,8 @@ defmodule Favn do
       * `params: map()` (default `%{}`)
       * `pipeline_context: map()` optional manual pipeline provenance/context payload
         projected to `ctx.pipeline` and persisted `%Favn.Run{}.pipeline`
+        (passed through as provided; unlike `run_pipeline/2`, no schedule normalization
+        is applied to manually injected `pipeline_context`)
       * `max_concurrency: pos_integer()` (default from runtime config, fallback `1`)
       * `timeout_ms: pos_integer()` timeout counted from run start
       * `retry: false | true | keyword() | map()` (default from app config, fallback disabled)

--- a/lib/favn/pipeline.ex
+++ b/lib/favn/pipeline.ex
@@ -10,6 +10,7 @@ defmodule Favn.Pipeline do
   """
 
   alias Favn.Pipeline.Definition
+  alias Favn.Triggers.Schedule
 
   @type fetch_error :: :not_pipeline_module | :pipeline_not_defined
 
@@ -76,12 +77,11 @@ defmodule Favn.Pipeline do
     end
   end
 
-  defmacro schedule(name) do
-    quote bind_quoted: [name: name] do
+  defmacro schedule(value) do
+    quote bind_quoted: [value: value] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "schedule")
       Favn.Pipeline.ensure_singleton_clause!(__MODULE__, :favn_pipeline_schedule, "schedule")
-      Favn.Pipeline.validate_atom_clause!(name, "schedule")
-      @favn_pipeline_schedule name
+      @favn_pipeline_schedule Favn.Pipeline.normalize_schedule_clause!(value)
     end
   end
 
@@ -275,5 +275,28 @@ defmodule Favn.Pipeline do
     else
       raise ArgumentError, "pipeline clause `outputs` must be a list of atoms"
     end
+  end
+
+  @doc false
+  @spec normalize_schedule_clause!(term()) ::
+          {:ref, Schedule.ref()} | {:inline, keyword()}
+  def normalize_schedule_clause!({module, name})
+      when is_atom(module) and is_atom(name) do
+    {:ref, {module, name}}
+  end
+
+  def normalize_schedule_clause!(opts) when is_list(opts) do
+    case Schedule.validate_supported_opts(opts) do
+      :ok ->
+        {:inline, opts}
+
+      {:error, reason} ->
+        raise ArgumentError, "pipeline clause `schedule` is invalid: #{inspect(reason)}"
+    end
+  end
+
+  def normalize_schedule_clause!(value) do
+    raise ArgumentError,
+          "pipeline clause `schedule` must be `{Module, :name}` or keyword options, got: #{inspect(value)}"
   end
 end

--- a/lib/favn/pipeline.ex
+++ b/lib/favn/pipeline.ex
@@ -279,16 +279,16 @@ defmodule Favn.Pipeline do
 
   @doc false
   @spec normalize_schedule_clause!(term()) ::
-          {:ref, Schedule.ref()} | {:inline, keyword()}
+          {:ref, Schedule.ref()} | {:inline, Schedule.unresolved_t()}
   def normalize_schedule_clause!({module, name})
       when is_atom(module) and is_atom(name) do
     {:ref, {module, name}}
   end
 
   def normalize_schedule_clause!(opts) when is_list(opts) do
-    case Schedule.validate_supported_opts(opts) do
-      :ok ->
-        {:inline, opts}
+    case Schedule.new_inline(opts) do
+      {:ok, schedule} ->
+        {:inline, schedule}
 
       {:error, reason} ->
         raise ArgumentError, "pipeline clause `schedule` is invalid: #{inspect(reason)}"

--- a/lib/favn/pipeline/definition.ex
+++ b/lib/favn/pipeline/definition.ex
@@ -14,7 +14,7 @@ defmodule Favn.Pipeline.Definition do
   @type selection_mode :: :shorthand | :select | nil
   @type schedule_clause ::
           {:ref, Favn.Triggers.Schedule.ref()}
-          | {:inline, keyword()}
+          | {:inline, Favn.Triggers.Schedule.unresolved_t()}
           | nil
 
   @type t :: %__MODULE__{

--- a/lib/favn/pipeline/definition.ex
+++ b/lib/favn/pipeline/definition.ex
@@ -12,6 +12,10 @@ defmodule Favn.Pipeline.Definition do
           | {:category, atom() | String.t()}
 
   @type selection_mode :: :shorthand | :select | nil
+  @type schedule_clause ::
+          {:ref, Favn.Triggers.Schedule.ref()}
+          | {:inline, keyword()}
+          | nil
 
   @type t :: %__MODULE__{
           module: module(),
@@ -21,7 +25,7 @@ defmodule Favn.Pipeline.Definition do
           deps: Favn.dependencies_mode(),
           config: map(),
           meta: map(),
-          schedule: atom() | nil,
+          schedule: schedule_clause(),
           partition: atom() | nil,
           source: atom() | nil,
           outputs: [atom()]

--- a/lib/favn/pipeline/resolver.ex
+++ b/lib/favn/pipeline/resolver.ex
@@ -8,6 +8,8 @@ defmodule Favn.Pipeline.Resolver do
 
   alias Favn.Pipeline.Definition
   alias Favn.Pipeline.Resolution
+  alias Favn.Triggers.Schedule
+  alias Favn.Triggers.Schedules
 
   @type resolve_opts :: [params: map(), trigger: map()]
 
@@ -15,10 +17,12 @@ defmodule Favn.Pipeline.Resolver do
   def resolve(%Definition{} = definition, opts \\ []) when is_list(opts) do
     trigger = Keyword.get(opts, :trigger, %{kind: :manual})
     params = Keyword.get(opts, :params, %{})
+    default_timezone = Schedule.default_timezone()
 
     with :ok <- validate_definition(definition),
          :ok <- validate_params(params),
          :ok <- validate_trigger(trigger),
+         {:ok, schedule} <- resolve_schedule(definition.schedule, default_timezone),
          {:ok, assets} <- Favn.list_assets(),
          {:ok, target_refs} <- resolve_selectors(definition, assets) do
       pipeline_ctx = %{
@@ -29,7 +33,7 @@ defmodule Favn.Pipeline.Resolver do
         trigger: trigger,
         params: params,
         runtime_window: nil,
-        schedule: definition.schedule,
+        schedule: schedule,
         partition: definition.partition,
         source: definition.source,
         outputs: definition.outputs
@@ -49,7 +53,6 @@ defmodule Favn.Pipeline.Resolver do
     with :ok <- validate_name(definition.name),
          :ok <- validate_deps(definition.deps),
          :ok <- validate_selectors(definition.selectors),
-         :ok <- validate_schedule(definition.schedule),
          :ok <- validate_partition(definition.partition),
          :ok <- validate_source(definition.source),
          :ok <- validate_outputs(definition.outputs) do
@@ -78,10 +81,6 @@ defmodule Favn.Pipeline.Resolver do
   defp valid_selector?({:category, value}) when is_atom(value) or is_binary(value), do: true
   defp valid_selector?(_), do: false
 
-  defp validate_schedule(nil), do: :ok
-  defp validate_schedule(value) when is_atom(value), do: :ok
-  defp validate_schedule(value), do: {:error, {:invalid_schedule, value}}
-
   defp validate_partition(nil), do: :ok
   defp validate_partition(value) when is_atom(value), do: :ok
   defp validate_partition(value), do: {:error, {:invalid_partition, value}}
@@ -101,6 +100,25 @@ defmodule Favn.Pipeline.Resolver do
 
   defp validate_trigger(trigger) when is_map(trigger), do: :ok
   defp validate_trigger(_invalid), do: {:error, :invalid_pipeline_trigger}
+
+  defp resolve_schedule(nil, _default_timezone), do: {:ok, nil}
+
+  defp resolve_schedule({:inline, opts}, default_timezone) when is_list(opts) do
+    with {:ok, schedule} <- Schedule.new_inline(opts),
+         {:ok, resolved} <- Schedule.apply_default_timezone(schedule, default_timezone) do
+      {:ok, resolved}
+    end
+  end
+
+  defp resolve_schedule({:ref, {module, name}}, default_timezone)
+       when is_atom(module) and is_atom(name) do
+    with {:ok, schedule} <- Schedules.fetch(module, name),
+         {:ok, resolved} <- Schedule.apply_default_timezone(schedule, default_timezone) do
+      {:ok, resolved}
+    end
+  end
+
+  defp resolve_schedule(value, _default_timezone), do: {:error, {:invalid_schedule, value}}
 
   defp resolve_selectors(%Definition{selectors: selectors}, assets) do
     assets_by_ref = Map.new(assets, &{&1.ref, &1})

--- a/lib/favn/pipeline/resolver.ex
+++ b/lib/favn/pipeline/resolver.ex
@@ -103,9 +103,8 @@ defmodule Favn.Pipeline.Resolver do
 
   defp resolve_schedule(nil, _default_timezone), do: {:ok, nil}
 
-  defp resolve_schedule({:inline, opts}, default_timezone) when is_list(opts) do
-    with {:ok, schedule} <- Schedule.new_inline(opts),
-         {:ok, resolved} <- Schedule.apply_default_timezone(schedule, default_timezone) do
+  defp resolve_schedule({:inline, %Schedule{} = schedule}, default_timezone) do
+    with {:ok, resolved} <- Schedule.apply_default_timezone(schedule, default_timezone) do
       {:ok, resolved}
     end
   end

--- a/lib/favn/triggers/schedule.ex
+++ b/lib/favn/triggers/schedule.ex
@@ -188,9 +188,12 @@ defmodule Favn.Triggers.Schedule do
   end
 
   defp cron_field_valid?(field, min, max) when is_binary(field) do
-    field
-    |> String.split(",", trim: true)
-    |> Enum.all?(fn token -> cron_token_valid?(token, min, max) end)
+    tokens = String.split(field, ",", trim: false)
+
+    Enum.all?(tokens, fn token ->
+      token = String.trim(token)
+      token != "" and cron_token_valid?(token, min, max)
+    end)
   end
 
   defp cron_token_valid?("*", _min, _max), do: true

--- a/lib/favn/triggers/schedule.ex
+++ b/lib/favn/triggers/schedule.ex
@@ -1,0 +1,139 @@
+defmodule Favn.Triggers.Schedule do
+  @moduledoc """
+  Normalized schedule trigger definition used by pipeline resolution/runtime context.
+
+  Cron is currently the only supported trigger kind.
+  """
+
+  @type kind :: :cron
+  @type missed_policy :: :skip | :one | :all
+  @type overlap_policy :: :forbid | :allow | :queue_one
+  @type ref :: {module(), atom()}
+
+  @enforce_keys [:kind, :cron, :timezone, :missed, :overlap, :origin]
+  defstruct id: nil,
+            ref: nil,
+            kind: :cron,
+            cron: nil,
+            timezone: nil,
+            timezone_source: :schedule,
+            missed: :skip,
+            overlap: :forbid,
+            origin: :inline
+
+  @type t :: %__MODULE__{
+          id: atom() | nil,
+          ref: ref() | nil,
+          kind: kind(),
+          cron: String.t(),
+          timezone: String.t(),
+          timezone_source: :schedule | :app_default,
+          missed: missed_policy(),
+          overlap: overlap_policy(),
+          origin: :inline | :named
+        }
+
+  @type compile_t :: %__MODULE__{timezone: String.t() | nil}
+
+  @spec new_inline(keyword()) :: {:ok, compile_t()} | {:error, term()}
+  def new_inline(opts) when is_list(opts) do
+    with :ok <- validate_supported_opts(opts),
+         {:ok, cron} <- fetch_cron(opts),
+         {:ok, timezone} <- validate_timezone(Keyword.get(opts, :timezone)),
+         {:ok, missed} <- validate_missed(Keyword.get(opts, :missed, :skip)),
+         {:ok, overlap} <- validate_overlap(Keyword.get(opts, :overlap, :forbid)) do
+      {:ok,
+       %__MODULE__{
+         kind: :cron,
+         cron: cron,
+         timezone: timezone,
+         missed: missed,
+         overlap: overlap,
+         origin: :inline,
+         timezone_source: if(timezone == nil, do: :app_default, else: :schedule)
+       }}
+    end
+  end
+
+  def new_inline(_invalid), do: {:error, :invalid_schedule}
+
+  @spec named(atom(), keyword()) :: {:ok, compile_t()} | {:error, term()}
+  def named(name, opts) when is_atom(name) and is_list(opts) do
+    with {:ok, schedule} <- new_inline(opts) do
+      {:ok, %{schedule | id: name, origin: :named}}
+    end
+  end
+
+  def named(_name, _opts), do: {:error, :invalid_schedule}
+
+  @spec apply_ref(compile_t(), ref()) :: t()
+  def apply_ref(%__MODULE__{} = schedule, {module, name}) do
+    %{schedule | id: schedule.id || name, ref: {module, name}, origin: :named}
+  end
+
+  @spec apply_default_timezone(compile_t(), String.t() | nil) :: {:ok, t()} | {:error, term()}
+  def apply_default_timezone(%__MODULE__{} = schedule, default_timezone) do
+    case schedule.timezone do
+      timezone when is_binary(timezone) ->
+        {:ok, %{schedule | timezone_source: :schedule}}
+
+      nil ->
+        with {:ok, effective} <- validate_timezone(default_timezone || "Etc/UTC") do
+          {:ok, %{schedule | timezone: effective, timezone_source: :app_default}}
+        end
+    end
+  end
+
+  @spec default_timezone() :: String.t()
+  def default_timezone do
+    case Application.get_env(:favn, :scheduler, []) do
+      scheduler when is_list(scheduler) -> Keyword.get(scheduler, :default_timezone, "Etc/UTC")
+      _ -> "Etc/UTC"
+    end
+  end
+
+  @spec validate_supported_opts(keyword()) :: :ok | {:error, term()}
+  def validate_supported_opts(opts) when is_list(opts) do
+    supported = [:cron, :timezone, :missed, :overlap]
+
+    case Keyword.keys(opts) -- supported do
+      [] -> :ok
+      unknown -> {:error, {:unsupported_schedule_opts, unknown}}
+    end
+  end
+
+  defp fetch_cron(opts) do
+    case Keyword.fetch(opts, :cron) do
+      {:ok, cron} when is_binary(cron) ->
+        if byte_size(String.trim(cron)) > 0 do
+          {:ok, cron}
+        else
+          {:error, {:invalid_schedule_cron, cron}}
+        end
+
+      {:ok, _invalid} ->
+        {:error, {:invalid_schedule_cron, Keyword.get(opts, :cron)}}
+
+      :error ->
+        {:error, :missing_schedule_cron}
+    end
+  end
+
+  defp validate_timezone(nil), do: {:ok, nil}
+
+  defp validate_timezone(timezone) when is_binary(timezone) do
+    if String.trim(timezone) == "" do
+      {:error, {:invalid_schedule_timezone, timezone}}
+    else
+      {:ok, timezone}
+    end
+  end
+
+  defp validate_timezone(other), do: {:error, {:invalid_schedule_timezone, other}}
+
+  defp validate_missed(value) when value in [:skip, :one, :all], do: {:ok, value}
+  defp validate_missed(other), do: {:error, {:invalid_schedule_missed, other}}
+
+  defp validate_overlap(value) when value in [:forbid, :allow, :queue_one], do: {:ok, value}
+  defp validate_overlap(other), do: {:error, {:invalid_schedule_overlap, other}}
+end

--- a/lib/favn/triggers/schedule.ex
+++ b/lib/favn/triggers/schedule.ex
@@ -21,6 +21,18 @@ defmodule Favn.Triggers.Schedule do
             overlap: :forbid,
             origin: :inline
 
+  @type unresolved_t :: %__MODULE__{
+          id: atom() | nil,
+          ref: ref() | nil,
+          kind: kind(),
+          cron: String.t(),
+          timezone: String.t() | nil,
+          timezone_source: :schedule | :app_default,
+          missed: missed_policy(),
+          overlap: overlap_policy(),
+          origin: :inline | :named
+        }
+
   @type t :: %__MODULE__{
           id: atom() | nil,
           ref: ref() | nil,
@@ -33,11 +45,11 @@ defmodule Favn.Triggers.Schedule do
           origin: :inline | :named
         }
 
-  @type compile_t :: %__MODULE__{timezone: String.t() | nil}
-
-  @spec new_inline(keyword()) :: {:ok, compile_t()} | {:error, term()}
+  @spec new_inline(keyword()) :: {:ok, unresolved_t()} | {:error, term()}
   def new_inline(opts) when is_list(opts) do
-    with :ok <- validate_supported_opts(opts),
+    with :ok <- validate_keyword_opts(opts),
+         :ok <- validate_duplicate_opts(opts),
+         :ok <- validate_supported_opts(opts),
          {:ok, cron} <- fetch_cron(opts),
          {:ok, timezone} <- validate_timezone(Keyword.get(opts, :timezone)),
          {:ok, missed} <- validate_missed(Keyword.get(opts, :missed, :skip)),
@@ -57,7 +69,7 @@ defmodule Favn.Triggers.Schedule do
 
   def new_inline(_invalid), do: {:error, :invalid_schedule}
 
-  @spec named(atom(), keyword()) :: {:ok, compile_t()} | {:error, term()}
+  @spec named(atom(), keyword()) :: {:ok, unresolved_t()} | {:error, term()}
   def named(name, opts) when is_atom(name) and is_list(opts) do
     with {:ok, schedule} <- new_inline(opts) do
       {:ok, %{schedule | id: name, origin: :named}}
@@ -66,12 +78,12 @@ defmodule Favn.Triggers.Schedule do
 
   def named(_name, _opts), do: {:error, :invalid_schedule}
 
-  @spec apply_ref(compile_t(), ref()) :: t()
+  @spec apply_ref(unresolved_t(), ref()) :: unresolved_t()
   def apply_ref(%__MODULE__{} = schedule, {module, name}) do
     %{schedule | id: schedule.id || name, ref: {module, name}, origin: :named}
   end
 
-  @spec apply_default_timezone(compile_t(), String.t() | nil) :: {:ok, t()} | {:error, term()}
+  @spec apply_default_timezone(unresolved_t(), String.t() | nil) :: {:ok, t()} | {:error, term()}
   def apply_default_timezone(%__MODULE__{} = schedule, default_timezone) do
     case schedule.timezone do
       timezone when is_binary(timezone) ->
@@ -81,6 +93,28 @@ defmodule Favn.Triggers.Schedule do
         with {:ok, effective} <- validate_timezone(default_timezone || "Etc/UTC") do
           {:ok, %{schedule | timezone: effective, timezone_source: :app_default}}
         end
+    end
+  end
+
+  @spec validate_keyword_opts(term()) :: :ok | {:error, :invalid_schedule}
+  def validate_keyword_opts(opts) when is_list(opts) do
+    if Keyword.keyword?(opts), do: :ok, else: {:error, :invalid_schedule}
+  end
+
+  def validate_keyword_opts(_invalid), do: {:error, :invalid_schedule}
+
+  @spec validate_duplicate_opts(keyword()) :: :ok | {:error, term()}
+  def validate_duplicate_opts(opts) when is_list(opts) do
+    duplicates =
+      opts
+      |> Keyword.keys()
+      |> Enum.frequencies()
+      |> Enum.filter(fn {_key, count} -> count > 1 end)
+      |> Enum.map(&elem(&1, 0))
+
+    case duplicates do
+      [] -> :ok
+      values -> {:error, {:duplicate_schedule_opts, values}}
     end
   end
 

--- a/lib/favn/triggers/schedule.ex
+++ b/lib/favn/triggers/schedule.ex
@@ -139,7 +139,9 @@ defmodule Favn.Triggers.Schedule do
   defp fetch_cron(opts) do
     case Keyword.fetch(opts, :cron) do
       {:ok, cron} when is_binary(cron) ->
-        if byte_size(String.trim(cron)) > 0 do
+        cron = String.trim(cron)
+
+        if byte_size(cron) > 0 and valid_cron_expression?(cron) do
           {:ok, cron}
         else
           {:error, {:invalid_schedule_cron, cron}}
@@ -156,14 +158,113 @@ defmodule Favn.Triggers.Schedule do
   defp validate_timezone(nil), do: {:ok, nil}
 
   defp validate_timezone(timezone) when is_binary(timezone) do
-    if String.trim(timezone) == "" do
+    timezone = String.trim(timezone)
+
+    if timezone == "" do
       {:error, {:invalid_schedule_timezone, timezone}}
     else
-      {:ok, timezone}
+      if valid_timezone_identifier?(timezone) do
+        {:ok, timezone}
+      else
+        {:error, {:invalid_schedule_timezone, timezone}}
+      end
     end
   end
 
   defp validate_timezone(other), do: {:error, {:invalid_schedule_timezone, other}}
+
+  defp valid_cron_expression?(value) when is_binary(value) do
+    case String.split(value, ~r/\s+/, trim: true) do
+      [minute, hour, day, month, weekday] ->
+        cron_field_valid?(minute, 0, 59) and
+          cron_field_valid?(hour, 0, 23) and
+          cron_field_valid?(day, 1, 31) and
+          cron_field_valid?(month, 1, 12) and
+          cron_field_valid?(weekday, 0, 7)
+
+      _other ->
+        false
+    end
+  end
+
+  defp cron_field_valid?(field, min, max) when is_binary(field) do
+    field
+    |> String.split(",", trim: true)
+    |> Enum.all?(fn token -> cron_token_valid?(token, min, max) end)
+  end
+
+  defp cron_token_valid?("*", _min, _max), do: true
+
+  defp cron_token_valid?(token, min, max) do
+    case String.split(token, "/", parts: 2) do
+      [base] ->
+        cron_base_valid?(base, min, max)
+
+      [base, step] ->
+        cron_base_valid?(base, min, max) and positive_int?(step)
+
+      _ ->
+        false
+    end
+  end
+
+  defp cron_base_valid?("*", _min, _max), do: true
+
+  defp cron_base_valid?(base, min, max) do
+    case String.split(base, "-", parts: 2) do
+      [single] ->
+        cron_number_in_range?(single, min, max)
+
+      [from, to] ->
+        case {parse_int(from), parse_int(to)} do
+          {{:ok, left}, {:ok, right}} when left <= right and left >= min and right <= max ->
+            true
+
+          _ ->
+            false
+        end
+
+      _ ->
+        false
+    end
+  end
+
+  defp cron_number_in_range?(value, min, max) do
+    case parse_int(value) do
+      {:ok, int} -> int >= min and int <= max
+      :error -> false
+    end
+  end
+
+  defp positive_int?(value) do
+    case parse_int(value) do
+      {:ok, int} -> int > 0
+      :error -> false
+    end
+  end
+
+  defp parse_int(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} -> {:ok, int}
+      _ -> :error
+    end
+  end
+
+  defp valid_timezone_identifier?(timezone) when is_binary(timezone) do
+    not String.contains?(timezone, "..") and
+      not String.starts_with?(timezone, "/") and
+      Enum.any?(zoneinfo_roots(), fn root ->
+        root
+        |> Path.join(timezone)
+        |> File.regular?()
+      end)
+  end
+
+  defp zoneinfo_roots do
+    ["/usr/share/zoneinfo", "/usr/share/lib/zoneinfo", "/etc/zoneinfo"]
+    |> Enum.uniq()
+    |> Enum.filter(&File.dir?/1)
+  end
 
   defp validate_missed(value) when value in [:skip, :one, :all], do: {:ok, value}
   defp validate_missed(other), do: {:error, {:invalid_schedule_missed, other}}

--- a/lib/favn/triggers/schedules.ex
+++ b/lib/favn/triggers/schedules.ex
@@ -1,0 +1,100 @@
+defmodule Favn.Triggers.Schedules do
+  @moduledoc """
+  Reusable named schedule trigger definitions.
+
+  Modules can declare repeated top-level `schedule/2` clauses:
+
+      defmodule MyApp.Schedules do
+        use Favn.Triggers.Schedules
+
+        schedule :daily,
+          cron: "0 2 * * *",
+          timezone: "Europe/Oslo",
+          missed: :skip,
+          overlap: :forbid
+      end
+  """
+
+  alias Favn.Triggers.Schedule
+
+  @type fetch_error ::
+          :not_schedule_module | :schedule_not_defined | {:schedule_not_found, atom()}
+
+  defmacro __using__(_opts) do
+    quote do
+      import Favn.Triggers.Schedules
+
+      Module.register_attribute(__MODULE__, :favn_named_schedules, accumulate: true)
+
+      @before_compile Favn.Triggers.Schedules
+    end
+  end
+
+  defmacro schedule(name, opts) do
+    schedule =
+      case Schedule.named(name, opts) do
+        {:ok, value} ->
+          value
+
+        {:error, reason} ->
+          raise ArgumentError,
+                "invalid schedule declaration #{inspect(name)}: #{inspect(reason)}"
+      end
+
+    quote bind_quoted: [name: name, schedule: Macro.escape(schedule)] do
+      unless is_atom(name) do
+        raise ArgumentError, "schedule name must be an atom"
+      end
+
+      existing = Module.get_attribute(__MODULE__, :favn_named_schedules) || []
+
+      if Enum.any?(existing, fn {existing_name, _schedule} -> existing_name == name end) do
+        raise ArgumentError,
+              "schedule #{inspect(name)} is already declared in #{inspect(__MODULE__)}"
+      end
+
+      Module.put_attribute(__MODULE__, :favn_named_schedules, {name, schedule})
+    end
+  end
+
+  defmacro __before_compile__(env) do
+    schedules =
+      env.module
+      |> Module.get_attribute(:favn_named_schedules)
+      |> Enum.reverse()
+      |> Map.new()
+
+    quote do
+      @doc false
+      @spec __favn_schedules__() :: %{optional(atom()) => Favn.Triggers.Schedule.compile_t()}
+      def __favn_schedules__, do: unquote(Macro.escape(schedules))
+
+      @doc false
+      @spec __favn_schedule__(atom()) ::
+              {:ok, Favn.Triggers.Schedule.compile_t()} | {:error, :not_found}
+      def __favn_schedule__(name) when is_atom(name) do
+        case Map.fetch(unquote(Macro.escape(schedules)), name) do
+          {:ok, schedule} -> {:ok, schedule}
+          :error -> {:error, :not_found}
+        end
+      end
+    end
+  end
+
+  @spec fetch(module(), atom()) :: {:ok, Schedule.t()} | {:error, fetch_error()}
+  def fetch(module, name) when is_atom(module) and is_atom(name) do
+    if function_exported?(module, :__favn_schedule__, 1) do
+      case module.__favn_schedule__(name) do
+        {:ok, %Schedule{} = schedule} -> {:ok, Schedule.apply_ref(schedule, {module, name})}
+        {:error, :not_found} -> {:error, {:schedule_not_found, name}}
+        _other -> {:error, :schedule_not_defined}
+      end
+    else
+      {:error, :not_schedule_module}
+    end
+  rescue
+    _error -> {:error, :schedule_not_defined}
+  end
+
+  def fetch(_module, _name), do: {:error, :not_schedule_module}
+end

--- a/lib/favn/triggers/schedules.ex
+++ b/lib/favn/triggers/schedules.ex
@@ -31,20 +31,20 @@ defmodule Favn.Triggers.Schedules do
   end
 
   defmacro schedule(name, opts) do
-    schedule =
-      case Schedule.named(name, opts) do
-        {:ok, value} ->
-          value
-
-        {:error, reason} ->
-          raise ArgumentError,
-                "invalid schedule declaration #{inspect(name)}: #{inspect(reason)}"
-      end
-
-    quote bind_quoted: [name: name, schedule: Macro.escape(schedule)] do
+    quote bind_quoted: [name: name, opts: opts] do
       unless is_atom(name) do
         raise ArgumentError, "schedule name must be an atom"
       end
+
+      schedule =
+        case Favn.Triggers.Schedule.named(name, opts) do
+          {:ok, value} ->
+            value
+
+          {:error, reason} ->
+            raise ArgumentError,
+                  "invalid schedule declaration #{inspect(name)}: #{inspect(reason)}"
+        end
 
       existing = Module.get_attribute(__MODULE__, :favn_named_schedules) || []
 
@@ -66,12 +66,12 @@ defmodule Favn.Triggers.Schedules do
 
     quote do
       @doc false
-      @spec __favn_schedules__() :: %{optional(atom()) => Favn.Triggers.Schedule.compile_t()}
+      @spec __favn_schedules__() :: %{optional(atom()) => Favn.Triggers.Schedule.unresolved_t()}
       def __favn_schedules__, do: unquote(Macro.escape(schedules))
 
       @doc false
       @spec __favn_schedule__(atom()) ::
-              {:ok, Favn.Triggers.Schedule.compile_t()} | {:error, :not_found}
+              {:ok, Favn.Triggers.Schedule.unresolved_t()} | {:error, :not_found}
       def __favn_schedule__(name) when is_atom(name) do
         case Map.fetch(unquote(Macro.escape(schedules)), name) do
           {:ok, schedule} -> {:ok, schedule}
@@ -81,7 +81,7 @@ defmodule Favn.Triggers.Schedules do
     end
   end
 
-  @spec fetch(module(), atom()) :: {:ok, Schedule.t()} | {:error, fetch_error()}
+  @spec fetch(module(), atom()) :: {:ok, Schedule.unresolved_t()} | {:error, fetch_error()}
   def fetch(module, name) when is_atom(module) and is_atom(name) do
     if function_exported?(module, :__favn_schedule__, 1) do
       case module.__favn_schedule__(name) do

--- a/test/pipeline_test.exs
+++ b/test/pipeline_test.exs
@@ -145,6 +145,22 @@ defmodule Favn.PipelineTest do
     assert ctx.pipeline.trigger == %{kind: :manual, requested_by: :api}
   end
 
+  test "run_asset/2 manual pipeline_context schedule is passed through without normalization" do
+    assert {:ok, run_id} =
+             Favn.run_asset({SalesAssets, :sales_daily},
+               dependencies: :none,
+               pipeline_context: %{
+                 id: :manual_passthrough,
+                 name: :manual_passthrough,
+                 trigger: %{kind: :manual},
+                 schedule: :legacy_schedule_atom
+               }
+             )
+
+    assert {:ok, run} = Favn.await_run(run_id, timeout: 5_000)
+    assert run.pipeline.schedule == :legacy_schedule_atom
+  end
+
   test "run_pipeline/2 injects pipeline context into asset ctx" do
     assert {:ok, run_id} =
              Favn.run_pipeline(SimplePipeline,
@@ -363,6 +379,81 @@ defmodule Favn.PipelineTest do
       """)
     end
 
+    assert_raise ArgumentError,
+                 ~r/pipeline clause `schedule` is invalid: {:invalid_schedule_cron/,
+                 fn ->
+                   Code.compile_string("""
+                   defmodule InvalidScheduleCronPipeline do
+                     use Favn.Pipeline
+
+                     pipeline :invalid_schedule_cron do
+                       asset {#{inspect(SalesAssets)}, :sales_daily}
+                       schedule cron: ""
+                     end
+                   end
+                   """)
+                 end
+
+    assert_raise ArgumentError,
+                 ~r/pipeline clause `schedule` is invalid: {:invalid_schedule_missed/,
+                 fn ->
+                   Code.compile_string("""
+                   defmodule InvalidScheduleMissedPipeline do
+                     use Favn.Pipeline
+
+                     pipeline :invalid_schedule_missed do
+                       asset {#{inspect(SalesAssets)}, :sales_daily}
+                       schedule cron: "0 2 * * *", missed: :later
+                     end
+                   end
+                   """)
+                 end
+
+    assert_raise ArgumentError,
+                 ~r/pipeline clause `schedule` is invalid: {:invalid_schedule_overlap/,
+                 fn ->
+                   Code.compile_string("""
+                   defmodule InvalidScheduleOverlapPipeline do
+                     use Favn.Pipeline
+
+                     pipeline :invalid_schedule_overlap do
+                       asset {#{inspect(SalesAssets)}, :sales_daily}
+                       schedule cron: "0 2 * * *", overlap: :maybe
+                     end
+                   end
+                   """)
+                 end
+
+    assert_raise ArgumentError,
+                 ~r/pipeline clause `schedule` is invalid: {:invalid_schedule_timezone/,
+                 fn ->
+                   Code.compile_string("""
+                   defmodule InvalidScheduleTimezonePipeline do
+                     use Favn.Pipeline
+
+                     pipeline :invalid_schedule_timezone do
+                       asset {#{inspect(SalesAssets)}, :sales_daily}
+                       schedule cron: "0 2 * * *", timezone: ""
+                     end
+                   end
+                   """)
+                 end
+
+    assert_raise ArgumentError,
+                 ~r/pipeline clause `schedule` is invalid: \{:duplicate_schedule_opts, \[:cron\]\}/,
+                 fn ->
+                   Code.compile_string("""
+                   defmodule DuplicateScheduleOptsPipeline do
+                     use Favn.Pipeline
+
+                     pipeline :duplicate_schedule_opts do
+                       asset {#{inspect(SalesAssets)}, :sales_daily}
+                       schedule cron: "0 2 * * *", cron: "0 3 * * *"
+                     end
+                   end
+                   """)
+                 end
+
     assert_raise ArgumentError, ~r/`partition` must be an atom/, fn ->
       Code.compile_string("""
       defmodule InvalidPartitionPipeline do
@@ -437,5 +528,73 @@ defmodule Favn.PipelineTest do
     assert run.pipeline.schedule.timezone_source == :app_default
     assert run.pipeline.schedule.missed == :one
     assert run.pipeline.schedule.overlap == :queue_one
+  end
+
+  test "pipeline schedule keeps explicit timezone over app default timezone" do
+    previous_scheduler = Application.get_env(:favn, :scheduler)
+    Application.put_env(:favn, :scheduler, default_timezone: "Europe/Oslo")
+
+    on_exit(fn ->
+      if previous_scheduler == nil do
+        Application.delete_env(:favn, :scheduler)
+      else
+        Application.put_env(:favn, :scheduler, previous_scheduler)
+      end
+    end)
+
+    defmodule ExplicitTimezonePipeline do
+      use Favn.Pipeline
+
+      pipeline :explicit_timezone do
+        asset({SalesAssets, :sales_daily})
+        schedule(cron: "0 2 * * *", timezone: "UTC")
+      end
+    end
+
+    assert {:ok, run_id} = Favn.run_pipeline(ExplicitTimezonePipeline)
+    assert {:ok, run} = Favn.await_run(run_id, timeout: 5_000)
+    assert %Schedule{} = run.pipeline.schedule
+    assert run.pipeline.schedule.timezone == "UTC"
+    assert run.pipeline.schedule.timezone_source == :schedule
+  end
+
+  test "plan_pipeline/2 returns error for missing schedule ref" do
+    defmodule MissingScheduleRefPipeline do
+      use Favn.Pipeline
+
+      pipeline :missing_schedule_ref do
+        asset({SalesAssets, :sales_daily})
+        schedule({Schedules, :missing_name})
+      end
+    end
+
+    assert {:error, {:schedule_not_found, :missing_name}} =
+             Favn.plan_pipeline(MissingScheduleRefPipeline)
+  end
+
+  test "plan_pipeline/2 returns error for invalid schedule module ref" do
+    defmodule InvalidScheduleModulePipeline do
+      use Favn.Pipeline
+
+      pipeline :invalid_schedule_module do
+        asset({SalesAssets, :sales_daily})
+        schedule({Enum, :daily})
+      end
+    end
+
+    assert {:error, :not_schedule_module} = Favn.plan_pipeline(InvalidScheduleModulePipeline)
+  end
+
+  test "resolver returns error for malformed stored schedule clause" do
+    definition = %Favn.Pipeline.Definition{
+      module: __MODULE__,
+      name: :malformed_schedule,
+      selectors: [{:asset, {SalesAssets, :sales_daily}}],
+      deps: :none,
+      schedule: {:bogus, :value}
+    }
+
+    assert {:error, {:invalid_schedule, {:bogus, :value}}} =
+             Favn.Pipeline.Resolver.resolve(definition)
   end
 end

--- a/test/pipeline_test.exs
+++ b/test/pipeline_test.exs
@@ -395,6 +395,21 @@ defmodule Favn.PipelineTest do
                  end
 
     assert_raise ArgumentError,
+                 ~r/pipeline clause `schedule` is invalid: {:invalid_schedule_cron/,
+                 fn ->
+                   Code.compile_string("""
+                   defmodule InvalidScheduleCronCommaListPipeline do
+                     use Favn.Pipeline
+
+                     pipeline :invalid_schedule_cron_comma_list do
+                       asset {#{inspect(SalesAssets)}, :sales_daily}
+                       schedule cron: "1,,2 2 * * *"
+                     end
+                   end
+                   """)
+                 end
+
+    assert_raise ArgumentError,
                  ~r/pipeline clause `schedule` is invalid: {:invalid_schedule_missed/,
                  fn ->
                    Code.compile_string("""

--- a/test/pipeline_test.exs
+++ b/test/pipeline_test.exs
@@ -433,7 +433,22 @@ defmodule Favn.PipelineTest do
 
                      pipeline :invalid_schedule_timezone do
                        asset {#{inspect(SalesAssets)}, :sales_daily}
-                       schedule cron: "0 2 * * *", timezone: ""
+                       schedule cron: "0 2 * * *", timezone: "Mars/Phobos"
+                     end
+                   end
+                   """)
+                 end
+
+    assert_raise ArgumentError,
+                 ~r/pipeline clause `schedule` is invalid: {:invalid_schedule_cron/,
+                 fn ->
+                   Code.compile_string("""
+                   defmodule InvalidScheduleCronShapePipeline do
+                     use Favn.Pipeline
+
+                     pipeline :invalid_schedule_cron_shape do
+                       asset {#{inspect(SalesAssets)}, :sales_daily}
+                       schedule cron: "0 2 * *"
                      end
                    end
                    """)

--- a/test/pipeline_test.exs
+++ b/test/pipeline_test.exs
@@ -7,6 +7,8 @@ defmodule Favn.PipelineTest do
   alias Favn.Test.Fixtures.Pipelines.AssetsShorthandPipeline
   alias Favn.Test.Fixtures.Pipelines.SelectPipeline
   alias Favn.Test.Fixtures.Pipelines.SimplePipeline
+  alias Favn.Test.Fixtures.Triggers.Schedules
+  alias Favn.Triggers.Schedule
 
   setup_all do
     start_supervised!(CtxRecorder)
@@ -89,7 +91,12 @@ defmodule Favn.PipelineTest do
     assert stored_run.pipeline.id == :daily_sales
     assert stored_run.pipeline.name == :daily_sales
     assert stored_run.pipeline.trigger == %{kind: :manual, requested_by: :user}
-    assert stored_run.pipeline.schedule == :daily_default
+    assert %Schedule{} = stored_run.pipeline.schedule
+    assert stored_run.pipeline.schedule.ref == {Schedules, :daily_default}
+    assert stored_run.pipeline.schedule.cron == "0 2 * * *"
+    assert stored_run.pipeline.schedule.timezone == "UTC"
+    assert stored_run.pipeline.schedule.missed == :skip
+    assert stored_run.pipeline.schedule.overlap == :forbid
     assert stored_run.pipeline.partition == :calendar_day
     assert stored_run.pipeline.source == :snowflake_primary
     assert stored_run.pipeline.outputs == [:warehouse_gold]
@@ -103,7 +110,17 @@ defmodule Favn.PipelineTest do
                  id: :manual_context,
                  name: :manual_context,
                  trigger: %{kind: :manual, requested_by: :api},
-                 schedule: :manual_schedule,
+                 schedule: %Schedule{
+                   id: :manual_schedule,
+                   ref: nil,
+                   kind: :cron,
+                   cron: "0 * * * *",
+                   timezone: "UTC",
+                   timezone_source: :schedule,
+                   missed: :skip,
+                   overlap: :forbid,
+                   origin: :inline
+                 },
                  partition: :manual_partition,
                  source: :manual_source,
                  outputs: [:manual_output]
@@ -114,7 +131,8 @@ defmodule Favn.PipelineTest do
     assert run.status == :ok
     assert run.pipeline.id == :manual_context
     assert run.pipeline.trigger == %{kind: :manual, requested_by: :api}
-    assert run.pipeline.schedule == :manual_schedule
+    assert %Schedule{} = run.pipeline.schedule
+    assert run.pipeline.schedule.id == :manual_schedule
     assert run.pipeline.partition == :manual_partition
     assert run.pipeline.source == :manual_source
     assert run.pipeline.outputs == [:manual_output]
@@ -147,7 +165,8 @@ defmodule Favn.PipelineTest do
     assert ctx.pipeline.trigger == %{kind: :manual, requested_by: :user}
     assert ctx.pipeline.params == %{requested_by: "operator"}
     assert ctx.pipeline.runtime_window == nil
-    assert ctx.pipeline.schedule == :daily_default
+    assert %Schedule{} = ctx.pipeline.schedule
+    assert ctx.pipeline.schedule.ref == {Schedules, :daily_default}
     assert ctx.pipeline.partition == :calendar_day
     assert ctx.pipeline.source == :snowflake_primary
     assert ctx.pipeline.outputs == [:warehouse_gold]
@@ -201,7 +220,7 @@ defmodule Favn.PipelineTest do
       pipeline :no_parens do
         asset {#{inspect(SalesAssets)}, :sales_daily}
         deps :none
-        schedule :daily_default
+        schedule {#{inspect(Schedules)}, :daily_default}
         partition :calendar_day
         source :snowflake_primary
         outputs [:warehouse_gold]
@@ -250,8 +269,8 @@ defmodule Favn.PipelineTest do
 
         pipeline :dup_schedule do
           asset {#{inspect(SalesAssets)}, :sales_daily}
-          schedule :daily
-          schedule :hourly
+          schedule {#{inspect(Schedules)}, :daily_default}
+          schedule cron: "0 3 * * *", timezone: "UTC"
         end
       end
       """)
@@ -331,14 +350,14 @@ defmodule Favn.PipelineTest do
   end
 
   test "pipeline DSL rejects invalid schedule, partition, source, and outputs" do
-    assert_raise ArgumentError, ~r/`schedule` must be an atom/, fn ->
+    assert_raise ArgumentError, ~r/`schedule` must be `{Module, :name}` or keyword options/, fn ->
       Code.compile_string("""
       defmodule InvalidSchedulePipeline do
         use Favn.Pipeline
 
         pipeline :invalid_schedule do
           asset {#{inspect(SalesAssets)}, :sales_daily}
-          schedule "daily"
+          schedule :daily
         end
       end
       """)
@@ -382,5 +401,41 @@ defmodule Favn.PipelineTest do
       end
       """)
     end
+  end
+
+  test "pipeline schedule supports inline keyword options and app default timezone inheritance" do
+    previous_scheduler = Application.get_env(:favn, :scheduler)
+    Application.put_env(:favn, :scheduler, default_timezone: "Europe/Oslo")
+
+    on_exit(fn ->
+      if previous_scheduler == nil do
+        Application.delete_env(:favn, :scheduler)
+      else
+        Application.put_env(:favn, :scheduler, previous_scheduler)
+      end
+    end)
+
+    defmodule InlineSchedulePipeline do
+      use Favn.Pipeline
+
+      pipeline :inline_schedule do
+        asset({SalesAssets, :sales_daily})
+
+        schedule(
+          cron: "0 2 * * *",
+          missed: :one,
+          overlap: :queue_one
+        )
+      end
+    end
+
+    assert {:ok, run_id} = Favn.run_pipeline(InlineSchedulePipeline)
+    assert {:ok, run} = Favn.await_run(run_id, timeout: 5_000)
+    assert run.status == :ok
+    assert %Schedule{} = run.pipeline.schedule
+    assert run.pipeline.schedule.timezone == "Europe/Oslo"
+    assert run.pipeline.schedule.timezone_source == :app_default
+    assert run.pipeline.schedule.missed == :one
+    assert run.pipeline.schedule.overlap == :queue_one
   end
 end

--- a/test/support/fixtures/assets/pipeline_assets.ex
+++ b/test/support/fixtures/assets/pipeline_assets.ex
@@ -58,6 +58,7 @@ defmodule Favn.Test.Fixtures.Pipelines.SimplePipeline do
   use Favn.Pipeline
 
   alias Favn.Test.Fixtures.Assets.Pipeline.SalesAssets
+  alias Favn.Test.Fixtures.Triggers.Schedules
 
   pipeline :daily_sales do
     asset({SalesAssets, :sales_daily})
@@ -66,11 +67,22 @@ defmodule Favn.Test.Fixtures.Pipelines.SimplePipeline do
     config(timezone: "UTC", notify: false)
     meta(owner: "data-platform", domain: :sales)
 
-    schedule(:daily_default)
+    schedule({Schedules, :daily_default})
     partition(:calendar_day)
     source(:snowflake_primary)
     outputs([:warehouse_gold])
   end
+end
+
+defmodule Favn.Test.Fixtures.Triggers.Schedules do
+  use Favn.Triggers.Schedules
+
+  schedule(:daily_default,
+    cron: "0 2 * * *",
+    timezone: "UTC",
+    missed: :skip,
+    overlap: :forbid
+  )
 end
 
 defmodule Favn.Test.Fixtures.Pipelines.SelectPipeline do

--- a/test/triggers_schedules_test.exs
+++ b/test/triggers_schedules_test.exs
@@ -7,8 +7,10 @@ defmodule Favn.TriggersSchedulesTest do
   defmodule ExampleSchedules do
     use Favn.Triggers.Schedules
 
+    @daily_cron "0 2 * * *"
+
     schedule(:daily_oslo,
-      cron: "0 2 * * *",
+      cron: @daily_cron,
       timezone: "Europe/Oslo",
       missed: :skip,
       overlap: :forbid
@@ -31,6 +33,60 @@ defmodule Favn.TriggersSchedulesTest do
         schedule :daily,
           cron: \"0 2 * * *\",
           unknown: true
+      end
+      """)
+    end
+  end
+
+  test "schedule DSL rejects invalid cron, missed, overlap, timezone, and duplicate options" do
+    assert_raise ArgumentError, ~r/invalid_schedule_cron/, fn ->
+      Code.compile_string("""
+      defmodule InvalidScheduleCron do
+        use Favn.Triggers.Schedules
+
+        schedule :daily, cron: ""
+      end
+      """)
+    end
+
+    assert_raise ArgumentError, ~r/invalid_schedule_missed/, fn ->
+      Code.compile_string("""
+      defmodule InvalidScheduleMissed do
+        use Favn.Triggers.Schedules
+
+        schedule :daily, cron: "0 2 * * *", missed: :later
+      end
+      """)
+    end
+
+    assert_raise ArgumentError, ~r/invalid_schedule_overlap/, fn ->
+      Code.compile_string("""
+      defmodule InvalidScheduleOverlap do
+        use Favn.Triggers.Schedules
+
+        schedule :daily, cron: "0 2 * * *", overlap: :maybe
+      end
+      """)
+    end
+
+    assert_raise ArgumentError, ~r/invalid_schedule_timezone/, fn ->
+      Code.compile_string("""
+      defmodule InvalidScheduleTimezone do
+        use Favn.Triggers.Schedules
+
+        schedule :daily, cron: "0 2 * * *", timezone: ""
+      end
+      """)
+    end
+
+    assert_raise ArgumentError, ~r/duplicate_schedule_opts/, fn ->
+      Code.compile_string("""
+      defmodule DuplicateScheduleOpts do
+        use Favn.Triggers.Schedules
+
+        schedule :daily,
+          cron: "0 2 * * *",
+          cron: "0 3 * * *"
       end
       """)
     end

--- a/test/triggers_schedules_test.exs
+++ b/test/triggers_schedules_test.exs
@@ -49,6 +49,36 @@ defmodule Favn.TriggersSchedulesTest do
       """)
     end
 
+    assert_raise ArgumentError, ~r/invalid_schedule_cron/, fn ->
+      Code.compile_string("""
+      defmodule InvalidScheduleCronCommaListDoubleComma do
+        use Favn.Triggers.Schedules
+
+        schedule :daily, cron: "1,,2 2 * * *"
+      end
+      """)
+    end
+
+    assert_raise ArgumentError, ~r/invalid_schedule_cron/, fn ->
+      Code.compile_string("""
+      defmodule InvalidScheduleCronCommaListLeadingComma do
+        use Favn.Triggers.Schedules
+
+        schedule :daily, cron: ",5 2 * * *"
+      end
+      """)
+    end
+
+    assert_raise ArgumentError, ~r/invalid_schedule_cron/, fn ->
+      Code.compile_string("""
+      defmodule InvalidScheduleCronCommaListTrailingComma do
+        use Favn.Triggers.Schedules
+
+        schedule :daily, cron: "5, 2 * * *"
+      end
+      """)
+    end
+
     assert_raise ArgumentError, ~r/invalid_schedule_missed/, fn ->
       Code.compile_string("""
       defmodule InvalidScheduleMissed do

--- a/test/triggers_schedules_test.exs
+++ b/test/triggers_schedules_test.exs
@@ -1,0 +1,51 @@
+defmodule Favn.TriggersSchedulesTest do
+  use ExUnit.Case
+
+  alias Favn.Triggers.Schedule
+  alias Favn.Triggers.Schedules
+
+  defmodule ExampleSchedules do
+    use Favn.Triggers.Schedules
+
+    schedule(:daily_oslo,
+      cron: "0 2 * * *",
+      timezone: "Europe/Oslo",
+      missed: :skip,
+      overlap: :forbid
+    )
+  end
+
+  test "fetch/2 resolves a named schedule with module ref" do
+    assert {:ok, %Schedule{} = schedule} = Schedules.fetch(ExampleSchedules, :daily_oslo)
+    assert schedule.id == :daily_oslo
+    assert schedule.ref == {ExampleSchedules, :daily_oslo}
+    assert schedule.origin == :named
+  end
+
+  test "schedule DSL rejects unknown option keys" do
+    assert_raise ArgumentError, ~r/invalid schedule declaration/, fn ->
+      Code.compile_string("""
+      defmodule InvalidScheduleOpts do
+        use Favn.Triggers.Schedules
+
+        schedule :daily,
+          cron: \"0 2 * * *\",
+          unknown: true
+      end
+      """)
+    end
+  end
+
+  test "schedule DSL rejects duplicate names" do
+    assert_raise ArgumentError, ~r/is already declared/, fn ->
+      Code.compile_string("""
+      defmodule DuplicateNamedSchedules do
+        use Favn.Triggers.Schedules
+
+        schedule :daily, cron: \"0 2 * * *\"
+        schedule :daily, cron: \"0 3 * * *\"
+      end
+      """)
+    end
+  end
+end

--- a/test/triggers_schedules_test.exs
+++ b/test/triggers_schedules_test.exs
@@ -74,7 +74,7 @@ defmodule Favn.TriggersSchedulesTest do
       defmodule InvalidScheduleTimezone do
         use Favn.Triggers.Schedules
 
-        schedule :daily, cron: "0 2 * * *", timezone: ""
+        schedule :daily, cron: "0 2 * * *", timezone: "Mars/Phobos"
       end
       """)
     end


### PR DESCRIPTION
### Motivation

- Introduce reusable and inline schedule trigger definitions so pipelines can reference named schedules or declare inline cron options.
- Remove the previous atom-only schedule references and expose a normalized schedule struct in pipeline/runtime context for consistent runtime handling.
- Allow a configurable scheduler default timezone via application config so inline schedules can inherit an app-wide timezone.

### Description

- Added `Favn.Triggers.Schedule` which models normalized schedule definitions, validates inline opts, and applies default timezone logic via `default_timezone/0` and `apply_default_timezone/2`.
- Added `Favn.Triggers.Schedules` which provides a module-level DSL `schedule/2` for declaring named schedules and runtime lookup via `fetch/2`.
- Updated the pipeline DSL to accept either a module ref tuple (`{Module, :name}`) or inline keyword options via `schedule/1` and added `Favn.Pipeline.normalize_schedule_clause!/1` to coerce and validate clauses.
- Updated `Favn.Pipeline.Definition` and `Favn.Pipeline.Resolver` to resolve schedule clauses into a normalized `Schedule` struct (respecting the app default timezone from `config :favn, scheduler: [default_timezone: ...]`), and to populate `ctx.pipeline.schedule` with the resolved struct.
- Documentation updates in `README.md` and `FEATURES.md` to reflect the new schedule authoring and configuration options.
- Tests and fixtures updated and added to exercise named schedules and inline schedule behavior and timezone inheritance.

### Testing

- Ran the test suite including `test/pipeline_test.exs` and new `test/triggers_schedules_test.exs` with `mix test` and all tests passed.
- Verified schedule DSL unit tests for validation, duplicate-name handling, and `Schedules.fetch/2` resolution succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d3dbb744f48328928bb14f4ee1be09)