### PR TITLE
Fix test-suite warnings and suppress expected runtime error logs

### DIFF
--- a/test/favn_test.exs
+++ b/test/favn_test.exs
@@ -56,8 +56,14 @@ defmodule FavnTest do
 
     @impl true
     def list_runs(_opts, _adapter_opts), do: {:error, :list_failed}
+
+    @impl true
     def scheduler_child_spec(_opts), do: :none
+
+    @impl true
     def put_scheduler_state(_state, _opts), do: :ok
+
+    @impl true
     def get_scheduler_state(_pipeline_module, _opts), do: {:ok, nil}
   end
 

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -331,8 +331,11 @@ defmodule Favn.RunnerTest do
     :ok = Favn.TestSetup.configure_storage_adapter(TerminalFailingStore, [])
     TerminalFailingStore.reset!()
 
-    assert {:ok, run_id} = Favn.run_asset({RunnerAssets, :final})
-    assert is_binary(run_id)
+    capture_log(fn ->
+      assert {:ok, run_id} = Favn.run_asset({RunnerAssets, :final})
+      assert is_binary(run_id)
+      Process.sleep(25)
+    end)
   end
 
   test "fails immediately when first persisted snapshot cannot be written" do
@@ -837,8 +840,16 @@ defmodule Favn.RunnerTest do
     assert resume_rerun.status == :ok
     assert resume_rerun.replay_mode == :resume_from_failure
 
-    assert {:ok, exact_rerun_id} = Favn.rerun_run(run_id, mode: :exact_replay)
-    assert {:error, exact_rerun} = Favn.await_run(exact_rerun_id)
+    parent = self()
+
+    capture_log(fn ->
+      assert {:ok, exact_rerun_id} = Favn.rerun_run(run_id, mode: :exact_replay)
+      assert {:error, exact_rerun} = Favn.await_run(exact_rerun_id)
+      send(parent, {:exact_rerun, exact_rerun})
+    end)
+
+    assert_receive {:exact_rerun, exact_rerun}
+
     assert exact_rerun.status == :error
     assert exact_rerun.replay_mode == :exact_replay
   end
@@ -895,8 +906,15 @@ defmodule Favn.RunnerTest do
       timezone: "Etc/UTC"
     }
 
-    assert {:ok, run_id} = Favn.backfill_asset({BackfillAssets, :daily_target}, range: range)
-    assert {:ok, run} = Favn.await_run(run_id)
+    parent = self()
+
+    capture_log(fn ->
+      assert {:ok, run_id} = Favn.backfill_asset({BackfillAssets, :daily_target}, range: range)
+      assert {:ok, run} = Favn.await_run(run_id)
+      send(parent, {:dedupe_backfill_run, run})
+    end)
+
+    assert_receive {:dedupe_backfill_run, run}
 
     source_results =
       run.node_results

--- a/test/scheduler_test.exs
+++ b/test/scheduler_test.exs
@@ -1,5 +1,6 @@
 defmodule Favn.SchedulerTest do
   use ExUnit.Case
+  import ExUnit.CaptureLog
 
   alias Favn.Scheduler.State
   alias Favn.Test.Fixtures.Assets.Pipeline.CtxRecorder
@@ -214,7 +215,10 @@ defmodule Favn.SchedulerTest do
     :ok = Favn.Scheduler.reload()
 
     :ok = Favn.TestSetup.setup_asset_modules([], reload_graph?: true)
-    :ok = Favn.Scheduler.tick()
+
+    capture_log(fn ->
+      assert :ok = Favn.Scheduler.tick()
+    end)
 
     assert {:ok, %State{} = reloaded} = Favn.Scheduler.Storage.get_state(SchedulerDailyPipeline)
     assert reloaded.last_due_at == previous_due

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -20,8 +20,14 @@ defmodule Favn.StorageTest do
 
     @impl true
     def list_runs(_opts, _adapter_opts), do: {:error, :list_failed}
+
+    @impl true
     def scheduler_child_spec(_opts), do: :none
+
+    @impl true
     def put_scheduler_state(_state, _opts), do: :ok
+
+    @impl true
     def get_scheduler_state(_pipeline_module, _opts), do: {:ok, nil}
   end
 
@@ -65,8 +71,14 @@ defmodule Favn.StorageTest do
 
     @impl true
     def list_runs(_opts, _adapter_opts), do: {:error, :invalid_opts}
+
+    @impl true
     def scheduler_child_spec(_opts), do: :none
+
+    @impl true
     def put_scheduler_state(_state, _opts), do: :ok
+
+    @impl true
     def get_scheduler_state(_pipeline_module, _opts), do: {:ok, nil}
   end
 


### PR DESCRIPTION
### Motivation
- Remove compiler warnings about missing `@impl true` on test adapter callbacks and reduce noisy but expected runtime error logs that clutter CI output.
- Keep tests deterministic and focused on behavior while not failing or being noisy due to intentional GenServer termination and scheduler failure-paths.

### Description
- Added missing `@impl true` annotations for scheduler-related callbacks in test doubles located in `test/storage_test.exs` and `test/favn_test.exs` to eliminate compiler warnings for `Favn.Storage.Adapter` callbacks.
- Imported `ExUnit.CaptureLog` into `test/scheduler_test.exs` and wrapped the expected-failure scheduler tick call in `capture_log/1` to suppress expected scheduler warning output while preserving assertions.
- Wrapped specific runner failure-path scenarios in `test/runner_test.exs` with `capture_log/1` and used message passing (`send/2` + `assert_receive/2`) or brief `Process.sleep/1` inside the capture block to preserve asserted run structs while preventing noisy GenServer termination logs from appearing in test output.
- Formatted tests with `mix format` and kept test semantics unchanged; only test-helper and test files were modified (`test/storage_test.exs`, `test/favn_test.exs`, `test/scheduler_test.exs`, `test/runner_test.exs`).

### Testing
- Ran `mix format` on changed test files to ensure consistent formatting and no code-style regressions.
- Ran `mix test` on the full suite and verified `14 doctests, 167 tests, 0 failures` with noisy runtime warnings suppressed.
- Ran targeted tests (`mix test test/scheduler_test.exs --trace` and `mix test test/runner_test.exs --trace`) during development to validate changes, and those runs also passed without altering asserted behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69d63acb03e08328bdea5f67e1694b4b)