### PR TITLE
Implement Phase 2 Favn.Asset single-asset DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ end
 
 - `@doc`
 - `@meta`
-- `@depends` (module shorthand `@depends MyApp.UpstreamAsset` or canonical tuple)
+- `@depends` (module shorthand `@depends MyApp.UpstreamAsset` only for single-asset modules; use tuple refs for multi-asset modules)
 - `@window`
 - `@produces`
 

--- a/README.md
+++ b/README.md
@@ -22,10 +22,40 @@
 ## Favn at a glance
 
 - Plain Elixir functions become assets with metadata and dependencies.
+- Preferred single-asset authoring uses one module with `use Favn.Asset` and `def asset(ctx)`.
 - Assets can optionally own produced warehouse relations through `@produces`.
 - Dependency graphs are discovered automatically from asset definitions.
 - Runs are planned deterministically and executed in dependency order.
 - Runtime state and run events are exposed through a small public API.
+
+## Preferred single-asset DSL
+
+Phase 2 introduces `Favn.Asset` as the preferred one-module-per-asset DSL:
+
+```elixir
+defmodule MyWarehouse.Raw.Sales.Orders do
+  use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+  use Favn.Asset
+
+  @doc "Extract raw orders from upstream API"
+  @meta owner: "data-platform", category: :sales, tags: [:raw]
+  @produces true
+  def asset(ctx) do
+    _target = ctx.asset.produces
+    :ok
+  end
+end
+```
+
+`Favn.Asset` supports:
+
+- `@doc`
+- `@meta`
+- `@depends` (module shorthand `@depends MyApp.UpstreamAsset` or canonical tuple)
+- `@window`
+- `@produces`
+
+Single-asset modules compile to one canonical `%Favn.Asset{}` with ref `{Module, :asset}`.
 
 ## Introduction
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -820,7 +820,7 @@ Implemented semantics:
 * one `use Favn.Asset` module compiles to exactly one canonical asset with ref `{Module, :asset}`
 * `@depends` in `Favn.Asset` accepts:
 
-  * `Some.Module` (normalized to `{Some.Module, :asset}`)
+  * `Some.Module` (only when `Some.Module` uses `Favn.Asset`, normalized to `{Some.Module, :asset}`)
   * `{Some.Module, :asset_name}`
 * `@produces true` relation-name inference for single-asset modules uses module leaf `Macro.underscore/1`
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Phase 1 implemented.
+Phase 1 and Phase 2 implemented.
 
 This document defines the target long-term asset authoring direction for Favn and the phased path to implement it safely.
 
@@ -799,19 +799,34 @@ This phase links Elixir materializing assets to warehouse relation ownership.
 
 Deliver:
 
-* `Favn.Asset` as preferred one-module-per-asset Elixir DSL
-* single asset entrypoint convention
-* support for:
+* [x] `Favn.Asset` as preferred one-module-per-asset Elixir DSL
+* [x] single asset entrypoint convention (`def asset(ctx)`)
+* [x] support for:
 
-  * `@doc`
-  * `@meta`
-  * `@depends`
-  * `@window`
-  * `@produces`
-  * relation defaults
-* compilation into one canonical `%Favn.Asset{}`
+  * [x] `@doc`
+  * [x] `@meta`
+  * [x] `@depends`
+  * [x] `@window`
+  * [x] `@produces`
+  * [x] relation defaults through `Favn.Namespace`
+* [x] compilation into one canonical `%Favn.Asset{}`
 
 This phase establishes the preferred Elixir asset model.
+
+#### Phase 2 implementation notes
+
+Implemented semantics:
+
+* one `use Favn.Asset` module compiles to exactly one canonical asset with ref `{Module, :asset}`
+* `@depends` in `Favn.Asset` accepts:
+
+  * `Some.Module` (normalized to `{Some.Module, :asset}`)
+  * `{Some.Module, :asset_name}`
+* `@produces true` relation-name inference for single-asset modules uses module leaf `Macro.underscore/1`
+
+  * `MyWarehouse.Raw.Sales.Orders` -> `"orders"`
+  * `MyWarehouse.Gold.Sales.FctOrders` -> `"fct_orders"`
+* `Favn.get_asset/1` now also accepts a single-asset module ref directly (`Favn.get_asset(MyAssetModule)`)
 
 ### Phase 3 — `Favn.SQL.Namespace` and `Favn.SQLAsset`
 
@@ -867,15 +882,23 @@ This phase supports repetitive ingestion without weakening the clarity of the co
 
 ### 1. Canonical ref shape for `Favn.Asset`
 
-Should single-asset modules use a module-only public convenience ref while still compiling to the existing canonical ref shape internally?
+Resolved in Phase 2.
+
+* canonical internal ref remains `{module, :asset}`
+* public convenience module lookup is supported by `Favn.get_asset(module)` for single-asset modules
 
 ### 2. Produced relation name inference
 
-What exact transformation should turn module names such as `FctOrders` into relation names such as `fact_orders`, and how configurable should that be? Rr should we just turn it to lowercase and user should override with `@produces name: "fct_orders"` if the need underscore? 
+Resolved in Phase 2.
+
+* default inference uses module leaf `Macro.underscore/1`
+* custom naming should be explicit via `@produces name: ...` when needed
 
 ### 3. `Favn.Asset` function naming
 
-Should the single-asset Elixir DSL require `def asset(ctx)` or support another convention? Should a  @behaviour be implemented to ensure this? 
+Resolved in Phase 2.
+
+* `Favn.Asset` requires exactly one public `def asset(ctx)` entrypoint
 
 ### 4. Namespace discovery rules
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -129,6 +129,14 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] relation normalization and validation (`database`/`table` aliases included)
   - [x] relation ownership uniqueness checks
   - [x] relation ownership index in the registry catalog
+- [x] Phase 2 single-asset Elixir DSL (`Favn.Asset`)
+  - [x] one-module-per-asset `def asset(ctx)` convention
+  - [x] `@doc`, `@meta`, `@depends`, `@window`, `@produces`
+  - [x] relation default inheritance via `Favn.Namespace`
+  - [x] canonical compile output as one `%Favn.Asset{ref: {Module, :asset}}`
+  - [x] module dependency shorthand normalization (`@depends Some.AssetModule`)
+  - [x] `@produces true` relation-name inference from module leaf (`Macro.underscore/1`)
+  - [x] module convenience lookup via `Favn.get_asset(module)` for single-asset modules
 - [ ] DuckDB adapter hardening + incremental strategy expansion
 - [ ] Typed source identities
 - [ ] `Favn.SQL` / `Favn.SQLAssets` authoring model

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -28,7 +28,12 @@ defmodule Favn do
   An asset is a function that represents a meaningful unit of work in a workflow, such as
   extracting data, transforming a dataset, or producing a modeled output.
 
-  Assets are intended to be authored in modules that `use Favn.Assets`. At compile time,
+  Assets can be authored with:
+
+    * `use Favn.Asset` (preferred single-asset module DSL)
+    * `use Favn.Assets` (compact multi-asset module DSL)
+
+  At compile time,
   Favn will collect metadata such as:
 
     * asset name
@@ -164,7 +169,19 @@ defmodule Favn do
 
   ## Authoring assets
 
-  Assets are defined in normal modules using `Favn.Assets`.
+  Preferred one-module-per-asset style uses `Favn.Asset`:
+
+      defmodule MyApp.Raw.Sales.Orders do
+        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Asset
+
+        @doc "Extract raw orders"
+        @meta owner: "data-platform", category: :sales, tags: [:raw]
+        @produces true
+        def asset(ctx), do: :ok
+      end
+
+  Compact multi-asset style uses `Favn.Assets`:
 
   A simplified example:
 
@@ -209,6 +226,8 @@ defmodule Favn do
 
       Favn.get_asset({MyApp.SalesETL, :normalize_orders})
 
+      Favn.get_asset(MyApp.Raw.Sales.Orders)
+
       Favn.upstream_assets({MyApp.GoldETL, :fact_sales})
 
       Favn.dependency_graph({MyApp.GoldETL, :fact_sales}, tags: [:warehouse])
@@ -252,7 +271,7 @@ defmodule Favn do
   A consumer application typically sets Favn up in four steps:
 
     1. add `:favn` as a dependency in `mix.exs`
-    2. define one or more asset modules with `use Favn.Assets`
+    2. define one or more asset modules with `use Favn.Asset` and/or `use Favn.Assets`
     3. register those modules under `config :favn, asset_modules: [...]`
     4. start the host application normally
 
@@ -646,6 +665,7 @@ defmodule Favn do
   Accepted input:
 
     * `{module, name}` where both values are atoms
+    * `module` for single-asset modules authored with `use Favn.Asset`
 
   Returns:
 
@@ -673,6 +693,20 @@ defmodule Favn do
       end
     else
       {:error, :not_asset_module}
+    end
+  end
+
+  @spec get_asset(module()) :: {:ok, asset()} | {:error, asset_error()}
+  def get_asset(module) when is_atom(module) do
+    cond do
+      not asset_module?(module) ->
+        {:error, :not_asset_module}
+
+      function_exported?(module, :__favn_single_asset__, 0) ->
+        Registry.get_asset({module, :asset})
+
+      true ->
+        {:error, :asset_not_found}
     end
   end
 

--- a/lib/favn/asset.ex
+++ b/lib/favn/asset.ex
@@ -5,6 +5,17 @@ defmodule Favn.Asset do
   `Favn.Asset` is the normalized shape used by the rest of Favn for
   introspection, dependency resolution, and execution planning.
 
+  It also provides the preferred single-asset Elixir DSL:
+
+      defmodule MyApp.Raw.Sales.Orders do
+        use Favn.Asset
+
+        @doc "Extract raw orders"
+        @meta owner: "data-platform", category: :sales, tags: [:raw]
+        @produces true
+        def asset(ctx), do: :ok
+      end
+
   This module owns validation of the final canonical asset shape after the DSL
   has normalized authoring-friendly input into runtime-ready values.
   """
@@ -12,6 +23,90 @@ defmodule Favn.Asset do
   alias Favn.Ref
   alias Favn.RelationRef
   alias Favn.Window.Spec
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      Module.register_attribute(__MODULE__, :depends, accumulate: true)
+      Module.register_attribute(__MODULE__, :meta, persist: false)
+      Module.register_attribute(__MODULE__, :produces, accumulate: true)
+      Module.register_attribute(__MODULE__, :window, accumulate: true)
+      Module.register_attribute(__MODULE__, :favn_single_asset_raw, persist: false)
+
+      @on_definition Favn.Asset
+      @before_compile Favn.Asset
+    end
+  end
+
+  @doc false
+  def __on_definition__(env, kind, name, args, _guards, _body) do
+    arity = length(args || [])
+
+    case {kind, name, arity} do
+      {:def, :asset, 1} ->
+        capture_single_asset_definition!(env)
+
+      {:def, :asset, _other_arity} ->
+        compile_error!(
+          env.file,
+          env.line,
+          "Favn.Asset requires exactly one public asset/1 function"
+        )
+
+      {:defp, :asset, _arity} ->
+        compile_error!(env.file, env.line, "Favn.Asset requires a public def asset(ctx)")
+
+      {kind, _name, _arity} when kind in [:def, :defp] ->
+        validate_no_stray_asset_attributes!(env, kind, name, arity)
+
+      _ ->
+        :ok
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    raw_asset = Module.get_attribute(env.module, :favn_single_asset_raw)
+
+    if is_nil(raw_asset) do
+      compile_error!(
+        env.file,
+        env.line,
+        "Favn.Asset modules must define exactly one public asset/1 function"
+      )
+    end
+
+    case {
+      Module.get_attribute(env.module, :depends),
+      Module.get_attribute(env.module, :meta),
+      Module.get_attribute(env.module, :window),
+      Module.get_attribute(env.module, :produces)
+    } do
+      {[], nil, [], []} ->
+        :ok
+
+      _ ->
+        compile_error!(
+          env.file,
+          env.line,
+          "@depends/@meta/@window/@produces must be attached to def asset(ctx)"
+        )
+    end
+
+    asset = build_single_asset!(raw_asset)
+
+    quote do
+      @doc false
+      @spec __favn_assets__() :: [Favn.Asset.t()]
+      def __favn_assets__, do: [unquote(Macro.escape(asset))]
+
+      @doc false
+      def __favn_assets_raw__, do: [unquote(Macro.escape(raw_asset))]
+
+      @doc false
+      def __favn_single_asset__, do: true
+    end
+  end
 
   @type t :: %__MODULE__{
           module: module(),
@@ -166,5 +261,193 @@ defmodule Favn.Asset do
   defp validate_produces!(value) do
     raise ArgumentError,
           "asset produces must be a Favn.RelationRef or nil, got: #{inspect(value)}"
+  end
+
+  defp capture_single_asset_definition!(env) do
+    if Module.get_attribute(env.module, :favn_single_asset_raw) do
+      compile_error!(
+        env.file,
+        env.line,
+        "Favn.Asset modules can define only one asset/1 function"
+      )
+    end
+
+    depends = env.module |> Module.get_attribute(:depends) |> Enum.reverse()
+    meta = Module.get_attribute(env.module, :meta)
+    window = env.module |> Module.get_attribute(:window) |> Enum.reverse()
+    produces = env.module |> Module.get_attribute(:produces) |> Enum.reverse()
+    validate_produces_attr!(produces, env)
+
+    Module.delete_attribute(env.module, :depends)
+    Module.delete_attribute(env.module, :meta)
+    Module.delete_attribute(env.module, :window)
+    Module.delete_attribute(env.module, :produces)
+
+    Module.put_attribute(env.module, :favn_single_asset_raw, %{
+      module: env.module,
+      name: :asset,
+      arity: 1,
+      doc: normalize_doc(Module.get_attribute(env.module, :doc)),
+      file: normalize_file(env.file),
+      line: env.line,
+      depends: depends,
+      meta: meta,
+      window: window,
+      produces: produces
+    })
+  end
+
+  defp build_single_asset!(raw_asset) do
+    depends_on = normalize_single_asset_depends!(raw_asset.depends, raw_asset)
+    meta = normalize_single_asset_meta!(raw_asset.meta, raw_asset)
+    window_spec = normalize_single_asset_window!(raw_asset.window, raw_asset)
+
+    asset = %__MODULE__{
+      module: raw_asset.module,
+      name: :asset,
+      ref: Ref.new(raw_asset.module, :asset),
+      arity: 1,
+      title: nil,
+      doc: raw_asset.doc,
+      file: raw_asset.file,
+      line: raw_asset.line,
+      meta: meta,
+      depends_on: depends_on,
+      window_spec: window_spec
+    }
+
+    try do
+      validate!(asset)
+    rescue
+      error in ArgumentError ->
+        compile_error!(raw_asset.file, raw_asset.line, error.message)
+    end
+  end
+
+  defp normalize_single_asset_depends!(depends, raw_asset) do
+    Enum.map(depends, fn
+      module when is_atom(module) ->
+        if module_atom?(module) do
+          Ref.new(module, :asset)
+        else
+          compile_error!(
+            raw_asset.file,
+            raw_asset.line,
+            "invalid @depends entry #{inspect(module)}; expected Module or {Module, :asset_name}"
+          )
+        end
+
+      {module, name} when is_atom(module) and is_atom(name) ->
+        if module_atom?(module) do
+          Ref.new(module, name)
+        else
+          compile_error!(
+            raw_asset.file,
+            raw_asset.line,
+            "invalid @depends entry #{inspect({module, name})}; expected Module or {Module, :asset_name}"
+          )
+        end
+
+      dependency ->
+        compile_error!(
+          raw_asset.file,
+          raw_asset.line,
+          "invalid @depends entry #{inspect(dependency)}; expected Module or {Module, :asset_name}"
+        )
+    end)
+  end
+
+  defp normalize_single_asset_meta!(meta, raw_asset) do
+    normalize_meta!(meta)
+  rescue
+    error in ArgumentError -> compile_error!(raw_asset.file, raw_asset.line, error.message)
+  end
+
+  defp normalize_single_asset_window!([], _raw_asset), do: nil
+  defp normalize_single_asset_window!([%Spec{} = spec], _raw_asset), do: spec
+
+  defp normalize_single_asset_window!([_a, _b | _rest], raw_asset) do
+    compile_error!(
+      raw_asset.file,
+      raw_asset.line,
+      "multiple @window attributes are not allowed; use at most one @window for def asset(ctx)"
+    )
+  end
+
+  defp normalize_single_asset_window!(value, raw_asset) do
+    compile_error!(
+      raw_asset.file,
+      raw_asset.line,
+      "invalid @window value #{inspect(value)}; expected Favn.Window spec like Favn.Window.daily()"
+    )
+  end
+
+  defp validate_produces_attr!([], _env), do: :ok
+
+  defp validate_produces_attr!([produces], env) do
+    valid? =
+      produces == true or (is_list(produces) and Keyword.keyword?(produces)) or is_map(produces)
+
+    if valid? do
+      :ok
+    else
+      compile_error!(
+        env.file,
+        env.line,
+        "invalid @produces value #{inspect(produces)}; expected true, a keyword list, or a map"
+      )
+    end
+  end
+
+  defp validate_produces_attr!([_a, _b | _rest], env) do
+    compile_error!(
+      env.file,
+      env.line,
+      "multiple @produces attributes are not allowed; use at most one @produces for def asset(ctx)"
+    )
+  end
+
+  defp validate_no_stray_asset_attributes!(env, kind, name, arity) do
+    depends = Module.get_attribute(env.module, :depends)
+    meta = Module.get_attribute(env.module, :meta)
+    window = Module.get_attribute(env.module, :window)
+    produces = Module.get_attribute(env.module, :produces)
+
+    if depends != [] or not is_nil(meta) or window != [] or produces != [] do
+      Module.delete_attribute(env.module, :depends)
+      Module.delete_attribute(env.module, :meta)
+      Module.delete_attribute(env.module, :window)
+      Module.delete_attribute(env.module, :produces)
+
+      compile_error!(
+        env.file,
+        env.line,
+        "@depends/@meta/@window/@produces on #{kind} #{name}/#{arity} requires def asset(ctx) immediately below those attributes"
+      )
+    else
+      :ok
+    end
+  end
+
+  defp normalize_doc({_line, false}), do: nil
+  defp normalize_doc({_line, doc}) when is_binary(doc), do: doc
+  defp normalize_doc(false), do: nil
+  defp normalize_doc(doc) when is_binary(doc), do: doc
+  defp normalize_doc(_), do: nil
+
+  defp normalize_file(file) do
+    file
+    |> to_string()
+    |> Path.relative_to_cwd()
+  end
+
+  defp compile_error!(file, line, description) do
+    raise CompileError, file: file, line: line, description: description
+  end
+
+  defp module_atom?(module) when is_atom(module) do
+    module
+    |> Atom.to_string()
+    |> String.starts_with?("Elixir.")
   end
 end

--- a/lib/favn/assets/compiler.ex
+++ b/lib/favn/assets/compiler.ex
@@ -72,19 +72,21 @@ defmodule Favn.Assets.Compiler do
   end
 
   defp resolve_produced_relation(%Asset{} = asset, defaults) do
+    inferred_name = inferred_relation_name(asset)
+
     produces =
       case fetch_raw_produces(asset.module, asset.name) do
         nil ->
           asset.produces
 
         true ->
-          RelationRef.new!(Map.put(defaults, :name, asset.name))
+          RelationRef.new!(Map.put(defaults, :name, inferred_name))
 
         attrs when is_list(attrs) ->
           if Keyword.keyword?(attrs) do
             attrs
             |> Map.new()
-            |> merge_produces_attrs(defaults, asset.name)
+            |> merge_produces_attrs(defaults, inferred_name)
             |> RelationRef.new!()
           else
             raise ArgumentError,
@@ -93,7 +95,7 @@ defmodule Favn.Assets.Compiler do
 
         attrs when is_map(attrs) ->
           attrs
-          |> merge_produces_attrs(defaults, asset.name)
+          |> merge_produces_attrs(defaults, inferred_name)
           |> RelationRef.new!()
 
         other ->
@@ -154,4 +156,17 @@ defmodule Favn.Assets.Compiler do
       end
     end)
   end
+
+  defp inferred_relation_name(%Asset{module: module, name: :asset}) do
+    if function_exported?(module, :__favn_single_asset__, 0) do
+      module
+      |> Module.split()
+      |> List.last()
+      |> Macro.underscore()
+    else
+      :asset
+    end
+  end
+
+  defp inferred_relation_name(%Asset{name: name}), do: name
 end

--- a/lib/favn/assets/compiler.ex
+++ b/lib/favn/assets/compiler.ex
@@ -54,8 +54,49 @@ defmodule Favn.Assets.Compiler do
   defp normalize_module_assets(assets, module) when is_list(assets) do
     normalize_assets(assets)
     |> case do
-      {:ok, assets} -> resolve_produced_relations(assets, module)
-      {:error, _reason} = error -> error
+      {:ok, assets} ->
+        try do
+          validate_single_asset_depends_shorthand!(module)
+          resolve_produced_relations(assets, module)
+        rescue
+          error in ArgumentError -> {:error, {:invalid_compiled_assets, error.message}}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp validate_single_asset_depends_shorthand!(module) do
+    if function_exported?(module, :__favn_single_asset__, 0) and
+         function_exported?(module, :__favn_assets_raw__, 0) do
+      module.__favn_assets_raw__()
+      |> Enum.flat_map(&Map.get(&1, :depends, []))
+      |> Enum.each(fn
+        dependency_module when is_atom(dependency_module) ->
+          ensure_single_asset_dependency_module!(module, dependency_module)
+
+        _other ->
+          :ok
+      end)
+    end
+
+    :ok
+  end
+
+  defp ensure_single_asset_dependency_module!(module, dependency_module) do
+    case Code.ensure_loaded(dependency_module) do
+      {:module, _loaded} ->
+        if function_exported?(dependency_module, :__favn_single_asset__, 0) do
+          :ok
+        else
+          raise ArgumentError,
+                "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a `use Favn.Asset` module, use {Module, :asset_name} for multi-asset modules"
+        end
+
+      _ ->
+        raise ArgumentError,
+              "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a loadable `use Favn.Asset` module"
     end
   end
 

--- a/test/assets_test.exs
+++ b/test/assets_test.exs
@@ -152,6 +152,106 @@ defmodule Favn.AssetsTest do
            }
   end
 
+  test "supports single-asset modules with use Favn.Asset" do
+    module_name = Module.concat(__MODULE__, "SingleAsset#{System.unique_integer([:positive])}")
+
+    source = """
+    defmodule #{inspect(module_name)} do
+      use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+      use Favn.Asset
+
+      @doc "Extract raw orders"
+      @meta owner: "data-platform", category: :sales, tags: [:raw]
+      @depends Favn.AssetsTest.Upstream
+      @window Favn.Window.daily(lookback: 2)
+      @produces true
+      def asset(ctx) do
+        _target = ctx.asset.produces
+        :ok
+      end
+    end
+    """
+
+    assert Enum.any?(Code.compile_string(source, "test/dynamic_assets_test.exs"), fn {mod, _} ->
+             mod == module_name
+           end)
+
+    assert {:ok, [%Asset{} = asset]} = Compiler.compile_module_assets(module_name)
+    expected_name = module_name |> Module.split() |> List.last() |> Macro.underscore()
+
+    assert asset.ref == {module_name, :asset}
+    assert asset.depends_on == [{Favn.AssetsTest.Upstream, :asset}]
+
+    assert asset.window_spec == %Favn.Window.Spec{kind: :day, lookback: 2, timezone: "Etc/UTC"}
+
+    assert asset.meta == %{owner: "data-platform", category: :sales, tags: [:raw]}
+
+    assert asset.produces == %RelationRef{
+             connection: :warehouse,
+             catalog: "raw",
+             schema: "sales",
+             name: expected_name
+           }
+  end
+
+  test "single-asset module infers relation name from module leaf" do
+    module_name = Module.concat(__MODULE__, "FctOrders#{System.unique_integer([:positive])}")
+
+    source = """
+    defmodule #{inspect(module_name)} do
+      use Favn.Asset
+
+      @produces true
+      def asset(_ctx), do: :ok
+    end
+    """
+
+    assert Enum.any?(Code.compile_string(source, "test/dynamic_assets_test.exs"), fn {mod, _} ->
+             mod == module_name
+           end)
+
+    assert {:ok, [%Asset{produces: %RelationRef{name: name}}]} =
+             Compiler.compile_module_assets(module_name)
+
+    assert name =~ ~r/^fct_orders\d+$/
+  end
+
+  test "single-asset module supports tuple and module depends refs" do
+    upstream = Module.concat(__MODULE__, "Upstream#{System.unique_integer([:positive])}")
+    module_name = Module.concat(__MODULE__, "Depends#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(upstream)} do
+        use Favn.Asset
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_assets_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(module_name)} do
+        use Favn.Asset
+
+        @depends #{inspect(upstream)}
+        @depends {#{inspect(Favn.AssetsTest.Upstream)}, :source_rows}
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_assets_test.exs"
+    )
+
+    assert {:ok, [%Asset{depends_on: depends_on}]} = Compiler.compile_module_assets(module_name)
+
+    assert depends_on == [
+             {upstream, :asset},
+             {Favn.AssetsTest.Upstream, :source_rows}
+           ]
+  end
+
   test "resolves namespace inheritance from separately compiled ancestor modules" do
     root = Module.concat(__MODULE__, "Root#{System.unique_integer([:positive])}")
     raw = Module.concat(root, Raw)
@@ -492,6 +592,48 @@ defmodule Favn.AssetsTest do
              Compiler.compile_module_assets(duplicate_name_module)
 
     assert message =~ "duplicate values for canonical key :name"
+
+    assert_raise CompileError, ~r/must define exactly one public asset\/1 function/, fn ->
+      compile_single_asset_module("""
+      use Favn.Asset
+      """)
+    end
+
+    assert_raise CompileError, ~r/requires exactly one public asset\/1 function/, fn ->
+      compile_single_asset_module("""
+      use Favn.Asset
+
+      def asset(_ctx, _opts), do: :ok
+      """)
+    end
+
+    assert_raise CompileError, ~r/can define only one asset\/1 function/, fn ->
+      compile_single_asset_module("""
+      use Favn.Asset
+
+      def asset(_ctx), do: :ok
+      def asset(_ctx), do: :ok
+      """)
+    end
+
+    assert_raise CompileError, ~r/requires a public def asset\(ctx\)/, fn ->
+      compile_single_asset_module("""
+      use Favn.Asset
+
+      defp asset(_ctx), do: :ok
+      """)
+    end
+
+    assert_raise CompileError, ~r/requires def asset\(ctx\) immediately below/, fn ->
+      compile_single_asset_module("""
+      use Favn.Asset
+
+      @meta owner: "data"
+      def helper(_ctx), do: :ok
+
+      def asset(_ctx), do: :ok
+      """)
+    end
   end
 
   test "consumes @depends and @meta only for the intended asset" do
@@ -592,6 +734,18 @@ defmodule Favn.AssetsTest do
 
   defp compile_test_module(body) do
     module_name = Module.concat(__MODULE__, "Dynamic#{System.unique_integer([:positive])}")
+
+    source = """
+    defmodule #{inspect(module_name)} do
+    #{indent(body, 2)}
+    end
+    """
+
+    Code.compile_string(source, "test/dynamic_assets_test.exs")
+  end
+
+  defp compile_single_asset_module(body) do
+    module_name = Module.concat(__MODULE__, "SingleDynamic#{System.unique_integer([:positive])}")
 
     source = """
     defmodule #{inspect(module_name)} do

--- a/test/assets_test.exs
+++ b/test/assets_test.exs
@@ -162,7 +162,7 @@ defmodule Favn.AssetsTest do
 
       @doc "Extract raw orders"
       @meta owner: "data-platform", category: :sales, tags: [:raw]
-      @depends Favn.AssetsTest.Upstream
+      @depends {Favn.AssetsTest.Upstream, :source_rows}
       @window Favn.Window.daily(lookback: 2)
       @produces true
       def asset(ctx) do
@@ -180,7 +180,7 @@ defmodule Favn.AssetsTest do
     expected_name = module_name |> Module.split() |> List.last() |> Macro.underscore()
 
     assert asset.ref == {module_name, :asset}
-    assert asset.depends_on == [{Favn.AssetsTest.Upstream, :asset}]
+    assert asset.depends_on == [{Favn.AssetsTest.Upstream, :source_rows}]
 
     assert asset.window_spec == %Favn.Window.Spec{kind: :day, lookback: 2, timezone: "Etc/UTC"}
 
@@ -250,6 +250,27 @@ defmodule Favn.AssetsTest do
              {upstream, :asset},
              {Favn.AssetsTest.Upstream, :source_rows}
            ]
+  end
+
+  test "single-asset module rejects module shorthand for multi-asset modules" do
+    module_name = Module.concat(__MODULE__, "BadDepends#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(module_name)} do
+        use Favn.Asset
+
+        @depends #{inspect(Favn.AssetsTest.Upstream)}
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_assets_test.exs"
+    )
+
+    assert {:error, {:invalid_compiled_assets, message}} =
+             Compiler.compile_module_assets(module_name)
+
+    assert message =~ "module shorthand requires a `use Favn.Asset` module"
   end
 
   test "resolves namespace inheritance from separately compiled ancestor modules" do

--- a/test/favn_test.exs
+++ b/test/favn_test.exs
@@ -209,6 +209,29 @@ defmodule FavnTest do
     assert {:error, :not_asset_module} = Favn.get_asset({Enum, :map})
   end
 
+  test "fetches single-asset module refs through the public facade" do
+    module_name =
+      Module.concat(__MODULE__, "SingleAssetFacade#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(module_name)} do
+        use Favn.Asset
+
+        @doc "Single asset facade"
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_assets_test.exs"
+    )
+
+    :ok = Favn.TestSetup.setup_asset_modules([module_name])
+
+    assert {:ok, asset} = Favn.get_asset(module_name)
+    assert asset.ref == {module_name, :asset}
+    assert asset.doc == "Single asset facade"
+  end
+
   test "inspects dependency queries through the public facade" do
     :ok =
       Favn.TestSetup.setup_asset_modules([SampleAssets, CrossModuleAssets], reload_graph?: true)


### PR DESCRIPTION
## Summary
- Add `use Favn.Asset` as the preferred single-asset Elixir DSL with strict compile-time rules around one public `asset/1` entrypoint and support for `@doc`, `@meta`, `@depends`, `@window`, and `@produces`.
- Extend produced-relation resolution so single-asset modules infer relation names from module leaf `Macro.underscore/1` when using `@produces true`, while preserving namespace/default merge and canonical `%Favn.Asset{}` output.
- Add public convenience lookup `Favn.get_asset(module)` for single-asset modules, plus tests and documentation updates (`README`, `lib/favn.ex`, `docs/ASSET_SQL_PLAN.md`, `docs/FEATURES.md`) marking Phase 2 complete.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`