### PR TITLE
add SQLAsset phase 3 authoring foundation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 - Plain Elixir functions become assets with metadata and dependencies.
 - Preferred single-asset authoring uses one module with `use Favn.Asset` and `def asset(ctx)`.
-- SQL assets can be authored as one module with `use Favn.SQLAsset` and inline `sql ~SQL""" ... """`.
+- SQL assets can be authored as one module with `use Favn.SQLAsset`, `query do ... end`, and a real `~SQL""" ... """` sigil.
 - Assets can optionally own produced warehouse relations through `@produces`.
 - Dependency graphs are discovered automatically from asset definitions.
 - Runs are planned deterministically and executed in dependency order.
@@ -73,14 +73,16 @@ defmodule MyWarehouse.Gold.Sales.FctOrders do
   @window Favn.Window.daily(lookback: 2)
   @materialized {:incremental, strategy: :delete_insert, unique_key: [:order_id]}
 
-  sql ~SQL"""
-  select
-    order_id,
-    customer_id,
-    order_date,
-    total_amount
-  from silver.sales.stg_orders
-  """
+  query do
+    ~SQL"""
+    select
+      order_id,
+      customer_id,
+      order_date,
+      total_amount
+    from silver.sales.stg_orders
+    """
+  end
 end
 ```
 
@@ -94,7 +96,33 @@ end
 - `@produces`
 
 SQL assets compile into the same canonical `%Favn.Asset{}` shape as Elixir assets, including ref `{Module, :asset}` and inferred produced relation ownership.
-Phase 3 is authoring/catalog integration only. SQL runtime execution and helper APIs land in a later phase, so direct execution currently returns an explicit not-yet-implemented error.
+Phase 3 is authoring/catalog integration only. The current implementation introduces a real `~SQL` sigil and `query do ... end`, but `~SQL` still compiles to a plain SQL string. SQL runtime execution and helper APIs land in a later phase, so direct execution currently returns an explicit not-yet-implemented error.
+
+## SQL DSL direction
+
+Favn SQL uses a real `~SQL` sigil as the single SQL body language.
+
+SQL assets declare their main query with `query do ... end`.
+Reusable SQL is planned to use `defsql ... do ... end`.
+
+Both asset queries and reusable SQL macros are intended to use the same `~SQL` body syntax and the same `@name` placeholder syntax for injected values.
+
+Implemented now:
+
+- real `~SQL` sigil
+- `query do ... end`
+- `~SQL` returning a plain SQL string
+- SQL string storage in `Favn.SQLAsset`
+
+Planned next:
+
+- reusable `defsql`
+- `@name` value binding
+- Favn-aware relation resolution from module references
+- SQL-aware macro expansion
+- SQL AST representation
+
+Favn explicitly avoids fake sigils, Jinja-style templating, arbitrary Elixir interpolation inside SQL, and string stitching as the normal authoring workflow.
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 
 - Plain Elixir functions become assets with metadata and dependencies.
 - Preferred single-asset authoring uses one module with `use Favn.Asset` and `def asset(ctx)`.
+- SQL assets can be authored as one module with `use Favn.SQLAsset` and inline `sql ~SQL""" ... """`.
 - Assets can optionally own produced warehouse relations through `@produces`.
 - Dependency graphs are discovered automatically from asset definitions.
 - Runs are planned deterministically and executed in dependency order.
@@ -56,6 +57,44 @@ end
 - `@produces`
 
 Single-asset modules compile to one canonical `%Favn.Asset{}` with ref `{Module, :asset}`.
+
+## Preferred single-asset SQL DSL
+
+Phase 3 introduces `Favn.SQLAsset` as the preferred one-module-per-asset SQL DSL:
+
+```elixir
+defmodule MyWarehouse.Gold.Sales.FctOrders do
+  use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+  use Favn.SQLAsset
+
+  @doc "Gold fact table for orders"
+  @meta owner: "analytics", category: :sales, tags: [:gold]
+  @depends MyWarehouse.Silver.Sales.StgOrders
+  @window Favn.Window.daily(lookback: 2)
+  @materialized {:incremental, strategy: :delete_insert, unique_key: [:order_id]}
+
+  sql ~SQL"""
+  select
+    order_id,
+    customer_id,
+    order_date,
+    total_amount
+  from silver.sales.stg_orders
+  """
+end
+```
+
+`Favn.SQLAsset` currently supports:
+
+- `@doc`
+- `@meta`
+- `@depends`
+- `@window`
+- `@materialized`
+- `@produces`
+
+SQL assets compile into the same canonical `%Favn.Asset{}` shape as Elixir assets, including ref `{Module, :asset}` and inferred produced relation ownership.
+Phase 3 is authoring/catalog integration only. SQL runtime execution and helper APIs land in a later phase, so direct execution currently returns an explicit not-yet-implemented error.
 
 ## Introduction
 
@@ -203,7 +242,7 @@ config :favn,
 
 Key settings:
 
-- `asset_modules`: modules that define assets with `use Favn.Assets`.
+- `asset_modules`: modules that define assets with `use Favn.Asset`, `use Favn.SQLAsset`, or `use Favn.Assets`.
 - `pipeline_modules`: pipeline modules discovered by the scheduler runtime.
 - `:pubsub_name`: PubSub server name used for run event broadcasting.
 - `:scheduler`: trigger scheduler runtime options (`enabled`, `default_timezone`, `tick_ms`). `enabled` defaults to `true`; `tick_ms` defaults to `15_000`.

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -336,21 +336,23 @@ defmodule MyWarehouse.Gold.Sales.FctOrders do
   @window Favn.Window.daily(on: :order_date, lookback: 2)
   @materialized {:incremental, strategy: :delete_insert, unique_key: [:order_id]}
 
-  sql ~SQL"""
-  select
-    order_id,
-    customer_id,
-    order_date,
-    total_amount
-  from gold.sales.stg_orders
-  """
+  query do
+    ~SQL"""
+    select
+      order_id,
+      customer_id,
+      order_date,
+      total_amount
+    from gold.sales.stg_orders
+    """
+  end
 end
 ```
 
 ### Core rules
 
 * one SQL asset module = one asset
-* SQL body remains normal SQL
+* SQL body remains normal SQL authored through a real `~SQL` sigil
 * metadata uses familiar Favn conventions
 * produced relation is normally inferred from namespace/module path
 * explicit override via `@produces` is allowed
@@ -367,12 +369,19 @@ Example:
 
 Favn should avoid custom SQL syntax in the SQL body for v1.
 
+Favn SQL should use one real SQL body language:
+
+* asset SQL uses `query do ... end`
+* reusable SQL should later use `defsql ... do ... end`
+* both should contain `~SQL` bodies
+
 Do not require:
 
 * `ref(...)`
 * `source(...)`
 * interpolation-heavy SQL DSL
 * Jinja-like templating
+* fake sigils
 
 The SQL text should stay as close to standard SQL as possible so ordinary SQL editor tooling remains usable.
 
@@ -625,10 +634,12 @@ Explicit dependency declaration must remain supported.
 SQL authoring should prefer:
 
 ```elixir
-sql ~SQL"""
-select *
-from raw.sales.orders
-"""
+query do
+  ~SQL"""
+  select *
+  from raw.sales.orders
+  """
+end
 ```
 
 not custom SQL DSL constructs inside the query body.
@@ -833,7 +844,8 @@ Implemented semantics:
 Deliver:
 
 * [x] one-module-per-asset SQL DSL
-* [x] inline SQL via `sql ~SQL""" ... """`
+* [x] real `~SQL""" ... """` sigil
+* [x] `query do ... end` for asset queries
 * [x] support for:
   * [x] `@doc`
   * [x] `@meta`
@@ -852,6 +864,8 @@ Implemented semantics:
 
 * one `use Favn.SQLAsset` module compiles to exactly one canonical asset with ref `{Module, :asset}`
 * `Favn.SQLAsset` reuses `Favn.Namespace` for inherited `connection` / `catalog` / `schema` defaults
+* SQL asset queries are authored as `query do ... end`
+* `~SQL` is now a real Elixir sigil and currently returns a plain SQL string
 * `@depends` accepts:
 
   * `Some.Module` only when `Some.Module` is another single-asset module, normalized to `{Some.Module, :asset}`
@@ -863,9 +877,43 @@ Implemented semantics:
   * `{:incremental, strategy: :append | :replace | :delete_insert | :merge, unique_key: [...]}`
 * SQL assets infer their produced relation from `Favn.Namespace` defaults plus module leaf `Macro.underscore/1`
 * SQL assets require a resolved produced relation with a connection name
-* `sql ~SQL` stays plain SQL and currently rejects interpolation/modifiers in phase 3
+* `~SQL` stays plain SQL and currently rejects interpolation/modifiers in phase 3
 * SQL modules expose the existing asset compiler seam via `__favn_asset_compiler__/0`
 * generated `asset/1` currently returns `{:error, :sql_asset_runtime_not_implemented}` until phase 4 runtime execution lands
+
+### SQL DSL direction
+
+Favn SQL uses a real `~SQL` sigil as the single SQL body language.
+
+SQL assets declare their main query with `query do ... end`.
+Reusable SQL should later be declared with `defsql ... do ... end`.
+
+Both asset queries and reusable SQL macros should use the same `~SQL` body syntax and the same `@name` placeholder syntax for injected values.
+
+What is implemented now:
+
+* real `~SQL` sigil
+* `query do ~SQL""" ... """ end`
+* `~SQL` returns a plain SQL string
+* `Favn.SQLAsset` stores that SQL string
+
+What is not implemented yet:
+
+* expression SQL macros
+* relation SQL macros
+* module-reference relation resolution
+* `@param` / runtime value binding
+* CTE composition helpers
+* SQL-aware macro expansion
+* SQL AST representation
+
+The DSL should explicitly avoid:
+
+* fake sigils
+* Jinja-style templating
+* arbitrary Elixir interpolation inside SQL
+* string stitching as the normal authoring workflow
+* multiple placeholder syntaxes across SQL contexts
 
 ### Phase 4 — SQL runtime integration and helper APIs
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -828,23 +828,44 @@ Implemented semantics:
   * `MyWarehouse.Gold.Sales.FctOrders` -> `"fct_orders"`
 * `Favn.get_asset/1` now also accepts a single-asset module ref directly (`Favn.get_asset(MyAssetModule)`)
 
-### Phase 3 — `Favn.SQL.Namespace` and `Favn.SQLAsset`
+### Phase 3 — `Favn.SQLAsset` authoring and catalog integration
 
 Deliver:
 
-* one-module-per-asset SQL DSL
-* inline SQL via `sql ~SQL""" ... """`
-* support for:
-  * `@doc`
-  * `@meta`
-  * `@depends`
-  * `@window`
-  * `@materialized`
-  * optional `@produces` override
-* produced relation inference from namespace/module path
-* compilation into one canonical `%Favn.Asset{}`
+* [x] one-module-per-asset SQL DSL
+* [x] inline SQL via `sql ~SQL""" ... """`
+* [x] support for:
+  * [x] `@doc`
+  * [x] `@meta`
+  * [x] `@depends`
+  * [x] `@window`
+  * [x] `@materialized`
+  * [x] optional `@produces` override
+* [x] produced relation inference from namespace/module path
+* [x] compilation into one canonical `%Favn.Asset{}`
 
 This phase establishes the SQL asset authoring model.
+
+#### Phase 3 implementation notes
+
+Implemented semantics:
+
+* one `use Favn.SQLAsset` module compiles to exactly one canonical asset with ref `{Module, :asset}`
+* `Favn.SQLAsset` reuses `Favn.Namespace` for inherited `connection` / `catalog` / `schema` defaults
+* `@depends` accepts:
+
+  * `Some.Module` only when `Some.Module` is another single-asset module, normalized to `{Some.Module, :asset}`
+  * `{Some.Module, :asset_name}`
+* `@materialized` is required and currently accepts:
+
+  * `:view`
+  * `:table`
+  * `{:incremental, strategy: :append | :replace | :delete_insert | :merge, unique_key: [...]}`
+* SQL assets infer their produced relation from `Favn.Namespace` defaults plus module leaf `Macro.underscore/1`
+* SQL assets require a resolved produced relation with a connection name
+* `sql ~SQL` stays plain SQL and currently rejects interpolation/modifiers in phase 3
+* SQL modules expose the existing asset compiler seam via `__favn_asset_compiler__/0`
+* generated `asset/1` currently returns `{:error, :sql_asset_runtime_not_implemented}` until phase 4 runtime execution lands
 
 ### Phase 4 — SQL runtime integration and helper APIs
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -137,15 +137,20 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] module dependency shorthand normalization (`@depends Some.AssetModule`)
   - [x] `@produces true` relation-name inference from module leaf (`Macro.underscore/1`)
   - [x] module convenience lookup via `Favn.get_asset(module)` for single-asset modules
+- [x] Phase 3 single-asset SQL DSL (`Favn.SQLAsset`)
+  - [x] one-module-per-asset SQL DSL with inline `sql ~SQL""" ... """`
+  - [x] `@doc`, `@meta`, `@depends`, `@window`, `@materialized`, `@produces`
+  - [x] relation default inheritance via `Favn.Namespace`
+  - [x] canonical compile output as one `%Favn.Asset{ref: {Module, :asset}}`
+  - [x] module convenience lookup via `Favn.get_asset(module)` for single-asset modules
+  - [x] explicit runtime guard until SQL execution lands
 - [ ] DuckDB adapter hardening + incremental strategy expansion
 - [ ] Typed source identities
-- [ ] `Favn.SQL` / `Favn.SQLAssets` authoring model
+- [ ] SQL execution through shared runtime
+- [ ] SQL helper APIs (`render`, `preview`, `explain`, `materialize`)
 - [ ] Multi-asset SQL modules
-- [ ] Inline SQL support
 - [ ] SQL file support
 - [ ] Dependency inference from typed SQL references
-- [ ] Materialization strategies: `:view`, `:table`, `:incremental`
-- [ ] SQL asset windowing
 - [ ] SQL asset dependency planning on the shared window-aware runtime model
 - [ ] Window-aware incremental execution
 - [ ] Lookback handling for incremental SQL assets

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -138,7 +138,7 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] `@produces true` relation-name inference from module leaf (`Macro.underscore/1`)
   - [x] module convenience lookup via `Favn.get_asset(module)` for single-asset modules
 - [x] Phase 3 single-asset SQL DSL (`Favn.SQLAsset`)
-  - [x] one-module-per-asset SQL DSL with inline `sql ~SQL""" ... """`
+  - [x] one-module-per-asset SQL DSL with `query do ... end` and a real `~SQL""" ... """` sigil
   - [x] `@doc`, `@meta`, `@depends`, `@window`, `@materialized`, `@produces`
   - [x] relation default inheritance via `Favn.Namespace`
   - [x] canonical compile output as one `%Favn.Asset{ref: {Module, :asset}}`
@@ -148,6 +148,10 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
 - [ ] Typed source identities
 - [ ] SQL execution through shared runtime
 - [ ] SQL helper APIs (`render`, `preview`, `explain`, `materialize`)
+- [ ] Reusable SQL via `Favn.SQL` and `defsql ... do ... end`
+- [ ] `@name` placeholder binding for SQL values
+- [ ] Favn-aware relation resolution from module refs inside SQL
+- [ ] SQL-aware macro expansion / AST model
 - [ ] Multi-asset SQL modules
 - [ ] SQL file support
 - [ ] Dependency inference from typed SQL references

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -55,6 +55,7 @@ lib/
     │       └── step.ex
     ├── scheduler.ex
     ├── sql.ex
+    ├── sql_asset.ex
     ├── sql/
     │   ├── adapter.ex
     │   ├── capabilities.ex
@@ -69,6 +70,11 @@ lib/
     │       ├── duckdb.ex
     │       └── duckdb/
     │           └── client.ex
+    ├── sql_asset/
+    │   ├── compiler.ex
+    │   ├── definition.ex
+    │   ├── materialization.ex
+    │   └── runtime.ex
     ├── scheduler/
     │   ├── cron.ex
     │   ├── registry.ex

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -21,6 +21,7 @@ test/
 ├── runtime_transitions_test.exs
 ├── scheduler_cron_test.exs
 ├── scheduler_test.exs
+├── sql_asset_test.exs
 ├── sql_duckdb_adapter_test.exs
 ├── sql_test.exs
 ├── sqlite_storage_bootstrap_test.exs

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -665,7 +665,7 @@ defmodule Favn do
   Accepted input:
 
     * `{module, name}` where both values are atoms
-    * `module` for single-asset modules authored with `use Favn.Asset`
+     * `module` for single-asset modules authored with `use Favn.Asset` or `use Favn.SQLAsset`
 
   Returns:
 

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -181,6 +181,29 @@ defmodule Favn do
         def asset(ctx), do: :ok
       end
 
+  Preferred one-module-per-asset SQL style uses `Favn.SQLAsset`:
+
+      defmodule MyApp.Gold.Sales.FctOrders do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+
+        @doc "Build the gold fact table for orders"
+        @meta owner: "analytics", category: :sales, tags: [:gold]
+        @materialized :table
+
+        query do
+          ~SQL\"\"\"
+          select *
+          from silver.sales.stg_orders
+          \"\"\"
+        end
+      end
+
+  The current SQL implementation keeps `~SQL` intentionally simple: it is a real
+  Elixir sigil, but it currently returns a plain SQL string. Future work is expected
+  to add reusable `defsql`, `@name` value binding, and Favn-aware relation resolution
+  while keeping `~SQL` as the one SQL body language.
+
   Compact multi-asset style uses `Favn.Assets`:
 
   A simplified example:

--- a/lib/favn/asset.ex
+++ b/lib/favn/asset.ex
@@ -22,6 +22,7 @@ defmodule Favn.Asset do
 
   alias Favn.Ref
   alias Favn.RelationRef
+  alias Favn.SQLAsset.Materialization
   alias Favn.Window.Spec
 
   @doc false
@@ -113,6 +114,7 @@ defmodule Favn.Asset do
           name: atom(),
           ref: Ref.t(),
           arity: non_neg_integer(),
+          type: :elixir | :sql,
           title: String.t() | nil,
           doc: String.t() | nil,
           file: String.t(),
@@ -120,7 +122,8 @@ defmodule Favn.Asset do
           meta: map(),
           depends_on: [Ref.t()],
           window_spec: Spec.t() | nil,
-          produces: RelationRef.t() | nil
+          produces: RelationRef.t() | nil,
+          materialization: Favn.SQLAsset.Materialization.t() | nil
         }
 
   @typedoc """
@@ -137,10 +140,12 @@ defmodule Favn.Asset do
     :doc,
     :file,
     :line,
+    type: :elixir,
     meta: %{},
     depends_on: [],
     window_spec: nil,
-    produces: nil
+    produces: nil,
+    materialization: nil
   ]
 
   @doc """
@@ -160,6 +165,8 @@ defmodule Favn.Asset do
     validate_depends_on!(asset.depends_on)
     validate_window_spec!(asset.window_spec)
     validate_produces!(asset.produces)
+    validate_type!(asset.type)
+    validate_materialization!(asset.materialization)
 
     %{asset | meta: meta}
   end
@@ -263,6 +270,21 @@ defmodule Favn.Asset do
           "asset produces must be a Favn.RelationRef or nil, got: #{inspect(value)}"
   end
 
+  defp validate_type!(type) when type in [:elixir, :sql], do: :ok
+
+  defp validate_type!(value) do
+    raise ArgumentError, "asset type must be :elixir or :sql, got: #{inspect(value)}"
+  end
+
+  defp validate_materialization!(nil), do: :ok
+
+  defp validate_materialization!(materialization) do
+    case Materialization.normalize!(materialization) do
+      normalized when normalized == materialization -> :ok
+      _normalized -> raise ArgumentError, "asset materialization must already be normalized"
+    end
+  end
+
   defp capture_single_asset_definition!(env) do
     if Module.get_attribute(env.module, :favn_single_asset_raw) do
       compile_error!(
@@ -307,6 +329,7 @@ defmodule Favn.Asset do
       name: :asset,
       ref: Ref.new(raw_asset.module, :asset),
       arity: 1,
+      type: :elixir,
       title: nil,
       doc: raw_asset.doc,
       file: raw_asset.file,

--- a/lib/favn/assets/compiler.ex
+++ b/lib/favn/assets/compiler.ex
@@ -25,7 +25,7 @@ defmodule Favn.Assets.Compiler do
              {:module, _loaded} <- Code.ensure_loaded(compiler),
              true <- function_exported?(compiler, :compile_assets, 1) do
           case compiler.compile_assets(module) do
-            {:ok, assets} -> normalize_assets(assets)
+            {:ok, assets} -> normalize_compiled_assets(assets, module)
             {:error, reason} -> {:error, reason}
             _ -> {:error, {:invalid_asset_compiler, module}}
           end
@@ -56,6 +56,22 @@ defmodule Favn.Assets.Compiler do
 
   defp normalize_assets(_), do: {:error, :invalid_compiled_assets}
 
+  defp normalize_compiled_assets(assets, module) do
+    normalize_assets(assets)
+    |> case do
+      {:ok, assets} ->
+        try do
+          validate_single_asset_depends_shorthand!(module)
+          {:ok, assets}
+        rescue
+          error in ArgumentError -> {:error, {:invalid_compiled_assets, error.message}}
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
   defp normalize_module_assets(assets, module) when is_list(assets) do
     normalize_assets(assets)
     |> case do
@@ -73,20 +89,44 @@ defmodule Favn.Assets.Compiler do
   end
 
   defp validate_single_asset_depends_shorthand!(module) do
-    if function_exported?(module, :__favn_single_asset__, 0) and
-         function_exported?(module, :__favn_assets_raw__, 0) do
-      module.__favn_assets_raw__()
-      |> Enum.flat_map(&Map.get(&1, :depends, []))
-      |> Enum.each(fn
-        dependency_module when is_atom(dependency_module) ->
-          ensure_single_asset_dependency_module!(module, dependency_module)
+    if function_exported?(module, :__favn_single_asset__, 0) do
+      case fetch_raw_assets(module) do
+        {:ok, raw_assets} ->
+          raw_assets
+          |> Enum.flat_map(&Map.get(&1, :depends, []))
+          |> Enum.each(fn
+            dependency_module when is_atom(dependency_module) ->
+              ensure_single_asset_dependency_module!(module, dependency_module)
 
-        _other ->
+            _other ->
+              :ok
+          end)
+
+        :error ->
           :ok
-      end)
+      end
     end
 
     :ok
+  end
+
+  defp fetch_raw_assets(module) do
+    cond do
+      function_exported?(module, :__favn_assets_raw__, 0) ->
+        {:ok, module.__favn_assets_raw__()}
+
+      function_exported?(module, :__favn_sql_asset_definition__, 0) ->
+        case module.__favn_sql_asset_definition__() do
+          %{asset: %{module: ^module}, depends_on: _depends_on} = definition ->
+            {:ok, [%{depends: Map.get(definition.asset, :depends_on, [])}]}
+
+          _other ->
+            :error
+        end
+
+      true ->
+        :error
+    end
   end
 
   defp ensure_single_asset_dependency_module!(module, dependency_module) do
@@ -96,12 +136,12 @@ defmodule Favn.Assets.Compiler do
           :ok
         else
           raise ArgumentError,
-                "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a `use Favn.Asset` module, use {Module, :asset_name} for multi-asset modules"
+                "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a single-asset module, use {Module, :asset_name} for multi-asset modules"
         end
 
       _ ->
         raise ArgumentError,
-              "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a loadable `use Favn.Asset` module"
+              "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a loadable single-asset module"
     end
   end
 

--- a/lib/favn/assets/compiler.ex
+++ b/lib/favn/assets/compiler.ex
@@ -111,21 +111,10 @@ defmodule Favn.Assets.Compiler do
   end
 
   defp fetch_raw_assets(module) do
-    cond do
-      function_exported?(module, :__favn_assets_raw__, 0) ->
-        {:ok, module.__favn_assets_raw__()}
-
-      function_exported?(module, :__favn_sql_asset_definition__, 0) ->
-        case module.__favn_sql_asset_definition__() do
-          %{asset: %{module: ^module}, depends_on: _depends_on} = definition ->
-            {:ok, [%{depends: Map.get(definition.asset, :depends_on, [])}]}
-
-          _other ->
-            :error
-        end
-
-      true ->
-        :error
+    if function_exported?(module, :__favn_assets_raw__, 0) do
+      {:ok, module.__favn_assets_raw__()}
+    else
+      :error
     end
   end
 

--- a/lib/favn/assets/compiler.ex
+++ b/lib/favn/assets/compiler.ex
@@ -22,10 +22,15 @@ defmodule Favn.Assets.Compiler do
 
       function_exported?(module, :__favn_asset_compiler__, 0) ->
         with compiler when is_atom(compiler) <- module.__favn_asset_compiler__(),
-             true <- function_exported?(compiler, :compile_assets, 1),
-             {:ok, assets} <- compiler.compile_assets(module) do
-          normalize_assets(assets)
+             {:module, _loaded} <- Code.ensure_loaded(compiler),
+             true <- function_exported?(compiler, :compile_assets, 1) do
+          case compiler.compile_assets(module) do
+            {:ok, assets} -> normalize_assets(assets)
+            {:error, reason} -> {:error, reason}
+            _ -> {:error, {:invalid_asset_compiler, module}}
+          end
         else
+          {:error, _reason} -> {:error, {:invalid_asset_compiler, module}}
           false -> {:error, {:invalid_asset_compiler, module}}
           _ -> {:error, {:invalid_asset_compiler, module}}
         end

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -1,0 +1,441 @@
+defmodule Favn.SQLAsset do
+  @moduledoc """
+  Preferred single-module SQL asset DSL.
+
+  `Favn.SQLAsset` compiles one SQL-authored module into one canonical
+  `%Favn.Asset{}` with ref `{Module, :asset}`.
+  """
+
+  alias Favn.Asset
+  alias Favn.Namespace
+  alias Favn.Ref
+  alias Favn.RelationRef
+  alias Favn.SQLAsset.Definition
+  alias Favn.SQLAsset.Materialization
+  alias Favn.SQLAsset.Runtime
+  alias Favn.Window.Spec
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      Module.register_attribute(__MODULE__, :depends, accumulate: true)
+      Module.register_attribute(__MODULE__, :meta, persist: false)
+      Module.register_attribute(__MODULE__, :produces, accumulate: true)
+      Module.register_attribute(__MODULE__, :window, accumulate: true)
+      Module.register_attribute(__MODULE__, :materialized, accumulate: true)
+      Module.register_attribute(__MODULE__, :favn_sql_asset_raw, persist: false)
+
+      @on_definition Favn.SQLAsset
+      @before_compile Favn.SQLAsset
+
+      import Favn.SQLAsset, only: [sql: 1]
+    end
+  end
+
+  @doc false
+  def __on_definition__(env, kind, name, args, _guards, _body) do
+    arity = length(args || [])
+
+    generated_definition? =
+      Module.get_attribute(env.module, :favn_sql_asset_generating) == true and
+        kind == :def and
+        name in [
+          :__favn_asset_compiler__,
+          :__favn_sql_asset_definition__,
+          :__favn_single_asset__,
+          :asset
+        ]
+
+    if generated_definition? do
+      :ok
+    else
+      case {kind, name, arity} do
+        {kind, :asset, _arity} when kind in [:def, :defp] ->
+          compile_error!(
+            env.file,
+            env.line,
+            "Favn.SQLAsset reserves asset/1 and generates it automatically"
+          )
+
+        {kind, _name, _arity} when kind in [:def, :defp] ->
+          validate_no_stray_asset_attributes!(env, kind, name, arity)
+
+        _ ->
+          :ok
+      end
+    end
+  end
+
+  @doc false
+  defmacro sql(body) do
+    raw_definition = Module.get_attribute(__CALLER__.module, :favn_sql_asset_raw)
+
+    if raw_definition do
+      compile_error!(
+        __CALLER__.file,
+        __CALLER__.line,
+        "Favn.SQLAsset modules can define only one sql body"
+      )
+    end
+
+    sql = extract_sql!(body, __CALLER__)
+
+    Module.put_attribute(__CALLER__.module, :favn_sql_asset_raw, %{
+      module: __CALLER__.module,
+      file: normalize_file(__CALLER__.file),
+      line: __CALLER__.line,
+      sql: sql
+    })
+
+    quote do
+      :ok
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    base_definition = Module.get_attribute(env.module, :favn_sql_asset_raw)
+
+    if is_nil(base_definition) do
+      compile_error!(env.file, env.line, "Favn.SQLAsset modules must define exactly one sql body")
+    end
+
+    raw_definition =
+      base_definition
+      |> Map.put(:doc, normalize_doc(Module.get_attribute(env.module, :doc)))
+      |> Map.put(:depends, env.module |> fetch_accum_attribute(:depends) |> Enum.reverse())
+      |> Map.put(:meta, Module.get_attribute(env.module, :meta))
+      |> Map.put(:window, env.module |> fetch_accum_attribute(:window) |> Enum.reverse())
+      |> Map.put(:produces, env.module |> fetch_accum_attribute(:produces) |> Enum.reverse())
+      |> Map.put(
+        :materialized,
+        env.module |> fetch_accum_attribute(:materialized) |> Enum.reverse()
+      )
+
+    definition = build_definition!(raw_definition)
+
+    Module.put_attribute(env.module, :favn_sql_asset_generating, true)
+
+    quote do
+      @doc false
+      @spec __favn_asset_compiler__() :: module()
+      def __favn_asset_compiler__, do: Favn.SQLAsset.Compiler
+
+      @doc false
+      @spec __favn_sql_asset_definition__() :: Favn.SQLAsset.Definition.t()
+      def __favn_sql_asset_definition__, do: unquote(Macro.escape(definition))
+
+      @doc false
+      def __favn_single_asset__, do: true
+
+      @doc false
+      @spec asset(Favn.Run.Context.t()) :: Favn.Asset.return_value()
+      def asset(ctx), do: Runtime.run(__MODULE__, ctx)
+    end
+  end
+
+  defp build_definition!(raw_definition) do
+    depends_on = normalize_depends!(raw_definition.depends, raw_definition)
+    meta = normalize_meta!(raw_definition.meta, raw_definition)
+    window_spec = normalize_window!(raw_definition.window, raw_definition)
+    materialization = normalize_materialized!(raw_definition.materialized, raw_definition)
+    produces = normalize_produces!(raw_definition, inferred_relation_name(raw_definition.module))
+
+    asset = %Asset{
+      module: raw_definition.module,
+      name: :asset,
+      ref: Ref.new(raw_definition.module, :asset),
+      arity: 1,
+      type: :sql,
+      title: nil,
+      doc: raw_definition.doc,
+      file: raw_definition.file,
+      line: raw_definition.line,
+      meta: meta,
+      depends_on: depends_on,
+      window_spec: window_spec,
+      produces: produces,
+      materialization: materialization
+    }
+
+    definition = %Definition{
+      module: raw_definition.module,
+      asset: asset,
+      sql: raw_definition.sql,
+      materialization: materialization
+    }
+
+    try do
+      _ = Asset.validate!(asset)
+      definition
+    rescue
+      error in ArgumentError ->
+        compile_error!(raw_definition.file, raw_definition.line, error.message)
+    end
+  end
+
+  defp normalize_depends!(depends, raw_definition) do
+    Enum.map(depends, fn
+      module when is_atom(module) ->
+        ensure_single_asset_dependency_module!(raw_definition.module, module)
+        Ref.new(module, :asset)
+
+      {module, name} when is_atom(module) and is_atom(name) ->
+        if module_atom?(module) do
+          Ref.new(module, name)
+        else
+          compile_error!(
+            raw_definition.file,
+            raw_definition.line,
+            "invalid @depends entry #{inspect({module, name})}; expected Module or {Module, :asset_name}"
+          )
+        end
+
+      dependency ->
+        compile_error!(
+          raw_definition.file,
+          raw_definition.line,
+          "invalid @depends entry #{inspect(dependency)}; expected Module or {Module, :asset_name}"
+        )
+    end)
+  end
+
+  defp ensure_single_asset_dependency_module!(module, dependency_module) do
+    case Code.ensure_loaded(dependency_module) do
+      {:module, _loaded} ->
+        if function_exported?(dependency_module, :__favn_single_asset__, 0) do
+          :ok
+        else
+          compile_error!(
+            __ENV__.file,
+            __ENV__.line,
+            "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a single-asset module, use {Module, :asset_name} for multi-asset modules"
+          )
+        end
+
+      _ ->
+        compile_error!(
+          __ENV__.file,
+          __ENV__.line,
+          "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a loadable single-asset module"
+        )
+    end
+  end
+
+  defp normalize_meta!(meta, raw_definition) do
+    Asset.normalize_meta!(meta)
+  rescue
+    error in ArgumentError ->
+      compile_error!(raw_definition.file, raw_definition.line, error.message)
+  end
+
+  defp normalize_window!([], _raw_definition), do: nil
+  defp normalize_window!([%Spec{} = spec], _raw_definition), do: spec
+
+  defp normalize_window!([_a, _b | _rest], raw_definition) do
+    compile_error!(
+      raw_definition.file,
+      raw_definition.line,
+      "multiple @window attributes are not allowed; use at most one @window for sql ..."
+    )
+  end
+
+  defp normalize_window!(value, raw_definition) do
+    compile_error!(
+      raw_definition.file,
+      raw_definition.line,
+      "invalid @window value #{inspect(value)}; expected Favn.Window spec like Favn.Window.daily()"
+    )
+  end
+
+  defp normalize_materialized!([value], raw_definition) do
+    Materialization.normalize!(value)
+  rescue
+    error in ArgumentError ->
+      compile_error!(raw_definition.file, raw_definition.line, error.message)
+  end
+
+  defp normalize_materialized!([], raw_definition) do
+    compile_error!(
+      raw_definition.file,
+      raw_definition.line,
+      "Favn.SQLAsset requires one @materialized attribute"
+    )
+  end
+
+  defp normalize_materialized!([_a, _b | _rest], raw_definition) do
+    compile_error!(
+      raw_definition.file,
+      raw_definition.line,
+      "multiple @materialized attributes are not allowed; use exactly one @materialized for sql ..."
+    )
+  end
+
+  defp normalize_produces!(raw_definition, inferred_name) do
+    defaults = Namespace.resolve(raw_definition.module)
+
+    produces_attrs =
+      case raw_definition.produces do
+        [] ->
+          %{}
+
+        [true] ->
+          %{}
+
+        [attrs] when is_list(attrs) ->
+          if Keyword.keyword?(attrs) do
+            Map.new(attrs)
+          else
+            compile_error!(
+              raw_definition.file,
+              raw_definition.line,
+              "invalid @produces value #{inspect(attrs)}; expected true, a keyword list, or a map"
+            )
+          end
+
+        [attrs] when is_map(attrs) ->
+          attrs
+
+        [other] ->
+          compile_error!(
+            raw_definition.file,
+            raw_definition.line,
+            "invalid @produces value #{inspect(other)}; expected true, a keyword list, or a map"
+          )
+      end
+
+    defaults
+    |> maybe_drop_default_key(produces_attrs, [:catalog], [:database, "database"])
+    |> maybe_drop_default_key(produces_attrs, [:name], [:table, "table", :name, "name"])
+    |> Map.merge(produces_attrs)
+    |> maybe_put_inferred_name(inferred_name)
+    |> RelationRef.new!()
+    |> ensure_sql_relation_connection!(raw_definition)
+  rescue
+    error in ArgumentError ->
+      compile_error!(raw_definition.file, raw_definition.line, error.message)
+  end
+
+  defp ensure_sql_relation_connection!(%RelationRef{connection: nil}, raw_definition) do
+    compile_error!(
+      raw_definition.file,
+      raw_definition.line,
+      "SQL assets require a connection through Favn.Namespace or @produces"
+    )
+  end
+
+  defp ensure_sql_relation_connection!(%RelationRef{} = relation_ref, _raw_definition),
+    do: relation_ref
+
+  defp validate_no_stray_asset_attributes!(env, kind, name, arity) do
+    depends = fetch_accum_attribute(env.module, :depends)
+    meta = Module.get_attribute(env.module, :meta)
+    window = fetch_accum_attribute(env.module, :window)
+    produces = fetch_accum_attribute(env.module, :produces)
+    materialized = fetch_accum_attribute(env.module, :materialized)
+
+    if depends != [] or not is_nil(meta) or window != [] or produces != [] or materialized != [] do
+      Module.delete_attribute(env.module, :depends)
+      Module.delete_attribute(env.module, :meta)
+      Module.delete_attribute(env.module, :window)
+      Module.delete_attribute(env.module, :produces)
+      Module.delete_attribute(env.module, :materialized)
+
+      compile_error!(
+        env.file,
+        env.line,
+        "@depends/@meta/@window/@produces/@materialized on #{kind} #{name}/#{arity} requires sql ... immediately below those attributes"
+      )
+    else
+      :ok
+    end
+  end
+
+  defp inferred_relation_name(module) do
+    module
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
+  end
+
+  defp maybe_drop_default_key(defaults, attrs, canonical_keys, authored_keys) do
+    if Enum.any?(authored_keys, &Map.has_key?(attrs, &1)) do
+      Enum.reduce(canonical_keys, defaults, &Map.delete(&2, &1))
+    else
+      defaults
+    end
+  end
+
+  defp maybe_put_inferred_name(attrs, inferred_name) do
+    if Enum.any?([:name, "name", :table, "table"], &Map.has_key?(attrs, &1)) do
+      attrs
+    else
+      Map.put(attrs, :name, inferred_name)
+    end
+  end
+
+  defp extract_sql!(body, env) do
+    case body do
+      binary when is_binary(binary) ->
+        binary
+
+      {:sigil_SQL, _meta, [parts_ast, modifiers]} ->
+        extract_sigil_sql!(parts_ast, modifiers, env)
+
+      _ ->
+        compile_error!(
+          env.file,
+          env.line,
+          "sql body must be a plain string or ~SQL sigil without interpolation"
+        )
+    end
+  end
+
+  defp extract_sigil_sql!(_parts_ast, modifiers, env) when modifiers != [] do
+    compile_error!(env.file, env.line, "sql ~SQL sigil does not support modifiers")
+  end
+
+  defp extract_sigil_sql!({:<<>>, _meta, parts}, [], env) do
+    if Enum.all?(parts, &is_binary/1) do
+      Enum.join(parts)
+    else
+      compile_error!(env.file, env.line, "sql ~SQL sigil does not support interpolation")
+    end
+  end
+
+  defp extract_sigil_sql!(_parts_ast, [], env) do
+    compile_error!(
+      env.file,
+      env.line,
+      "sql body must be a plain string or ~SQL sigil without interpolation"
+    )
+  end
+
+  defp normalize_doc({_line, false}), do: nil
+  defp normalize_doc({_line, doc}) when is_binary(doc), do: doc
+  defp normalize_doc(false), do: nil
+  defp normalize_doc(doc) when is_binary(doc), do: doc
+  defp normalize_doc(_), do: nil
+
+  defp fetch_accum_attribute(module, attribute) do
+    module
+    |> Module.get_attribute(attribute)
+    |> List.wrap()
+  end
+
+  defp normalize_file(file) do
+    file
+    |> to_string()
+    |> Path.relative_to_cwd()
+  end
+
+  defp compile_error!(file, line, description) do
+    raise CompileError, file: file, line: line, description: description
+  end
+
+  defp module_atom?(module) when is_atom(module) do
+    module
+    |> Atom.to_string()
+    |> String.starts_with?("Elixir.")
+  end
+end

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -41,6 +41,7 @@ defmodule Favn.SQLAsset do
         kind == :def and
         name in [
           :__favn_asset_compiler__,
+          :__favn_assets_raw__,
           :__favn_sql_asset_definition__,
           :__favn_single_asset__,
           :asset
@@ -122,6 +123,9 @@ defmodule Favn.SQLAsset do
       def __favn_asset_compiler__, do: Favn.SQLAsset.Compiler
 
       @doc false
+      def __favn_assets_raw__, do: [unquote(Macro.escape(raw_definition))]
+
+      @doc false
       @spec __favn_sql_asset_definition__() :: Favn.SQLAsset.Definition.t()
       def __favn_sql_asset_definition__, do: unquote(Macro.escape(definition))
 
@@ -162,7 +166,8 @@ defmodule Favn.SQLAsset do
       module: raw_definition.module,
       asset: asset,
       sql: raw_definition.sql,
-      materialization: materialization
+      materialization: materialization,
+      raw_asset: raw_definition
     }
 
     try do
@@ -177,7 +182,6 @@ defmodule Favn.SQLAsset do
   defp normalize_depends!(depends, raw_definition) do
     Enum.map(depends, fn
       module when is_atom(module) ->
-        ensure_single_asset_dependency_module!(raw_definition.module, module)
         Ref.new(module, :asset)
 
       {module, name} when is_atom(module) and is_atom(name) ->
@@ -198,28 +202,6 @@ defmodule Favn.SQLAsset do
           "invalid @depends entry #{inspect(dependency)}; expected Module or {Module, :asset_name}"
         )
     end)
-  end
-
-  defp ensure_single_asset_dependency_module!(module, dependency_module) do
-    case Code.ensure_loaded(dependency_module) do
-      {:module, _loaded} ->
-        if function_exported?(dependency_module, :__favn_single_asset__, 0) do
-          :ok
-        else
-          compile_error!(
-            __ENV__.file,
-            __ENV__.line,
-            "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a single-asset module, use {Module, :asset_name} for multi-asset modules"
-          )
-        end
-
-      _ ->
-        compile_error!(
-          __ENV__.file,
-          __ENV__.line,
-          "invalid @depends entry #{inspect(dependency_module)} in #{inspect(module)}; module shorthand requires a loadable single-asset module"
-        )
-    end
   end
 
   defp normalize_meta!(meta, raw_definition) do
@@ -295,6 +277,13 @@ defmodule Favn.SQLAsset do
 
         [attrs] when is_map(attrs) ->
           attrs
+
+        [_a, _b | _rest] ->
+          compile_error!(
+            raw_definition.file,
+            raw_definition.line,
+            "multiple @produces attributes are not allowed; use at most one @produces for sql ..."
+          )
 
         [other] ->
           compile_error!(

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -250,7 +250,7 @@ defmodule Favn.SQLAsset do
     compile_error!(
       raw_definition.file,
       raw_definition.line,
-      "multiple @window attributes are not allowed; use at most one @window for sql ..."
+      "multiple @window attributes are not allowed; use at most one @window before query do ... end"
     )
   end
 
@@ -281,7 +281,7 @@ defmodule Favn.SQLAsset do
     compile_error!(
       raw_definition.file,
       raw_definition.line,
-      "multiple @materialized attributes are not allowed; use exactly one @materialized for sql ..."
+      "multiple @materialized attributes are not allowed; use exactly one @materialized before query do ... end"
     )
   end
 
@@ -314,7 +314,7 @@ defmodule Favn.SQLAsset do
           compile_error!(
             raw_definition.file,
             raw_definition.line,
-            "multiple @produces attributes are not allowed; use at most one @produces for sql ..."
+            "multiple @produces attributes are not allowed; use at most one @produces before query do ... end"
           )
 
         [other] ->
@@ -365,7 +365,7 @@ defmodule Favn.SQLAsset do
       compile_error!(
         env.file,
         env.line,
-        "@depends/@meta/@window/@produces/@materialized on #{kind} #{name}/#{arity} requires sql ... immediately below those attributes"
+        "@depends/@meta/@window/@produces/@materialized on #{kind} #{name}/#{arity} requires query do ... end immediately below those attributes"
       )
     else
       :ok
@@ -397,9 +397,6 @@ defmodule Favn.SQLAsset do
 
   defp extract_sql!(body, env) do
     case body do
-      binary when is_binary(binary) ->
-        binary
-
       {:sigil_SQL, _meta, [parts_ast, modifiers]} ->
         extract_sigil_sql!(parts_ast, modifiers, env)
 

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -4,6 +4,9 @@ defmodule Favn.SQLAsset do
 
   `Favn.SQLAsset` compiles one SQL-authored module into one canonical
   `%Favn.Asset{}` with ref `{Module, :asset}`.
+
+  SQL bodies are authored with `query do ... end` and a real `~SQL` sigil.
+  In the current phase, `~SQL` simply returns a plain SQL string.
   """
 
   alias Favn.Asset
@@ -28,7 +31,7 @@ defmodule Favn.SQLAsset do
       @on_definition Favn.SQLAsset
       @before_compile Favn.SQLAsset
 
-      import Favn.SQLAsset, only: [sql: 1]
+      import Favn.SQLAsset, only: [query: 1, sigil_SQL: 2]
     end
   end
 
@@ -68,14 +71,39 @@ defmodule Favn.SQLAsset do
   end
 
   @doc false
-  defmacro sql(body) do
+  defmacro sigil_SQL({:<<>>, _meta, parts}, modifiers) when is_list(modifiers) do
+    if modifiers != [] do
+      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL sigil does not support modifiers")
+    end
+
+    if Enum.all?(parts, &is_binary/1) do
+      Enum.join(parts)
+    else
+      compile_error!(
+        __CALLER__.file,
+        __CALLER__.line,
+        "~SQL sigil does not support interpolation"
+      )
+    end
+  end
+
+  defmacro sigil_SQL(_body, modifiers) do
+    if modifiers != [] do
+      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL sigil does not support modifiers")
+    else
+      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL body must be a literal string")
+    end
+  end
+
+  @doc false
+  defmacro query(do: body) do
     raw_definition = Module.get_attribute(__CALLER__.module, :favn_sql_asset_raw)
 
     if raw_definition do
       compile_error!(
         __CALLER__.file,
         __CALLER__.line,
-        "Favn.SQLAsset modules can define only one sql body"
+        "Favn.SQLAsset modules can define only one query body"
       )
     end
 
@@ -98,7 +126,11 @@ defmodule Favn.SQLAsset do
     base_definition = Module.get_attribute(env.module, :favn_sql_asset_raw)
 
     if is_nil(base_definition) do
-      compile_error!(env.file, env.line, "Favn.SQLAsset modules must define exactly one sql body")
+      compile_error!(
+        env.file,
+        env.line,
+        "Favn.SQLAsset modules must define exactly one query body"
+      )
     end
 
     raw_definition =
@@ -375,29 +407,25 @@ defmodule Favn.SQLAsset do
         compile_error!(
           env.file,
           env.line,
-          "sql body must be a plain string or ~SQL sigil without interpolation"
+          "query body must contain a ~SQL literal"
         )
     end
   end
 
   defp extract_sigil_sql!(_parts_ast, modifiers, env) when modifiers != [] do
-    compile_error!(env.file, env.line, "sql ~SQL sigil does not support modifiers")
+    compile_error!(env.file, env.line, "~SQL sigil does not support modifiers")
   end
 
   defp extract_sigil_sql!({:<<>>, _meta, parts}, [], env) do
     if Enum.all?(parts, &is_binary/1) do
       Enum.join(parts)
     else
-      compile_error!(env.file, env.line, "sql ~SQL sigil does not support interpolation")
+      compile_error!(env.file, env.line, "~SQL sigil does not support interpolation")
     end
   end
 
   defp extract_sigil_sql!(_parts_ast, [], env) do
-    compile_error!(
-      env.file,
-      env.line,
-      "sql body must be a plain string or ~SQL sigil without interpolation"
-    )
+    compile_error!(env.file, env.line, "query body must contain a ~SQL literal")
   end
 
   defp normalize_doc({_line, false}), do: nil

--- a/lib/favn/sql_asset/compiler.ex
+++ b/lib/favn/sql_asset/compiler.ex
@@ -1,0 +1,31 @@
+defmodule Favn.SQLAsset.Compiler do
+  @moduledoc """
+  Compiler bridge for `Favn.SQLAsset` modules.
+  """
+
+  @behaviour Favn.Assets.Compiler
+
+  alias Favn.SQLAsset.Definition
+
+  @impl true
+  def compile_assets(module) when is_atom(module) do
+    case fetch_definition(module) do
+      {:ok, %Definition{asset: asset}} -> {:ok, [asset]}
+      {:error, _reason} -> {:error, :invalid_compiled_assets}
+    end
+  end
+
+  @spec fetch_definition(module()) :: {:ok, Definition.t()} | {:error, term()}
+  def fetch_definition(module) when is_atom(module) do
+    if function_exported?(module, :__favn_sql_asset_definition__, 0) do
+      case module.__favn_sql_asset_definition__() do
+        %Definition{} = definition -> {:ok, definition}
+        _other -> {:error, :invalid_sql_asset_definition}
+      end
+    else
+      {:error, :invalid_sql_asset_definition}
+    end
+  rescue
+    _ -> {:error, :invalid_sql_asset_definition}
+  end
+end

--- a/lib/favn/sql_asset/definition.ex
+++ b/lib/favn/sql_asset/definition.ex
@@ -7,12 +7,13 @@ defmodule Favn.SQLAsset.Definition do
   alias Favn.SQLAsset.Materialization
 
   @enforce_keys [:module, :asset, :sql, :materialization]
-  defstruct [:module, :asset, :sql, :materialization]
+  defstruct [:module, :asset, :sql, :materialization, raw_asset: nil]
 
   @type t :: %__MODULE__{
           module: module(),
           asset: Asset.t(),
           sql: String.t(),
-          materialization: Materialization.t()
+          materialization: Materialization.t(),
+          raw_asset: map() | nil
         }
 end

--- a/lib/favn/sql_asset/definition.ex
+++ b/lib/favn/sql_asset/definition.ex
@@ -1,0 +1,18 @@
+defmodule Favn.SQLAsset.Definition do
+  @moduledoc """
+  Internal compiled SQL asset definition used by the SQL asset frontend.
+  """
+
+  alias Favn.Asset
+  alias Favn.SQLAsset.Materialization
+
+  @enforce_keys [:module, :asset, :sql, :materialization]
+  defstruct [:module, :asset, :sql, :materialization]
+
+  @type t :: %__MODULE__{
+          module: module(),
+          asset: Asset.t(),
+          sql: String.t(),
+          materialization: Materialization.t()
+        }
+end

--- a/lib/favn/sql_asset/materialization.ex
+++ b/lib/favn/sql_asset/materialization.ex
@@ -1,0 +1,73 @@
+defmodule Favn.SQLAsset.Materialization do
+  @moduledoc """
+  Canonical SQL asset materialization metadata.
+  """
+
+  @type strategy :: :append | :replace | :delete_insert | :merge
+  @type incremental_opts :: [strategy: strategy(), unique_key: [atom()]]
+  @type t :: :view | :table | {:incremental, incremental_opts()}
+
+  @spec normalize!(t()) :: t()
+  def normalize!(:view), do: :view
+  def normalize!(:table), do: :table
+
+  def normalize!({:incremental, opts}) when is_list(opts) do
+    if not Keyword.keyword?(opts) do
+      raise ArgumentError,
+            "incremental materialization options must be a keyword list, got: #{inspect(opts)}"
+    end
+
+    ensure_unique_keys!(opts)
+    validate_incremental_opts!(opts)
+    {:incremental, opts}
+  end
+
+  def normalize!(value) do
+    raise ArgumentError,
+          "materialization must be :view, :table, or {:incremental, keyword()}, got: #{inspect(value)}"
+  end
+
+  defp ensure_unique_keys!(opts) do
+    keys = Keyword.keys(opts)
+
+    if length(keys) == length(Enum.uniq(keys)) do
+      :ok
+    else
+      raise ArgumentError, "incremental materialization options contain duplicate keys"
+    end
+  end
+
+  defp validate_incremental_opts!(opts) do
+    Enum.each(opts, fn
+      {:strategy, strategy} when strategy in [:append, :replace, :delete_insert, :merge] ->
+        :ok
+
+      {:strategy, value} ->
+        raise ArgumentError,
+              "incremental materialization strategy must be :append, :replace, :delete_insert, or :merge, got: #{inspect(value)}"
+
+      {:unique_key, keys} when is_list(keys) ->
+        Enum.each(keys, fn
+          key when is_atom(key) ->
+            :ok
+
+          key ->
+            raise ArgumentError,
+                  "incremental materialization unique_key entries must be atoms, got: #{inspect(key)}"
+        end)
+
+      {:unique_key, value} ->
+        raise ArgumentError,
+              "incremental materialization unique_key must be a list of atoms, got: #{inspect(value)}"
+
+      {key, _value} ->
+        raise ArgumentError,
+              "incremental materialization contains unsupported key #{inspect(key)}; allowed keys: [:strategy, :unique_key]"
+    end)
+
+    case Keyword.fetch(opts, :strategy) do
+      {:ok, _strategy} -> :ok
+      :error -> raise ArgumentError, "incremental materialization requires :strategy"
+    end
+  end
+end

--- a/lib/favn/sql_asset/runtime.ex
+++ b/lib/favn/sql_asset/runtime.ex
@@ -1,0 +1,8 @@
+defmodule Favn.SQLAsset.Runtime do
+  @moduledoc false
+
+  alias Favn.Run.Context
+
+  @spec run(module(), Context.t()) :: {:error, :sql_asset_runtime_not_implemented}
+  def run(_module, %Context{}), do: {:error, :sql_asset_runtime_not_implemented}
+end

--- a/test/assets_test.exs
+++ b/test/assets_test.exs
@@ -270,7 +270,7 @@ defmodule Favn.AssetsTest do
     assert {:error, {:invalid_compiled_assets, message}} =
              Compiler.compile_module_assets(module_name)
 
-    assert message =~ "module shorthand requires a `use Favn.Asset` module"
+    assert message =~ "module shorthand requires a single-asset module"
   end
 
   test "resolves namespace inheritance from separately compiled ancestor modules" do

--- a/test/sql_asset_test.exs
+++ b/test/sql_asset_test.exs
@@ -1,0 +1,250 @@
+defmodule Favn.SQLAssetTest do
+  use ExUnit.Case
+
+  alias Favn.Asset
+  alias Favn.Assets.Compiler
+  alias Favn.SQLAsset.Compiler, as: SQLAssetCompiler
+  alias Favn.SQLAsset.Definition
+
+  setup do
+    state = Favn.TestSetup.capture_state()
+
+    on_exit(fn ->
+      Favn.TestSetup.restore_state(state, reload_graph?: true)
+    end)
+
+    :ok
+  end
+
+  test "compiles one SQL asset module into one canonical asset" do
+    root = Module.concat(__MODULE__, "Warehouse#{System.unique_integer([:positive])}")
+    gold = Module.concat(root, Gold)
+    sales = Module.concat(gold, Sales)
+    asset_module = Module.concat(sales, FctOrders)
+
+    Code.compile_string(
+      "defmodule #{inspect(root)} do\n  use Favn.Namespace, connection: :warehouse\nend",
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    Code.compile_string(
+      "defmodule #{inspect(gold)} do\n  use Favn.Namespace, catalog: :gold\nend",
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    Code.compile_string(
+      "defmodule #{inspect(sales)} do\n  use Favn.Namespace, schema: :sales\nend",
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.SQLAsset
+
+        @doc "Gold fact table for orders"
+        @meta owner: "analytics", category: :sales, tags: [:gold]
+        @window Favn.Window.daily(lookback: 2)
+        @materialized {:incremental, strategy: :delete_insert, unique_key: [:order_id]}
+
+        sql "select order_id from silver.sales.stg_orders"
+      end
+      """,
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    assert {:ok, [%Asset{} = asset]} = Compiler.compile_module_assets(asset_module)
+    assert {:ok, %Definition{} = definition} = SQLAssetCompiler.fetch_definition(asset_module)
+
+    assert asset.ref == {asset_module, :asset}
+    assert asset.type == :sql
+    assert asset.doc == "Gold fact table for orders"
+    assert asset.meta == %{owner: "analytics", category: :sales, tags: [:gold]}
+
+    assert asset.materialization ==
+             {:incremental, strategy: :delete_insert, unique_key: [:order_id]}
+
+    assert asset.window_spec == %Favn.Window.Spec{kind: :day, lookback: 2, timezone: "Etc/UTC"}
+
+    assert asset.produces == %Favn.RelationRef{
+             connection: :warehouse,
+             catalog: "gold",
+             schema: "sales",
+             name: "fct_orders"
+           }
+
+    assert definition.asset.ref == asset.ref
+    assert definition.sql =~ "select order_id"
+    assert definition.materialization == asset.materialization
+  end
+
+  test "supports explicit depends and produces overrides for SQL assets" do
+    upstream = Module.concat(__MODULE__, "Upstream#{System.unique_integer([:positive])}")
+    asset_module = Module.concat(__MODULE__, "SqlDepends#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(upstream)} do
+        use Favn.Asset
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :silver, schema: :sales
+        use Favn.SQLAsset
+
+        @depends #{inspect(upstream)}
+        @materialized :table
+        @produces schema: :mart, table: :fact_orders
+        sql "select * from silver.sales.stg_orders"
+      end
+      """,
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    assert {:ok, [%Asset{} = asset]} = Compiler.compile_module_assets(asset_module)
+
+    assert asset.depends_on == [{upstream, :asset}]
+
+    assert asset.produces == %Favn.RelationRef{
+             connection: :warehouse,
+             catalog: "silver",
+             schema: "mart",
+             name: "fact_orders"
+           }
+  end
+
+  test "public facade treats SQLAsset modules as single-asset modules" do
+    asset_module = Module.concat(__MODULE__, "Facade#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+
+        @doc "Facade SQL asset"
+        @materialized :view
+        sql "select 1 as id"
+      end
+      """,
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    :ok = Favn.TestSetup.setup_asset_modules([asset_module])
+
+    assert Favn.asset_module?(asset_module)
+    assert {:ok, asset} = Favn.get_asset(asset_module)
+    assert asset.type == :sql
+    assert asset.ref == {asset_module, :asset}
+  end
+
+  test "runtime execution returns an explicit not-implemented error for SQL assets" do
+    asset_module = Module.concat(__MODULE__, "Runtime#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+
+        @materialized :table
+        sql "select 1 as id"
+      end
+      """,
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+
+    assert {:ok, run_id} = Favn.run_asset({asset_module, :asset}, dependencies: :none)
+    assert {:error, run} = Favn.await_run(run_id, timeout: 5_000)
+
+    assert run.status == :error
+
+    assert run.asset_results[{asset_module, :asset}].error.reason ==
+             :sql_asset_runtime_not_implemented
+  end
+
+  test "rejects missing materialized attribute" do
+    assert_raise CompileError, ~r/Favn\.SQLAsset requires one @materialized attribute/, fn ->
+      compile_sql_asset_module("""
+      use Favn.Namespace, connection: :warehouse
+      use Favn.SQLAsset
+
+      sql "select 1"
+      """)
+    end
+  end
+
+  test "rejects missing connection for produced SQL relation" do
+    assert_raise CompileError,
+                 ~r/SQL assets require a connection through Favn\.Namespace or @produces/,
+                 fn ->
+                   compile_sql_asset_module("""
+                   use Favn.SQLAsset
+
+                   @materialized :view
+                   sql "select 1"
+                   """)
+                 end
+  end
+
+  test "rejects SQL sigil modifiers" do
+    assert_raise CompileError, ~r/sql ~SQL sigil does not support modifiers/, fn ->
+      module_name =
+        Module.concat(__MODULE__, "SigilModifiers#{System.unique_integer([:positive])}")
+
+      Code.compile_string(
+        "defmodule #{inspect(module_name)} do\n" <>
+          "  use Favn.Namespace, connection: :warehouse\n" <>
+          "  use Favn.SQLAsset\n\n" <>
+          "  @materialized :view\n" <>
+          "  sql ~SQL[select 1]x\n" <>
+          "end\n",
+        "test/dynamic_sql_asset_test.exs"
+      )
+    end
+  end
+
+  test "rejects module shorthand depends for multi-asset modules" do
+    assert_raise CompileError, ~r/module shorthand requires a single-asset module/, fn ->
+      compile_sql_asset_module("""
+      use Favn.Namespace, connection: :warehouse
+      use Favn.SQLAsset
+
+      @depends Favn.AssetsTest.Upstream
+      @materialized :view
+      sql "select 1"
+      """)
+    end
+  end
+
+  defp compile_sql_asset_module(body) do
+    module_name = Module.concat(__MODULE__, "Dynamic#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(module_name)} do
+      #{indent(body, 2)}
+      end
+      """,
+      "test/dynamic_sql_asset_test.exs"
+    )
+  end
+
+  defp indent(string, spaces) do
+    padding = String.duplicate(" ", spaces)
+
+    string
+    |> String.trim_trailing()
+    |> String.split("\n")
+    |> Enum.map_join("\n", &(padding <> &1))
+  end
+end

--- a/test/sql_asset_test.exs
+++ b/test/sql_asset_test.exs
@@ -214,16 +214,74 @@ defmodule Favn.SQLAssetTest do
   end
 
   test "rejects module shorthand depends for multi-asset modules" do
-    assert_raise CompileError, ~r/module shorthand requires a single-asset module/, fn ->
+    asset_module = Module.concat(__MODULE__, "BadDepends#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace, connection: :warehouse
+        use Favn.SQLAsset
+
+        @depends #{inspect(Favn.AssetsTest.Upstream)}
+        @materialized :view
+        sql "select 1"
+      end
+      """,
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    assert {:error, {:invalid_compiled_assets, message}} =
+             Compiler.compile_module_assets(asset_module)
+
+    assert message =~ "invalid @depends entry #{inspect(Favn.AssetsTest.Upstream)}"
+    assert message =~ "single-asset module"
+  end
+
+  test "rejects multiple produces attributes with a controlled compile error" do
+    assert_raise CompileError, ~r/multiple @produces attributes are not allowed/, fn ->
       compile_sql_asset_module("""
       use Favn.Namespace, connection: :warehouse
       use Favn.SQLAsset
 
-      @depends Favn.AssetsTest.Upstream
       @materialized :view
+      @produces true
+      @produces name: :orders
       sql "select 1"
       """)
     end
+  end
+
+  test "single-asset module shorthand depends is compile-order independent for SQL assets" do
+    upstream = Module.concat(__MODULE__, "LateUpstream#{System.unique_integer([:positive])}")
+    asset_module = Module.concat(__MODULE__, "LateDepends#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+
+        @depends #{inspect(upstream)}
+        @materialized :view
+        sql "select 1"
+      end
+      """,
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(upstream)} do
+        use Favn.Asset
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_asset_test.exs"
+    )
+
+    assert {:ok, [%Asset{} = asset]} = Compiler.compile_module_assets(asset_module)
+    assert asset.depends_on == [{upstream, :asset}]
   end
 
   defp compile_sql_asset_module(body) do

--- a/test/sql_asset_test.exs
+++ b/test/sql_asset_test.exs
@@ -47,7 +47,9 @@ defmodule Favn.SQLAssetTest do
         @window Favn.Window.daily(lookback: 2)
         @materialized {:incremental, strategy: :delete_insert, unique_key: [:order_id]}
 
-        sql "select order_id from silver.sales.stg_orders"
+        query do
+          ~SQL[select order_id from silver.sales.stg_orders]
+        end
       end
       """,
       "test/dynamic_sql_asset_test.exs"
@@ -102,7 +104,9 @@ defmodule Favn.SQLAssetTest do
         @depends #{inspect(upstream)}
         @materialized :table
         @produces schema: :mart, table: :fact_orders
-        sql "select * from silver.sales.stg_orders"
+        query do
+          ~SQL[select * from silver.sales.stg_orders]
+        end
       end
       """,
       "test/dynamic_sql_asset_test.exs"
@@ -131,7 +135,10 @@ defmodule Favn.SQLAssetTest do
 
         @doc "Facade SQL asset"
         @materialized :view
-        sql "select 1 as id"
+
+        query do
+          ~SQL[select 1 as id]
+        end
       end
       """,
       "test/dynamic_sql_asset_test.exs"
@@ -155,7 +162,10 @@ defmodule Favn.SQLAssetTest do
         use Favn.SQLAsset
 
         @materialized :table
-        sql "select 1 as id"
+
+        query do
+          ~SQL[select 1 as id]
+        end
       end
       """,
       "test/dynamic_sql_asset_test.exs"
@@ -178,7 +188,9 @@ defmodule Favn.SQLAssetTest do
       use Favn.Namespace, connection: :warehouse
       use Favn.SQLAsset
 
-      sql "select 1"
+      query do
+        ~SQL[select 1]
+      end
       """)
     end
   end
@@ -191,13 +203,15 @@ defmodule Favn.SQLAssetTest do
                    use Favn.SQLAsset
 
                    @materialized :view
-                   sql "select 1"
+                   query do
+                     ~SQL[select 1]
+                   end
                    """)
                  end
   end
 
   test "rejects SQL sigil modifiers" do
-    assert_raise CompileError, ~r/sql ~SQL sigil does not support modifiers/, fn ->
+    assert_raise CompileError, ~r/~SQL sigil does not support modifiers/, fn ->
       module_name =
         Module.concat(__MODULE__, "SigilModifiers#{System.unique_integer([:positive])}")
 
@@ -206,7 +220,9 @@ defmodule Favn.SQLAssetTest do
           "  use Favn.Namespace, connection: :warehouse\n" <>
           "  use Favn.SQLAsset\n\n" <>
           "  @materialized :view\n" <>
-          "  sql ~SQL[select 1]x\n" <>
+          "  query do\n" <>
+          "    ~SQL[select 1]x\n" <>
+          "  end\n" <>
           "end\n",
         "test/dynamic_sql_asset_test.exs"
       )
@@ -224,7 +240,10 @@ defmodule Favn.SQLAssetTest do
 
         @depends #{inspect(Favn.AssetsTest.Upstream)}
         @materialized :view
-        sql "select 1"
+
+        query do
+          ~SQL[select 1]
+        end
       end
       """,
       "test/dynamic_sql_asset_test.exs"
@@ -246,7 +265,10 @@ defmodule Favn.SQLAssetTest do
       @materialized :view
       @produces true
       @produces name: :orders
-      sql "select 1"
+
+      query do
+        ~SQL[select 1]
+      end
       """)
     end
   end
@@ -263,7 +285,10 @@ defmodule Favn.SQLAssetTest do
 
         @depends #{inspect(upstream)}
         @materialized :view
-        sql "select 1"
+
+        query do
+          ~SQL[select 1]
+        end
       end
       """,
       "test/dynamic_sql_asset_test.exs"

--- a/test/sql_asset_test.exs
+++ b/test/sql_asset_test.exs
@@ -229,6 +229,21 @@ defmodule Favn.SQLAssetTest do
     end
   end
 
+  test "rejects plain string query bodies" do
+    assert_raise CompileError, ~r/query body must contain a ~SQL literal/, fn ->
+      compile_sql_asset_module("""
+      use Favn.Namespace, connection: :warehouse
+      use Favn.SQLAsset
+
+      @materialized :view
+
+      query do
+        "select 1"
+      end
+      """)
+    end
+  end
+
   test "rejects module shorthand depends for multi-asset modules" do
     asset_module = Module.concat(__MODULE__, "BadDepends#{System.unique_integer([:positive])}")
 


### PR DESCRIPTION
## Summary
- add `Favn.SQLAsset` as the single-module SQL authoring DSL with required `@materialized`, namespace-based produced relation inference, and canonical `%Favn.Asset{ref: {Module, :asset}}` compilation
- extend the shared asset/compiler seam so SQL-authored assets are first-class in catalog discovery while direct execution returns an explicit phase-4 runtime-not-implemented error
- update roadmap and public docs for the implemented phase 3 contract and add focused SQL asset tests plus library/test structure docs

## Verification
- mix format
- mix compile --warnings-as-errors
- mix test
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected