### PR TITLE
Finalize Phase 3 SQL authoring DSL and SQL IR

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,14 @@ Implemented now:
 - direct asset references in relation position, such as `from MyApp.Raw.Sales.Orders`
 - compile-time normalization into a dedicated SQL IR
 
+Not supported yet for direct SQL asset refs:
+
+- dialect-specific table functions
+- `update ... from`
+- `merge into`
+- arbitrary nested dialect syntax
+- plain relation names inferred from raw text
+
 Planned next:
 
 - Phase 4 runtime execution and helper APIs on top of that IR

--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ Implemented now:
 - `query do ... end`
 - reusable `defsql ... do ... end` via `Favn.SQL`
 - one `@name` placeholder model for runtime inputs and reusable SQL arguments
+- ordered scanner-based SQL IR with parsed placeholders, reusable SQL calls, and asset refs
 - expression SQL macros and relation SQL macros
 - direct asset references in relation position, such as `from MyApp.Raw.Sales.Orders`
-- compile-time normalization into a dedicated SQL IR
+- compile-time validation for duplicate visible SQL definitions and reusable SQL cycles
 
 Not supported yet for direct SQL asset refs:
 
@@ -130,6 +131,11 @@ Planned next:
 - Phase 4 runtime execution and helper APIs on top of that IR
 
 Favn explicitly avoids fake sigils, Jinja-style templating, arbitrary Elixir interpolation inside SQL, and string stitching as the normal authoring workflow.
+
+Placeholder rules:
+
+- in `query` bodies, non-reserved `@name` placeholders resolve from runtime params
+- in `defsql` bodies, non-reserved `@name` placeholders must match declared arguments
 
 ## Introduction
 

--- a/README.md
+++ b/README.md
@@ -96,31 +96,30 @@ end
 - `@produces`
 
 SQL assets compile into the same canonical `%Favn.Asset{}` shape as Elixir assets, including ref `{Module, :asset}` and inferred produced relation ownership.
-Phase 3 is authoring/catalog integration only. The current implementation introduces a real `~SQL` sigil and `query do ... end`, but `~SQL` still compiles to a plain SQL string. SQL runtime execution and helper APIs land in a later phase, so direct execution currently returns an explicit not-yet-implemented error.
+Phase 3 is authoring/catalog integration only. SQL runtime execution and helper APIs land in a later phase, so direct execution currently returns an explicit not-yet-implemented error.
 
 ## SQL DSL direction
 
 Favn SQL uses a real `~SQL` sigil as the single SQL body language.
 
 SQL assets declare their main query with `query do ... end`.
-Reusable SQL is planned to use `defsql ... do ... end`.
+Reusable SQL uses `defsql ... do ... end` through `Favn.SQL`.
 
-Both asset queries and reusable SQL macros are intended to use the same `~SQL` body syntax and the same `@name` placeholder syntax for injected values.
+Both asset queries and reusable SQL macros use the same `~SQL` body syntax and the same `@name` placeholder syntax for injected values.
 
 Implemented now:
 
 - real `~SQL` sigil
 - `query do ... end`
-- `~SQL` returning a plain SQL string
-- SQL string storage in `Favn.SQLAsset`
+- reusable `defsql ... do ... end` via `Favn.SQL`
+- one `@name` placeholder model for runtime inputs and reusable SQL arguments
+- expression SQL macros and relation SQL macros
+- direct asset references in relation position, such as `from MyApp.Raw.Sales.Orders`
+- compile-time normalization into a dedicated SQL IR
 
 Planned next:
 
-- reusable `defsql`
-- `@name` value binding
-- Favn-aware relation resolution from module references
-- SQL-aware macro expansion
-- SQL AST representation
+- Phase 4 runtime execution and helper APIs on top of that IR
 
 Favn explicitly avoids fake sigils, Jinja-style templating, arbitrary Elixir interpolation inside SQL, and string stitching as the normal authoring workflow.
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -1059,7 +1059,7 @@ Phase 3 validates:
 * duplicate reusable SQL names / arities in a module
 * reserved input names are not used as `defsql` arguments
 * `defsql` call arity matches the declared reusable SQL definition
-* direct asset references resolve to compiled modules when possible
+* direct asset references must resolve to compiled single-asset modules with produced relations
 * obvious relation-only positions such as `from` / `join` do not receive known expression macros
 * obvious expression positions do not receive known relation macros
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -886,7 +886,7 @@ Implemented semantics:
 Favn SQL uses a real `~SQL` sigil as the single SQL body language.
 
 SQL assets declare their main query with `query do ... end`.
-Reusable SQL should later be declared with `defsql ... do ... end`.
+Reusable SQL is declared with `defsql ... do ... end`.
 
 Both asset queries and reusable SQL macros use the same `~SQL` body syntax and the same `@name` placeholder syntax for injected values.
 
@@ -981,8 +981,9 @@ Inside any `~SQL` body, `@name` is the only value placeholder syntax.
 Meaning:
 
 * SQL built-ins such as `@window_start` and `@window_end` resolve from reserved runtime inputs
-* any other `@name` resolves from SQL params supplied by the caller
+* in asset `query` bodies, any other `@name` resolves from SQL params supplied by the caller
 * inside `defsql`, function arguments become local SQL params with the same names
+* in `defsql`, non-reserved placeholders must match declared arguments; reusable SQL does not implicitly capture query params
 * when a `defsql` body calls another `defsql`, passed arguments bind that callee's local SQL params
 * SQL bodies never reference `ctx` directly
 
@@ -1059,7 +1060,10 @@ Phase 3 validates:
 * duplicate reusable SQL names / arities in a module
 * reserved input names are not used as `defsql` arguments
 * `defsql` call arity matches the declared reusable SQL definition
-* direct asset references must resolve to compiled single-asset modules with produced relations
+* duplicate visible imported/local reusable SQL definitions are compile-time errors
+* cyclic reusable SQL definitions are compile-time errors
+* compiled asset references must resolve to single-asset modules with produced relations
+* unresolved asset references stay as deferred symbolic refs in the SQL IR
 * obvious relation-only positions such as `from` / `join` do not receive known expression macros
 * obvious expression positions do not receive known relation macros
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -1018,6 +1018,14 @@ join MyApp.Silver.Sales.StgCustomers
 These should normalize into Favn-aware relation reference nodes in the internal SQL
 representation.
 
+Not supported yet for direct asset refs:
+
+* dialect-specific table functions
+* `update ... from`
+* `merge into`
+* arbitrary nested dialect syntax
+* plain relation names inferred from raw text
+
 In Phase 3 this is a SQL authoring and validation feature, not yet full dependency
 inference. Dependency inference remains Phase 5 work.
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -888,24 +888,206 @@ Favn SQL uses a real `~SQL` sigil as the single SQL body language.
 SQL assets declare their main query with `query do ... end`.
 Reusable SQL should later be declared with `defsql ... do ... end`.
 
-Both asset queries and reusable SQL macros should use the same `~SQL` body syntax and the same `@name` placeholder syntax for injected values.
+Both asset queries and reusable SQL macros use the same `~SQL` body syntax and the same `@name` placeholder syntax for injected values.
 
 What is implemented now:
 
 * real `~SQL` sigil
 * `query do ~SQL""" ... """ end`
-* `~SQL` returns a plain SQL string
-* `Favn.SQLAsset` stores that SQL string
+* `defsql ... do ... end` reusable SQL definitions through `Favn.SQL`
+* expression SQL macros and relation SQL macros
+* direct asset references in relation position
+* one `@name` placeholder/input model with reserved runtime inputs
+* compile-time normalization and validation into SQL IR
 
-What is not implemented yet:
+#### Phase 3 follow-up — finalized SQL authoring DSL
 
-* expression SQL macros
-* relation SQL macros
-* module-reference relation resolution
-* `@param` / runtime value binding
-* CTE composition helpers
-* SQL-aware macro expansion
-* SQL AST representation
+This follow-up completes the SQL authoring model before Phase 4 runtime execution.
+
+The finalized DSL contract includes:
+
+* asset queries via `query do ... end`
+* reusable SQL via `defsql ... do ... end`
+* one `~SQL` body language across both
+* one `@name` placeholder model across both
+* expression SQL macros and relation SQL macros from day one
+* direct Favn asset references in relation position
+* compile-time SQL normalization and validation
+* an internal SQL representation suitable for later render/execute work
+
+##### Proposed public DSL
+
+Asset query example:
+
+```elixir
+defmodule MyApp.Gold.Sales.FctCustomerRevenue do
+  use Favn.SQLAsset
+  use MyApp.SQL
+
+  @materialized :table
+
+  query do
+    ~SQL"""
+    select
+      customer_id,
+      sum(cents_to_dollars(total_amount_cents)) as gross_revenue
+    from orders_in_window(@window_start, @window_end)
+    where (@country is null or country = @country)
+    group by 1
+    """
+  end
+end
+```
+
+Reusable expression SQL example:
+
+```elixir
+defmodule MyApp.SQL do
+  use Favn.SQL
+
+  defsql cents_to_dollars(amount_cents) do
+    ~SQL"""
+    cast((@amount_cents / 100.0) as numeric(16, 2))
+    """
+  end
+end
+```
+
+Reusable relation SQL example:
+
+```elixir
+defmodule MyApp.SQL do
+  use Favn.SQL
+
+  defsql orders_in_window(start_at, end_at) do
+    ~SQL"""
+    select
+      order_id,
+      customer_id,
+      total_amount,
+      country
+    from MyApp.Raw.Sales.Orders
+    where inserted_at >= @start_at
+      and inserted_at < @end_at
+    """
+  end
+end
+```
+
+##### `@name` placeholder model
+
+Inside any `~SQL` body, `@name` is the only value placeholder syntax.
+
+Meaning:
+
+* SQL built-ins such as `@window_start` and `@window_end` resolve from reserved runtime inputs
+* any other `@name` resolves from SQL params supplied by the caller
+* inside `defsql`, function arguments become local SQL params with the same names
+* when a `defsql` body calls another `defsql`, passed arguments bind that callee's local SQL params
+* SQL bodies never reference `ctx` directly
+
+The model should stay intentionally small:
+
+* reserved runtime inputs are explicit and documented
+* all non-reserved names come from params
+* missing inputs fail with clear diagnostics
+* reserved names cannot be shadowed by `defsql` arguments
+
+##### Expression and relation SQL macros
+
+`defsql` should compile to reusable SQL fragments with one of two validated shapes:
+
+* expression macro: body expands to a SQL expression and can be used in expression position
+* relation macro: body expands to a relation-producing query and can be used in `from` / `join` / relation position
+
+Phase 3 should support both from the beginning, with the distinction captured in the
+compiled representation and validated at compile time where possible.
+
+The author should not need separate syntaxes such as `defsql_expr` or `defsql_relation`.
+Instead, Favn should infer and store the shape during normalization.
+
+##### Direct asset references inside SQL
+
+Phase 3 should allow direct module references in relation position, for example:
+
+```sql
+from MyApp.Raw.Sales.Orders
+join MyApp.Silver.Sales.StgCustomers
+```
+
+These should normalize into Favn-aware relation reference nodes in the internal SQL
+representation.
+
+In Phase 3 this is a SQL authoring and validation feature, not yet full dependency
+inference. Dependency inference remains Phase 5 work.
+
+##### Internal representation recommendation
+
+Phase 3 should stop treating `~SQL` as only a stored plain string.
+
+Recommended direction:
+
+* preserve the original SQL source string for docs/debugging
+* normalize the SQL body into a dedicated Favn SQL IR at compile time
+* the IR should represent at least:
+  * literal SQL segments
+  * `@name` placeholders
+  * `defsql` calls with resolved module/name/arity metadata
+  * direct asset references in relation position
+  * normalized query bodies for assets and reusable SQL definitions
+  * definition kind metadata for expression vs relation bodies
+
+This does not require a full SQL parser in Phase 3.
+It does require enough structure that Phase 4 rendering and adapter execution can work
+from the IR instead of re-parsing authored strings or forcing a rewrite.
+
+##### Compile-time validation in this follow-up
+
+Phase 3 validates:
+
+* `query` contains exactly one `~SQL` body
+* `defsql` contains exactly one `~SQL` body
+* no interpolation or arbitrary Elixir execution inside `~SQL`
+* duplicate reusable SQL names / arities in a module
+* reserved input names are not used as `defsql` arguments
+* `defsql` call arity matches the declared reusable SQL definition
+* direct asset references resolve to compiled modules when possible
+* obvious relation-only positions such as `from` / `join` do not receive known expression macros
+* obvious expression positions do not receive known relation macros
+
+Phase 3 defers:
+
+* runtime value presence checks against actual invocation params
+* adapter-specific SQL type validation
+* full dependency inference from relation usage
+* execution-time parameter encoding and prepared-statement behavior
+* full SQL semantic analysis across every dialect edge case
+
+##### Phase boundary discipline
+
+What belongs in Phase 3:
+
+* final authoring syntax
+* final placeholder/input model
+* reusable SQL definition and call model
+* expression vs relation macro distinction
+* direct asset-reference syntax in SQL
+* compile-time normalization/validation
+* stable SQL IR for later runtime work
+
+What belongs in Phase 4:
+
+* render final executable SQL plus bound params
+* preview / explain / materialize helper APIs
+* runtime context to SQL-input resolution
+* adapter integration and execution
+* execution-time errors for missing params or backend failures
+
+What belongs in Phase 5:
+
+* dependency inference from normalized relation references
+* additive inferred `@depends` diagnostics
+* relation-ownership-driven lineage and compile-time warnings around unresolved refs
 
 The DSL should explicitly avoid:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -144,18 +144,28 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] canonical compile output as one `%Favn.Asset{ref: {Module, :asset}}`
   - [x] module convenience lookup via `Favn.get_asset(module)` for single-asset modules
   - [x] explicit runtime guard until SQL execution lands
+- [x] Phase 3 follow-up: finalize SQL authoring DSL before runtime integration
+  - [x] `Favn.SQL` reusable SQL modules via `defsql ... do ... end`
+  - [x] keep `~SQL` as the only SQL body syntax for both `query` and `defsql`
+  - [x] one `@name` placeholder/input model across asset queries and reusable SQL
+  - [x] reserved runtime SQL inputs such as `@window_start` / `@window_end`
+  - [x] param-driven SQL inputs for non-reserved `@name` placeholders
+  - [x] expression SQL macros and relation SQL macros from day one
+  - [x] direct asset references in relation position, e.g. `from MyApp.Raw.Sales.Orders`
+  - [x] compile-time normalization and validation of reusable SQL definitions/calls
+  - [x] dedicated SQL IR instead of plain-string-only storage
 - [ ] DuckDB adapter hardening + incremental strategy expansion
 - [ ] Typed source identities
-- [ ] SQL execution through shared runtime
-- [ ] SQL helper APIs (`render`, `preview`, `explain`, `materialize`)
-- [ ] Reusable SQL via `Favn.SQL` and `defsql ... do ... end`
-- [ ] `@name` placeholder binding for SQL values
-- [ ] Favn-aware relation resolution from module refs inside SQL
-- [ ] SQL-aware macro expansion / AST model
+- [ ] Phase 4 runtime integration for SQL assets
+  - [ ] SQL execution through shared runtime
+  - [ ] SQL helper APIs (`render`, `preview`, `explain`, `materialize`)
+  - [ ] runtime SQL input resolution and parameter binding
+  - [ ] adapter-backed rendering/materialization from the SQL IR
 - [ ] Multi-asset SQL modules
 - [ ] SQL file support
-- [ ] Dependency inference from typed SQL references
-- [ ] SQL asset dependency planning on the shared window-aware runtime model
+- [ ] Phase 5 relation-based SQL inference
+  - [ ] dependency inference from typed SQL relation references
+  - [ ] SQL asset dependency planning on the shared window-aware runtime model
 - [ ] Window-aware incremental execution
 - [ ] Lookback handling for incremental SQL assets
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -152,8 +152,11 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] param-driven SQL inputs for non-reserved `@name` placeholders
   - [x] expression SQL macros and relation SQL macros from day one
   - [x] direct asset references in relation position, e.g. `from MyApp.Raw.Sales.Orders`
+  - [x] scanner-based ordered SQL IR instead of plain-string-only storage
   - [x] compile-time normalization and validation of reusable SQL definitions/calls
-  - [x] dedicated SQL IR instead of plain-string-only storage
+  - [x] duplicate visible reusable SQL definition detection across local/imported definitions
+  - [x] reusable SQL cycle detection
+  - [x] deferred symbolic asset refs for not-yet-compiled modules
 - [ ] DuckDB adapter hardening + incremental strategy expansion
 - [ ] Typed source identities
 - [ ] Phase 4 runtime integration for SQL assets

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -60,11 +60,13 @@ lib/
     │   ├── adapter.ex
     │   ├── capabilities.ex
     │   ├── column.ex
+    │   ├── definition.ex
     │   ├── error.ex
     │   ├── relation.ex
     │   ├── relation_ref.ex
     │   ├── result.ex
     │   ├── session.ex
+    │   ├── template.ex
     │   ├── write_plan.ex
     │   └── adapter/
     │       ├── duckdb.ex

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -23,6 +23,7 @@ test/
 ├── scheduler_test.exs
 ├── sql_asset_test.exs
 ├── sql_template_asset_ref_test.exs
+├── sql_template_ir_test.exs
 ├── sql_dsl_test.exs
 ├── sql_duckdb_adapter_test.exs
 ├── sql_test.exs

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -22,6 +22,7 @@ test/
 ├── scheduler_cron_test.exs
 ├── scheduler_test.exs
 ├── sql_asset_test.exs
+├── sql_dsl_test.exs
 ├── sql_duckdb_adapter_test.exs
 ├── sql_test.exs
 ├── sqlite_storage_bootstrap_test.exs

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -22,6 +22,7 @@ test/
 ├── scheduler_cron_test.exs
 ├── scheduler_test.exs
 ├── sql_asset_test.exs
+├── sql_template_asset_ref_test.exs
 ├── sql_dsl_test.exs
 ├── sql_duckdb_adapter_test.exs
 ├── sql_test.exs

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -199,10 +199,11 @@ defmodule Favn do
         end
       end
 
-  The current SQL implementation keeps `~SQL` intentionally simple: it is a real
-  Elixir sigil, but it currently returns a plain SQL string. Future work is expected
-  to add reusable `defsql`, `@name` value binding, and Favn-aware relation resolution
-  while keeping `~SQL` as the one SQL body language.
+  The current SQL implementation keeps `~SQL` as the one SQL body language across
+  `query` and reusable `defsql` definitions. SQL authoring now includes one `@name`
+  placeholder model for SQL inputs, expression and relation SQL macros, direct asset
+  references in relation position, and compile-time normalization into a dedicated SQL
+  IR. Runtime SQL execution APIs remain a later phase.
 
   Compact multi-asset style uses `Favn.Assets`:
 

--- a/lib/favn/sql.ex
+++ b/lib/favn/sql.ex
@@ -16,6 +16,7 @@ defmodule Favn.SQL do
   alias Favn.Connection.Resolved
   alias Favn.RelationRef
   alias Favn.SQL.Definition
+  alias Favn.SQL.Definition.Param
   alias Favn.SQL.{Error, Result, Session, WritePlan}
   alias Favn.SQL.RelationRef, as: SQLRelationRef
   alias Favn.SQL.Template
@@ -411,44 +412,45 @@ defmodule Favn.SQL do
 
     provisional =
       Enum.map(raw_definitions, fn raw ->
-        shape = infer_shape(raw.sql)
-
         %Definition{
           module: module,
           name: raw.name,
           arity: raw.arity,
-          params: raw.args,
-          shape: shape,
+          params:
+            Enum.with_index(raw.args, fn name, index -> %Param{name: name, index: index} end),
+          shape: :expression,
           sql: raw.sql,
-          template: %Template{
-            source: raw.sql,
-            inputs: MapSet.new(),
-            runtime_inputs: MapSet.new(),
-            param_inputs: MapSet.new()
-          },
+          template: nil,
           file: raw.file,
           line: raw.line
         }
       end)
 
     known_definitions =
-      (provisional ++ imported_definitions)
-      |> Enum.map(fn %Definition{name: name, arity: arity} = definition ->
-        {{name, arity}, definition}
+      build_visible_definition_catalog!(module, provisional, imported_definitions)
+
+    local_definitions =
+      Enum.map(provisional, fn %Definition{} = definition ->
+        template =
+          Template.compile!(definition.sql,
+            known_definitions: known_definitions,
+            file: definition.file,
+            line: definition.line,
+            module: module,
+            scope: :definition,
+            local_args: Enum.map(definition.params, & &1.name),
+            enforce_query_root: false
+          )
+
+        shape = if template.root_kind == :query, do: :relation, else: :expression
+        %Definition{definition | template: template, shape: shape}
       end)
-      |> Map.new()
 
-    Enum.map(provisional, fn %Definition{} = definition ->
-      template =
-        Template.compile!(definition.sql,
-          known_definitions: known_definitions,
-          file: definition.file,
-          line: definition.line,
-          module: module
-        )
+    visible_definitions =
+      build_visible_definition_catalog!(module, local_definitions, imported_definitions)
 
-      %Definition{definition | template: template}
-    end)
+    detect_definition_cycles!(local_definitions, visible_definitions)
+    local_definitions
   end
 
   defp fetch_imported_definitions!(imports) do
@@ -458,23 +460,21 @@ defmodule Favn.SQL do
           if function_exported?(module, :__favn_sql_definitions__, 0) do
             module.__favn_sql_definitions__()
           else
-            []
+            compile_error!(
+              "nofile",
+              1,
+              "imported SQL provider #{inspect(module)} does not define reusable SQL"
+            )
           end
 
         {:error, _reason} ->
-          []
+          compile_error!(
+            "nofile",
+            1,
+            "imported SQL provider #{inspect(module)} could not be resolved"
+          )
       end
     end)
-  end
-
-  defp infer_shape(sql) do
-    normalized = String.trim_leading(sql)
-
-    if Regex.match?(~r/^(?:select|with)\b/i, normalized) do
-      :relation
-    else
-      :expression
-    end
   end
 
   defp normalize_defsql_args!(args_ast, env) do
@@ -521,6 +521,57 @@ defmodule Favn.SQL do
           definition.line,
           "duplicate defsql #{name}/#{arity}; each defsql name/arity must be unique per module"
         )
+    end)
+  end
+
+  defp build_visible_definition_catalog!(owner_module, local_definitions, imported_definitions) do
+    (local_definitions ++ imported_definitions)
+    |> Enum.group_by(&Definition.key/1)
+    |> Enum.map(fn
+      {_key, [%Definition{} = definition]} ->
+        {Definition.key(definition), definition}
+
+      {{name, arity}, definitions} ->
+        providers = definitions |> Enum.map(&inspect(&1.module)) |> Enum.sort() |> Enum.join(", ")
+
+        compile_error!(
+          hd(definitions).file,
+          hd(definitions).line,
+          "duplicate visible defsql #{name}/#{arity} for #{inspect(owner_module)}; conflicting providers: #{providers}"
+        )
+    end)
+    |> Map.new()
+  end
+
+  defp detect_definition_cycles!(local_definitions, visible_definitions) do
+    Enum.each(local_definitions, fn definition ->
+      detect_definition_cycle!(definition, visible_definitions, [])
+    end)
+  end
+
+  defp detect_definition_cycle!(definition, visible_definitions, stack) do
+    key = Definition.key(definition)
+
+    if key in stack do
+      path =
+        Enum.reverse([key | stack])
+        |> Enum.map_join(" -> ", fn {name, arity} -> "#{name}/#{arity}" end)
+
+      compile_error!(
+        definition.file,
+        definition.line,
+        "cyclic defsql definitions detected: #{path}"
+      )
+    end
+
+    Enum.each(Template.called_definition_keys(definition.template), fn child_key ->
+      case Map.fetch(visible_definitions, child_key) do
+        {:ok, child_definition} ->
+          detect_definition_cycle!(child_definition, visible_definitions, [key | stack])
+
+        :error ->
+          :ok
+      end
     end)
   end
 

--- a/lib/favn/sql.ex
+++ b/lib/favn/sql.ex
@@ -412,13 +412,19 @@ defmodule Favn.SQL do
 
     provisional =
       Enum.map(raw_definitions, fn raw ->
+        inferred_root_kind =
+          Template.infer_root_kind!(raw.sql,
+            file: raw.file,
+            line: raw.line
+          )
+
         %Definition{
           module: module,
           name: raw.name,
           arity: raw.arity,
           params:
             Enum.with_index(raw.args, fn name, index -> %Param{name: name, index: index} end),
-          shape: :expression,
+          shape: if(inferred_root_kind == :query, do: :relation, else: :expression),
           sql: raw.sql,
           template: nil,
           file: raw.file,
@@ -438,12 +444,11 @@ defmodule Favn.SQL do
             line: definition.line,
             module: module,
             scope: :definition,
-            local_args: Enum.map(definition.params, & &1.name),
+            local_arg_index: Map.new(definition.params, &{&1.name, &1.index}),
             enforce_query_root: false
           )
 
-        shape = if template.root_kind == :query, do: :relation, else: :expression
-        %Definition{definition | template: template, shape: shape}
+        %Definition{definition | template: template}
       end)
 
     visible_definitions =

--- a/lib/favn/sql.ex
+++ b/lib/favn/sql.ex
@@ -1,18 +1,137 @@
 defmodule Favn.SQL do
   @moduledoc """
-  Internal SQL facade used at runtime for adapter orchestration.
+  SQL runtime facade and reusable SQL authoring DSL.
 
   Compiler/discovery and planner flows should remain independent from SQL sessions.
-  This facade starts from `%Favn.Connection.Resolved{}` and is runtime-only.
+  Runtime SQL session APIs in this module start from `%Favn.Connection.Resolved{}`.
+
+  The same module also exposes SQL authoring macros:
+
+    * `use Favn.SQL`
+    * `defsql ... do ... end`
+    * `~SQL\""" ... \"""`
   """
 
   alias Favn.Connection.Registry
   alias Favn.Connection.Resolved
   alias Favn.RelationRef
+  alias Favn.SQL.Definition
   alias Favn.SQL.{Error, Result, Session, WritePlan}
   alias Favn.SQL.RelationRef, as: SQLRelationRef
+  alias Favn.SQL.Template
 
   @type opts :: keyword()
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      Module.register_attribute(__MODULE__, :favn_sql_raw_definitions, accumulate: true)
+
+      Module.register_attribute(__MODULE__, :favn_sql_imports, accumulate: true)
+
+      @before_compile Favn.SQL
+
+      import Favn.SQL, only: [defsql: 2, sigil_SQL: 2]
+    end
+  end
+
+  @doc false
+  defmacro sigil_SQL({:<<>>, _meta, parts}, modifiers) when is_list(modifiers) do
+    if modifiers != [] do
+      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL sigil does not support modifiers")
+    end
+
+    if Enum.all?(parts, &is_binary/1) do
+      Enum.join(parts)
+    else
+      compile_error!(
+        __CALLER__.file,
+        __CALLER__.line,
+        "~SQL sigil does not support interpolation"
+      )
+    end
+  end
+
+  defmacro sigil_SQL(_body, modifiers) do
+    if modifiers != [] do
+      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL sigil does not support modifiers")
+    else
+      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL body must be a literal string")
+    end
+  end
+
+  @doc false
+  defmacro defsql({name, _meta, args_ast}, do: body)
+           when is_atom(name) and (is_list(args_ast) or is_nil(args_ast)) do
+    args = normalize_defsql_args!(args_ast || [], __CALLER__)
+    validate_reserved_arg_names!(args, __CALLER__)
+    sql = extract_sql!(body, __CALLER__, "defsql body must contain a ~SQL literal")
+    arity = length(args)
+
+    raw = %{
+      module: __CALLER__.module,
+      name: name,
+      args: args,
+      arity: arity,
+      sql: sql,
+      file: normalize_file(__CALLER__.file),
+      line: __CALLER__.line
+    }
+
+    quote bind_quoted: [raw: Macro.escape(raw)] do
+      @favn_sql_raw_definitions raw
+      :ok
+    end
+  end
+
+  defmacro defsql(_head, do: _body) do
+    compile_error!(
+      __CALLER__.file,
+      __CALLER__.line,
+      "defsql expects a function-style head, for example defsql my_macro(arg) do ... end"
+    )
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    provider_module = env.module
+
+    raw_definitions =
+      env.module
+      |> Module.get_attribute(:favn_sql_raw_definitions)
+      |> List.wrap()
+      |> Enum.reverse()
+
+    ensure_unique_definition_keys!(raw_definitions)
+
+    imports =
+      env.module
+      |> Module.get_attribute(:favn_sql_imports)
+      |> List.wrap()
+      |> Enum.reverse()
+      |> Enum.uniq()
+
+    definitions = build_sql_definitions!(env.module, raw_definitions, imports)
+
+    using_ast =
+      quote do
+        if not Module.has_attribute?(__MODULE__, :favn_sql_imports) do
+          Module.register_attribute(__MODULE__, :favn_sql_imports, accumulate: true)
+        end
+
+        @favn_sql_imports unquote(provider_module)
+        import Favn.SQL, only: [sigil_SQL: 2]
+      end
+
+    quote do
+      @doc false
+      @spec __favn_sql_definitions__() :: [Favn.SQL.Definition.t()]
+      def __favn_sql_definitions__, do: unquote(Macro.escape(definitions))
+
+      @doc false
+      defmacro __using__(_opts), do: unquote(Macro.escape(using_ast))
+    end
+  end
 
   @spec resolve_connection(atom()) :: {:ok, Resolved.t()} | {:error, Error.t()}
   def resolve_connection(name) when is_atom(name) do
@@ -285,6 +404,162 @@ defmodule Favn.SQL do
         run_statements(session, statements, opts)
       end
     end
+  end
+
+  defp build_sql_definitions!(module, raw_definitions, imports) do
+    imported_definitions = fetch_imported_definitions!(imports)
+
+    provisional =
+      Enum.map(raw_definitions, fn raw ->
+        shape = infer_shape(raw.sql)
+
+        %Definition{
+          module: module,
+          name: raw.name,
+          arity: raw.arity,
+          params: raw.args,
+          shape: shape,
+          sql: raw.sql,
+          template: %Template{
+            source: raw.sql,
+            inputs: MapSet.new(),
+            runtime_inputs: MapSet.new(),
+            param_inputs: MapSet.new()
+          },
+          file: raw.file,
+          line: raw.line
+        }
+      end)
+
+    known_definitions =
+      (provisional ++ imported_definitions)
+      |> Enum.map(fn %Definition{name: name, arity: arity} = definition ->
+        {{name, arity}, definition}
+      end)
+      |> Map.new()
+
+    Enum.map(provisional, fn %Definition{} = definition ->
+      template =
+        Template.compile!(definition.sql,
+          known_definitions: known_definitions,
+          file: definition.file,
+          line: definition.line,
+          module: module
+        )
+
+      %Definition{definition | template: template}
+    end)
+  end
+
+  defp fetch_imported_definitions!(imports) do
+    Enum.flat_map(imports, fn module ->
+      case Code.ensure_compiled(module) do
+        {:module, _} ->
+          if function_exported?(module, :__favn_sql_definitions__, 0) do
+            module.__favn_sql_definitions__()
+          else
+            []
+          end
+
+        {:error, _reason} ->
+          []
+      end
+    end)
+  end
+
+  defp infer_shape(sql) do
+    normalized = String.trim_leading(sql)
+
+    if Regex.match?(~r/^(?:select|with)\b/i, normalized) do
+      :relation
+    else
+      :expression
+    end
+  end
+
+  defp normalize_defsql_args!(args_ast, env) do
+    Enum.map(args_ast, fn
+      {name, _meta, context} when is_atom(name) and is_atom(context) ->
+        name
+
+      {name, _meta, nil} when is_atom(name) ->
+        name
+
+      other ->
+        compile_error!(
+          env.file,
+          env.line,
+          "defsql arguments must be plain variable names, got: #{Macro.to_string(other)}"
+        )
+    end)
+  end
+
+  defp validate_reserved_arg_names!(args, env) do
+    reserved = MapSet.new(Template.reserved_runtime_inputs())
+
+    Enum.each(args, fn arg ->
+      if MapSet.member?(reserved, arg) do
+        compile_error!(
+          env.file,
+          env.line,
+          "defsql argument @#{arg} is reserved for runtime SQL inputs"
+        )
+      end
+    end)
+  end
+
+  defp ensure_unique_definition_keys!(raw_definitions) do
+    raw_definitions
+    |> Enum.group_by(fn definition -> {definition.name, definition.arity} end)
+    |> Enum.each(fn
+      {{_name, _arity}, [_single]} ->
+        :ok
+
+      {{name, arity}, [definition | _rest]} ->
+        compile_error!(
+          definition.file,
+          definition.line,
+          "duplicate defsql #{name}/#{arity}; each defsql name/arity must be unique per module"
+        )
+    end)
+  end
+
+  @doc false
+  @spec extract_sql!(Macro.t(), Macro.Env.t(), String.t()) :: String.t()
+  def extract_sql!(body, env, error_message) do
+    case body do
+      {:sigil_SQL, _meta, [parts_ast, modifiers]} ->
+        extract_sigil_sql!(parts_ast, modifiers, env, error_message)
+
+      _ ->
+        compile_error!(env.file, env.line, error_message)
+    end
+  end
+
+  defp extract_sigil_sql!(_parts_ast, modifiers, env, _error_message) when modifiers != [] do
+    compile_error!(env.file, env.line, "~SQL sigil does not support modifiers")
+  end
+
+  defp extract_sigil_sql!({:<<>>, _meta, parts}, [], env, _error_message) do
+    if Enum.all?(parts, &is_binary/1) do
+      Enum.join(parts)
+    else
+      compile_error!(env.file, env.line, "~SQL sigil does not support interpolation")
+    end
+  end
+
+  defp extract_sigil_sql!(_parts_ast, [], env, error_message) do
+    compile_error!(env.file, env.line, error_message)
+  end
+
+  defp normalize_file(file) do
+    file
+    |> to_string()
+    |> Path.relative_to_cwd()
+  end
+
+  defp compile_error!(file, line, description) do
+    raise CompileError, file: file, line: line, description: description
   end
 
   defp run_statements(session, statements, opts) do

--- a/lib/favn/sql/definition.ex
+++ b/lib/favn/sql/definition.ex
@@ -7,6 +7,14 @@ defmodule Favn.SQL.Definition do
 
   @type shape :: :expression | :relation
 
+  defmodule Param do
+    @moduledoc false
+    @enforce_keys [:name, :index]
+    defstruct [:name, :index]
+
+    @type t :: %__MODULE__{name: atom(), index: non_neg_integer()}
+  end
+
   @enforce_keys [:module, :name, :arity, :params, :shape, :sql, :template, :file, :line]
   defstruct [:module, :name, :arity, :params, :shape, :sql, :template, :file, :line]
 
@@ -14,11 +22,14 @@ defmodule Favn.SQL.Definition do
           module: module(),
           name: atom(),
           arity: non_neg_integer(),
-          params: [atom()],
+          params: [Param.t()],
           shape: shape(),
           sql: String.t(),
           template: Template.t(),
           file: String.t(),
           line: pos_integer()
         }
+
+  @spec key(t()) :: {atom(), non_neg_integer()}
+  def key(%__MODULE__{name: name, arity: arity}), do: {name, arity}
 end

--- a/lib/favn/sql/definition.ex
+++ b/lib/favn/sql/definition.ex
@@ -1,0 +1,24 @@
+defmodule Favn.SQL.Definition do
+  @moduledoc """
+  Compiled reusable SQL definition declared via `defsql`.
+  """
+
+  alias Favn.SQL.Template
+
+  @type shape :: :expression | :relation
+
+  @enforce_keys [:module, :name, :arity, :params, :shape, :sql, :template, :file, :line]
+  defstruct [:module, :name, :arity, :params, :shape, :sql, :template, :file, :line]
+
+  @type t :: %__MODULE__{
+          module: module(),
+          name: atom(),
+          arity: non_neg_integer(),
+          params: [atom()],
+          shape: shape(),
+          sql: String.t(),
+          template: Template.t(),
+          file: String.t(),
+          line: pos_integer()
+        }
+end

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -160,10 +160,21 @@ defmodule Favn.SQL.Template do
           | {:module, module() | nil}
           | {:scope, :query | :definition | :fragment}
           | {:local_args, [atom()]}
+          | {:local_arg_index, %{optional(atom()) => non_neg_integer()}}
           | {:enforce_query_root, boolean()}
 
   @spec reserved_runtime_inputs() :: [atom()]
   def reserved_runtime_inputs, do: @reserved_runtime_inputs
+
+  @spec infer_root_kind!(String.t(), keyword()) :: root_kind()
+  def infer_root_kind!(sql, opts) when is_binary(sql) and is_list(opts) do
+    file = Keyword.fetch!(opts, :file)
+    line = Keyword.fetch!(opts, :line)
+    column = Keyword.get(opts, :column, 1)
+    offset = Keyword.get(opts, :offset, 0)
+    start_pos = %Position{offset: offset, line: line, column: column}
+    infer_root_kind!(sql, file, line, start_pos)
+  end
 
   @spec compile!(String.t(), [compile_opt()]) :: t()
   def compile!(sql, opts \\ []) when is_binary(sql) and is_list(opts) do
@@ -174,7 +185,14 @@ defmodule Favn.SQL.Template do
     known_definitions = Keyword.get(opts, :known_definitions, %{})
     module = Keyword.get(opts, :module)
     scope = Keyword.get(opts, :scope, :query)
-    local_args = Keyword.get(opts, :local_args, [])
+
+    local_arg_index =
+      Keyword.get_lazy(opts, :local_arg_index, fn ->
+        opts
+        |> Keyword.get(:local_args, [])
+        |> local_arg_index()
+      end)
+
     enforce_query_root = Keyword.get(opts, :enforce_query_root, false)
 
     start_pos = %Position{offset: offset, line: line, column: column}
@@ -188,13 +206,14 @@ defmodule Favn.SQL.Template do
       file: file,
       module: module,
       known_definitions: known_definitions,
-      local_args: local_arg_index(local_args),
+      local_args: local_arg_index,
       position: start_pos,
       relation_entry?: false,
       join_prefix: nil,
       paren_depth: 0,
       statement_kind: top_level_statement_kind(root_kind),
-      scope: scope
+      scope: scope,
+      root_kind: root_kind
     }
 
     {nodes, end_state} = parse_nodes(String.to_charlist(sql), parser_state, [])
@@ -368,9 +387,42 @@ defmodule Favn.SQL.Template do
     parse_identifier(chars, state, acc)
   end
 
-  defp parse_nodes([char | rest], state, acc) do
+  defp parse_nodes([char | rest], state, acc) when char not in [?(, ?), ?;] do
     {next_state, text} = consume_single_char(char, state)
     parse_nodes(rest, next_state, [text_node(text, state.position, next_state.position) | acc])
+  end
+
+  defp parse_nodes([?( | rest], state, acc) do
+    next_state =
+      state
+      |> advance_state(~c"(")
+      |> Map.put(:paren_depth, state.paren_depth + 1)
+      |> Map.put(:relation_entry?, false)
+      |> Map.put(:join_prefix, nil)
+
+    parse_nodes(rest, next_state, [text_node("(", state.position, next_state.position) | acc])
+  end
+
+  defp parse_nodes([?) | rest], state, acc) do
+    next_state =
+      state
+      |> advance_state(~c")")
+      |> Map.put(:paren_depth, max(state.paren_depth - 1, 0))
+      |> Map.put(:relation_entry?, false)
+      |> Map.put(:join_prefix, nil)
+
+    parse_nodes(rest, next_state, [text_node(")", state.position, next_state.position) | acc])
+  end
+
+  defp parse_nodes([?; | rest], %{paren_depth: 0} = state, acc) do
+    next_state =
+      state
+      |> advance_state(~c";")
+      |> Map.put(:relation_entry?, false)
+      |> Map.put(:join_prefix, nil)
+      |> Map.put(:statement_kind, top_level_statement_kind(state.root_kind))
+
+    parse_nodes(rest, next_state, [text_node(";", state.position, next_state.position) | acc])
   end
 
   defp parse_placeholder([next | _] = rest, state, acc)
@@ -692,7 +744,7 @@ defmodule Favn.SQL.Template do
         offset: start_pos.offset,
         module: state.module,
         scope: state.scope,
-        local_args: Map.keys(state.local_args),
+        local_arg_index: state.local_args,
         enforce_query_root: false
       )
 
@@ -1041,11 +1093,16 @@ defmodule Favn.SQL.Template do
   defp top_level_statement_kind(:query), do: :query
   defp top_level_statement_kind(:expression), do: :expression
 
-  defp update_statement_kind(kind, word, _depth) do
-    cond do
-      word == "update" -> :update
-      word == "merge" -> :merge
-      true -> kind
+  defp update_statement_kind(kind, word, depth) do
+    if depth > 0 do
+      kind
+    else
+      cond do
+        kind in [:update, :merge] -> kind
+        word == "update" -> :update
+        word == "merge" -> :merge
+        true -> kind
+      end
     end
   end
 

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -1,0 +1,304 @@
+defmodule Favn.SQL.Template do
+  @moduledoc """
+  Normalized SQL template representation used by SQL asset authoring.
+  """
+
+  @relation_prefix_regex ~r/(?:^|\s)(?:from|join|inner\s+join|left(?:\s+outer)?\s+join|right(?:\s+outer)?\s+join|full(?:\s+outer)?\s+join|cross\s+join)\s*$/i
+
+  @enforce_keys [:source, :inputs, :runtime_inputs, :param_inputs]
+  defstruct [
+    :source,
+    :inputs,
+    :runtime_inputs,
+    :param_inputs,
+    calls: [],
+    asset_refs: []
+  ]
+
+  @type context :: :expression | :relation
+
+  defmodule Call do
+    @moduledoc false
+    @enforce_keys [:name, :arity, :context, :line]
+    defstruct [:name, :arity, :context, :line]
+
+    @type t :: %__MODULE__{
+            name: atom(),
+            arity: non_neg_integer(),
+            context: Favn.SQL.Template.context(),
+            line: pos_integer()
+          }
+  end
+
+  defmodule AssetRef do
+    @moduledoc false
+    @enforce_keys [:module, :line]
+    defstruct [:module, :line]
+
+    @type t :: %__MODULE__{module: module(), line: pos_integer()}
+  end
+
+  @type t :: %__MODULE__{
+          source: String.t(),
+          inputs: MapSet.t(atom()),
+          runtime_inputs: MapSet.t(atom()),
+          param_inputs: MapSet.t(atom()),
+          calls: [Call.t()],
+          asset_refs: [AssetRef.t()]
+        }
+
+  @spec reserved_runtime_inputs() :: [atom()]
+  def reserved_runtime_inputs, do: [:window_start, :window_end]
+
+  @spec compile!(String.t(), keyword()) :: t()
+  def compile!(sql, opts \\ []) when is_binary(sql) and is_list(opts) do
+    known_definitions = Keyword.get(opts, :known_definitions, %{})
+    file = Keyword.fetch!(opts, :file)
+    line = Keyword.fetch!(opts, :line)
+    module = Keyword.get(opts, :module)
+
+    calls = extract_calls(sql, known_definitions)
+    validate_calls!(calls, known_definitions, file, line)
+
+    asset_refs = extract_asset_refs(sql)
+    validate_asset_refs!(asset_refs, module, file, line)
+
+    inputs = extract_inputs(sql)
+    reserved_inputs = MapSet.new(reserved_runtime_inputs())
+    runtime_inputs = MapSet.intersection(inputs, reserved_inputs)
+    param_inputs = MapSet.difference(inputs, reserved_inputs)
+
+    %__MODULE__{
+      source: sql,
+      inputs: inputs,
+      runtime_inputs: runtime_inputs,
+      param_inputs: param_inputs,
+      calls: calls,
+      asset_refs: asset_refs
+    }
+  end
+
+  defp extract_inputs(sql) do
+    ~r/@([a-z][a-z0-9_]*)/
+    |> Regex.scan(sql, capture: :all_but_first)
+    |> List.flatten()
+    |> Enum.map(&String.to_atom/1)
+    |> MapSet.new()
+  end
+
+  defp extract_calls(sql, known_definitions) do
+    known_definitions
+    |> Map.keys()
+    |> Enum.map(&elem(&1, 0))
+    |> Enum.uniq()
+    |> Enum.flat_map(&extract_named_calls(sql, &1))
+    |> Enum.uniq_by(fn %Call{name: name, arity: arity, context: context, line: line} ->
+      {name, arity, context, line}
+    end)
+  end
+
+  defp extract_named_calls(sql, name) do
+    pattern = ~r/\b#{name}\s*\(/
+
+    pattern
+    |> Regex.scan(sql, return: :index)
+    |> Enum.flat_map(fn [{start_idx, _len}] ->
+      case parse_call(sql, start_idx, name) do
+        {:ok, call} -> [call]
+        :error -> []
+      end
+    end)
+  end
+
+  defp parse_call(sql, start_idx, name) do
+    name_string = Atom.to_string(name)
+    after_name_idx = start_idx + byte_size(name_string)
+    open_idx = skip_spaces(sql, after_name_idx)
+
+    if open_idx >= byte_size(sql) do
+      :error
+    else
+      prefix = String.slice(sql, 0, start_idx)
+      line = line_for_index(prefix)
+
+      if String.at(sql, open_idx) == "(" do
+        args_source = String.slice(sql, (open_idx + 1)..-1//1)
+
+        case parse_arity(args_source) do
+          {:ok, arity} ->
+            context = if relation_prefix?(prefix), do: :relation, else: :expression
+            {:ok, %Call{name: name, arity: arity, context: context, line: line}}
+
+          :error ->
+            :error
+        end
+      else
+        :error
+      end
+    end
+  end
+
+  defp parse_arity(source) do
+    chars = String.to_charlist(source)
+
+    do_parse_arity(chars, 0, :outside, false, 0)
+  end
+
+  defp do_parse_arity([], _depth, _quote_state, _seen_nonspace, _count), do: :error
+
+  defp do_parse_arity([char | rest], depth, quote_state, _seen_nonspace, count)
+       when quote_state in [:single, :double] do
+    case {quote_state, char} do
+      {:single, ?'} -> do_parse_arity(rest, depth, :outside, true, count)
+      {:double, ?"} -> do_parse_arity(rest, depth, :outside, true, count)
+      _ -> do_parse_arity(rest, depth, quote_state, true, count)
+    end
+  end
+
+  defp do_parse_arity([char | rest], depth, :outside, seen_nonspace, count) do
+    cond do
+      char == ?' ->
+        do_parse_arity(rest, depth, :single, true, count)
+
+      char == ?" ->
+        do_parse_arity(rest, depth, :double, true, count)
+
+      char == ?( ->
+        do_parse_arity(rest, depth + 1, :outside, true, count)
+
+      char == ?) and depth > 0 ->
+        do_parse_arity(rest, depth - 1, :outside, true, count)
+
+      char == ?) and depth == 0 ->
+        final_count = if seen_nonspace, do: count + 1, else: 0
+        {:ok, final_count}
+
+      char == ?, and depth == 0 ->
+        do_parse_arity(rest, depth, :outside, false, count + 1)
+
+      char in [32, 9, 10, 13] ->
+        do_parse_arity(rest, depth, :outside, seen_nonspace, count)
+
+      true ->
+        do_parse_arity(rest, depth, :outside, true, count)
+    end
+  end
+
+  defp relation_prefix?(prefix) do
+    line_prefix =
+      prefix
+      |> String.split("\n")
+      |> List.last()
+      |> to_string()
+      |> String.trim_leading()
+
+    Regex.match?(@relation_prefix_regex, line_prefix)
+  end
+
+  defp line_for_index(prefix) do
+    prefix
+    |> String.split("\n")
+    |> length()
+  end
+
+  defp skip_spaces(sql, index) do
+    case String.at(sql, index) do
+      value when value in [" ", "\t", "\n", "\r"] -> skip_spaces(sql, index + 1)
+      _ -> index
+    end
+  end
+
+  defp validate_calls!(calls, known_definitions, file, fallback_line) do
+    Enum.each(calls, fn %Call{name: name, arity: arity, context: context, line: line} ->
+      case Map.fetch(known_definitions, {name, arity}) do
+        {:ok, definition} ->
+          validate_call_context!(definition.shape, context, name, arity, file, line)
+
+        :error ->
+          arities =
+            known_definitions
+            |> Map.keys()
+            |> Enum.filter(fn {candidate_name, _candidate_arity} -> candidate_name == name end)
+            |> Enum.map(&elem(&1, 1))
+            |> Enum.sort()
+
+          if arities != [] do
+            compile_error!(
+              file,
+              line || fallback_line,
+              "invalid SQL call #{name}/#{arity}; expected one of arities #{inspect(arities)}"
+            )
+          end
+      end
+    end)
+  end
+
+  defp validate_call_context!(:expression, :relation, name, arity, file, line) do
+    compile_error!(
+      file,
+      line,
+      "invalid SQL call #{name}/#{arity} in relation position; expected a relation SQL macro"
+    )
+  end
+
+  defp validate_call_context!(:relation, :expression, name, arity, file, line) do
+    compile_error!(
+      file,
+      line,
+      "invalid SQL call #{name}/#{arity} in expression position; expected an expression SQL macro"
+    )
+  end
+
+  defp validate_call_context!(_shape, _context, _name, _arity, _file, _line), do: :ok
+
+  defp extract_asset_refs(sql) do
+    pattern =
+      ~r/\b(?:from|join|inner\s+join|left(?:\s+outer)?\s+join|right(?:\s+outer)?\s+join|full(?:\s+outer)?\s+join|cross\s+join)\s+([A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)+)/i
+
+    pattern
+    |> Regex.scan(sql, capture: :all_but_first, return: :index)
+    |> Enum.map(fn [{name_start, name_len}] ->
+      name = String.slice(sql, name_start, name_len)
+      module = name |> String.split(".") |> Module.concat()
+      line = line_for_index(String.slice(sql, 0, name_start))
+      %AssetRef{module: module, line: line}
+    end)
+  end
+
+  defp validate_asset_refs!(asset_refs, current_module, file, fallback_line) do
+    Enum.each(asset_refs, fn %AssetRef{module: module, line: line} ->
+      if module == current_module do
+        compile_error!(
+          file,
+          line || fallback_line,
+          "SQL asset cannot reference itself as a relation"
+        )
+      else
+        validate_compiled_asset_module!(module, file, line || fallback_line)
+      end
+    end)
+  end
+
+  defp validate_compiled_asset_module!(module, file, line) do
+    case Code.ensure_compiled(module) do
+      {:module, _module} ->
+        if function_exported?(module, :__favn_single_asset__, 0) and
+             module.__favn_single_asset__() do
+          :ok
+        else
+          compile_error!(
+            file,
+            line,
+            "invalid SQL asset reference #{inspect(module)}; expected a compiled single-asset module"
+          )
+        end
+
+      {:error, _reason} ->
+        :ok
+    end
+  end
+
+  defp compile_error!(file, line, description) do
+    raise CompileError, file: file, line: line, description: description
+  end
+end

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -425,6 +425,11 @@ defmodule Favn.SQL.Template do
     parse_nodes(rest, next_state, [text_node(";", state.position, next_state.position) | acc])
   end
 
+  defp parse_nodes([?; | rest], %{paren_depth: depth} = state, acc) when depth > 0 do
+    next_state = advance_state(state, ~c";")
+    parse_nodes(rest, next_state, [text_node(";", state.position, next_state.position) | acc])
+  end
+
   defp parse_placeholder([next | _] = rest, state, acc)
        when (next >= ?a and next <= ?z) or next == ?_ or (next >= ?A and next <= ?Z) or
               (next >= ?0 and next <= ?9) do

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -1,392 +1,966 @@
 defmodule Favn.SQL.Template do
   @moduledoc """
-  Normalized SQL template representation used by SQL asset authoring.
+  Ordered SQL template IR used by Phase 3 SQL authoring.
   """
 
   alias Favn.Assets.Compiler
+  alias Favn.RelationRef
+  alias Favn.SQL.Definition
 
-  @relation_prefix_regex ~r/(?:^|\s)(?:from|join|inner\s+join|left(?:\s+outer)?\s+join|right(?:\s+outer)?\s+join|full(?:\s+outer)?\s+join|cross\s+join)\s*$/i
-
-  @enforce_keys [:source, :inputs, :runtime_inputs, :param_inputs]
-  defstruct [
-    :source,
-    :inputs,
-    :runtime_inputs,
-    :param_inputs,
-    calls: [],
-    asset_refs: []
+  @reserved_runtime_inputs [:window_start, :window_end]
+  @join_prefixes ["inner", "left", "right", "full", "cross"]
+  @outer_join_prefixes ["left", "right", "full"]
+  @join_entry_prefixes [
+    "inner",
+    "left",
+    "right",
+    "full",
+    "cross",
+    "left outer",
+    "right outer",
+    "full outer"
   ]
 
+  @type root_kind :: :query | :expression
+  @type placeholder_source :: :runtime | :query_param | {:local_arg, non_neg_integer()}
   @type context :: :expression | :relation
 
-  defmodule Call do
+  defmodule Position do
     @moduledoc false
-    @enforce_keys [:name, :arity, :context, :line]
-    defstruct [:name, :arity, :context, :line]
+    @enforce_keys [:offset, :line, :column]
+    defstruct [:offset, :line, :column]
+
+    @type t :: %__MODULE__{offset: non_neg_integer(), line: pos_integer(), column: pos_integer()}
+  end
+
+  defmodule Span do
+    @moduledoc false
+    @enforce_keys [
+      :start_offset,
+      :end_offset,
+      :start_line,
+      :start_column,
+      :end_line,
+      :end_column
+    ]
+    defstruct [
+      :start_offset,
+      :end_offset,
+      :start_line,
+      :start_column,
+      :end_line,
+      :end_column
+    ]
+
+    @type t :: %__MODULE__{
+            start_offset: non_neg_integer(),
+            end_offset: non_neg_integer(),
+            start_line: pos_integer(),
+            start_column: pos_integer(),
+            end_line: pos_integer(),
+            end_column: pos_integer()
+          }
+  end
+
+  defmodule Requirements do
+    @moduledoc false
+    @enforce_keys [:runtime_inputs, :query_params]
+    defstruct [:runtime_inputs, :query_params]
+
+    @type t :: %__MODULE__{runtime_inputs: MapSet.t(atom()), query_params: MapSet.t(atom())}
+  end
+
+  defmodule Fragment do
+    @moduledoc false
+    @enforce_keys [:nodes, :span]
+    defstruct [:nodes, :span]
+
+    @type t :: %__MODULE__{nodes: [Favn.SQL.Template.ir_node()], span: Favn.SQL.Template.Span.t()}
+  end
+
+  defmodule Text do
+    @moduledoc false
+    @enforce_keys [:sql, :span]
+    defstruct [:sql, :span]
+
+    @type t :: %__MODULE__{sql: String.t(), span: Favn.SQL.Template.Span.t()}
+  end
+
+  defmodule Placeholder do
+    @moduledoc false
+    @enforce_keys [:name, :source, :span]
+    defstruct [:name, :source, :span]
 
     @type t :: %__MODULE__{
             name: atom(),
+            source: Favn.SQL.Template.placeholder_source(),
+            span: Favn.SQL.Template.Span.t()
+          }
+  end
+
+  defmodule DefinitionRef do
+    @moduledoc false
+    @enforce_keys [:provider, :name, :arity, :kind]
+    defstruct [:provider, :name, :arity, :kind]
+
+    @type t :: %__MODULE__{
+            provider: module(),
+            name: atom(),
             arity: non_neg_integer(),
+            kind: :expression | :relation
+          }
+  end
+
+  defmodule Call do
+    @moduledoc false
+    @enforce_keys [:definition, :args, :context, :span]
+    defstruct [:definition, :args, :context, :span]
+
+    @type t :: %__MODULE__{
+            definition: Favn.SQL.Template.DefinitionRef.t(),
+            args: [Favn.SQL.Template.Fragment.t()],
             context: Favn.SQL.Template.context(),
-            line: pos_integer()
+            span: Favn.SQL.Template.Span.t()
           }
   end
 
   defmodule AssetRef do
     @moduledoc false
-    @enforce_keys [:module, :line]
-    defstruct [:module, :line]
+    @enforce_keys [:module, :asset_ref, :produced_relation, :resolution, :span]
+    defstruct [:module, :asset_ref, :produced_relation, :resolution, :span]
 
-    @type t :: %__MODULE__{module: module(), line: pos_integer()}
+    @type t :: %__MODULE__{
+            module: module(),
+            asset_ref: {module(), :asset},
+            produced_relation: RelationRef.t() | nil,
+            resolution: :resolved | :deferred,
+            span: Favn.SQL.Template.Span.t()
+          }
   end
+
+  @type ir_node :: Text.t() | Placeholder.t() | Call.t() | AssetRef.t()
+
+  @enforce_keys [:source, :root_kind, :nodes, :span, :requires]
+  defstruct [:source, :root_kind, :nodes, :span, :requires]
 
   @type t :: %__MODULE__{
           source: String.t(),
-          inputs: MapSet.t(atom()),
-          runtime_inputs: MapSet.t(atom()),
-          param_inputs: MapSet.t(atom()),
-          calls: [Call.t()],
-          asset_refs: [AssetRef.t()]
+          root_kind: root_kind(),
+          nodes: [ir_node()],
+          span: Span.t(),
+          requires: Requirements.t()
         }
 
-  @spec reserved_runtime_inputs() :: [atom()]
-  def reserved_runtime_inputs, do: [:window_start, :window_end]
+  @type compile_opt ::
+          {:known_definitions, %{optional({atom(), non_neg_integer()}) => Definition.t()}}
+          | {:file, String.t()}
+          | {:line, pos_integer()}
+          | {:column, pos_integer()}
+          | {:offset, non_neg_integer()}
+          | {:module, module() | nil}
+          | {:scope, :query | :definition | :fragment}
+          | {:local_args, [atom()]}
+          | {:enforce_query_root, boolean()}
 
-  @spec compile!(String.t(), keyword()) :: t()
+  @spec reserved_runtime_inputs() :: [atom()]
+  def reserved_runtime_inputs, do: @reserved_runtime_inputs
+
+  @spec compile!(String.t(), [compile_opt()]) :: t()
   def compile!(sql, opts \\ []) when is_binary(sql) and is_list(opts) do
-    known_definitions = Keyword.get(opts, :known_definitions, %{})
     file = Keyword.fetch!(opts, :file)
     line = Keyword.fetch!(opts, :line)
+    column = Keyword.get(opts, :column, 1)
+    offset = Keyword.get(opts, :offset, 0)
+    known_definitions = Keyword.get(opts, :known_definitions, %{})
     module = Keyword.get(opts, :module)
+    scope = Keyword.get(opts, :scope, :query)
+    local_args = Keyword.get(opts, :local_args, [])
+    enforce_query_root = Keyword.get(opts, :enforce_query_root, false)
 
-    calls = extract_calls(sql, known_definitions)
-    validate_calls!(calls, known_definitions, file, line)
+    start_pos = %Position{offset: offset, line: line, column: column}
+    root_kind = infer_root_kind!(sql, file, line, start_pos)
 
-    asset_refs = extract_asset_refs(sql)
-    validate_asset_refs!(asset_refs, module, file, line)
+    if enforce_query_root and root_kind != :query do
+      compile_error!(file, line, "query body must start with select or with")
+    end
 
-    inputs = extract_inputs(sql)
-    reserved_inputs = MapSet.new(reserved_runtime_inputs())
-    runtime_inputs = MapSet.intersection(inputs, reserved_inputs)
-    param_inputs = MapSet.difference(inputs, reserved_inputs)
+    parser_state = %{
+      file: file,
+      module: module,
+      known_definitions: known_definitions,
+      local_args: local_arg_index(local_args),
+      position: start_pos,
+      relation_entry?: false,
+      join_prefix: nil,
+      paren_depth: 0,
+      statement_kind: top_level_statement_kind(root_kind),
+      scope: scope
+    }
+
+    {nodes, end_state} = parse_nodes(String.to_charlist(sql), parser_state, [])
+    span = span(start_pos, end_state.position)
 
     %__MODULE__{
       source: sql,
-      inputs: inputs,
-      runtime_inputs: runtime_inputs,
-      param_inputs: param_inputs,
-      calls: calls,
-      asset_refs: asset_refs
+      root_kind: root_kind,
+      nodes: nodes,
+      span: span,
+      requires: gather_requirements(nodes)
     }
   end
 
-  defp extract_inputs(sql) do
-    ~r/@([a-z][a-z0-9_]*)/
-    |> Regex.scan(sql, capture: :all_but_first)
-    |> List.flatten()
-    |> Enum.map(&String.to_atom/1)
-    |> MapSet.new()
-  end
+  @spec called_definition_keys(t()) :: [{atom(), non_neg_integer()}]
+  def called_definition_keys(%__MODULE__{nodes: nodes}),
+    do: called_definition_keys_from_nodes(nodes)
 
-  defp extract_calls(sql, known_definitions) do
-    known_definitions
-    |> Map.keys()
-    |> Enum.map(&elem(&1, 0))
+  @spec runtime_inputs(t()) :: MapSet.t(atom())
+  def runtime_inputs(%__MODULE__{requires: %Requirements{runtime_inputs: runtime_inputs}}),
+    do: runtime_inputs
+
+  @spec query_params(t()) :: MapSet.t(atom())
+  def query_params(%__MODULE__{requires: %Requirements{query_params: query_params}}),
+    do: query_params
+
+  @spec asset_refs(t()) :: [AssetRef.t()]
+  def asset_refs(%__MODULE__{nodes: nodes}), do: collect_asset_refs(nodes)
+
+  @spec calls(t()) :: [Call.t()]
+  def calls(%__MODULE__{nodes: nodes}), do: collect_calls(nodes)
+
+  defp called_definition_keys_from_nodes(nodes) do
+    nodes
+    |> Enum.flat_map(fn
+      %Call{definition: %DefinitionRef{name: name, arity: arity}, args: args} ->
+        [{name, arity} | Enum.flat_map(args, &called_definition_keys_from_nodes(&1.nodes))]
+
+      _other ->
+        []
+    end)
     |> Enum.uniq()
-    |> Enum.flat_map(&extract_named_calls(sql, &1))
-    |> Enum.uniq_by(fn %Call{name: name, arity: arity, context: context, line: line} ->
-      {name, arity, context, line}
+  end
+
+  defp collect_asset_refs(nodes) do
+    Enum.flat_map(nodes, fn
+      %AssetRef{} = asset_ref -> [asset_ref]
+      %Call{args: args} -> Enum.flat_map(args, &collect_asset_refs(&1.nodes))
+      _other -> []
     end)
   end
 
-  defp extract_named_calls(sql, name) do
-    pattern = ~r/\b#{name}\s*\(/
-
-    pattern
-    |> Regex.scan(sql, return: :index)
-    |> Enum.flat_map(fn [{start_idx, _len}] ->
-      case parse_call(sql, start_idx, name) do
-        {:ok, call} -> [call]
-        :error -> []
-      end
+  defp collect_calls(nodes) do
+    Enum.flat_map(nodes, fn
+      %Call{} = call -> [call | Enum.flat_map(call.args, &collect_calls(&1.nodes))]
+      _other -> []
     end)
   end
 
-  defp parse_call(sql, start_idx, name) do
-    name_string = Atom.to_string(name)
-    after_name_idx = start_idx + byte_size(name_string)
-    open_idx = skip_spaces(sql, after_name_idx)
-
-    if open_idx >= byte_size(sql) do
-      :error
-    else
-      prefix = String.slice(sql, 0, start_idx)
-      line = line_for_index(prefix)
-
-      if String.at(sql, open_idx) == "(" do
-        args_source = String.slice(sql, (open_idx + 1)..-1//1)
-
-        case parse_arity(args_source) do
-          {:ok, arity} ->
-            context = if relation_prefix?(prefix), do: :relation, else: :expression
-            {:ok, %Call{name: name, arity: arity, context: context, line: line}}
-
-          :error ->
-            :error
-        end
-      else
-        :error
-      end
+  defp infer_root_kind!(sql, file, line, _start_pos) do
+    case first_top_level_token(String.to_charlist(sql), :code, 0) do
+      nil -> compile_error!(file, line, "SQL body cannot be empty")
+      "select" -> :query
+      "with" -> :query
+      _other -> :expression
     end
   end
 
-  defp parse_arity(source) do
-    chars = String.to_charlist(source)
+  defp first_top_level_token([], _lex_state, _depth), do: nil
 
-    do_parse_arity(chars, 0, :outside, false, 0)
+  defp first_top_level_token([?-, ?- | rest], :code, depth),
+    do: first_top_level_token(rest, :line_comment, depth)
+
+  defp first_top_level_token([?/, ?* | rest], :code, depth),
+    do: first_top_level_token(rest, :block_comment, depth)
+
+  defp first_top_level_token([?' | rest], :code, depth),
+    do: first_top_level_token(rest, :single_quote, depth)
+
+  defp first_top_level_token([?" | rest], :code, depth),
+    do: first_top_level_token(rest, :double_quote, depth)
+
+  defp first_top_level_token([char | rest], :line_comment, depth) do
+    if char == ?\n,
+      do: first_top_level_token(rest, :code, depth),
+      else: first_top_level_token(rest, :line_comment, depth)
   end
 
-  defp do_parse_arity([], _depth, _quote_state, _seen_nonspace, _count), do: :error
+  defp first_top_level_token([?*, ?/ | rest], :block_comment, depth),
+    do: first_top_level_token(rest, :code, depth)
 
-  defp do_parse_arity([char | rest], depth, quote_state, _seen_nonspace, count)
-       when quote_state in [:single, :double] do
-    case {quote_state, char} do
-      {:single, ?'} -> do_parse_arity(rest, depth, :outside, true, count)
-      {:double, ?"} -> do_parse_arity(rest, depth, :outside, true, count)
-      _ -> do_parse_arity(rest, depth, quote_state, true, count)
+  defp first_top_level_token([_char | rest], :block_comment, depth),
+    do: first_top_level_token(rest, :block_comment, depth)
+
+  defp first_top_level_token([?', ?' | rest], :single_quote, depth),
+    do: first_top_level_token(rest, :single_quote, depth)
+
+  defp first_top_level_token([?' | rest], :single_quote, depth),
+    do: first_top_level_token(rest, :code, depth)
+
+  defp first_top_level_token([_char | rest], :single_quote, depth),
+    do: first_top_level_token(rest, :single_quote, depth)
+
+  defp first_top_level_token([?", ?" | rest], :double_quote, depth),
+    do: first_top_level_token(rest, :double_quote, depth)
+
+  defp first_top_level_token([?" | rest], :double_quote, depth),
+    do: first_top_level_token(rest, :code, depth)
+
+  defp first_top_level_token([_char | rest], :double_quote, depth),
+    do: first_top_level_token(rest, :double_quote, depth)
+
+  defp first_top_level_token([char | rest], :code, depth) when char in [32, 9, 10, 13],
+    do: first_top_level_token(rest, :code, depth)
+
+  defp first_top_level_token([?( | rest], :code, depth),
+    do: first_top_level_token(rest, :code, depth + 1)
+
+  defp first_top_level_token([?) | rest], :code, depth) when depth > 0,
+    do: first_top_level_token(rest, :code, depth - 1)
+
+  defp first_top_level_token([char | _rest] = chars, :code, 0)
+       when (char >= ?A and char <= ?Z) or (char >= ?a and char <= ?z) or char == ?_ do
+    {word, _tail} = read_identifier(chars)
+    String.downcase(word)
+  end
+
+  defp first_top_level_token([_char | rest], :code, depth),
+    do: first_top_level_token(rest, :code, depth)
+
+  defp parse_nodes([], state, acc), do: {Enum.reverse(acc), state}
+
+  defp parse_nodes([?-, ?- | rest], state, acc) do
+    {text, tail, next_pos} = consume_line_comment(rest, state.position, ~c"--")
+
+    parse_nodes(tail, %{state | position: next_pos}, [
+      text_node(text, state.position, next_pos) | acc
+    ])
+  end
+
+  defp parse_nodes([?/, ?* | rest], state, acc) do
+    {text, tail, next_pos} = consume_block_comment(rest, state.position, ~c"/*")
+
+    parse_nodes(tail, %{state | position: next_pos}, [
+      text_node(text, state.position, next_pos) | acc
+    ])
+  end
+
+  defp parse_nodes([?' | rest], state, acc) do
+    {text, tail, next_pos} = consume_quoted(rest, state.position, ?')
+
+    parse_nodes(tail, %{state | position: next_pos}, [
+      text_node(text, state.position, next_pos) | acc
+    ])
+  end
+
+  defp parse_nodes([?" | rest], state, acc) do
+    {text, tail, next_pos} = consume_quoted(rest, state.position, ?")
+
+    parse_nodes(tail, %{state | position: next_pos}, [
+      text_node(text, state.position, next_pos) | acc
+    ])
+  end
+
+  defp parse_nodes([?@ | rest], state, acc) do
+    parse_placeholder(rest, state, acc)
+  end
+
+  defp parse_nodes([char | _rest] = chars, state, acc)
+       when (char >= ?A and char <= ?Z) or (char >= ?a and char <= ?z) or char == ?_ do
+    parse_identifier(chars, state, acc)
+  end
+
+  defp parse_nodes([char | rest], state, acc) do
+    {next_state, text} = consume_single_char(char, state)
+    parse_nodes(rest, next_state, [text_node(text, state.position, next_state.position) | acc])
+  end
+
+  defp parse_placeholder([next | _] = rest, state, acc)
+       when (next >= ?a and next <= ?z) or next == ?_ or (next >= ?A and next <= ?Z) or
+              (next >= ?0 and next <= ?9) do
+    case rest do
+      [valid | _] when valid >= ?a and valid <= ?z ->
+        {name_string, tail} = read_identifier(rest)
+        name = String.to_atom(name_string)
+        next_state = advance_state(state, ~c"@" ++ String.to_charlist(name_string))
+        placeholder = build_placeholder(name, state, next_state)
+        parse_nodes(tail, next_state, [placeholder | acc])
+
+      _other ->
+        compile_error!(
+          state.file,
+          state.position.line,
+          "invalid SQL placeholder at line #{state.position.line}, column #{state.position.column}"
+        )
     end
   end
 
-  defp do_parse_arity([char | rest], depth, :outside, seen_nonspace, count) do
+  defp parse_placeholder(rest, state, acc) do
+    next_state = advance_state(state, ~c"@")
+    parse_nodes(rest, next_state, [text_node("@", state.position, next_state.position) | acc])
+  end
+
+  defp parse_identifier(chars, state, acc) do
+    {word, tail} = read_identifier(chars)
+    context = if state.relation_entry?, do: :relation, else: :expression
+
     cond do
-      char == ?' ->
-        do_parse_arity(rest, depth, :single, true, count)
+      asset_ref_candidate?(word, tail, state) ->
+        parse_asset_ref(word, tail, state, acc)
 
-      char == ?" ->
-        do_parse_arity(rest, depth, :double, true, count)
-
-      char == ?( ->
-        do_parse_arity(rest, depth + 1, :outside, true, count)
-
-      char == ?) and depth > 0 ->
-        do_parse_arity(rest, depth - 1, :outside, true, count)
-
-      char == ?) and depth == 0 ->
-        final_count = if seen_nonspace, do: count + 1, else: 0
-        {:ok, final_count}
-
-      char == ?, and depth == 0 ->
-        do_parse_arity(rest, depth, :outside, false, count + 1)
-
-      char in [32, 9, 10, 13] ->
-        do_parse_arity(rest, depth, :outside, seen_nonspace, count)
+      call_candidate?(word, tail, state) ->
+        parse_call(word, tail, state, context, acc)
 
       true ->
-        do_parse_arity(rest, depth, :outside, true, count)
+        next_state =
+          advance_state(state, String.to_charlist(word))
+          |> update_relation_context(String.downcase(word))
+
+        parse_nodes(tail, next_state, [text_node(word, state.position, next_state.position) | acc])
     end
   end
 
-  defp relation_prefix?(prefix) do
-    line_prefix =
-      prefix
-      |> String.split("\n")
-      |> List.last()
-      |> to_string()
-      |> String.trim_leading()
+  defp parse_asset_ref(word, tail, state, acc) do
+    {segments, tail_after_module} = read_alias_chain(tail, [word])
+    next_char = peek_nonspace_char(tail_after_module)
 
-    Regex.match?(@relation_prefix_regex, line_prefix)
-  end
+    if length(segments) >= 2 and uppercase_alias_segments?(segments) and next_char != ?( do
+      raw = Enum.join(segments, ".")
 
-  defp line_for_index(prefix) do
-    prefix
-    |> String.split("\n")
-    |> length()
-  end
+      next_state =
+        advance_state(state, String.to_charlist(raw))
+        |> Map.put(:relation_entry?, false)
+        |> Map.put(:join_prefix, nil)
 
-  defp skip_spaces(sql, index) do
-    case String.at(sql, index) do
-      value when value in [" ", "\t", "\n", "\r"] -> skip_spaces(sql, index + 1)
-      _ -> index
+      node = build_asset_ref(Module.concat(segments), state, next_state)
+      parse_nodes(tail_after_module, next_state, [node | acc])
+    else
+      next_state =
+        advance_state(state, String.to_charlist(word))
+        |> update_relation_context(String.downcase(word))
+
+      parse_nodes(tail, next_state, [text_node(word, state.position, next_state.position) | acc])
     end
   end
 
-  defp validate_calls!(calls, known_definitions, file, fallback_line) do
-    Enum.each(calls, fn %Call{name: name, arity: arity, context: context, line: line} ->
-      case Map.fetch(known_definitions, {name, arity}) do
-        {:ok, definition} ->
-          validate_call_context!(definition.shape, context, name, arity, file, line)
+  defp parse_call(word, tail, state, context, acc) do
+    {space_chars, after_spaces} = take_horizontal_space(tail, [])
 
-        :error ->
-          arities =
-            known_definitions
-            |> Map.keys()
-            |> Enum.filter(fn {candidate_name, _candidate_arity} -> candidate_name == name end)
-            |> Enum.map(&elem(&1, 1))
-            |> Enum.sort()
+    case after_spaces do
+      [?( | rest_after_open] ->
+        start_pos = state.position
+        open_state = advance_state(state, String.to_charlist(word) ++ space_chars ++ ~c"(")
 
-          if arities != [] do
+        {args, tail_after_call, end_pos} =
+          parse_call_arguments(rest_after_open, open_state.position, state, [])
+
+        arity = length(args)
+        visible_arities = visible_arities(word, state.known_definitions)
+
+        case Map.fetch(state.known_definitions, {String.to_atom(word), arity}) do
+          {:ok, definition} ->
+            call = build_call(definition, args, context, start_pos, end_pos)
+
+            next_state = %{
+              state
+              | position: end_pos,
+                relation_entry?: false,
+                join_prefix: nil,
+                paren_depth: state.paren_depth
+            }
+
+            validate_call_context!(call, state.file)
+            parse_nodes(tail_after_call, next_state, [call | acc])
+
+          :error when visible_arities != [] ->
             compile_error!(
-              file,
-              line || fallback_line,
-              "invalid SQL call #{name}/#{arity}; expected one of arities #{inspect(arities)}"
+              state.file,
+              start_pos.line,
+              "invalid SQL call #{word}/#{arity}; expected one of arities #{inspect(visible_arities)}"
             )
-          end
-      end
-    end)
+
+          :error ->
+            next_state =
+              advance_state(state, String.to_charlist(word))
+              |> update_relation_context(String.downcase(word))
+
+            parse_nodes(tail, next_state, [
+              text_node(word, state.position, next_state.position) | acc
+            ])
+        end
+
+      _other ->
+        next_state =
+          advance_state(state, String.to_charlist(word))
+          |> update_relation_context(String.downcase(word))
+
+        parse_nodes(tail, next_state, [text_node(word, state.position, next_state.position) | acc])
+    end
   end
 
-  defp validate_call_context!(:expression, :relation, name, arity, file, line) do
+  defp parse_call_arguments(chars, current_pos, state, acc) do
+    do_parse_call_arguments(chars, current_pos, current_pos, :code, 0, [], state, acc)
+  end
+
+  defp do_parse_call_arguments(
+         [],
+         _current_pos,
+         _arg_start,
+         _lex_state,
+         _depth,
+         _buffer,
+         state,
+         _acc
+       ) do
+    compile_error!(state.file, state.position.line, "unterminated SQL call arguments")
+  end
+
+  defp do_parse_call_arguments(
+         [?-, ?- | rest],
+         current_pos,
+         arg_start,
+         :code,
+         depth,
+         buffer,
+         state,
+         acc
+       ),
+       do: consume_arg_line_comment(rest, current_pos, arg_start, depth, buffer, state, acc)
+
+  defp do_parse_call_arguments(
+         [?/, ?* | rest],
+         current_pos,
+         arg_start,
+         :code,
+         depth,
+         buffer,
+         state,
+         acc
+       ),
+       do: consume_arg_block_comment(rest, current_pos, arg_start, depth, buffer, state, acc)
+
+  defp do_parse_call_arguments(
+         [?' | rest],
+         current_pos,
+         arg_start,
+         :code,
+         depth,
+         buffer,
+         state,
+         acc
+       ),
+       do: consume_arg_quoted(rest, current_pos, arg_start, depth, buffer, state, acc, ?')
+
+  defp do_parse_call_arguments(
+         [?" | rest],
+         current_pos,
+         arg_start,
+         :code,
+         depth,
+         buffer,
+         state,
+         acc
+       ),
+       do: consume_arg_quoted(rest, current_pos, arg_start, depth, buffer, state, acc, ?")
+
+  defp do_parse_call_arguments(
+         [?( | rest],
+         current_pos,
+         arg_start,
+         :code,
+         depth,
+         buffer,
+         state,
+         acc
+       ) do
+    next_pos = advance_position(current_pos, ~c"(")
+
+    do_parse_call_arguments(
+      rest,
+      next_pos,
+      arg_start,
+      :code,
+      depth + 1,
+      [?( | buffer],
+      state,
+      acc
+    )
+  end
+
+  defp do_parse_call_arguments([?) | rest], current_pos, arg_start, :code, 0, buffer, state, acc) do
+    end_pos = advance_position(current_pos, ~c")")
+    fragment = build_argument_fragment(Enum.reverse(buffer), arg_start, current_pos, state)
+    {Enum.reverse([fragment | acc]), rest, end_pos}
+  end
+
+  defp do_parse_call_arguments(
+         [?) | rest],
+         current_pos,
+         arg_start,
+         :code,
+         depth,
+         buffer,
+         state,
+         acc
+       ) do
+    next_pos = advance_position(current_pos, ~c")")
+
+    do_parse_call_arguments(
+      rest,
+      next_pos,
+      arg_start,
+      :code,
+      depth - 1,
+      [?) | buffer],
+      state,
+      acc
+    )
+  end
+
+  defp do_parse_call_arguments([?, | rest], current_pos, arg_start, :code, 0, buffer, state, acc) do
+    comma_pos = advance_position(current_pos, ~c",")
+    fragment = build_argument_fragment(Enum.reverse(buffer), arg_start, current_pos, state)
+    do_parse_call_arguments(rest, comma_pos, comma_pos, :code, 0, [], state, [fragment | acc])
+  end
+
+  defp do_parse_call_arguments(
+         [char | rest],
+         current_pos,
+         arg_start,
+         :code,
+         depth,
+         buffer,
+         state,
+         acc
+       ) do
+    next_pos = advance_position(current_pos, [char])
+    do_parse_call_arguments(rest, next_pos, arg_start, :code, depth, [char | buffer], state, acc)
+  end
+
+  defp consume_arg_line_comment(rest, current_pos, arg_start, depth, buffer, state, acc) do
+    {text, tail, next_pos} = consume_line_comment(rest, current_pos, ~c"--")
+
+    do_parse_call_arguments(
+      tail,
+      next_pos,
+      arg_start,
+      :code,
+      depth,
+      Enum.reverse(String.to_charlist(text)) ++ buffer,
+      state,
+      acc
+    )
+  end
+
+  defp consume_arg_block_comment(rest, current_pos, arg_start, depth, buffer, state, acc) do
+    {text, tail, next_pos} = consume_block_comment(rest, current_pos, ~c"/*")
+
+    do_parse_call_arguments(
+      tail,
+      next_pos,
+      arg_start,
+      :code,
+      depth,
+      Enum.reverse(String.to_charlist(text)) ++ buffer,
+      state,
+      acc
+    )
+  end
+
+  defp consume_arg_quoted(rest, current_pos, arg_start, depth, buffer, state, acc, quote_char) do
+    {text, tail, next_pos} = consume_quoted(rest, current_pos, [quote_char])
+
+    do_parse_call_arguments(
+      tail,
+      next_pos,
+      arg_start,
+      :code,
+      depth,
+      Enum.reverse(String.to_charlist(text)) ++ buffer,
+      state,
+      acc
+    )
+  end
+
+  defp build_argument_fragment(chars, start_pos, end_pos, state) do
+    source = chars |> to_string()
+
+    template =
+      compile!(source,
+        known_definitions: state.known_definitions,
+        file: state.file,
+        line: start_pos.line,
+        column: start_pos.column,
+        offset: start_pos.offset,
+        module: state.module,
+        scope: state.scope,
+        local_args: Map.keys(state.local_args),
+        enforce_query_root: false
+      )
+
+    %Fragment{nodes: template.nodes, span: span(start_pos, end_pos)}
+  end
+
+  defp build_placeholder(name, state, next_state) do
+    source = classify_placeholder_source(name, state)
+    %Placeholder{name: name, source: source, span: span(state.position, next_state.position)}
+  end
+
+  defp build_call(definition, args, context, start_pos, end_pos) do
+    %Call{
+      definition: %DefinitionRef{
+        provider: definition.module,
+        name: definition.name,
+        arity: definition.arity,
+        kind: definition.shape
+      },
+      args: args,
+      context: context,
+      span: span(start_pos, end_pos)
+    }
+  end
+
+  defp build_asset_ref(module, state, next_state) do
+    {resolution, produced_relation} =
+      resolve_asset_reference(module, state.file, state.position.line, state.module)
+
+    %AssetRef{
+      module: module,
+      asset_ref: {module, :asset},
+      produced_relation: produced_relation,
+      resolution: resolution,
+      span: span(state.position, next_state.position)
+    }
+  end
+
+  defp classify_placeholder_source(name, _state) when name in @reserved_runtime_inputs,
+    do: :runtime
+
+  defp classify_placeholder_source(name, %{scope: :definition, local_args: local_args} = state) do
+    case Map.fetch(local_args, name) do
+      {:ok, index} ->
+        {:local_arg, index}
+
+      :error ->
+        compile_error!(
+          state.file,
+          state.position.line,
+          "undefined defsql placeholder @#{name}; expected one of #{inspect(Map.keys(local_args))}"
+        )
+    end
+  end
+
+  defp classify_placeholder_source(_name, _state), do: :query_param
+
+  defp asset_ref_candidate?(word, tail, state) do
+    state.statement_kind not in [:update, :merge] and
+      state.relation_entry? and
+      String.match?(word, ~r/^[A-Z][A-Za-z0-9_]*$/) and
+      List.first(tail) == ?.
+  end
+
+  defp call_candidate?(word, tail, state) do
+    state.known_definitions != %{} and
+      visible_arities(word, state.known_definitions) != [] and
+      peek_nonspace_char(tail) == ?(
+  end
+
+  defp visible_arities(word, known_definitions) do
+    name = String.to_atom(word)
+
+    known_definitions
+    |> Map.keys()
+    |> Enum.filter(fn {candidate_name, _arity} -> candidate_name == name end)
+    |> Enum.map(&elem(&1, 1))
+    |> Enum.sort()
+  end
+
+  defp validate_call_context!(
+         %Call{
+           definition: %DefinitionRef{kind: :expression, name: name, arity: arity},
+           context: :relation,
+           span: span
+         },
+         file
+       ) do
     compile_error!(
       file,
-      line,
+      span.start_line,
       "invalid SQL call #{name}/#{arity} in relation position; expected a relation SQL macro"
     )
   end
 
-  defp validate_call_context!(:relation, :expression, name, arity, file, line) do
+  defp validate_call_context!(
+         %Call{
+           definition: %DefinitionRef{kind: :relation, name: name, arity: arity},
+           context: :expression,
+           span: span
+         },
+         file
+       ) do
     compile_error!(
       file,
-      line,
+      span.start_line,
       "invalid SQL call #{name}/#{arity} in expression position; expected an expression SQL macro"
     )
   end
 
-  defp validate_call_context!(_shape, _context, _name, _arity, _file, _line), do: :ok
+  defp validate_call_context!(_call, _file), do: :ok
 
-  defp extract_asset_refs(sql) do
-    sql
-    |> String.to_charlist()
-    |> do_extract_asset_refs(
-      1,
-      :code,
-      %{asset_refs_enabled?: true, relation_entry?: false, join_prefix: nil, paren_depth: 0},
-      []
-    )
-    |> Enum.reverse()
-  end
+  defp resolve_asset_reference(module, file, line, current_module) do
+    if module == current_module do
+      compile_error!(file, line, "SQL asset cannot reference itself as a relation")
+    end
 
-  defp do_extract_asset_refs([], _line, _state, _ctx, acc), do: acc
-
-  defp do_extract_asset_refs([?-, ?- | rest], line, :code, ctx, acc),
-    do: do_extract_asset_refs(rest, line, :line_comment, ctx, acc)
-
-  defp do_extract_asset_refs([?/, ?* | rest], line, :code, ctx, acc),
-    do: do_extract_asset_refs(rest, line, :block_comment, ctx, acc)
-
-  defp do_extract_asset_refs([?' | rest], line, :code, ctx, acc),
-    do: do_extract_asset_refs(rest, line, :single_quote, ctx, acc)
-
-  defp do_extract_asset_refs([?" | rest], line, :code, ctx, acc),
-    do: do_extract_asset_refs(rest, line, :double_quote, ctx, acc)
-
-  defp do_extract_asset_refs([char | rest], line, :line_comment, ctx, acc) do
-    if char == ?\n do
-      do_extract_asset_refs(rest, line + 1, :code, ctx, acc)
-    else
-      do_extract_asset_refs(rest, line, :line_comment, ctx, acc)
+    case Code.ensure_compiled(module) do
+      {:module, _} -> validate_compiled_asset_module!(module, file, line)
+      {:error, _reason} -> {:deferred, nil}
     end
   end
 
-  defp do_extract_asset_refs([?*, ?/ | rest], line, :block_comment, ctx, acc),
-    do: do_extract_asset_refs(rest, line, :code, ctx, acc)
+  defp validate_compiled_asset_module!(module, file, line) do
+    if function_exported?(module, :__favn_single_asset__, 0) and module.__favn_single_asset__() do
+      case Compiler.compile_module_assets(module) do
+        {:ok, [%{produces: %RelationRef{} = produces}]} ->
+          {:resolved, produces}
 
-  defp do_extract_asset_refs([char | rest], line, :block_comment, ctx, acc) do
-    next_line = if char == ?\n, do: line + 1, else: line
-    do_extract_asset_refs(rest, next_line, :block_comment, ctx, acc)
-  end
+        {:ok, [%{produces: nil}]} ->
+          compile_error!(
+            file,
+            line,
+            "SQL asset reference #{inspect(module)} does not resolve to a produced relation"
+          )
 
-  defp do_extract_asset_refs([?' | rest], line, :single_quote, ctx, acc),
-    do: do_extract_asset_refs(rest, line, :code, ctx, acc)
+        {:ok, [_asset | _rest]} ->
+          compile_error!(
+            file,
+            line,
+            "invalid SQL asset reference #{inspect(module)}; expected a compiled single-asset module"
+          )
 
-  defp do_extract_asset_refs([char | rest], line, :single_quote, ctx, acc) do
-    next_line = if char == ?\n, do: line + 1, else: line
-    do_extract_asset_refs(rest, next_line, :single_quote, ctx, acc)
-  end
-
-  defp do_extract_asset_refs([?" | rest], line, :double_quote, ctx, acc),
-    do: do_extract_asset_refs(rest, line, :code, ctx, acc)
-
-  defp do_extract_asset_refs([char | rest], line, :double_quote, ctx, acc) do
-    next_line = if char == ?\n, do: line + 1, else: line
-    do_extract_asset_refs(rest, next_line, :double_quote, ctx, acc)
-  end
-
-  defp do_extract_asset_refs([char | rest], line, :code, ctx, acc)
-       when char in [32, 9, 13] do
-    do_extract_asset_refs(rest, line, :code, ctx, acc)
-  end
-
-  defp do_extract_asset_refs([?\n | rest], line, :code, ctx, acc),
-    do: do_extract_asset_refs(rest, line + 1, :code, ctx, acc)
-
-  defp do_extract_asset_refs([char | _rest] = chars, line, :code, ctx, acc)
-       when (char >= ?A and char <= ?Z) or (char >= ?a and char <= ?z) or char == ?_ do
-    {word, tail} = read_identifier(chars)
-    word_down = String.downcase(word)
-    ctx = update_statement_context(ctx, word_down)
-
-    if relation_reference_candidate?(ctx, word, tail) do
-      {segments, tail_after_module} = read_alias_chain(tail, [word])
-      next_char = skip_horizontal_space(tail_after_module)
-
-      if length(segments) >= 2 and uppercase_alias_segments?(segments) and next_char != ?( do
-        module = Module.concat(segments)
-        ref = %AssetRef{module: module, line: line}
-        next_ctx = %{ctx | relation_entry?: false, join_prefix: nil}
-        do_extract_asset_refs(tail_after_module, line, :code, next_ctx, [ref | acc])
-      else
-        next_ctx = update_relation_context(ctx, word_down)
-        do_extract_asset_refs(tail, line, :code, next_ctx, acc)
+        {:error, _reason} ->
+          compile_error!(
+            file,
+            line,
+            "invalid SQL asset reference #{inspect(module)}; failed to compile asset definition"
+          )
       end
     else
-      next_ctx = update_relation_context(ctx, word_down)
-      do_extract_asset_refs(tail, line, :code, next_ctx, acc)
+      compile_error!(
+        file,
+        line,
+        "invalid SQL asset reference #{inspect(module)}; expected a compiled single-asset module"
+      )
     end
   end
 
-  defp do_extract_asset_refs([?( | rest], line, :code, ctx, acc) do
-    next_ctx = %{ctx | relation_entry?: false, join_prefix: nil, paren_depth: ctx.paren_depth + 1}
-    do_extract_asset_refs(rest, line, :code, next_ctx, acc)
+  defp gather_requirements(nodes) do
+    {runtime_inputs, query_params} = gather_requirements(nodes, MapSet.new(), MapSet.new())
+    %Requirements{runtime_inputs: runtime_inputs, query_params: query_params}
   end
 
-  defp do_extract_asset_refs([?) | rest], line, :code, ctx, acc) do
-    next_ctx = %{
-      ctx
-      | relation_entry?: false,
-        join_prefix: nil,
-        paren_depth: max(ctx.paren_depth - 1, 0)
-    }
+  defp gather_requirements([], runtime_inputs, query_params), do: {runtime_inputs, query_params}
 
-    do_extract_asset_refs(rest, line, :code, next_ctx, acc)
+  defp gather_requirements([node | rest], runtime_inputs, query_params) do
+    {runtime_inputs, query_params} =
+      case node do
+        %Placeholder{name: name, source: :runtime} ->
+          {MapSet.put(runtime_inputs, name), query_params}
+
+        %Placeholder{name: name, source: :query_param} ->
+          {runtime_inputs, MapSet.put(query_params, name)}
+
+        %Call{args: args} ->
+          Enum.reduce(args, {runtime_inputs, query_params}, fn %Fragment{nodes: arg_nodes}, acc ->
+            gather_requirements(arg_nodes, elem(acc, 0), elem(acc, 1))
+          end)
+
+        _other ->
+          {runtime_inputs, query_params}
+      end
+
+    gather_requirements(rest, runtime_inputs, query_params)
   end
 
-  defp do_extract_asset_refs([?; | rest], line, :code, %{paren_depth: 0} = ctx, acc) do
-    next_ctx = %{ctx | relation_entry?: false, join_prefix: nil, asset_refs_enabled?: true}
-    do_extract_asset_refs(rest, line, :code, next_ctx, acc)
+  defp text_node(text, start_pos, end_pos),
+    do: %Text{sql: to_string(text), span: span(start_pos, end_pos)}
+
+  defp consume_single_char(char, state) do
+    text = <<char::utf8>>
+    {advance_state(state, [char]), text}
   end
 
-  defp do_extract_asset_refs([_char | rest], line, :code, ctx, acc) do
-    next_ctx = %{ctx | relation_entry?: false, join_prefix: nil}
-    do_extract_asset_refs(rest, line, :code, next_ctx, acc)
+  defp consume_line_comment(rest, start_pos, prefix_chars) do
+    do_consume_line_comment(
+      rest,
+      advance_position(start_pos, prefix_chars),
+      Enum.reverse(prefix_chars)
+    )
   end
 
-  defp update_statement_context(%{paren_depth: depth} = ctx, _word) when depth > 0, do: ctx
+  defp do_consume_line_comment([], pos, acc), do: {acc |> Enum.reverse() |> to_string(), [], pos}
 
-  defp update_statement_context(ctx, "update"), do: %{ctx | asset_refs_enabled?: false}
+  defp do_consume_line_comment([char | rest] = chars, pos, acc) do
+    next_pos = advance_position(pos, [char])
 
-  defp update_statement_context(ctx, "merge"), do: %{ctx | asset_refs_enabled?: false}
-
-  defp update_statement_context(ctx, _word), do: ctx
-
-  defp relation_reference_candidate?(
-         %{asset_refs_enabled?: true, relation_entry?: true},
-         word,
-         tail
-       ) do
-    String.match?(word, ~r/^[A-Z][A-Za-z0-9_]*$/) and List.first(tail) == ?.
+    if char == ?\n do
+      {[char | acc] |> Enum.reverse() |> to_string(), rest, next_pos}
+    else
+      do_consume_line_comment(chars |> tl(), next_pos, [char | acc])
+    end
   end
 
-  defp relation_reference_candidate?(_ctx, _word, _tail), do: false
+  defp consume_block_comment(rest, start_pos, prefix_chars) do
+    do_consume_block_comment(
+      rest,
+      advance_position(start_pos, prefix_chars),
+      Enum.reverse(prefix_chars)
+    )
+  end
+
+  defp do_consume_block_comment([], pos, acc), do: {acc |> Enum.reverse() |> to_string(), [], pos}
+
+  defp do_consume_block_comment([?*, ?/ | rest], pos, acc) do
+    next_pos = advance_position(pos, ~c"*/")
+    {[?/, ?* | acc] |> Enum.reverse() |> to_string(), rest, next_pos}
+  end
+
+  defp do_consume_block_comment([char | rest], pos, acc) do
+    do_consume_block_comment(rest, advance_position(pos, [char]), [char | acc])
+  end
+
+  defp consume_quoted(rest, start_pos, quote_char) when is_integer(quote_char),
+    do: consume_quoted(rest, start_pos, [quote_char])
+
+  defp consume_quoted(rest, start_pos, [quote_char]) do
+    do_consume_quoted(rest, advance_position(start_pos, [quote_char]), [quote_char], quote_char)
+  end
+
+  defp do_consume_quoted([], pos, acc, _quote_char),
+    do: {acc |> Enum.reverse() |> to_string(), [], pos}
+
+  defp do_consume_quoted([quote_char, quote_char | rest], pos, acc, quote_char) do
+    next_pos = advance_position(pos, [quote_char, quote_char])
+    do_consume_quoted(rest, next_pos, [quote_char, quote_char | acc], quote_char)
+  end
+
+  defp do_consume_quoted([quote_char | rest], pos, acc, quote_char) do
+    next_pos = advance_position(pos, [quote_char])
+    {[quote_char | acc] |> Enum.reverse() |> to_string(), rest, next_pos}
+  end
+
+  defp do_consume_quoted([char | rest], pos, acc, quote_char) do
+    do_consume_quoted(rest, advance_position(pos, [char]), [char | acc], quote_char)
+  end
+
+  defp take_horizontal_space([char | rest], acc) when char in [32, 9, 10, 13],
+    do: take_horizontal_space(rest, [char | acc])
+
+  defp take_horizontal_space(rest, acc), do: {Enum.reverse(acc), rest}
+
+  defp peek_nonspace_char([char | rest]) when char in [32, 9, 10, 13],
+    do: peek_nonspace_char(rest)
+
+  defp peek_nonspace_char([char | _rest]), do: char
+  defp peek_nonspace_char([]), do: nil
 
   defp read_identifier(chars), do: do_read_identifier(chars, [])
 
@@ -411,98 +985,98 @@ defmodule Favn.SQL.Template do
 
   defp read_alias_chain(rest, segments), do: {segments, rest}
 
-  defp uppercase_alias_segments?(segments) do
-    Enum.all?(segments, &String.match?(&1, ~r/^[A-Z][A-Za-z0-9_]*$/))
+  defp uppercase_alias_segments?(segments),
+    do: Enum.all?(segments, &String.match?(&1, ~r/^[A-Z][A-Za-z0-9_]*$/))
+
+  defp update_relation_context(state, "from"),
+    do: %{
+      state
+      | relation_entry?: true,
+        join_prefix: nil,
+        statement_kind: update_statement_kind(state.statement_kind, "from", state.paren_depth)
+    }
+
+  defp update_relation_context(state, "join"),
+    do: %{
+      state
+      | relation_entry?: true,
+        join_prefix: nil,
+        statement_kind: update_statement_kind(state.statement_kind, "join", state.paren_depth)
+    }
+
+  defp update_relation_context(state, word) when word in @join_prefixes,
+    do: %{
+      state
+      | relation_entry?: false,
+        join_prefix: word,
+        statement_kind: update_statement_kind(state.statement_kind, word, state.paren_depth)
+    }
+
+  defp update_relation_context(%{join_prefix: prefix} = state, "outer")
+       when prefix in @outer_join_prefixes,
+       do: %{
+         state
+         | relation_entry?: false,
+           join_prefix: "#{prefix} outer",
+           statement_kind: update_statement_kind(state.statement_kind, "outer", state.paren_depth)
+       }
+
+  defp update_relation_context(%{join_prefix: prefix} = state, "join")
+       when prefix in @join_entry_prefixes,
+       do: %{
+         state
+         | relation_entry?: true,
+           join_prefix: nil,
+           statement_kind: update_statement_kind(state.statement_kind, "join", state.paren_depth)
+       }
+
+  defp update_relation_context(state, word),
+    do: %{
+      state
+      | relation_entry?: false,
+        join_prefix: nil,
+        statement_kind: update_statement_kind(state.statement_kind, word, state.paren_depth)
+    }
+
+  defp top_level_statement_kind(:query), do: :query
+  defp top_level_statement_kind(:expression), do: :expression
+
+  defp update_statement_kind(kind, word, _depth) do
+    cond do
+      word == "update" -> :update
+      word == "merge" -> :merge
+      true -> kind
+    end
   end
 
-  defp skip_horizontal_space([char | rest]) when char in [32, 9, 13],
-    do: skip_horizontal_space(rest)
+  defp local_arg_index(args) do
+    args
+    |> Enum.with_index()
+    |> Map.new(fn {name, index} -> {name, index} end)
+  end
 
-  defp skip_horizontal_space([char | _]), do: char
-  defp skip_horizontal_space([]), do: nil
+  defp span(%Position{} = start_pos, %Position{} = end_pos) do
+    %Span{
+      start_offset: start_pos.offset,
+      end_offset: end_pos.offset,
+      start_line: start_pos.line,
+      start_column: start_pos.column,
+      end_line: end_pos.line,
+      end_column: end_pos.column
+    }
+  end
 
-  defp update_relation_context(ctx, "from"), do: %{ctx | relation_entry?: true, join_prefix: nil}
-  defp update_relation_context(ctx, "join"), do: %{ctx | relation_entry?: true, join_prefix: nil}
+  defp advance_state(state, chars),
+    do: %{state | position: advance_position(state.position, chars)}
 
-  defp update_relation_context(ctx, word)
-       when word in ["inner", "left", "right", "full", "cross"],
-       do: %{ctx | relation_entry?: false, join_prefix: word}
-
-  defp update_relation_context(%{join_prefix: prefix} = ctx, "outer")
-       when prefix in ["left", "right", "full"],
-       do: %{ctx | relation_entry?: false, join_prefix: "#{prefix} outer"}
-
-  defp update_relation_context(%{join_prefix: prefix} = ctx, "join")
-       when prefix in [
-              "inner",
-              "left",
-              "right",
-              "full",
-              "cross",
-              "left outer",
-              "right outer",
-              "full outer"
-            ],
-       do: %{ctx | relation_entry?: true, join_prefix: nil}
-
-  defp update_relation_context(ctx, _word), do: %{ctx | relation_entry?: false, join_prefix: nil}
-
-  defp validate_asset_refs!(asset_refs, current_module, file, fallback_line) do
-    Enum.each(asset_refs, fn %AssetRef{module: module, line: line} ->
-      if module == current_module do
-        compile_error!(
-          file,
-          line || fallback_line,
-          "SQL asset cannot reference itself as a relation"
-        )
+  defp advance_position(%Position{} = pos, chars) when is_list(chars) do
+    Enum.reduce(chars, pos, fn char, acc ->
+      if char == ?\n do
+        %Position{offset: acc.offset + 1, line: acc.line + 1, column: 1}
       else
-        validate_compiled_asset_module!(module, file, line || fallback_line)
+        %Position{offset: acc.offset + 1, line: acc.line, column: acc.column + 1}
       end
     end)
-  end
-
-  defp validate_compiled_asset_module!(module, file, line) do
-    case Code.ensure_compiled(module) do
-      {:module, _module} ->
-        if function_exported?(module, :__favn_single_asset__, 0) and
-             module.__favn_single_asset__() do
-          validate_produced_relation!(module, file, line)
-        else
-          compile_error!(
-            file,
-            line,
-            "invalid SQL asset reference #{inspect(module)}; expected a compiled single-asset module"
-          )
-        end
-
-      {:error, _reason} ->
-        compile_error!(
-          file,
-          line,
-          "invalid SQL asset reference #{inspect(module)}; module could not be resolved"
-        )
-    end
-  end
-
-  defp validate_produced_relation!(module, file, line) do
-    case Compiler.compile_module_assets(module) do
-      {:ok, [%{produces: nil}]} ->
-        compile_error!(
-          file,
-          line,
-          "SQL asset reference #{inspect(module)} does not resolve to a produced relation"
-        )
-
-      {:ok, [_asset]} ->
-        :ok
-
-      {:error, _reason} ->
-        compile_error!(
-          file,
-          line,
-          "invalid SQL asset reference #{inspect(module)}; failed to compile asset definition"
-        )
-    end
   end
 
   defp compile_error!(file, line, description) do

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -3,6 +3,8 @@ defmodule Favn.SQL.Template do
   Normalized SQL template representation used by SQL asset authoring.
   """
 
+  alias Favn.Assets.Compiler
+
   @relation_prefix_regex ~r/(?:^|\s)(?:from|join|inner\s+join|left(?:\s+outer)?\s+join|right(?:\s+outer)?\s+join|full(?:\s+outer)?\s+join|cross\s+join)\s*$/i
 
   @enforce_keys [:source, :inputs, :runtime_inputs, :param_inputs]
@@ -252,18 +254,181 @@ defmodule Favn.SQL.Template do
   defp validate_call_context!(_shape, _context, _name, _arity, _file, _line), do: :ok
 
   defp extract_asset_refs(sql) do
-    pattern =
-      ~r/\b(?:from|join|inner\s+join|left(?:\s+outer)?\s+join|right(?:\s+outer)?\s+join|full(?:\s+outer)?\s+join|cross\s+join)\s+([A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)+)/i
-
-    pattern
-    |> Regex.scan(sql, capture: :all_but_first, return: :index)
-    |> Enum.map(fn [{name_start, name_len}] ->
-      name = String.slice(sql, name_start, name_len)
-      module = name |> String.split(".") |> Module.concat()
-      line = line_for_index(String.slice(sql, 0, name_start))
-      %AssetRef{module: module, line: line}
-    end)
+    sql
+    |> String.to_charlist()
+    |> do_extract_asset_refs(
+      1,
+      :code,
+      %{allow_refs?: nil, relation_entry?: false, join_prefix: nil},
+      []
+    )
+    |> Enum.reverse()
   end
+
+  defp do_extract_asset_refs([], _line, _state, _ctx, acc), do: acc
+
+  defp do_extract_asset_refs([?-, ?- | rest], line, :code, ctx, acc),
+    do: do_extract_asset_refs(rest, line, :line_comment, ctx, acc)
+
+  defp do_extract_asset_refs([?/, ?* | rest], line, :code, ctx, acc),
+    do: do_extract_asset_refs(rest, line, :block_comment, ctx, acc)
+
+  defp do_extract_asset_refs([?' | rest], line, :code, ctx, acc),
+    do: do_extract_asset_refs(rest, line, :single_quote, ctx, acc)
+
+  defp do_extract_asset_refs([?" | rest], line, :code, ctx, acc),
+    do: do_extract_asset_refs(rest, line, :double_quote, ctx, acc)
+
+  defp do_extract_asset_refs([char | rest], line, :line_comment, ctx, acc) do
+    if char == ?\n do
+      do_extract_asset_refs(rest, line + 1, :code, ctx, acc)
+    else
+      do_extract_asset_refs(rest, line, :line_comment, ctx, acc)
+    end
+  end
+
+  defp do_extract_asset_refs([?*, ?/ | rest], line, :block_comment, ctx, acc),
+    do: do_extract_asset_refs(rest, line, :code, ctx, acc)
+
+  defp do_extract_asset_refs([char | rest], line, :block_comment, ctx, acc) do
+    next_line = if char == ?\n, do: line + 1, else: line
+    do_extract_asset_refs(rest, next_line, :block_comment, ctx, acc)
+  end
+
+  defp do_extract_asset_refs([?' | rest], line, :single_quote, ctx, acc),
+    do: do_extract_asset_refs(rest, line, :code, ctx, acc)
+
+  defp do_extract_asset_refs([char | rest], line, :single_quote, ctx, acc) do
+    next_line = if char == ?\n, do: line + 1, else: line
+    do_extract_asset_refs(rest, next_line, :single_quote, ctx, acc)
+  end
+
+  defp do_extract_asset_refs([?" | rest], line, :double_quote, ctx, acc),
+    do: do_extract_asset_refs(rest, line, :code, ctx, acc)
+
+  defp do_extract_asset_refs([char | rest], line, :double_quote, ctx, acc) do
+    next_line = if char == ?\n, do: line + 1, else: line
+    do_extract_asset_refs(rest, next_line, :double_quote, ctx, acc)
+  end
+
+  defp do_extract_asset_refs([char | rest], line, :code, ctx, acc)
+       when char in [32, 9, 13] do
+    do_extract_asset_refs(rest, line, :code, ctx, acc)
+  end
+
+  defp do_extract_asset_refs([?\n | rest], line, :code, ctx, acc),
+    do: do_extract_asset_refs(rest, line + 1, :code, ctx, acc)
+
+  defp do_extract_asset_refs([char | _rest] = chars, line, :code, ctx, acc)
+       when (char >= ?A and char <= ?Z) or (char >= ?a and char <= ?z) or char == ?_ do
+    {word, tail} = read_identifier(chars)
+    word_down = String.downcase(word)
+    ctx = maybe_set_allow_refs(ctx, word_down)
+
+    if relation_reference_candidate?(ctx, word, tail) do
+      {segments, tail_after_module} = read_alias_chain(tail, [word])
+      next_char = skip_horizontal_space(tail_after_module)
+
+      if length(segments) >= 2 and uppercase_alias_segments?(segments) and next_char != ?( do
+        module = Module.concat(segments)
+        ref = %AssetRef{module: module, line: line}
+        next_ctx = %{ctx | relation_entry?: false, join_prefix: nil}
+        do_extract_asset_refs(tail_after_module, line, :code, next_ctx, [ref | acc])
+      else
+        next_ctx = update_relation_context(ctx, word_down)
+        do_extract_asset_refs(tail, line, :code, next_ctx, acc)
+      end
+    else
+      next_ctx = update_relation_context(ctx, word_down)
+      do_extract_asset_refs(tail, line, :code, next_ctx, acc)
+    end
+  end
+
+  defp do_extract_asset_refs([?( | rest], line, :code, ctx, acc) do
+    next_ctx = %{ctx | relation_entry?: false, join_prefix: nil}
+    do_extract_asset_refs(rest, line, :code, next_ctx, acc)
+  end
+
+  defp do_extract_asset_refs([_char | rest], line, :code, ctx, acc) do
+    next_ctx = %{ctx | relation_entry?: false, join_prefix: nil}
+    do_extract_asset_refs(rest, line, :code, next_ctx, acc)
+  end
+
+  defp maybe_set_allow_refs(%{allow_refs?: nil} = ctx, "update"),
+    do: %{ctx | allow_refs?: false}
+
+  defp maybe_set_allow_refs(%{allow_refs?: nil} = ctx, "merge"),
+    do: %{ctx | allow_refs?: false}
+
+  defp maybe_set_allow_refs(%{allow_refs?: nil} = ctx, _word),
+    do: %{ctx | allow_refs?: true}
+
+  defp maybe_set_allow_refs(ctx, _word), do: ctx
+
+  defp relation_reference_candidate?(%{allow_refs?: true, relation_entry?: true}, word, tail) do
+    String.match?(word, ~r/^[A-Z][A-Za-z0-9_]*$/) and List.first(tail) == ?.
+  end
+
+  defp relation_reference_candidate?(_ctx, _word, _tail), do: false
+
+  defp read_identifier(chars), do: do_read_identifier(chars, [])
+
+  defp do_read_identifier([char | rest], acc)
+       when (char >= ?A and char <= ?Z) or (char >= ?a and char <= ?z) or
+              (char >= ?0 and char <= ?9) or char == ?_ do
+    do_read_identifier(rest, [char | acc])
+  end
+
+  defp do_read_identifier(rest, acc), do: {acc |> Enum.reverse() |> to_string(), rest}
+
+  defp read_alias_chain([?. | rest], segments) do
+    case rest do
+      [char | _] when (char >= ?A and char <= ?Z) or (char >= ?a and char <= ?z) or char == ?_ ->
+        {segment, tail} = read_identifier(rest)
+        read_alias_chain(tail, segments ++ [segment])
+
+      _ ->
+        {segments, [?. | rest]}
+    end
+  end
+
+  defp read_alias_chain(rest, segments), do: {segments, rest}
+
+  defp uppercase_alias_segments?(segments) do
+    Enum.all?(segments, &String.match?(&1, ~r/^[A-Z][A-Za-z0-9_]*$/))
+  end
+
+  defp skip_horizontal_space([char | rest]) when char in [32, 9, 13],
+    do: skip_horizontal_space(rest)
+
+  defp skip_horizontal_space([char | _]), do: char
+  defp skip_horizontal_space([]), do: nil
+
+  defp update_relation_context(ctx, "from"), do: %{ctx | relation_entry?: true, join_prefix: nil}
+  defp update_relation_context(ctx, "join"), do: %{ctx | relation_entry?: true, join_prefix: nil}
+
+  defp update_relation_context(ctx, word)
+       when word in ["inner", "left", "right", "full", "cross"],
+       do: %{ctx | relation_entry?: false, join_prefix: word}
+
+  defp update_relation_context(%{join_prefix: prefix} = ctx, "outer")
+       when prefix in ["left", "right", "full"],
+       do: %{ctx | relation_entry?: false, join_prefix: "#{prefix} outer"}
+
+  defp update_relation_context(%{join_prefix: prefix} = ctx, "join")
+       when prefix in [
+              "inner",
+              "left",
+              "right",
+              "full",
+              "cross",
+              "left outer",
+              "right outer",
+              "full outer"
+            ],
+       do: %{ctx | relation_entry?: true, join_prefix: nil}
+
+  defp update_relation_context(ctx, _word), do: %{ctx | relation_entry?: false, join_prefix: nil}
 
   defp validate_asset_refs!(asset_refs, current_module, file, fallback_line) do
     Enum.each(asset_refs, fn %AssetRef{module: module, line: line} ->
@@ -284,7 +449,7 @@ defmodule Favn.SQL.Template do
       {:module, _module} ->
         if function_exported?(module, :__favn_single_asset__, 0) and
              module.__favn_single_asset__() do
-          :ok
+          validate_produced_relation!(module, file, line)
         else
           compile_error!(
             file,
@@ -295,6 +460,27 @@ defmodule Favn.SQL.Template do
 
       {:error, _reason} ->
         :ok
+    end
+  end
+
+  defp validate_produced_relation!(module, file, line) do
+    case Compiler.compile_module_assets(module) do
+      {:ok, [%{produces: nil}]} ->
+        compile_error!(
+          file,
+          line,
+          "SQL asset reference #{inspect(module)} does not resolve to a produced relation"
+        )
+
+      {:ok, [_asset]} ->
+        :ok
+
+      {:error, _reason} ->
+        compile_error!(
+          file,
+          line,
+          "invalid SQL asset reference #{inspect(module)}; failed to compile asset definition"
+        )
     end
   end
 

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -259,7 +259,7 @@ defmodule Favn.SQL.Template do
     |> do_extract_asset_refs(
       1,
       :code,
-      %{allow_refs?: nil, relation_entry?: false, join_prefix: nil},
+      %{asset_refs_enabled?: true, relation_entry?: false, join_prefix: nil, paren_depth: 0},
       []
     )
     |> Enum.reverse()
@@ -323,7 +323,7 @@ defmodule Favn.SQL.Template do
        when (char >= ?A and char <= ?Z) or (char >= ?a and char <= ?z) or char == ?_ do
     {word, tail} = read_identifier(chars)
     word_down = String.downcase(word)
-    ctx = maybe_set_allow_refs(ctx, word_down)
+    ctx = update_statement_context(ctx, word_down)
 
     if relation_reference_candidate?(ctx, word, tail) do
       {segments, tail_after_module} = read_alias_chain(tail, [word])
@@ -345,7 +345,23 @@ defmodule Favn.SQL.Template do
   end
 
   defp do_extract_asset_refs([?( | rest], line, :code, ctx, acc) do
-    next_ctx = %{ctx | relation_entry?: false, join_prefix: nil}
+    next_ctx = %{ctx | relation_entry?: false, join_prefix: nil, paren_depth: ctx.paren_depth + 1}
+    do_extract_asset_refs(rest, line, :code, next_ctx, acc)
+  end
+
+  defp do_extract_asset_refs([?) | rest], line, :code, ctx, acc) do
+    next_ctx = %{
+      ctx
+      | relation_entry?: false,
+        join_prefix: nil,
+        paren_depth: max(ctx.paren_depth - 1, 0)
+    }
+
+    do_extract_asset_refs(rest, line, :code, next_ctx, acc)
+  end
+
+  defp do_extract_asset_refs([?; | rest], line, :code, %{paren_depth: 0} = ctx, acc) do
+    next_ctx = %{ctx | relation_entry?: false, join_prefix: nil, asset_refs_enabled?: true}
     do_extract_asset_refs(rest, line, :code, next_ctx, acc)
   end
 
@@ -354,18 +370,19 @@ defmodule Favn.SQL.Template do
     do_extract_asset_refs(rest, line, :code, next_ctx, acc)
   end
 
-  defp maybe_set_allow_refs(%{allow_refs?: nil} = ctx, "update"),
-    do: %{ctx | allow_refs?: false}
+  defp update_statement_context(%{paren_depth: depth} = ctx, _word) when depth > 0, do: ctx
 
-  defp maybe_set_allow_refs(%{allow_refs?: nil} = ctx, "merge"),
-    do: %{ctx | allow_refs?: false}
+  defp update_statement_context(ctx, "update"), do: %{ctx | asset_refs_enabled?: false}
 
-  defp maybe_set_allow_refs(%{allow_refs?: nil} = ctx, _word),
-    do: %{ctx | allow_refs?: true}
+  defp update_statement_context(ctx, "merge"), do: %{ctx | asset_refs_enabled?: false}
 
-  defp maybe_set_allow_refs(ctx, _word), do: ctx
+  defp update_statement_context(ctx, _word), do: ctx
 
-  defp relation_reference_candidate?(%{allow_refs?: true, relation_entry?: true}, word, tail) do
+  defp relation_reference_candidate?(
+         %{asset_refs_enabled?: true, relation_entry?: true},
+         word,
+         tail
+       ) do
     String.match?(word, ~r/^[A-Z][A-Za-z0-9_]*$/) and List.first(tail) == ?.
   end
 
@@ -459,7 +476,11 @@ defmodule Favn.SQL.Template do
         end
 
       {:error, _reason} ->
-        :ok
+        compile_error!(
+          file,
+          line,
+          "invalid SQL asset reference #{inspect(module)}; module could not be resolved"
+        )
     end
   end
 

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -6,13 +6,17 @@ defmodule Favn.SQLAsset do
   `%Favn.Asset{}` with ref `{Module, :asset}`.
 
   SQL bodies are authored with `query do ... end` and a real `~SQL` sigil.
-  In the current phase, `~SQL` simply returns a plain SQL string.
+  SQL compilation keeps the authored SQL source and a normalized SQL template IR
+  so reusable SQL definitions and relation references can be validated at compile time.
   """
 
   alias Favn.Asset
   alias Favn.Namespace
   alias Favn.Ref
   alias Favn.RelationRef
+  alias Favn.SQL
+  alias Favn.SQL.Definition, as: SQLDefinition
+  alias Favn.SQL.Template
   alias Favn.SQLAsset.Definition
   alias Favn.SQLAsset.Materialization
   alias Favn.SQLAsset.Runtime
@@ -27,11 +31,13 @@ defmodule Favn.SQLAsset do
       Module.register_attribute(__MODULE__, :window, accumulate: true)
       Module.register_attribute(__MODULE__, :materialized, accumulate: true)
       Module.register_attribute(__MODULE__, :favn_sql_asset_raw, persist: false)
+      Module.register_attribute(__MODULE__, :favn_sql_imports, accumulate: true)
 
       @on_definition Favn.SQLAsset
       @before_compile Favn.SQLAsset
 
-      import Favn.SQLAsset, only: [query: 1, sigil_SQL: 2]
+      import Favn.SQLAsset, only: [query: 1]
+      import Favn.SQL, only: [sigil_SQL: 2]
     end
   end
 
@@ -67,31 +73,6 @@ defmodule Favn.SQLAsset do
         _ ->
           :ok
       end
-    end
-  end
-
-  @doc false
-  defmacro sigil_SQL({:<<>>, _meta, parts}, modifiers) when is_list(modifiers) do
-    if modifiers != [] do
-      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL sigil does not support modifiers")
-    end
-
-    if Enum.all?(parts, &is_binary/1) do
-      Enum.join(parts)
-    else
-      compile_error!(
-        __CALLER__.file,
-        __CALLER__.line,
-        "~SQL sigil does not support interpolation"
-      )
-    end
-  end
-
-  defmacro sigil_SQL(_body, modifiers) do
-    if modifiers != [] do
-      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL sigil does not support modifiers")
-    else
-      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL body must be a literal string")
     end
   end
 
@@ -144,6 +125,10 @@ defmodule Favn.SQLAsset do
         :materialized,
         env.module |> fetch_accum_attribute(:materialized) |> Enum.reverse()
       )
+      |> Map.put(
+        :sql_imports,
+        env.module |> fetch_accum_attribute(:favn_sql_imports) |> Enum.reverse()
+      )
 
     definition = build_definition!(raw_definition)
 
@@ -176,6 +161,15 @@ defmodule Favn.SQLAsset do
     window_spec = normalize_window!(raw_definition.window, raw_definition)
     materialization = normalize_materialized!(raw_definition.materialized, raw_definition)
     produces = normalize_produces!(raw_definition, inferred_relation_name(raw_definition.module))
+    known_definitions = fetch_sql_definitions!(raw_definition)
+
+    template =
+      Template.compile!(raw_definition.sql,
+        known_definitions: known_definitions,
+        file: raw_definition.file,
+        line: raw_definition.line,
+        module: raw_definition.module
+      )
 
     asset = %Asset{
       module: raw_definition.module,
@@ -198,6 +192,8 @@ defmodule Favn.SQLAsset do
       module: raw_definition.module,
       asset: asset,
       sql: raw_definition.sql,
+      template: template,
+      sql_definitions: Map.values(known_definitions),
       materialization: materialization,
       raw_asset: raw_definition
     }
@@ -396,33 +392,38 @@ defmodule Favn.SQLAsset do
   end
 
   defp extract_sql!(body, env) do
-    case body do
-      {:sigil_SQL, _meta, [parts_ast, modifiers]} ->
-        extract_sigil_sql!(parts_ast, modifiers, env)
+    SQL.extract_sql!(body, env, "query body must contain a ~SQL literal")
+  end
 
-      _ ->
+  defp fetch_sql_definitions!(raw_definition) do
+    raw_definition
+    |> Map.get(:sql_imports, [])
+    |> Enum.uniq()
+    |> Enum.flat_map(fn module ->
+      case Code.ensure_compiled(module) do
+        {:module, _} ->
+          if function_exported?(module, :__favn_sql_definitions__, 0) do
+            module.__favn_sql_definitions__()
+          else
+            []
+          end
+
+        {:error, _reason} ->
+          []
+      end
+    end)
+    |> Enum.map(fn
+      %SQLDefinition{name: name, arity: arity} = definition ->
+        {{name, arity}, definition}
+
+      other ->
         compile_error!(
-          env.file,
-          env.line,
-          "query body must contain a ~SQL literal"
+          raw_definition.file,
+          raw_definition.line,
+          "invalid SQL definition import #{inspect(other)}"
         )
-    end
-  end
-
-  defp extract_sigil_sql!(_parts_ast, modifiers, env) when modifiers != [] do
-    compile_error!(env.file, env.line, "~SQL sigil does not support modifiers")
-  end
-
-  defp extract_sigil_sql!({:<<>>, _meta, parts}, [], env) do
-    if Enum.all?(parts, &is_binary/1) do
-      Enum.join(parts)
-    else
-      compile_error!(env.file, env.line, "~SQL sigil does not support interpolation")
-    end
-  end
-
-  defp extract_sigil_sql!(_parts_ast, [], env) do
-    compile_error!(env.file, env.line, "query body must contain a ~SQL literal")
+    end)
+    |> Map.new()
   end
 
   defp normalize_doc({_line, false}), do: nil

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -168,7 +168,10 @@ defmodule Favn.SQLAsset do
         known_definitions: known_definitions,
         file: raw_definition.file,
         line: raw_definition.line,
-        module: raw_definition.module
+        module: raw_definition.module,
+        scope: :query,
+        local_args: [],
+        enforce_query_root: true
       )
 
     asset = %Asset{
@@ -405,18 +408,39 @@ defmodule Favn.SQLAsset do
           if function_exported?(module, :__favn_sql_definitions__, 0) do
             module.__favn_sql_definitions__()
           else
-            []
+            compile_error!(
+              raw_definition.file,
+              raw_definition.line,
+              "imported SQL provider #{inspect(module)} does not define reusable SQL"
+            )
           end
 
         {:error, _reason} ->
-          []
+          compile_error!(
+            raw_definition.file,
+            raw_definition.line,
+            "imported SQL provider #{inspect(module)} could not be resolved"
+          )
       end
     end)
+    |> Enum.group_by(fn
+      %SQLDefinition{name: name, arity: arity} -> {name, arity}
+      other -> other
+    end)
     |> Enum.map(fn
-      %SQLDefinition{name: name, arity: arity} = definition ->
+      {{name, arity}, [%SQLDefinition{} = definition]} ->
         {{name, arity}, definition}
 
-      other ->
+      {{name, arity}, definitions} ->
+        providers = definitions |> Enum.map(&inspect(&1.module)) |> Enum.sort() |> Enum.join(", ")
+
+        compile_error!(
+          raw_definition.file,
+          raw_definition.line,
+          "duplicate visible defsql #{name}/#{arity}; conflicting providers: #{providers}"
+        )
+
+      {other, _definitions} ->
         compile_error!(
           raw_definition.file,
           raw_definition.line,

--- a/lib/favn/sql_asset/definition.ex
+++ b/lib/favn/sql_asset/definition.ex
@@ -4,16 +4,27 @@ defmodule Favn.SQLAsset.Definition do
   """
 
   alias Favn.Asset
+  alias Favn.SQL
   alias Favn.SQLAsset.Materialization
 
-  @enforce_keys [:module, :asset, :sql, :materialization]
-  defstruct [:module, :asset, :sql, :materialization, raw_asset: nil]
+  @enforce_keys [:module, :asset, :sql, :template, :materialization]
+  defstruct [
+    :module,
+    :asset,
+    :sql,
+    :template,
+    :materialization,
+    sql_definitions: [],
+    raw_asset: nil
+  ]
 
   @type t :: %__MODULE__{
           module: module(),
           asset: Asset.t(),
           sql: String.t(),
+          template: SQL.Template.t(),
           materialization: Materialization.t(),
+          sql_definitions: [SQL.Definition.t()],
           raw_asset: map() | nil
         }
 end

--- a/test/sql_dsl_test.exs
+++ b/test/sql_dsl_test.exs
@@ -25,7 +25,10 @@ defmodule Favn.SQLDSLTest do
     Code.compile_string(
       """
       defmodule #{inspect(raw_orders)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
         use Favn.Asset
+
+        @produces true
 
         def asset(_ctx), do: :ok
       end
@@ -177,7 +180,10 @@ defmodule Favn.SQLDSLTest do
     Code.compile_string(
       """
       defmodule #{inspect(raw_orders)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
         use Favn.Asset
+
+        @produces true
 
         def asset(_ctx), do: :ok
       end

--- a/test/sql_dsl_test.exs
+++ b/test/sql_dsl_test.exs
@@ -93,15 +93,17 @@ defmodule Favn.SQLDSLTest do
            ] =
              Enum.sort_by(definition.sql_definitions, &{&1.name, &1.arity})
 
-    assert definition.template.runtime_inputs == MapSet.new([:window_start, :window_end])
-    assert definition.template.param_inputs == MapSet.new([:country])
+    assert Template.runtime_inputs(definition.template) ==
+             MapSet.new([:window_start, :window_end])
 
-    assert Enum.any?(definition.template.calls, fn %Template.Call{} = call ->
-             call.name == :cents_to_dollars and call.context == :expression
+    assert Template.query_params(definition.template) == MapSet.new([:country])
+
+    assert Enum.any?(Template.calls(definition.template), fn %Template.Call{} = call ->
+             call.definition.name == :cents_to_dollars and call.context == :expression
            end)
 
-    assert Enum.any?(definition.template.calls, fn %Template.Call{} = call ->
-             call.name == :orders_in_window and call.context == :relation
+    assert Enum.any?(Template.calls(definition.template), fn %Template.Call{} = call ->
+             call.definition.name == :orders_in_window and call.context == :relation
            end)
 
     assert {:ok, [_asset]} = Compiler.compile_module_assets(asset_module)

--- a/test/sql_dsl_test.exs
+++ b/test/sql_dsl_test.exs
@@ -1,0 +1,309 @@
+defmodule Favn.SQLDSLTest do
+  use ExUnit.Case
+
+  alias Favn.Assets.Compiler
+  alias Favn.SQL.Definition, as: SQLDefinition
+  alias Favn.SQL.Template
+  alias Favn.SQLAsset.Compiler, as: SQLAssetCompiler
+
+  setup do
+    state = Favn.TestSetup.capture_state()
+
+    on_exit(fn ->
+      Favn.TestSetup.restore_state(state, reload_graph?: true)
+    end)
+
+    :ok
+  end
+
+  test "supports defsql reusable SQL and query validation" do
+    root = Module.concat(__MODULE__, "Root#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    raw_orders = Module.concat(root, RawOrders)
+    asset_module = Module.concat(root, Revenue)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(raw_orders)} do
+        use Favn.Asset
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_dsl_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql cents_to_dollars(amount_cents) do
+          ~SQL[
+          cast((@amount_cents / 100.0) as numeric(16, 2))
+          ]
+        end
+
+        defsql orders_in_window(start_at, end_at) do
+          ~SQL[
+          select order_id, customer_id, total_amount
+          from #{inspect(raw_orders)}
+          where inserted_at >= @start_at
+            and inserted_at < @end_at
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_dsl_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+        use #{inspect(sql_module)}
+
+        @materialized :table
+
+        query do
+          ~SQL[
+          select
+            customer_id,
+            sum(cents_to_dollars(total_amount_cents)) as gross_revenue
+          from orders_in_window(@window_start, @window_end)
+          where (@country is null or country = @country)
+          group by 1
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_dsl_test.exs"
+    )
+
+    assert {:ok, %Favn.SQLAsset.Definition{} = definition} =
+             SQLAssetCompiler.fetch_definition(asset_module)
+
+    assert [
+             %SQLDefinition{name: :cents_to_dollars, arity: 1, shape: :expression},
+             %SQLDefinition{name: :orders_in_window, arity: 2, shape: :relation}
+           ] =
+             Enum.sort_by(definition.sql_definitions, &{&1.name, &1.arity})
+
+    assert definition.template.runtime_inputs == MapSet.new([:window_start, :window_end])
+    assert definition.template.param_inputs == MapSet.new([:country])
+
+    assert Enum.any?(definition.template.calls, fn %Template.Call{} = call ->
+             call.name == :cents_to_dollars and call.context == :expression
+           end)
+
+    assert Enum.any?(definition.template.calls, fn %Template.Call{} = call ->
+             call.name == :orders_in_window and call.context == :relation
+           end)
+
+    assert {:ok, [_asset]} = Compiler.compile_module_assets(asset_module)
+  end
+
+  test "rejects reserved runtime names as defsql arguments" do
+    assert_raise CompileError, ~r/defsql argument @window_start is reserved/, fn ->
+      Code.compile_string(
+        """
+        defmodule #{inspect(Module.concat(__MODULE__, "Reserved#{System.unique_integer([:positive])}"))} do
+          use Favn.SQL
+
+          defsql bad(window_start) do
+            ~SQL[
+            @window_start
+            ]
+          end
+        end
+        """,
+        "test/dynamic_sql_dsl_test.exs"
+      )
+    end
+  end
+
+  test "rejects expression macro in relation position" do
+    root = Module.concat(__MODULE__, "ExprInFrom#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    asset_module = Module.concat(root, Asset)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql cents_to_dollars(amount_cents) do
+          ~SQL[
+          cast((@amount_cents / 100.0) as numeric(16, 2))
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_dsl_test.exs"
+    )
+
+    assert_raise CompileError,
+                 ~r/invalid SQL call cents_to_dollars\/1 in relation position/,
+                 fn ->
+                   Code.compile_string(
+                     """
+                     defmodule #{inspect(asset_module)} do
+                       use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+                       use Favn.SQLAsset
+                       use #{inspect(sql_module)}
+
+                       @materialized :view
+
+                       query do
+                         ~SQL[
+                         select *
+                         from cents_to_dollars(total_amount_cents)
+                         ]
+                       end
+                     end
+                     """,
+                     "test/dynamic_sql_dsl_test.exs"
+                   )
+                 end
+  end
+
+  test "rejects relation macro in expression position" do
+    root = Module.concat(__MODULE__, "RelInExpr#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    raw_orders = Module.concat(root, RawOrders)
+    asset_module = Module.concat(root, Asset)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(raw_orders)} do
+        use Favn.Asset
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_dsl_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql orders_in_window(start_at, end_at) do
+          ~SQL[
+          select *
+          from #{inspect(raw_orders)}
+          where inserted_at >= @start_at and inserted_at < @end_at
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_dsl_test.exs"
+    )
+
+    assert_raise CompileError,
+                 ~r/invalid SQL call orders_in_window\/2 in expression position/,
+                 fn ->
+                   Code.compile_string(
+                     """
+                     defmodule #{inspect(asset_module)} do
+                       use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+                       use Favn.SQLAsset
+                       use #{inspect(sql_module)}
+
+                       @materialized :view
+
+                       query do
+                         ~SQL[
+                         select orders_in_window(@window_start, @window_end) as bad
+                         ]
+                       end
+                     end
+                     """,
+                     "test/dynamic_sql_dsl_test.exs"
+                   )
+                 end
+  end
+
+  test "rejects invalid compiled module in relation position" do
+    bad_module = Module.concat(__MODULE__, "BadRelation#{System.unique_integer([:positive])}")
+
+    asset_module =
+      Module.concat(__MODULE__, "BadRelationAsset#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(bad_module)} do
+      end
+      """,
+      "test/dynamic_sql_dsl_test.exs"
+    )
+
+    assert_raise CompileError,
+                 ~r/invalid SQL asset reference .*expected a compiled single-asset module/,
+                 fn ->
+                   Code.compile_string(
+                     """
+                     defmodule #{inspect(asset_module)} do
+                       use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+                       use Favn.SQLAsset
+
+                        @materialized :view
+
+                        query do
+                          ~SQL[
+                          select * from #{inspect(bad_module)}
+                          ]
+                        end
+                      end
+                     """,
+                     "test/dynamic_sql_dsl_test.exs"
+                   )
+                 end
+  end
+
+  test "rejects defsql arity mismatch" do
+    root = Module.concat(__MODULE__, "Arity#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    asset_module = Module.concat(root, Asset)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql cents_to_dollars(amount_cents) do
+          ~SQL[
+          cast((@amount_cents / 100.0) as numeric(16, 2))
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_dsl_test.exs"
+    )
+
+    assert_raise CompileError,
+                 ~r/invalid SQL call cents_to_dollars\/2; expected one of arities \[1\]/,
+                 fn ->
+                   Code.compile_string(
+                     """
+                     defmodule #{inspect(asset_module)} do
+                       use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+                       use Favn.SQLAsset
+                       use #{inspect(sql_module)}
+
+                       @materialized :view
+
+                       query do
+                         ~SQL[
+                         select cents_to_dollars(total_amount_cents, fee_cents)
+                         ]
+                       end
+                     end
+                     """,
+                     "test/dynamic_sql_dsl_test.exs"
+                   )
+                 end
+  end
+end

--- a/test/sql_template_asset_ref_test.exs
+++ b/test/sql_template_asset_ref_test.exs
@@ -1,0 +1,132 @@
+defmodule Favn.SQLTemplateAssetRefTest do
+  use ExUnit.Case
+
+  alias Favn.SQL.Template
+
+  setup do
+    state = Favn.TestSetup.capture_state()
+
+    on_exit(fn ->
+      Favn.TestSetup.restore_state(state, reload_graph?: true)
+    end)
+
+    :ok
+  end
+
+  test "detects direct asset refs in from and join positions" do
+    sql = """
+    select *
+    from MyApp.Gold.Sales.FctOrders o
+    left outer join /* customer lookup */ MyApp.Silver.Sales.StgCustomers c on c.customer_id = o.customer_id
+    """
+
+    template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+
+    assert Enum.map(template.asset_refs, & &1.module) == [
+             MyApp.Gold.Sales.FctOrders,
+             MyApp.Silver.Sales.StgCustomers
+           ]
+  end
+
+  test "ignores module-looking values outside relation position" do
+    sql = """
+    -- from MyApp.Gold.Sales.FctOrders
+    select 'MyApp.Gold.Sales.FctOrders' as label,
+           "MyApp.Gold.Sales.FctOrders" as quoted,
+           MyApp.Gold.Sales.FctOrders as expression_like
+    """
+
+    template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+    assert template.asset_refs == []
+  end
+
+  test "does not treat table function syntax as direct asset ref" do
+    sql = """
+    select *
+    from MyApp.Gold.Sales.FctOrders(@window_start)
+    """
+
+    template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+    assert template.asset_refs == []
+  end
+
+  test "does not support update from and merge into asset refs" do
+    update_sql = """
+    update silver.sales.orders as o
+    set customer_id = s.customer_id
+    from MyApp.Silver.Sales.StgCustomers s
+    """
+
+    merge_sql = """
+    merge into silver.sales.orders as tgt
+    using MyApp.Silver.Sales.StgCustomers as src
+    on tgt.customer_id = src.customer_id
+    """
+
+    update_template =
+      Template.compile!(update_sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+
+    merge_template =
+      Template.compile!(merge_sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+
+    assert update_template.asset_refs == []
+    assert merge_template.asset_refs == []
+  end
+
+  test "raises for compiled module that is not a single asset module" do
+    bad_module = Module.concat(__MODULE__, "NotAsset#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      "defmodule #{inspect(bad_module)} do\nend",
+      "test/dynamic_sql_template_asset_ref.exs"
+    )
+
+    assert_raise CompileError,
+                 ~r/invalid SQL asset reference .* expected a compiled single-asset module/,
+                 fn ->
+                   Template.compile!(
+                     "select * from #{inspect(bad_module)}",
+                     file: "test/sql_template_asset_ref_test.exs",
+                     line: 1
+                   )
+                 end
+  end
+
+  test "raises for compiled single-asset module without produced relation" do
+    no_produces = Module.concat(__MODULE__, "NoProduces#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(no_produces)} do
+        use Favn.Asset
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_template_asset_ref.exs"
+    )
+
+    assert_raise CompileError,
+                 ~r/does not resolve to a produced relation/,
+                 fn ->
+                   Template.compile!(
+                     "select * from #{inspect(no_produces)}",
+                     file: "test/sql_template_asset_ref_test.exs",
+                     line: 1
+                   )
+                 end
+  end
+
+  test "raises on self-reference" do
+    current_module = Module.concat(__MODULE__, "SelfRef#{System.unique_integer([:positive])}")
+
+    assert_raise CompileError, ~r/cannot reference itself as a relation/, fn ->
+      Template.compile!(
+        "select * from #{inspect(current_module)}",
+        file: "test/sql_template_asset_ref_test.exs",
+        line: 1,
+        module: current_module
+      )
+    end
+  end
+end

--- a/test/sql_template_asset_ref_test.exs
+++ b/test/sql_template_asset_ref_test.exs
@@ -14,17 +14,23 @@ defmodule Favn.SQLTemplateAssetRefTest do
   end
 
   test "detects direct asset refs in from and join positions" do
+    orders_module = Module.concat(__MODULE__, "Orders#{System.unique_integer([:positive])}")
+    customers_module = Module.concat(__MODULE__, "Customers#{System.unique_integer([:positive])}")
+
+    compile_single_asset_module!(orders_module)
+    compile_single_asset_module!(customers_module)
+
     sql = """
     select *
-    from MyApp.Gold.Sales.FctOrders o
-    left outer join /* customer lookup */ MyApp.Silver.Sales.StgCustomers c on c.customer_id = o.customer_id
+    from #{inspect(orders_module)} o
+    left outer join /* customer lookup */ #{inspect(customers_module)} c on c.customer_id = o.customer_id
     """
 
     template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
 
     assert Enum.map(template.asset_refs, & &1.module) == [
-             MyApp.Gold.Sales.FctOrders,
-             MyApp.Silver.Sales.StgCustomers
+             orders_module,
+             customers_module
            ]
   end
 
@@ -63,14 +69,50 @@ defmodule Favn.SQLTemplateAssetRefTest do
     on tgt.customer_id = src.customer_id
     """
 
+    with_update_sql = """
+    with src as (
+      select 1 as customer_id
+    )
+    update silver.sales.orders as o
+    set customer_id = s.customer_id
+    from MyApp.Silver.Sales.StgCustomers s
+    """
+
+    with_merge_sql = """
+    with src as (
+      select 1 as customer_id
+    )
+    merge into silver.sales.orders as tgt
+    using MyApp.Silver.Sales.StgCustomers as src
+    on tgt.customer_id = src.customer_id
+    """
+
     update_template =
       Template.compile!(update_sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
 
     merge_template =
       Template.compile!(merge_sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
 
+    with_update_template =
+      Template.compile!(with_update_sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+
+    with_merge_template =
+      Template.compile!(with_merge_sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+
     assert update_template.asset_refs == []
     assert merge_template.asset_refs == []
+    assert with_update_template.asset_refs == []
+    assert with_merge_template.asset_refs == []
+  end
+
+  test "raises for unresolved module references" do
+    assert_raise CompileError, ~r/module could not be resolved/, fn ->
+      Template.compile!(
+        "select * from MyApp.Gold.Sales.FctOrdres",
+        file: "test/sql_template_asset_ref_test.exs",
+        line: 1
+      )
+    end
   end
 
   test "raises for compiled module that is not a single asset module" do
@@ -128,5 +170,21 @@ defmodule Favn.SQLTemplateAssetRefTest do
         module: current_module
       )
     end
+  end
+
+  defp compile_single_asset_module!(module) do
+    Code.compile_string(
+      """
+      defmodule #{inspect(module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Asset
+
+        @produces true
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_template_asset_ref.exs"
+    )
   end
 end

--- a/test/sql_template_asset_ref_test.exs
+++ b/test/sql_template_asset_ref_test.exs
@@ -28,7 +28,7 @@ defmodule Favn.SQLTemplateAssetRefTest do
 
     template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
 
-    assert Enum.map(template.asset_refs, & &1.module) == [
+    assert Enum.map(Template.asset_refs(template), & &1.module) == [
              orders_module,
              customers_module
            ]
@@ -43,7 +43,7 @@ defmodule Favn.SQLTemplateAssetRefTest do
     """
 
     template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
-    assert template.asset_refs == []
+    assert Template.asset_refs(template) == []
   end
 
   test "does not treat table function syntax as direct asset ref" do
@@ -53,7 +53,7 @@ defmodule Favn.SQLTemplateAssetRefTest do
     """
 
     template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
-    assert template.asset_refs == []
+    assert Template.asset_refs(template) == []
   end
 
   test "does not support update from and merge into asset refs" do
@@ -99,20 +99,22 @@ defmodule Favn.SQLTemplateAssetRefTest do
     with_merge_template =
       Template.compile!(with_merge_sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
 
-    assert update_template.asset_refs == []
-    assert merge_template.asset_refs == []
-    assert with_update_template.asset_refs == []
-    assert with_merge_template.asset_refs == []
+    assert Template.asset_refs(update_template) == []
+    assert Template.asset_refs(merge_template) == []
+    assert Template.asset_refs(with_update_template) == []
+    assert Template.asset_refs(with_merge_template) == []
   end
 
-  test "raises for unresolved module references" do
-    assert_raise CompileError, ~r/module could not be resolved/, fn ->
+  test "keeps unresolved module references as deferred asset refs" do
+    template =
       Template.compile!(
         "select * from MyApp.Gold.Sales.FctOrdres",
         file: "test/sql_template_asset_ref_test.exs",
         line: 1
       )
-    end
+
+    assert [%Template.AssetRef{module: MyApp.Gold.Sales.FctOrdres, resolution: :deferred}] =
+             Template.asset_refs(template)
   end
 
   test "raises for compiled module that is not a single asset module" do

--- a/test/sql_template_ir_test.exs
+++ b/test/sql_template_ir_test.exs
@@ -1,0 +1,244 @@
+defmodule Favn.SQLTemplateIRTest do
+  use ExUnit.Case
+
+  alias Favn.SQL.Template
+
+  setup do
+    state = Favn.TestSetup.capture_state()
+
+    on_exit(fn ->
+      Favn.TestSetup.restore_state(state, reload_graph?: true)
+    end)
+
+    :ok
+  end
+
+  test "ignores placeholders inside strings and comments" do
+    template =
+      Template.compile!(
+        """
+        -- @ignored_line
+        select '@ignored_string', col /* @ignored_block */
+        from sales.orders
+        where country = @country
+        """,
+        file: "test/sql_template_ir_test.exs",
+        line: 1
+      )
+
+    assert Template.query_params(template) == MapSet.new([:country])
+    assert Template.runtime_inputs(template) == MapSet.new()
+  end
+
+  test "rejects malformed placeholders" do
+    assert_raise CompileError, ~r/invalid SQL placeholder/, fn ->
+      Template.compile!("select @1bad", file: "test/sql_template_ir_test.exs", line: 1)
+    end
+  end
+
+  test "infers query root kind after leading comments" do
+    template =
+      Template.compile!(
+        """
+        -- leading comment
+        /* another comment */
+        with src as (select 1)
+        select * from src
+        """,
+        file: "test/sql_template_ir_test.exs",
+        line: 1
+      )
+
+    assert template.root_kind == :query
+  end
+
+  test "preserves repeated calls and nested call args" do
+    root = Module.concat(__MODULE__, "Nested#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql cents_to_dollars(amount_cents) do
+          ~SQL[cast((@amount_cents / 100.0) as numeric(16, 2))]
+        end
+
+        defsql add_money(left_amount, right_amount) do
+          ~SQL[@left_amount + @right_amount]
+        end
+      end
+      """,
+      "test/dynamic_sql_template_ir_test.exs"
+    )
+
+    definitions = sql_module.__favn_sql_definitions__()
+    catalog = Map.new(definitions, &{{&1.name, &1.arity}, &1})
+
+    template =
+      Template.compile!(
+        "select add_money(cents_to_dollars(fee_cents), cents_to_dollars(tax_cents)), cents_to_dollars(total_cents)",
+        file: "test/sql_template_ir_test.exs",
+        line: 1,
+        known_definitions: catalog,
+        scope: :query
+      )
+
+    calls = Template.calls(template)
+
+    assert Enum.count(calls, &(&1.definition.name == :cents_to_dollars)) == 3
+    assert Enum.count(calls, &(&1.definition.name == :add_money)) == 1
+  end
+
+  test "parses relation macro calls across newlines" do
+    root = Module.concat(__MODULE__, "Relation#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    raw_orders = Module.concat(root, RawOrders)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(raw_orders)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Asset
+
+        @produces true
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_template_ir_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql orders_in_window(start_at, end_at) do
+          ~SQL[
+          select *
+          from #{inspect(raw_orders)}
+          where inserted_at >= @start_at and inserted_at < @end_at
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_template_ir_test.exs"
+    )
+
+    [definition] = sql_module.__favn_sql_definitions__()
+    catalog = %{{definition.name, definition.arity} => definition}
+
+    template =
+      Template.compile!(
+        "select * from orders_in_window(\n  @window_start,\n  @window_end\n)",
+        file: "test/sql_template_ir_test.exs",
+        line: 1,
+        known_definitions: catalog,
+        scope: :query
+      )
+
+    assert [
+             %Template.Call{
+               context: :relation,
+               definition: %{name: :orders_in_window},
+               args: [_, _]
+             }
+           ] =
+             Template.calls(template)
+  end
+
+  test "rejects undefined defsql placeholders" do
+    assert_raise CompileError, ~r/undefined defsql placeholder @country/, fn ->
+      Code.compile_string(
+        """
+        defmodule #{inspect(Module.concat(__MODULE__, "BadPlaceholder#{System.unique_integer([:positive])}"))} do
+          use Favn.SQL
+
+          defsql bad_filter(start_at) do
+            ~SQL[
+            @country >= @start_at
+            ]
+          end
+        end
+        """,
+        "test/dynamic_sql_template_ir_test.exs"
+      )
+    end
+  end
+
+  test "rejects duplicate imported visible definitions" do
+    root = Module.concat(__MODULE__, "Conflicts#{System.unique_integer([:positive])}")
+    sql_a = Module.concat(root, SQLA)
+    sql_b = Module.concat(root, SQLB)
+    asset_module = Module.concat(root, Asset)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_a)} do
+        use Favn.SQL
+
+        defsql cents_to_dollars(amount_cents) do
+          ~SQL[@amount_cents]
+        end
+      end
+      """,
+      "test/dynamic_sql_template_ir_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_b)} do
+        use Favn.SQL
+
+        defsql cents_to_dollars(amount_cents) do
+          ~SQL[@amount_cents]
+        end
+      end
+      """,
+      "test/dynamic_sql_template_ir_test.exs"
+    )
+
+    assert_raise CompileError, ~r/duplicate visible defsql cents_to_dollars\/1/, fn ->
+      Code.compile_string(
+        """
+        defmodule #{inspect(asset_module)} do
+          use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+          use Favn.SQLAsset
+          use #{inspect(sql_a)}
+          use #{inspect(sql_b)}
+
+          @materialized :view
+
+          query do
+            ~SQL[select 1]
+          end
+        end
+        """,
+        "test/dynamic_sql_template_ir_test.exs"
+      )
+    end
+  end
+
+  test "rejects cyclic defsql definitions" do
+    assert_raise CompileError, ~r/cyclic defsql definitions detected/, fn ->
+      Code.compile_string(
+        """
+        defmodule #{inspect(Module.concat(__MODULE__, "Cycles#{System.unique_integer([:positive])}"))} do
+          use Favn.SQL
+
+          defsql first_filter(amount_cents) do
+            ~SQL[second_filter(@amount_cents)]
+          end
+
+          defsql second_filter(amount_cents) do
+            ~SQL[first_filter(@amount_cents)]
+          end
+        end
+        """,
+        "test/dynamic_sql_template_ir_test.exs"
+      )
+    end
+  end
+end

--- a/test/sql_template_ir_test.exs
+++ b/test/sql_template_ir_test.exs
@@ -371,6 +371,20 @@ defmodule Favn.SQLTemplateIRTest do
              Template.asset_refs(template)
   end
 
+  test "treats semicolon inside parentheses as ordinary text" do
+    template =
+      Template.compile!(
+        "select (1;2)",
+        file: "test/sql_template_ir_test.exs",
+        line: 1
+      )
+
+    assert Enum.any?(template.nodes, fn
+             %Template.Text{sql: ";"} -> true
+             _other -> false
+           end)
+  end
+
   defp non_text_nodes(nodes) do
     Enum.reject(nodes, &match?(%Template.Text{}, &1))
   end

--- a/test/sql_template_ir_test.exs
+++ b/test/sql_template_ir_test.exs
@@ -91,6 +91,75 @@ defmodule Favn.SQLTemplateIRTest do
     assert Enum.count(calls, &(&1.definition.name == :add_money)) == 1
   end
 
+  test "allows local relation macros to call earlier local relation macros" do
+    root = Module.concat(__MODULE__, "LocalRelation#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    raw_orders = Module.concat(root, RawOrders)
+
+    compile_single_asset_module!(raw_orders)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql base_orders(start_at, end_at) do
+          ~SQL[
+          select *
+          from #{inspect(raw_orders)}
+          where inserted_at >= @start_at and inserted_at < @end_at
+          ]
+        end
+
+        defsql orders_in_window(start_at, end_at) do
+          ~SQL[
+          select *
+          from base_orders(@start_at, @end_at)
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_template_ir_test.exs"
+    )
+
+    definitions = sql_module.__favn_sql_definitions__()
+    orders_in_window = Enum.find(definitions, &(&1.name == :orders_in_window))
+
+    assert orders_in_window.shape == :relation
+
+    assert [%Template.Call{context: :relation, definition: %{name: :base_orders}}] =
+             Template.calls(orders_in_window.template)
+  end
+
+  test "preserves declared local arg indexes inside nested fragments" do
+    root = Module.concat(__MODULE__, "ArgIndex#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql add_money(left_amount, right_amount) do
+          ~SQL[@left_amount + @right_amount]
+        end
+
+        defsql swap_money(left_amount, right_amount) do
+          ~SQL[add_money(@right_amount, @left_amount)]
+        end
+      end
+      """,
+      "test/dynamic_sql_template_ir_test.exs"
+    )
+
+    definitions = sql_module.__favn_sql_definitions__()
+    swap_money = Enum.find(definitions, &(&1.name == :swap_money))
+    [%Template.Call{args: [first_arg, second_arg]}] = Template.calls(swap_money.template)
+
+    assert [%Template.Placeholder{source: {:local_arg, 1}}] = non_text_nodes(first_arg.nodes)
+    assert [%Template.Placeholder{source: {:local_arg, 0}}] = non_text_nodes(second_arg.nodes)
+  end
+
   test "parses relation macro calls across newlines" do
     root = Module.concat(__MODULE__, "Relation#{System.unique_integer([:positive])}")
     sql_module = Module.concat(root, SQL)
@@ -221,6 +290,41 @@ defmodule Favn.SQLTemplateIRTest do
     end
   end
 
+  test "rejects duplicate visible definitions between imported and local sql" do
+    root = Module.concat(__MODULE__, "LocalImportConflict#{System.unique_integer([:positive])}")
+    imported_sql = Module.concat(root, ImportedSQL)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(imported_sql)} do
+        use Favn.SQL
+
+        defsql cents_to_dollars(amount_cents) do
+          ~SQL[@amount_cents]
+        end
+      end
+      """,
+      "test/dynamic_sql_template_ir_test.exs"
+    )
+
+    assert_raise CompileError, ~r/duplicate visible defsql cents_to_dollars\/1/, fn ->
+      Code.compile_string(
+        """
+        defmodule #{inspect(Module.concat(root, LocalSQL))} do
+          use Favn.SQL
+          use #{inspect(imported_sql)}
+          import Favn.SQL, only: [defsql: 2, sigil_SQL: 2]
+
+          defsql cents_to_dollars(amount_cents) do
+            ~SQL[@amount_cents]
+          end
+        end
+        """,
+        "test/dynamic_sql_template_ir_test.exs"
+      )
+    end
+  end
+
   test "rejects cyclic defsql definitions" do
     assert_raise CompileError, ~r/cyclic defsql definitions detected/, fn ->
       Code.compile_string(
@@ -240,5 +344,50 @@ defmodule Favn.SQLTemplateIRTest do
         "test/dynamic_sql_template_ir_test.exs"
       )
     end
+  end
+
+  test "does not let nested update statements disable later top-level asset refs" do
+    asset_module =
+      Module.concat(__MODULE__, "NestedUpdateAsset#{System.unique_integer([:positive])}")
+
+    compile_single_asset_module!(asset_module)
+
+    template =
+      Template.compile!(
+        """
+        with nested as (
+          update sales.orders
+          set customer_id = 1
+          returning customer_id
+        )
+        select *
+        from #{inspect(asset_module)}
+        """,
+        file: "test/sql_template_ir_test.exs",
+        line: 1
+      )
+
+    assert [%Template.AssetRef{module: ^asset_module, resolution: :resolved}] =
+             Template.asset_refs(template)
+  end
+
+  defp non_text_nodes(nodes) do
+    Enum.reject(nodes, &match?(%Template.Text{}, &1))
+  end
+
+  defp compile_single_asset_module!(module) do
+    Code.compile_string(
+      """
+      defmodule #{inspect(module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Asset
+
+        @produces true
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_template_ir_test.exs"
+    )
   end
 end


### PR DESCRIPTION
## Summary
- complete the Phase 3 SQL authoring follow-up by adding `Favn.SQL` reusable `defsql ... do ... end`, keeping `~SQL` as the shared SQL body language across `query` and `defsql`
- add a dedicated compile-time SQL IR (`Favn.SQL.Template`) plus reusable SQL definition model (`Favn.SQL.Definition`), and wire SQLAsset compilation to store normalized templates and imported SQL definitions
- enforce compile-time validation for reserved runtime inputs, defsql arity/position rules (expression vs relation macros), and direct asset references in relation positions
- update roadmap and user docs (`docs/ASSET_SQL_PLAN.md`, `docs/FEATURES.md`, `README.md`, `lib/favn.ex`) and add focused SQL DSL tests

## Validation
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`