### PR TITLE
Implement Phase 4a SQL runtime render and execution helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,16 @@ end
 - `@produces`
 
 SQL assets compile into the same canonical `%Favn.Asset{}` shape as Elixir assets, including ref `{Module, :asset}` and inferred produced relation ownership.
-Phase 3 is authoring/catalog integration only. SQL runtime execution and helper APIs land in a later phase, so direct execution currently returns an explicit not-yet-implemented error.
+
+Phase 4a runtime integration now includes:
+
+- `Favn.render/2`
+- `Favn.preview/2`
+- `Favn.explain/2`
+- `Favn.materialize/2`
+
+`render/2` is backend/session free and emits canonical rendered SQL plus backend-neutral positional bindings.
+`preview/2` returns both canonical rendered SQL (`preview.render.sql`) and the actual executed preview statement (`preview.statement`).
 
 ## SQL DSL direction
 
@@ -128,7 +137,8 @@ Not supported yet for direct SQL asset refs:
 
 Planned next:
 
-- Phase 4 runtime execution and helper APIs on top of that IR
+- dedicated incremental SQL materialization phase (`:append` / `:delete_insert` first)
+- relation-based dependency inference in a later separate phase
 
 Favn explicitly avoids fake sigils, Jinja-style templating, arbitrary Elixir interpolation inside SQL, and string stitching as the normal authoring workflow.
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -670,12 +670,31 @@ Target helper capabilities include:
 * inspect resolved connection
 * inspect resolved produced relation
 
-Possible public APIs:
+Recommended public APIs:
 
-* `Favn.render_asset_sql(asset_ref_or_module, opts)`
-* `Favn.preview_asset(asset_ref_or_module, opts)`
-* `Favn.explain_asset(asset_ref_or_module, opts)`
-* `Favn.materialize_asset(asset_ref_or_module, opts)`
+* `Favn.render(asset, opts)`
+* `Favn.preview(asset, opts)`
+* `Favn.explain(asset, opts)`
+* `Favn.materialize(asset, opts)`
+
+Recommended accepted public inputs:
+
+* single-asset module such as `MyApp.Gold.Sales.FctOrders`
+* canonical asset ref such as `{MyApp.Gold.Sales.FctOrders, :asset}`
+* `%Favn.Asset{type: :sql}` for already-resolved assets
+
+These helpers should stay SQL-asset focused in Phase 4. Internal runtime/render code may work from
+compiled `%Favn.SQLAsset.Definition{}` values, but that struct should not be part of the public API.
+
+Additional Phase 4 API rules:
+
+* `render/2` is a pure render helper from the caller's point of view: it may resolve compiled modules,
+  asset metadata, and reusable SQL definitions, but it must not open SQL sessions or hit the backend
+* `preview/2` should expose the actual executed preview statement separately from the canonical rendered
+  query SQL; the canonical query remains in `render.sql`
+* renderer output uses one backend-neutral positional binding model; adapters may rewrite placeholders if
+  needed, but renderer output stays adapter-neutral
+* direct SQL asset refs across different connections are a render-time error in Phase 4
 
 Similar conveniences may later be added for Elixir materializing assets.
 
@@ -1087,13 +1106,27 @@ What belongs in Phase 3:
 * compile-time normalization/validation
 * stable SQL IR for later runtime work
 
-What belongs in Phase 4:
+What belongs in Phase 4a:
 
-* render final executable SQL plus bound params
+* render final executable query SQL plus canonical bound params
 * preview / explain / materialize helper APIs
 * runtime context to SQL-input resolution
+* pure render helper semantics with no backend/session work in `render/2`
+* one backend-neutral positional binding model from renderer to adapters
+* render-time deferred asset-ref resolution
+* render-time validation that direct SQL asset refs stay within one connection
+* fully inlined `defsql` expansion
+* materialization planning for `:view` and `:table`
 * adapter integration and execution
 * execution-time errors for missing params or backend failures
+
+What belongs in Phase 4b:
+
+* dedicated incremental materialization planning
+* explicit strategy semantics and validation
+* window-aware incremental execution and lookback handling
+* first backend support for safe incremental strategies
+* clear unsupported-strategy errors for deferred strategies
 
 What belongs in Phase 5:
 
@@ -1109,15 +1142,52 @@ The DSL should explicitly avoid:
 * string stitching as the normal authoring workflow
 * multiple placeholder syntaxes across SQL contexts
 
-### Phase 4 — SQL runtime integration and helper APIs
+### Phase 4a — SQL runtime integration and helper APIs
+
+Status: implemented in current codebase.
 
 Deliver:
 
 * SQL execution through shared runtime
 * render/preview/explain/materialize helper APIs
 * inspectable resolved connection and produced relation
+* strict render result struct with final SQL, canonical bound params, and diagnostics metadata
+* pure `render/2` semantics with no backend calls or session creation
+* backend-neutral positional bindings from renderer, with adapter-side placeholder rewriting when needed
+* render-time deferred asset-ref resolution and fully inlined `defsql` expansion
+* explicit render-time failure for cross-connection direct asset refs
+* materialization planning for `:view` and `:table`
 
 This phase makes SQL assets practical for everyday work.
+
+Preview helper rule:
+
+* `preview/2` should return the canonical rendered query in `preview.render.sql`
+* `preview.statement` should be the actual preview SQL executed against the adapter, for example with an
+  added preview `limit`
+
+Important limit for this phase:
+
+* incremental SQL materialization is not part of Phase 4a
+* `@materialized {:incremental, ...}` should keep compiling but fail at runtime with a clear unsupported-phase error until Phase 4b lands
+
+### Phase 4b — incremental SQL materialization
+
+Deliver:
+
+* dedicated incremental planning layer on top of rendered query SQL
+* explicit first-pass strategy support for `:append` and `:delete_insert`
+* required strategy metadata and validation for window-aware writes
+* explicit deferral of `:merge` until backend capability and planner semantics are ready
+* explicit deferral of current `:replace` incremental semantics until they are renamed or specified more precisely
+
+This phase keeps incremental behavior deliberate instead of letting it drift into runtime integration.
+
+Write-plan naming rule for Phase 4a:
+
+* avoid using incremental-style `replace` language for normal `:view` and `:table` rebuild behavior
+* prefer names such as `replace_existing?`, `rebuild?`, or explicit `create_or_replace` semantics
+* reserve incremental strategy naming for the dedicated incremental materialization phase
 
 ### Phase 5 — relation-based inference
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -1170,6 +1170,7 @@ Important limit for this phase:
 
 * incremental SQL materialization is not part of Phase 4a
 * `@materialized {:incremental, ...}` should keep compiling but fail at runtime with a clear unsupported-phase error until Phase 4b lands
+* rendered direct relation identifiers currently assume standard unquoted identifier compatibility; dialect-specific identifier quoting should be introduced behind adapter-aware rendering in a later phase
 
 ### Phase 4b — incremental SQL materialization
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -157,20 +157,29 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] duplicate visible reusable SQL definition detection across local/imported definitions
   - [x] reusable SQL cycle detection
   - [x] deferred symbolic asset refs for not-yet-compiled modules
-- [ ] DuckDB adapter hardening + incremental strategy expansion
+- [ ] DuckDB adapter hardening for runtime execution
 - [ ] Typed source identities
-- [ ] Phase 4 runtime integration for SQL assets
-  - [ ] SQL execution through shared runtime
-  - [ ] SQL helper APIs (`render`, `preview`, `explain`, `materialize`)
-  - [ ] runtime SQL input resolution and parameter binding
-  - [ ] adapter-backed rendering/materialization from the SQL IR
+- [x] Phase 4a runtime integration for SQL assets
+  - [x] SQL execution through shared runtime
+  - [x] SQL helper APIs (`Favn.render/2`, `Favn.preview/2`, `Favn.explain/2`, `Favn.materialize/2`)
+  - [x] strict render result struct with final SQL, canonical bound params, and diagnostics metadata
+  - [x] `render/2` remains backend-free and session-free; it resolves compiled metadata but does not hit adapters
+  - [x] runtime SQL input resolution and parameter binding from explicit `params` plus normalized runtime inputs
+  - [x] renderer always emits one backend-neutral positional binding model; adapters may rewrite placeholders if required
+  - [x] render-time deferred asset-ref resolution and fully inlined `defsql` expansion from the SQL IR
+  - [x] cross-connection direct asset refs fail during render with clear diagnostics
+  - [x] materialization planning for `:view` and `:table`
+  - [x] `preview/2` returns both canonical rendered SQL and the actual executed preview statement
+- [ ] Phase 4b incremental SQL materialization
+  - [ ] incremental planning layer that extends render output into backend-agnostic `WritePlan`s
+  - [ ] first safe incremental strategies: `:append` and `:delete_insert`
+  - [ ] explicit runtime guard for unsupported incremental strategies such as `:merge` and current `:replace`
+  - [ ] window-aware incremental execution and explicit lookback handling
 - [ ] Multi-asset SQL modules
 - [ ] SQL file support
 - [ ] Phase 5 relation-based SQL inference
   - [ ] dependency inference from typed SQL relation references
   - [ ] SQL asset dependency planning on the shared window-aware runtime model
-- [ ] Window-aware incremental execution
-- [ ] Lookback handling for incremental SQL assets
 
 ---
 

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -77,6 +77,7 @@ lib/
     │   ├── compiler.ex
     │   ├── definition.ex
     │   ├── error.ex
+    │   ├── input.ex
     │   ├── materialization.ex
     │   ├── renderer.ex
     │   └── runtime.ex

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -62,6 +62,7 @@ lib/
     │   ├── column.ex
     │   ├── definition.ex
     │   ├── error.ex
+    │   ├── render.ex
     │   ├── relation.ex
     │   ├── relation_ref.ex
     │   ├── result.ex
@@ -75,7 +76,9 @@ lib/
     ├── sql_asset/
     │   ├── compiler.ex
     │   ├── definition.ex
+    │   ├── error.ex
     │   ├── materialization.ex
+    │   ├── renderer.ex
     │   └── runtime.ex
     ├── scheduler/
     │   ├── cron.ex

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -22,6 +22,7 @@ test/
 ├── scheduler_cron_test.exs
 ├── scheduler_test.exs
 ├── sql_asset_test.exs
+├── sql_asset_runtime_test.exs
 ├── sql_template_asset_ref_test.exs
 ├── sql_template_ir_test.exs
 ├── sql_dsl_test.exs

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -628,6 +628,7 @@ defmodule Favn do
   alias Favn.Pipeline.Resolver
   alias Favn.Runtime.Engine
   alias Favn.Runtime.Events
+  alias Favn.SQLAsset.Compiler, as: SQLAssetCompiler
   alias Favn.SQLAsset.Error, as: SQLAssetError
   alias Favn.SQLAsset.Runtime, as: SQLAssetRuntime
   alias Favn.Window.Anchor
@@ -828,37 +829,24 @@ defmodule Favn do
   end
 
   defp normalize_sql_asset_input({module, name} = ref) when is_atom(module) and is_atom(name) do
-    case get_asset(ref) do
-      {:ok, %Favn.Asset{} = asset} ->
-        normalize_sql_asset_input(asset)
+    case name do
+      :asset ->
+        resolve_sql_asset_module(module, ref)
 
-      {:error, reason} ->
+      _other ->
         {:error,
          %SQLAssetError{
            type: :invalid_asset_input,
            phase: :render,
            asset_ref: ref,
-           message: "could not resolve SQL asset #{inspect(ref)}",
-           details: %{reason: reason}
+           message: "invalid SQL asset ref #{inspect(ref)}; expected {module, :asset}",
+           details: %{reason: :invalid_sql_asset_ref_name}
          }}
     end
   end
 
   defp normalize_sql_asset_input(module) when is_atom(module) do
-    case get_asset(module) do
-      {:ok, %Favn.Asset{} = asset} ->
-        normalize_sql_asset_input(asset)
-
-      {:error, reason} ->
-        {:error,
-         %SQLAssetError{
-           type: :invalid_asset_input,
-           phase: :render,
-           asset_ref: {module, :asset},
-           message: "could not resolve SQL asset #{inspect(module)}",
-           details: %{reason: reason}
-         }}
-    end
+    resolve_sql_asset_module(module, {module, :asset})
   end
 
   defp normalize_sql_asset_input(other) do
@@ -869,6 +857,29 @@ defmodule Favn do
        message: "invalid SQL asset input; expected module, {module, name}, or %Favn.Asset{}",
        details: %{input: other}
      }}
+  end
+
+  defp resolve_sql_asset_module(module, asset_ref) do
+    case SQLAssetCompiler.fetch_definition(module) do
+      {:ok, %Favn.SQLAsset.Definition{asset: %Favn.Asset{} = asset}} ->
+        {:ok, asset}
+
+      {:error, _reason} ->
+        case get_asset(module) do
+          {:ok, %Favn.Asset{} = asset} ->
+            normalize_sql_asset_input(asset)
+
+          {:error, reason} ->
+            {:error,
+             %SQLAssetError{
+               type: :invalid_asset_input,
+               phase: :render,
+               asset_ref: asset_ref,
+               message: "could not resolve SQL asset #{inspect(module)}",
+               details: %{reason: reason}
+             }}
+        end
+    end
   end
 
   @typedoc """

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -854,7 +854,7 @@ defmodule Favn do
      %SQLAssetError{
        type: :invalid_asset_input,
        phase: :render,
-       message: "invalid SQL asset input; expected module, {module, name}, or %Favn.Asset{}",
+       message: "invalid SQL asset input; expected module, {module, :asset}, or %Favn.Asset{}",
        details: %{input: other}
      }}
   end

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -628,8 +628,8 @@ defmodule Favn do
   alias Favn.Pipeline.Resolver
   alias Favn.Runtime.Engine
   alias Favn.Runtime.Events
-  alias Favn.SQLAsset.Compiler, as: SQLAssetCompiler
   alias Favn.SQLAsset.Error, as: SQLAssetError
+  alias Favn.SQLAsset.Input, as: SQLAssetInput
   alias Favn.SQLAsset.Runtime, as: SQLAssetRuntime
   alias Favn.Window.Anchor
 
@@ -771,7 +771,7 @@ defmodule Favn do
   @spec render(sql_asset_input(), sql_helper_opts()) ::
           {:ok, Favn.SQL.Render.t()} | {:error, SQLAssetError.t()}
   def render(asset_input, opts \\ []) when is_list(opts) do
-    case normalize_sql_asset_input(asset_input) do
+    case SQLAssetInput.normalize(asset_input) do
       {:ok, asset} -> SQLAssetRuntime.render(asset, opts)
       {:error, %SQLAssetError{} = error} -> {:error, error}
     end
@@ -786,7 +786,7 @@ defmodule Favn do
   @spec preview(sql_asset_input(), sql_preview_opts()) ::
           {:ok, Favn.SQL.Preview.t()} | {:error, SQLAssetError.t()}
   def preview(asset_input, opts \\ []) when is_list(opts) do
-    case normalize_sql_asset_input(asset_input) do
+    case SQLAssetInput.normalize(asset_input) do
       {:ok, asset} -> SQLAssetRuntime.preview(asset, opts)
       {:error, %SQLAssetError{} = error} -> {:error, error}
     end
@@ -798,7 +798,7 @@ defmodule Favn do
   @spec explain(sql_asset_input(), sql_explain_opts()) ::
           {:ok, Favn.SQL.Explain.t()} | {:error, SQLAssetError.t()}
   def explain(asset_input, opts \\ []) when is_list(opts) do
-    case normalize_sql_asset_input(asset_input) do
+    case SQLAssetInput.normalize(asset_input) do
       {:ok, asset} -> SQLAssetRuntime.explain(asset, opts)
       {:error, %SQLAssetError{} = error} -> {:error, error}
     end
@@ -810,75 +810,9 @@ defmodule Favn do
   @spec materialize(sql_asset_input(), sql_helper_opts()) ::
           {:ok, Favn.SQL.MaterializationResult.t()} | {:error, SQLAssetError.t()}
   def materialize(asset_input, opts \\ []) when is_list(opts) do
-    case normalize_sql_asset_input(asset_input) do
+    case SQLAssetInput.normalize(asset_input) do
       {:ok, asset} -> SQLAssetRuntime.materialize(asset, opts)
       {:error, %SQLAssetError{} = error} -> {:error, error}
-    end
-  end
-
-  defp normalize_sql_asset_input(%Favn.Asset{type: :sql} = asset), do: {:ok, asset}
-
-  defp normalize_sql_asset_input(%Favn.Asset{} = asset) do
-    {:error,
-     %SQLAssetError{
-       type: :not_sql_asset,
-       phase: :render,
-       asset_ref: asset.ref,
-       message: "asset #{inspect(asset.ref)} is not a SQL asset"
-     }}
-  end
-
-  defp normalize_sql_asset_input({module, name} = ref) when is_atom(module) and is_atom(name) do
-    case name do
-      :asset ->
-        resolve_sql_asset_module(module, ref)
-
-      _other ->
-        {:error,
-         %SQLAssetError{
-           type: :invalid_asset_input,
-           phase: :render,
-           asset_ref: ref,
-           message: "invalid SQL asset ref #{inspect(ref)}; expected {module, :asset}",
-           details: %{reason: :invalid_sql_asset_ref_name}
-         }}
-    end
-  end
-
-  defp normalize_sql_asset_input(module) when is_atom(module) do
-    resolve_sql_asset_module(module, {module, :asset})
-  end
-
-  defp normalize_sql_asset_input(other) do
-    {:error,
-     %SQLAssetError{
-       type: :invalid_asset_input,
-       phase: :render,
-       message: "invalid SQL asset input; expected module, {module, :asset}, or %Favn.Asset{}",
-       details: %{input: other}
-     }}
-  end
-
-  defp resolve_sql_asset_module(module, asset_ref) do
-    case SQLAssetCompiler.fetch_definition(module) do
-      {:ok, %Favn.SQLAsset.Definition{asset: %Favn.Asset{} = asset}} ->
-        {:ok, asset}
-
-      {:error, _reason} ->
-        case get_asset(module) do
-          {:ok, %Favn.Asset{} = asset} ->
-            normalize_sql_asset_input(asset)
-
-          {:error, reason} ->
-            {:error,
-             %SQLAssetError{
-               type: :invalid_asset_input,
-               phase: :render,
-               asset_ref: asset_ref,
-               message: "could not resolve SQL asset #{inspect(module)}",
-               details: %{reason: reason}
-             }}
-        end
     end
   end
 

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -203,7 +203,8 @@ defmodule Favn do
   `query` and reusable `defsql` definitions. SQL authoring now includes one `@name`
   placeholder model for SQL inputs, expression and relation SQL macros, direct asset
   references in relation position, and compile-time normalization into a dedicated SQL
-  IR. Runtime SQL execution APIs remain a later phase.
+  IR. Runtime helper APIs are available through `render/2`, `preview/2`, `explain/2`,
+  and `materialize/2`.
 
   Compact multi-asset style uses `Favn.Assets`:
 
@@ -627,6 +628,8 @@ defmodule Favn do
   alias Favn.Pipeline.Resolver
   alias Favn.Runtime.Engine
   alias Favn.Runtime.Events
+  alias Favn.SQLAsset.Error, as: SQLAssetError
+  alias Favn.SQLAsset.Runtime, as: SQLAssetRuntime
   alias Favn.Window.Anchor
 
   @doc """
@@ -732,6 +735,140 @@ defmodule Favn do
       true ->
         {:error, :asset_not_found}
     end
+  end
+
+  @typedoc """
+  Accepted SQL asset helper target input.
+  """
+  @type sql_asset_input :: module() | asset_ref() | asset()
+
+  @typedoc """
+  Common options for SQL helper APIs.
+
+  `:params` contains query parameter values for non-reserved `@name` placeholders.
+  `:runtime` contains reserved runtime SQL inputs such as `:window_start`, `:window_end`,
+  or `:window` (`%Favn.Window.Runtime{}`).
+  """
+  @type sql_helper_opts :: [params: map(), runtime: map(), timeout_ms: pos_integer()]
+
+  @typedoc """
+  SQL preview options.
+  """
+  @type sql_preview_opts :: keyword()
+
+  @typedoc """
+  SQL explain options.
+  """
+  @type sql_explain_opts :: keyword()
+
+  @doc """
+  Render one SQL asset into canonical executable SQL and canonical bound params.
+
+  This helper is backend/session free: it resolves compiled asset metadata and SQL
+  definitions but does not open a SQL connection.
+  """
+  @spec render(sql_asset_input(), sql_helper_opts()) ::
+          {:ok, Favn.SQL.Render.t()} | {:error, SQLAssetError.t()}
+  def render(asset_input, opts \\ []) when is_list(opts) do
+    case normalize_sql_asset_input(asset_input) do
+      {:ok, asset} -> SQLAssetRuntime.render(asset, opts)
+      {:error, %SQLAssetError{} = error} -> {:error, error}
+    end
+  end
+
+  @doc """
+  Preview one SQL asset query result.
+
+  `preview.statement` is the actual SQL executed for preview. `preview.render.sql`
+  remains the canonical rendered SQL query.
+  """
+  @spec preview(sql_asset_input(), sql_preview_opts()) ::
+          {:ok, Favn.SQL.Preview.t()} | {:error, SQLAssetError.t()}
+  def preview(asset_input, opts \\ []) when is_list(opts) do
+    case normalize_sql_asset_input(asset_input) do
+      {:ok, asset} -> SQLAssetRuntime.preview(asset, opts)
+      {:error, %SQLAssetError{} = error} -> {:error, error}
+    end
+  end
+
+  @doc """
+  Explain one SQL asset query.
+  """
+  @spec explain(sql_asset_input(), sql_explain_opts()) ::
+          {:ok, Favn.SQL.Explain.t()} | {:error, SQLAssetError.t()}
+  def explain(asset_input, opts \\ []) when is_list(opts) do
+    case normalize_sql_asset_input(asset_input) do
+      {:ok, asset} -> SQLAssetRuntime.explain(asset, opts)
+      {:error, %SQLAssetError{} = error} -> {:error, error}
+    end
+  end
+
+  @doc """
+  Materialize one SQL asset.
+  """
+  @spec materialize(sql_asset_input(), sql_helper_opts()) ::
+          {:ok, Favn.SQL.MaterializationResult.t()} | {:error, SQLAssetError.t()}
+  def materialize(asset_input, opts \\ []) when is_list(opts) do
+    case normalize_sql_asset_input(asset_input) do
+      {:ok, asset} -> SQLAssetRuntime.materialize(asset, opts)
+      {:error, %SQLAssetError{} = error} -> {:error, error}
+    end
+  end
+
+  defp normalize_sql_asset_input(%Favn.Asset{type: :sql} = asset), do: {:ok, asset}
+
+  defp normalize_sql_asset_input(%Favn.Asset{} = asset) do
+    {:error,
+     %SQLAssetError{
+       type: :not_sql_asset,
+       phase: :render,
+       asset_ref: asset.ref,
+       message: "asset #{inspect(asset.ref)} is not a SQL asset"
+     }}
+  end
+
+  defp normalize_sql_asset_input({module, name} = ref) when is_atom(module) and is_atom(name) do
+    case get_asset(ref) do
+      {:ok, %Favn.Asset{} = asset} ->
+        normalize_sql_asset_input(asset)
+
+      {:error, reason} ->
+        {:error,
+         %SQLAssetError{
+           type: :invalid_asset_input,
+           phase: :render,
+           asset_ref: ref,
+           message: "could not resolve SQL asset #{inspect(ref)}",
+           details: %{reason: reason}
+         }}
+    end
+  end
+
+  defp normalize_sql_asset_input(module) when is_atom(module) do
+    case get_asset(module) do
+      {:ok, %Favn.Asset{} = asset} ->
+        normalize_sql_asset_input(asset)
+
+      {:error, reason} ->
+        {:error,
+         %SQLAssetError{
+           type: :invalid_asset_input,
+           phase: :render,
+           asset_ref: {module, :asset},
+           message: "could not resolve SQL asset #{inspect(module)}",
+           details: %{reason: reason}
+         }}
+    end
+  end
+
+  defp normalize_sql_asset_input(other) do
+    {:error,
+     %SQLAssetError{
+       type: :invalid_asset_input,
+       phase: :render,
+       message: "invalid SQL asset input; expected module, {module, name}, or %Favn.Asset{}",
+       details: %{input: other}
+     }}
   end
 
   @typedoc """

--- a/lib/favn/sql/adapter/duckdb.ex
+++ b/lib/favn/sql/adapter/duckdb.ex
@@ -430,6 +430,9 @@ defmodule Favn.SQL.Adapter.DuckDB do
     end
   end
 
+  defp create_view_statement(target, %WritePlan{replace_existing?: true, select_sql: sql}),
+    do: ["CREATE OR REPLACE VIEW ", target, " AS ", sql]
+
   defp create_view_statement(target, %WritePlan{replace?: true, select_sql: sql}),
     do: ["CREATE OR REPLACE VIEW ", target, " AS ", sql]
 
@@ -438,6 +441,9 @@ defmodule Favn.SQL.Adapter.DuckDB do
 
   defp create_view_statement(target, %WritePlan{select_sql: sql}),
     do: ["CREATE VIEW ", target, " AS ", sql]
+
+  defp create_table_statement(target, %WritePlan{replace_existing?: true, select_sql: sql}),
+    do: ["CREATE OR REPLACE TABLE ", target, " AS ", sql]
 
   defp create_table_statement(target, %WritePlan{replace?: true, select_sql: sql}),
     do: ["CREATE OR REPLACE TABLE ", target, " AS ", sql]

--- a/lib/favn/sql/render.ex
+++ b/lib/favn/sql/render.ex
@@ -1,0 +1,128 @@
+defmodule Favn.SQL.ParamBinding do
+  @moduledoc """
+  One canonical SQL bind value emitted by the SQL asset renderer.
+  """
+
+  alias Favn.SQL.Template.Span
+
+  @enforce_keys [:ordinal, :name, :source, :value]
+  defstruct [:ordinal, :name, :source, :value, :span]
+
+  @type source :: :runtime | :query_param
+
+  @type t :: %__MODULE__{
+          ordinal: pos_integer(),
+          name: atom(),
+          source: source(),
+          value: term(),
+          span: Span.t() | nil
+        }
+end
+
+defmodule Favn.SQL.Params do
+  @moduledoc """
+  Canonical SQL parameter payload emitted by the SQL asset renderer.
+  """
+
+  alias Favn.SQL.ParamBinding
+
+  @enforce_keys [:format, :bindings]
+  defstruct [:format, :bindings]
+
+  @type format :: :positional
+
+  @type t :: %__MODULE__{format: format(), bindings: [ParamBinding.t()]}
+
+  @spec to_adapter_params(t()) :: [term()]
+  def to_adapter_params(%__MODULE__{format: :positional, bindings: bindings}) do
+    Enum.map(bindings, & &1.value)
+  end
+end
+
+defmodule Favn.SQL.Render do
+  @moduledoc """
+  Canonical SQL asset render output.
+
+  This payload is backend-neutral and does not require opening a SQL session.
+  """
+
+  alias Favn.RelationRef
+  alias Favn.SQL.Params
+  alias Favn.Window.Runtime
+
+  @enforce_keys [:asset_ref, :connection, :produced_relation, :materialization, :sql, :params]
+  defstruct [
+    :asset_ref,
+    :connection,
+    :produced_relation,
+    :materialization,
+    :sql,
+    :params,
+    :runtime,
+    resolved_asset_refs: [],
+    metadata: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          asset_ref: Favn.asset_ref(),
+          connection: atom(),
+          produced_relation: RelationRef.t(),
+          materialization: Favn.SQLAsset.Materialization.t(),
+          sql: String.t(),
+          params: Params.t(),
+          runtime: Runtime.t() | map() | nil,
+          resolved_asset_refs: [map()],
+          metadata: map()
+        }
+end
+
+defmodule Favn.SQL.Preview do
+  @moduledoc """
+  SQL preview output.
+
+  `statement` is the actual SQL statement executed for preview.
+  """
+
+  alias Favn.SQL.{Render, Result}
+
+  @enforce_keys [:render, :limit, :statement, :result]
+  defstruct [:render, :limit, :statement, :result]
+
+  @type t :: %__MODULE__{
+          render: Render.t(),
+          limit: pos_integer(),
+          statement: String.t(),
+          result: Result.t()
+        }
+end
+
+defmodule Favn.SQL.Explain do
+  @moduledoc """
+  SQL explain output.
+  """
+
+  alias Favn.SQL.{Render, Result}
+
+  @enforce_keys [:render, :statement, :analyze?, :result]
+  defstruct [:render, :statement, :analyze?, :result]
+
+  @type t :: %__MODULE__{
+          render: Render.t(),
+          statement: String.t(),
+          analyze?: boolean(),
+          result: Result.t()
+        }
+end
+
+defmodule Favn.SQL.MaterializationResult do
+  @moduledoc """
+  SQL materialization output for one SQL asset.
+  """
+
+  alias Favn.SQL.{Render, Result, WritePlan}
+
+  @enforce_keys [:render, :write_plan, :result]
+  defstruct [:render, :write_plan, :result]
+
+  @type t :: %__MODULE__{render: Render.t(), write_plan: WritePlan.t(), result: Result.t()}
+end

--- a/lib/favn/sql/write_plan.ex
+++ b/lib/favn/sql/write_plan.ex
@@ -10,10 +10,15 @@ defmodule Favn.SQL.WritePlan do
 
   @enforce_keys [:materialization, :target, :select_sql]
   defstruct [
+    :asset_ref,
+    :connection,
     :materialization,
     :strategy,
     :target,
+    :query,
     :select_sql,
+    :params,
+    :replace_existing?,
     :replace?,
     :if_not_exists?,
     :transactional?,
@@ -27,10 +32,15 @@ defmodule Favn.SQL.WritePlan do
   ]
 
   @type t :: %__MODULE__{
+          asset_ref: Favn.asset_ref() | nil,
+          connection: atom() | nil,
           materialization: materialization(),
           strategy: strategy() | nil,
           target: Relation.t(),
+          query: term() | nil,
           select_sql: iodata(),
+          params: term() | nil,
+          replace_existing?: boolean() | nil,
           replace?: boolean() | nil,
           if_not_exists?: boolean() | nil,
           transactional?: boolean() | nil,

--- a/lib/favn/sql_asset/error.ex
+++ b/lib/favn/sql_asset/error.ex
@@ -1,0 +1,51 @@
+defmodule Favn.SQLAsset.Error do
+  @moduledoc """
+  Normalized SQL asset runtime/render error.
+  """
+
+  alias Favn.SQL.Template.Span
+
+  @enforce_keys [:type, :phase, :message]
+  defstruct [
+    :type,
+    :phase,
+    :message,
+    :asset_ref,
+    :span,
+    :file,
+    :line,
+    stack: [],
+    details: %{},
+    cause: nil
+  ]
+
+  @type type ::
+          :invalid_asset_input
+          | :not_sql_asset
+          | :invalid_sql_asset_definition
+          | :missing_runtime_input
+          | :missing_query_param
+          | :unresolved_asset_ref
+          | :invalid_produced_relation
+          | :cross_connection_asset_ref
+          | :defsql_expansion_failed
+          | :binding_failure
+          | :materialization_planning_failed
+          | :backend_execution_failed
+          | :unsupported_materialization
+
+  @type phase :: :render | :preview | :explain | :materialize | :runtime
+
+  @type t :: %__MODULE__{
+          type: type(),
+          phase: phase(),
+          message: String.t(),
+          asset_ref: Favn.asset_ref() | nil,
+          span: Span.t() | nil,
+          file: String.t() | nil,
+          line: pos_integer() | nil,
+          stack: [map()],
+          details: map(),
+          cause: term()
+        }
+end

--- a/lib/favn/sql_asset/input.ex
+++ b/lib/favn/sql_asset/input.ex
@@ -1,0 +1,75 @@
+defmodule Favn.SQLAsset.Input do
+  @moduledoc false
+
+  alias Favn.SQLAsset.Compiler, as: SQLAssetCompiler
+  alias Favn.SQLAsset.Error, as: SQLAssetError
+
+  @type input :: module() | Favn.asset_ref() | Favn.asset()
+
+  @spec normalize(input()) :: {:ok, Favn.asset()} | {:error, SQLAssetError.t()}
+  def normalize(%Favn.Asset{type: :sql} = asset), do: {:ok, asset}
+
+  def normalize(%Favn.Asset{} = asset) do
+    {:error,
+     %SQLAssetError{
+       type: :not_sql_asset,
+       phase: :render,
+       asset_ref: asset.ref,
+       message: "asset #{inspect(asset.ref)} is not a SQL asset"
+     }}
+  end
+
+  def normalize({module, name} = ref) when is_atom(module) and is_atom(name) do
+    case name do
+      :asset ->
+        resolve_sql_asset_module(module, ref)
+
+      _other ->
+        {:error,
+         %SQLAssetError{
+           type: :invalid_asset_input,
+           phase: :render,
+           asset_ref: ref,
+           message: "invalid SQL asset ref #{inspect(ref)}; expected {module, :asset}",
+           details: %{reason: :invalid_sql_asset_ref_name}
+         }}
+    end
+  end
+
+  def normalize(module) when is_atom(module) do
+    resolve_sql_asset_module(module, {module, :asset})
+  end
+
+  def normalize(other) do
+    {:error,
+     %SQLAssetError{
+       type: :invalid_asset_input,
+       phase: :render,
+       message: "invalid SQL asset input; expected module, {module, :asset}, or %Favn.Asset{}",
+       details: %{input: other}
+     }}
+  end
+
+  defp resolve_sql_asset_module(module, asset_ref) do
+    case SQLAssetCompiler.fetch_definition(module) do
+      {:ok, %Favn.SQLAsset.Definition{asset: %Favn.Asset{} = asset}} ->
+        {:ok, asset}
+
+      {:error, _reason} ->
+        case Favn.get_asset(module) do
+          {:ok, %Favn.Asset{} = asset} ->
+            normalize(asset)
+
+          {:error, reason} ->
+            {:error,
+             %SQLAssetError{
+               type: :invalid_asset_input,
+               phase: :render,
+               asset_ref: asset_ref,
+               message: "could not resolve SQL asset #{inspect(module)}",
+               details: %{reason: reason}
+             }}
+        end
+    end
+  end
+end

--- a/lib/favn/sql_asset/renderer.ex
+++ b/lib/favn/sql_asset/renderer.ex
@@ -1,0 +1,469 @@
+defmodule Favn.SQLAsset.Renderer do
+  @moduledoc false
+
+  alias Favn.Assets.Compiler
+  alias Favn.RelationRef
+  alias Favn.SQL.Definition, as: SQLDefinition
+  alias Favn.SQL.{ParamBinding, Params, Render, Template}
+  alias Favn.SQL.Template.{AssetRef, Call, Placeholder, Text}
+  alias Favn.SQLAsset.{Definition, Error}
+  alias Favn.Window.Runtime
+
+  defmodule Fragment do
+    @moduledoc false
+    defstruct sql: "", bindings: [], resolved_asset_refs: []
+  end
+
+  @type opts :: [params: map(), runtime: map()]
+
+  @spec render(Definition.t(), opts()) :: {:ok, Render.t()} | {:error, Error.t()}
+  def render(%Definition{} = definition, opts \\ []) when is_list(opts) do
+    with {:ok, params} <- normalize_params(opts),
+         {:ok, runtime_inputs} <- normalize_runtime_inputs(definition, opts),
+         {:ok, definition_catalog} <- definition_catalog(definition),
+         env <- base_env(definition, params, runtime_inputs, definition_catalog),
+         {:ok, %Fragment{} = fragment} <- render_nodes(definition.template.nodes, env),
+         {:ok, %Params{} = normalized_params} <- normalize_bindings(fragment.bindings) do
+      {:ok,
+       %Render{
+         asset_ref: definition.asset.ref,
+         connection: definition.asset.produces.connection,
+         produced_relation: definition.asset.produces,
+         materialization: definition.materialization,
+         sql: fragment.sql,
+         params: normalized_params,
+         runtime: runtime_inputs.runtime,
+         resolved_asset_refs: fragment.resolved_asset_refs,
+         metadata: %{
+           source_sql: definition.sql,
+           template_root_kind: definition.template.root_kind,
+           query_param_names:
+             Template.query_params(definition.template) |> MapSet.to_list() |> Enum.sort(),
+           runtime_input_names:
+             Template.runtime_inputs(definition.template) |> MapSet.to_list() |> Enum.sort()
+         }
+       }}
+    end
+  end
+
+  defp normalize_params(opts) do
+    case Keyword.get(opts, :params, %{}) do
+      params when is_map(params) ->
+        {:ok, params}
+
+      other ->
+        {:error,
+         %Error{
+           type: :binding_failure,
+           phase: :render,
+           message: "render params must be a map",
+           details: %{params: other}
+         }}
+    end
+  end
+
+  defp normalize_runtime_inputs(%Definition{} = definition, opts) do
+    runtime = Keyword.get(opts, :runtime, %{})
+
+    case runtime do
+      runtime when is_map(runtime) ->
+        case Map.get(runtime, :window) || Map.get(runtime, "window") do
+          %Runtime{} = window ->
+            {:ok,
+             %{
+               runtime: window,
+               runtime_values: %{window_start: window.start_at, window_end: window.end_at}
+             }}
+
+          nil ->
+            runtime_values = %{
+              window_start: runtime[:window_start] || runtime["window_start"],
+              window_end: runtime[:window_end] || runtime["window_end"]
+            }
+
+            {:ok, %{runtime: runtime, runtime_values: runtime_values}}
+
+          other ->
+            {:error,
+             %Error{
+               type: :binding_failure,
+               phase: :render,
+               asset_ref: definition.asset.ref,
+               message: "runtime.window must be a Favn.Window.Runtime struct",
+               details: %{window: other}
+             }}
+        end
+
+      _other ->
+        {:error,
+         %Error{
+           type: :binding_failure,
+           phase: :render,
+           asset_ref: definition.asset.ref,
+           message: "render runtime must be a map",
+           details: %{runtime: runtime}
+         }}
+    end
+  end
+
+  defp definition_catalog(%Definition{} = definition) do
+    catalog =
+      definition.sql_definitions
+      |> Enum.map(fn %SQLDefinition{} = entry -> {SQLDefinition.key(entry), entry} end)
+      |> Map.new()
+
+    {:ok, catalog}
+  end
+
+  defp base_env(definition, params, runtime_inputs, definition_catalog) do
+    %{
+      asset_ref: definition.asset.ref,
+      root_connection: definition.asset.produces.connection,
+      params: params,
+      runtime_values: runtime_inputs.runtime_values,
+      local_args: %{},
+      definition_catalog: definition_catalog,
+      stack: [],
+      cache: %{}
+    }
+  end
+
+  defp render_nodes(nodes, env) when is_list(nodes) do
+    Enum.reduce_while(nodes, {:ok, %Fragment{}, env}, fn node, {:ok, acc, env_acc} ->
+      case render_node(node, env_acc) do
+        {:ok, %Fragment{} = fragment, next_env} ->
+          {:cont, {:ok, merge_fragment(acc, fragment), next_env}}
+
+        {:error, %Error{} = error} ->
+          {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:ok, fragment, next_env} -> {:ok, fragment, next_env}
+      {:error, %Error{} = error} -> {:error, error}
+    end
+    |> case do
+      {:ok, fragment, _env} -> {:ok, fragment}
+      {:error, %Error{} = error} -> {:error, error}
+    end
+  end
+
+  defp render_node(%Text{sql: sql}, env), do: {:ok, %Fragment{sql: sql}, env}
+
+  defp render_node(%Placeholder{source: :runtime, name: name, span: span}, env) do
+    case Map.fetch(env.runtime_values, name) do
+      {:ok, nil} -> missing_runtime_input_error(name, span, env)
+      {:ok, value} -> {:ok, value_fragment(name, :runtime, value, span), env}
+      :error -> missing_runtime_input_error(name, span, env)
+    end
+  end
+
+  defp render_node(%Placeholder{source: :query_param, name: name, span: span}, env) do
+    if Map.has_key?(env.params, name) do
+      {:ok, value_fragment(name, :query_param, Map.fetch!(env.params, name), span), env}
+    else
+      missing_query_param_error(name, span, env)
+    end
+  end
+
+  defp render_node(%Placeholder{source: {:local_arg, index}, span: span}, env) do
+    case Map.fetch(env.local_args, index) do
+      {:ok, %Fragment{} = fragment} ->
+        {:ok, fragment, env}
+
+      :error ->
+        {:error,
+         %Error{
+           type: :defsql_expansion_failed,
+           phase: :render,
+           asset_ref: env.asset_ref,
+           span: span,
+           line: span.start_line,
+           message: "failed to resolve local defsql argument @#{index}",
+           stack: env.stack
+         }}
+    end
+  end
+
+  defp render_node(%Call{} = call, env) do
+    with {:ok, definition} <- fetch_definition(call, env),
+         {:ok, arg_fragments, next_env} <- render_call_args(call, env),
+         callee_env <-
+           env
+           |> Map.put(:local_args, local_arg_map(arg_fragments))
+           |> Map.put(:stack, [stack_frame(call, definition) | env.stack])
+           |> Map.put(:cache, next_env.cache),
+         {:ok, %Fragment{} = expanded} <- render_nodes(definition.template.nodes, callee_env) do
+      {:ok, expanded, %{env | cache: callee_env.cache}}
+    else
+      {:error, %Error{} = error} -> {:error, error}
+    end
+  rescue
+    error ->
+      {:error,
+       %Error{
+         type: :defsql_expansion_failed,
+         phase: :render,
+         asset_ref: env.asset_ref,
+         message:
+           "failed to expand SQL definition #{call.definition.name}/#{call.definition.arity}",
+         span: call.span,
+         line: call.span.start_line,
+         stack: env.stack,
+         cause: error
+       }}
+  end
+
+  defp render_node(%AssetRef{} = asset_ref, env) do
+    with {:ok, relation_ref, next_env} <- resolve_asset_ref(asset_ref, env) do
+      fragment = %Fragment{
+        sql: relation_to_sql(relation_ref),
+        resolved_asset_refs: [resolved_ref(asset_ref, relation_ref)]
+      }
+
+      {:ok, fragment, next_env}
+    end
+  end
+
+  defp fetch_definition(%Call{definition: %{name: name, arity: arity}, span: span}, env) do
+    case Map.fetch(env.definition_catalog, {name, arity}) do
+      {:ok, %SQLDefinition{} = definition} ->
+        {:ok, definition}
+
+      :error ->
+        {:error,
+         %Error{
+           type: :defsql_expansion_failed,
+           phase: :render,
+           asset_ref: env.asset_ref,
+           span: span,
+           line: span.start_line,
+           message: "failed to find SQL definition #{name}/#{arity} during render",
+           stack: env.stack,
+           details: %{name: name, arity: arity}
+         }}
+    end
+  end
+
+  defp render_call_args(call, env) do
+    Enum.reduce_while(call.args, {:ok, [], env}, fn fragment, {:ok, acc, env_acc} ->
+      case render_nodes(fragment.nodes, env_acc) do
+        {:ok, rendered_fragment} ->
+          {:cont, {:ok, [rendered_fragment | acc], env_acc}}
+
+        {:error, %Error{} = error} ->
+          {:halt, {:error, error}}
+      end
+    end)
+    |> case do
+      {:ok, reversed, env_after} -> {:ok, Enum.reverse(reversed), env_after}
+      {:error, %Error{} = error} -> {:error, error}
+    end
+  end
+
+  defp local_arg_map(arg_fragments) do
+    arg_fragments
+    |> Enum.with_index()
+    |> Map.new(fn {fragment, index} -> {index, fragment} end)
+  end
+
+  defp stack_frame(call, %SQLDefinition{} = definition) do
+    %{
+      definition: {definition.module, definition.name, definition.arity},
+      call_span: call.span,
+      file: definition.file,
+      line: definition.line
+    }
+  end
+
+  defp resolve_asset_ref(
+         %AssetRef{resolution: :resolved, produced_relation: %RelationRef{} = relation_ref} =
+           asset_ref,
+         env
+       ) do
+    with :ok <- ensure_same_connection(asset_ref, relation_ref, env) do
+      {:ok, relation_ref, env}
+    end
+  end
+
+  defp resolve_asset_ref(%AssetRef{resolution: :deferred, module: module} = asset_ref, env) do
+    case Map.fetch(env.cache, module) do
+      {:ok, %RelationRef{} = relation_ref} ->
+        with :ok <- ensure_same_connection(asset_ref, relation_ref, env) do
+          {:ok, relation_ref, env}
+        end
+
+      :error ->
+        with {:ok, relation_ref} <-
+               resolve_deferred_module(module, env.asset_ref, asset_ref.span, env.stack),
+             :ok <- ensure_same_connection(asset_ref, relation_ref, env) do
+          {:ok, relation_ref, %{env | cache: Map.put(env.cache, module, relation_ref)}}
+        end
+    end
+  end
+
+  defp resolve_deferred_module(module, asset_ref, span, stack) do
+    case Code.ensure_compiled(module) do
+      {:module, _compiled} ->
+        case Compiler.compile_module_assets(module) do
+          {:ok, [%{produces: %RelationRef{} = relation_ref}]} ->
+            {:ok, relation_ref}
+
+          {:ok, [%{produces: nil}]} ->
+            {:error,
+             %Error{
+               type: :invalid_produced_relation,
+               phase: :render,
+               asset_ref: asset_ref,
+               span: span,
+               line: span.start_line,
+               message:
+                 "SQL asset reference #{inspect(module)} resolved, but it does not produce a relation",
+               stack: stack,
+               details: %{module: module}
+             }}
+
+          {:ok, _many} ->
+            {:error,
+             %Error{
+               type: :invalid_produced_relation,
+               phase: :render,
+               asset_ref: asset_ref,
+               span: span,
+               line: span.start_line,
+               message:
+                 "invalid SQL asset reference #{inspect(module)}; expected a compiled single-asset module",
+               stack: stack,
+               details: %{module: module}
+             }}
+
+          {:error, _reason} ->
+            {:error,
+             %Error{
+               type: :unresolved_asset_ref,
+               phase: :render,
+               asset_ref: asset_ref,
+               span: span,
+               line: span.start_line,
+               message:
+                 "SQL asset reference #{inspect(module)} could not be resolved at render time",
+               stack: stack,
+               details: %{module: module}
+             }}
+        end
+
+      {:error, _reason} ->
+        {:error,
+         %Error{
+           type: :unresolved_asset_ref,
+           phase: :render,
+           asset_ref: asset_ref,
+           span: span,
+           line: span.start_line,
+           message: "SQL asset reference #{inspect(module)} could not be resolved at render time",
+           stack: stack,
+           details: %{module: module}
+         }}
+    end
+  end
+
+  defp ensure_same_connection(
+         %AssetRef{module: _module, span: _span},
+         %RelationRef{connection: connection},
+         env
+       )
+       when connection == env.root_connection,
+       do: :ok
+
+  defp ensure_same_connection(
+         %AssetRef{module: module, span: span},
+         %RelationRef{} = relation_ref,
+         env
+       ) do
+    {:error,
+     %Error{
+       type: :cross_connection_asset_ref,
+       phase: :render,
+       asset_ref: env.asset_ref,
+       span: span,
+       line: span.start_line,
+       message:
+         "SQL asset reference #{inspect(module)} resolves to connection #{inspect(relation_ref.connection)}, expected #{inspect(env.root_connection)}",
+       stack: env.stack,
+       details: %{
+         module: module,
+         expected_connection: env.root_connection,
+         actual_connection: relation_ref.connection
+       }
+     }}
+  end
+
+  defp normalize_bindings(bindings) do
+    numbered =
+      bindings
+      |> Enum.with_index(1)
+      |> Enum.map(fn {%ParamBinding{} = binding, ordinal} ->
+        %ParamBinding{binding | ordinal: ordinal}
+      end)
+
+    {:ok, %Params{format: :positional, bindings: numbered}}
+  end
+
+  defp merge_fragment(%Fragment{} = left, %Fragment{} = right) do
+    %Fragment{
+      sql: left.sql <> right.sql,
+      bindings: left.bindings ++ right.bindings,
+      resolved_asset_refs: left.resolved_asset_refs ++ right.resolved_asset_refs
+    }
+  end
+
+  defp value_fragment(name, source, value, span) do
+    %Fragment{
+      sql: "?",
+      bindings: [%ParamBinding{ordinal: 0, name: name, source: source, value: value, span: span}]
+    }
+  end
+
+  defp relation_to_sql(%RelationRef{} = relation_ref) do
+    [relation_ref.catalog, relation_ref.schema, relation_ref.name]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(".")
+  end
+
+  defp resolved_ref(%AssetRef{} = asset_ref, %RelationRef{} = relation_ref) do
+    %{
+      module: asset_ref.module,
+      relation: relation_ref,
+      span: asset_ref.span,
+      resolution: :resolved
+    }
+  end
+
+  defp missing_runtime_input_error(name, span, env) do
+    {:error,
+     %Error{
+       type: :missing_runtime_input,
+       phase: :render,
+       asset_ref: env.asset_ref,
+       span: span,
+       line: span.start_line,
+       message: "missing runtime SQL input :#{name} for #{inspect(env.asset_ref)}",
+       stack: env.stack,
+       details: %{name: name}
+     }}
+  end
+
+  defp missing_query_param_error(name, span, env) do
+    {:error,
+     %Error{
+       type: :missing_query_param,
+       phase: :render,
+       asset_ref: env.asset_ref,
+       span: span,
+       line: span.start_line,
+       message: "missing SQL param :#{name} for #{inspect(env.asset_ref)}",
+       stack: env.stack,
+       details: %{name: name}
+     }}
+  end
+end

--- a/lib/favn/sql_asset/renderer.ex
+++ b/lib/favn/sql_asset/renderer.ex
@@ -22,7 +22,7 @@ defmodule Favn.SQLAsset.Renderer do
          {:ok, runtime_inputs} <- normalize_runtime_inputs(definition, opts),
          {:ok, definition_catalog} <- definition_catalog(definition),
          env <- base_env(definition, params, runtime_inputs, definition_catalog),
-         {:ok, %Fragment{} = fragment} <- render_nodes(definition.template.nodes, env),
+         {:ok, %Fragment{} = fragment, _env} <- render_nodes(definition.template.nodes, env),
          {:ok, %Params{} = normalized_params} <- normalize_bindings(fragment.bindings) do
       {:ok,
        %Render{
@@ -142,10 +142,6 @@ defmodule Favn.SQLAsset.Renderer do
       {:ok, fragment, next_env} -> {:ok, fragment, next_env}
       {:error, %Error{} = error} -> {:error, error}
     end
-    |> case do
-      {:ok, fragment, _env} -> {:ok, fragment}
-      {:error, %Error{} = error} -> {:error, error}
-    end
   end
 
   defp render_node(%Text{sql: sql}, env), do: {:ok, %Fragment{sql: sql}, env}
@@ -193,8 +189,9 @@ defmodule Favn.SQLAsset.Renderer do
            |> Map.put(:local_args, local_arg_map(arg_fragments))
            |> Map.put(:stack, [stack_frame(call, definition) | env.stack])
            |> Map.put(:cache, next_env.cache),
-         {:ok, %Fragment{} = expanded} <- render_nodes(definition.template.nodes, callee_env) do
-      {:ok, expanded, %{env | cache: callee_env.cache}}
+         {:ok, %Fragment{} = expanded, callee_env_after} <-
+           render_nodes(definition.template.nodes, callee_env) do
+      {:ok, expanded, %{env | cache: callee_env_after.cache}}
     else
       {:error, %Error{} = error} -> {:error, error}
     end
@@ -248,8 +245,8 @@ defmodule Favn.SQLAsset.Renderer do
   defp render_call_args(call, env) do
     Enum.reduce_while(call.args, {:ok, [], env}, fn fragment, {:ok, acc, env_acc} ->
       case render_nodes(fragment.nodes, env_acc) do
-        {:ok, rendered_fragment} ->
-          {:cont, {:ok, [rendered_fragment | acc], env_acc}}
+        {:ok, rendered_fragment, env_after_arg} ->
+          {:cont, {:ok, [rendered_fragment | acc], env_after_arg}}
 
         {:error, %Error{} = error} ->
           {:halt, {:error, error}}

--- a/lib/favn/sql_asset/runtime.ex
+++ b/lib/favn/sql_asset/runtime.ex
@@ -1,8 +1,249 @@
 defmodule Favn.SQLAsset.Runtime do
   @moduledoc false
 
+  alias Favn.Asset
   alias Favn.Run.Context
+  alias Favn.SQL
+  alias Favn.SQL.{Explain, MaterializationResult, Params, Preview, Render, WritePlan}
+  alias Favn.SQLAsset.{Compiler, Definition, Error, Renderer}
 
-  @spec run(module(), Context.t()) :: {:error, :sql_asset_runtime_not_implemented}
-  def run(_module, %Context{}), do: {:error, :sql_asset_runtime_not_implemented}
+  @type opts :: [params: map(), runtime: map(), timeout_ms: pos_integer()]
+
+  @spec render(Asset.t(), opts()) :: {:ok, Render.t()} | {:error, Error.t()}
+  def render(asset, opts \\ [])
+
+  def render(%Asset{type: :sql, module: module}, opts) when is_list(opts) do
+    with {:ok, %Definition{} = definition} <- fetch_definition(module),
+         {:ok, %Render{} = rendered} <- Renderer.render(definition, opts) do
+      {:ok, rendered}
+    end
+  end
+
+  def render(%Asset{} = asset, _opts) do
+    {:error,
+     %Error{
+       type: :not_sql_asset,
+       phase: :render,
+       asset_ref: asset.ref,
+       message: "asset #{inspect(asset.ref)} is not a SQL asset"
+     }}
+  end
+
+  @spec preview(Asset.t(), opts()) :: {:ok, Preview.t()} | {:error, Error.t()}
+  def preview(%Asset{} = asset, opts \\ []) when is_list(opts) do
+    limit = Keyword.get(opts, :limit, 100)
+
+    with :ok <- validate_limit(limit),
+         {:ok, %Render{} = rendered} <- render(asset, opts),
+         statement <- preview_statement(rendered.sql, limit),
+         {:ok, result} <- query_render(rendered, statement, :preview, opts) do
+      {:ok, %Preview{render: rendered, limit: limit, statement: statement, result: result}}
+    end
+  end
+
+  @spec explain(Asset.t(), opts()) :: {:ok, Explain.t()} | {:error, Error.t()}
+  def explain(%Asset{} = asset, opts \\ []) when is_list(opts) do
+    analyze? = Keyword.get(opts, :analyze?, false)
+
+    with {:ok, %Render{} = rendered} <- render(asset, opts),
+         statement <- explain_statement(rendered.sql, analyze?),
+         {:ok, result} <- query_render(rendered, statement, :explain, opts) do
+      {:ok, %Explain{render: rendered, statement: statement, analyze?: analyze?, result: result}}
+    end
+  end
+
+  @spec materialize(Asset.t(), opts()) :: {:ok, MaterializationResult.t()} | {:error, Error.t()}
+  def materialize(%Asset{} = asset, opts \\ []) when is_list(opts) do
+    with {:ok, %Render{} = rendered} <- render(asset, opts),
+         {:ok, write_plan} <- build_write_plan(rendered),
+         {:ok, result} <- materialize_render(rendered, write_plan, opts) do
+      {:ok, %MaterializationResult{render: rendered, write_plan: write_plan, result: result}}
+    end
+  end
+
+  @spec run(module(), Context.t()) :: Asset.return_value()
+  def run(module, %Context{} = ctx) when is_atom(module) do
+    with {:ok, %Definition{asset: %Asset{} = asset}} <- fetch_definition(module),
+         opts <- run_opts(ctx),
+         {:ok, %MaterializationResult{} = output} <- materialize(asset, opts) do
+      {:ok,
+       %{
+         materialized: output.write_plan.materialization,
+         connection: output.render.connection,
+         rows_affected: output.result.rows_affected,
+         command: output.result.command
+       }}
+    else
+      {:error, %Error{} = error} -> {:error, error}
+    end
+  end
+
+  defp run_opts(%Context{} = ctx) do
+    runtime =
+      case ctx.window do
+        nil -> %{}
+        window -> %{window: window}
+      end
+
+    [params: ctx.params || %{}, runtime: runtime]
+  end
+
+  defp fetch_definition(module) do
+    case Compiler.fetch_definition(module) do
+      {:ok, %Definition{} = definition} ->
+        {:ok, definition}
+
+      {:error, reason} ->
+        {:error,
+         %Error{
+           type: :invalid_sql_asset_definition,
+           phase: :render,
+           message: "failed to load SQL asset definition for #{inspect(module)}",
+           details: %{module: module, reason: reason}
+         }}
+    end
+  end
+
+  defp validate_limit(limit) when is_integer(limit) and limit > 0, do: :ok
+
+  defp validate_limit(limit) do
+    {:error,
+     %Error{
+       type: :binding_failure,
+       phase: :preview,
+       message: "preview limit must be a positive integer",
+       details: %{limit: limit}
+     }}
+  end
+
+  defp preview_statement(sql, limit) do
+    "SELECT * FROM (#{trim_sql(sql)}) AS favn_preview LIMIT #{limit}"
+  end
+
+  defp explain_statement(sql, true), do: "EXPLAIN ANALYZE #{trim_sql(sql)}"
+  defp explain_statement(sql, false), do: "EXPLAIN #{trim_sql(sql)}"
+
+  defp query_render(%Render{} = rendered, statement, phase, opts) do
+    with_session(rendered.connection, opts, fn session ->
+      SQL.query(session, statement, params: adapter_params(rendered.params))
+    end)
+    |> map_sql_result_error(rendered.asset_ref, phase)
+  end
+
+  defp materialize_render(%Render{} = rendered, %WritePlan{} = write_plan, opts) do
+    with_session(rendered.connection, opts, fn session ->
+      SQL.materialize(session, write_plan, params: adapter_params(rendered.params))
+    end)
+    |> map_sql_result_error(rendered.asset_ref, :materialize)
+  end
+
+  defp with_session(connection, opts, fun) when is_function(fun, 1) do
+    timeout_opts =
+      case Keyword.get(opts, :timeout_ms) do
+        timeout when is_integer(timeout) and timeout > 0 -> [timeout_ms: timeout]
+        _ -> []
+      end
+
+    with {:ok, session} <- SQL.connect(connection, timeout_opts) do
+      try do
+        fun.(session)
+      after
+        _ = SQL.disconnect(session)
+      end
+    end
+  rescue
+    error -> {:error, error}
+  end
+
+  defp map_sql_result_error({:ok, result}, _asset_ref, _phase), do: {:ok, result}
+
+  defp map_sql_result_error({:error, %SQL.Error{} = error}, asset_ref, phase) do
+    {:error,
+     %Error{
+       type: :backend_execution_failed,
+       phase: phase,
+       asset_ref: asset_ref,
+       message: error.message || "SQL execution failed",
+       details: %{connection: error.connection, operation: error.operation},
+       cause: error
+     }}
+  end
+
+  defp map_sql_result_error({:error, %Error{} = error}, _asset_ref, _phase), do: {:error, error}
+
+  defp map_sql_result_error({:error, reason}, asset_ref, phase) do
+    {:error,
+     %Error{
+       type: :backend_execution_failed,
+       phase: phase,
+       asset_ref: asset_ref,
+       message: "SQL execution failed",
+       cause: reason
+     }}
+  end
+
+  defp build_write_plan(%Render{materialization: :view} = render) do
+    {:ok,
+     %WritePlan{
+       asset_ref: render.asset_ref,
+       connection: render.connection,
+       materialization: :view,
+       target: relation(render),
+       query: render,
+       select_sql: render.sql,
+       params: render.params,
+       replace_existing?: true,
+       replace?: true,
+       metadata: %{create_or_replace?: true}
+     }}
+  end
+
+  defp build_write_plan(%Render{materialization: :table} = render) do
+    {:ok,
+     %WritePlan{
+       asset_ref: render.asset_ref,
+       connection: render.connection,
+       materialization: :table,
+       target: relation(render),
+       query: render,
+       select_sql: render.sql,
+       params: render.params,
+       replace_existing?: true,
+       replace?: true,
+       metadata: %{rebuild?: true}
+     }}
+  end
+
+  defp build_write_plan(%Render{materialization: {:incremental, _opts}} = render) do
+    {:error,
+     %Error{
+       type: :unsupported_materialization,
+       phase: :materialize,
+       asset_ref: render.asset_ref,
+       message: "incremental SQL materialization is not supported in Phase 4a",
+       details: %{materialization: render.materialization}
+     }}
+  end
+
+  defp relation(%Render{} = render) do
+    %Favn.SQL.Relation{
+      catalog: render.produced_relation.catalog,
+      schema: render.produced_relation.schema,
+      name: render.produced_relation.name,
+      type: materialization_type(render),
+      metadata: %{}
+    }
+  end
+
+  defp trim_sql(sql) when is_binary(sql) do
+    sql
+    |> String.trim()
+    |> String.trim_trailing(";")
+    |> String.trim()
+  end
+
+  defp adapter_params(%Params{} = params), do: Params.to_adapter_params(params)
+
+  defp materialization_type(%Render{materialization: :view}), do: :view
+  defp materialization_type(%Render{materialization: :table}), do: :table
 end

--- a/test/sql_asset_runtime_test.exs
+++ b/test/sql_asset_runtime_test.exs
@@ -1,0 +1,339 @@
+defmodule Favn.SQLAssetRuntimeTest do
+  use ExUnit.Case
+
+  alias Favn.Connection.Definition
+  alias Favn.Connection.Loader
+  alias Favn.Connection.Registry
+  alias Favn.SQL.{Capabilities, Params, Result, WritePlan}
+  alias Favn.SQLAsset.Error
+
+  @events_table :sql_asset_runtime_test_events
+
+  defmodule ConnectionProvider do
+    @behaviour Favn.Connection
+
+    @impl true
+    def definition do
+      %Definition{
+        name: :sql_asset_runtime,
+        adapter: Favn.SQLAssetRuntimeTest.Adapter,
+        config_schema: [%{key: :database, required: true, type: :string}]
+      }
+    end
+  end
+
+  defmodule Adapter do
+    @behaviour Favn.SQL.Adapter
+
+    @events_table :sql_asset_runtime_test_events
+
+    @impl true
+    def connect(_resolved, _opts) do
+      record({:connect})
+      {:ok, :runtime_conn}
+    end
+
+    @impl true
+    def disconnect(:runtime_conn, _opts) do
+      record({:disconnect})
+      :ok
+    end
+
+    @impl true
+    def capabilities(_resolved, _opts) do
+      {:ok, %Capabilities{replace_view: :supported, replace_table: :supported}}
+    end
+
+    @impl true
+    def execute(:runtime_conn, statement, opts) do
+      sql = IO.iodata_to_binary(statement)
+      record({:execute, sql, Keyword.get(opts, :params, [])})
+      {:ok, %Result{kind: :execute, command: sql, rows_affected: 1, metadata: %{}}}
+    end
+
+    @impl true
+    def query(:runtime_conn, statement, opts) do
+      sql = IO.iodata_to_binary(statement)
+      params = Keyword.get(opts, :params, [])
+      record({:query, sql, params})
+
+      {:ok,
+       %Result{kind: :query, command: sql, rows: [%{"ok" => true}], metadata: %{params: params}}}
+    end
+
+    @impl true
+    def introspection_query(_kind, _payload, _opts), do: {:ok, "SELECT 1"}
+
+    @impl true
+    def materialization_statements(%WritePlan{} = plan, %Capabilities{}, _opts) do
+      target = plan.target.name
+      {:ok, ["-- pre", "CREATE OR REPLACE #{target} AS #{plan.select_sql}", "-- post"]}
+    end
+
+    defp record(event) do
+      if :ets.whereis(@events_table) != :undefined do
+        :ets.insert(@events_table, {System.unique_integer([:positive]), event})
+      end
+
+      :ok
+    end
+  end
+
+  setup do
+    state = Favn.TestSetup.capture_state()
+
+    on_exit(fn ->
+      Favn.TestSetup.restore_state(state, reload_graph?: true)
+      Registry.reload(%{})
+
+      if :ets.whereis(@events_table) != :undefined do
+        :ets.delete(@events_table)
+      end
+    end)
+
+    :ets.new(@events_table, [:named_table, :ordered_set, :public])
+
+    Application.put_env(:favn, :connection_modules, [ConnectionProvider])
+    Application.put_env(:favn, :connections, sql_asset_runtime: [database: "local"])
+    {:ok, resolved} = Loader.load()
+    :ok = Registry.reload(resolved)
+    :ok
+  end
+
+  test "render is backend-free and emits canonical positional params" do
+    %{asset: asset_module} = compile_runtime_modules!()
+
+    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+
+    window_start = ~U[2025-01-01 00:00:00Z]
+    window_end = ~U[2025-01-02 00:00:00Z]
+
+    assert {:ok, render} =
+             Favn.render(asset_module,
+               params: %{country: "NO"},
+               runtime: %{window_start: window_start, window_end: window_end}
+             )
+
+    assert render.params.format == :positional
+    assert Enum.map(render.params.bindings, & &1.source) == [:runtime, :runtime, :query_param]
+    assert Params.to_adapter_params(render.params) == [window_start, window_end, "NO"]
+    assert length(render.resolved_asset_refs) == 1
+
+    refute Enum.any?(events(), fn event -> event == {:connect} end)
+  end
+
+  test "preview returns executed preview statement and keeps canonical rendered SQL" do
+    %{asset: asset_module} = compile_runtime_modules!()
+
+    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+
+    assert {:ok, preview} =
+             Favn.preview(asset_module,
+               params: %{country: "NO"},
+               runtime: %{
+                 window_start: ~U[2025-01-01 00:00:00Z],
+                 window_end: ~U[2025-01-02 00:00:00Z]
+               },
+               limit: 5
+             )
+
+    assert preview.statement =~ "LIMIT 5"
+    refute preview.render.sql =~ "favn_preview"
+    assert preview.result.command == preview.statement
+  end
+
+  test "explain executes explain statement" do
+    %{asset: asset_module} = compile_runtime_modules!()
+
+    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+
+    assert {:ok, explain} =
+             Favn.explain(asset_module,
+               params: %{country: "NO"},
+               runtime: %{
+                 window_start: ~U[2025-01-01 00:00:00Z],
+                 window_end: ~U[2025-01-02 00:00:00Z]
+               }
+             )
+
+    assert String.starts_with?(explain.statement, "EXPLAIN ")
+    assert explain.result.command == explain.statement
+  end
+
+  test "materialize builds write plan with replace_existing semantics" do
+    %{asset: asset_module} = compile_runtime_modules!()
+
+    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+
+    assert {:ok, output} =
+             Favn.materialize(asset_module,
+               params: %{country: "NO"},
+               runtime: %{
+                 window_start: ~U[2025-01-01 00:00:00Z],
+                 window_end: ~U[2025-01-02 00:00:00Z]
+               }
+             )
+
+    assert output.write_plan.materialization == :table
+    assert output.write_plan.replace_existing?
+    assert output.write_plan.params.format == :positional
+    assert output.result.kind == :materialize
+  end
+
+  test "render fails with missing params and missing runtime inputs" do
+    %{asset: asset_module} = compile_runtime_modules!()
+
+    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+
+    assert {:error, %Error{type: :missing_query_param}} =
+             Favn.render(asset_module,
+               runtime: %{
+                 window_start: ~U[2025-01-01 00:00:00Z],
+                 window_end: ~U[2025-01-02 00:00:00Z]
+               }
+             )
+
+    assert {:error, %Error{type: :missing_runtime_input}} =
+             Favn.render(asset_module, params: %{country: "NO"})
+  end
+
+  test "render fails hard for cross-connection direct asset refs" do
+    %{cross: cross_asset} = compile_cross_connection_modules!()
+
+    assert :ok = Favn.TestSetup.setup_asset_modules([cross_asset], reload_graph?: true)
+
+    assert {:error, %Error{type: :cross_connection_asset_ref}} = Favn.render(cross_asset)
+  end
+
+  defp compile_runtime_modules! do
+    root = Module.concat(__MODULE__, "Runtime#{System.unique_integer([:positive])}")
+    raw_namespace = Module.concat([root, Raw, Sales])
+    gold_namespace = Module.concat([root, Gold, Sales])
+    raw_orders = Module.concat(raw_namespace, Orders)
+    sql_provider = Module.concat(root, SQL)
+    asset_module = Module.concat(gold_namespace, FctOrders)
+
+    Code.compile_string(
+      "defmodule #{inspect(raw_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :raw, schema: :sales\nend",
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :gold, schema: :sales\nend",
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(raw_orders)} do
+        use Favn.Namespace
+        use Favn.Asset
+
+        @produces true
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_provider)} do
+        use Favn.SQL
+
+        defsql orders_in_window(start_at, end_at) do
+          ~SQL[
+          select order_id, customer_id, country
+          from #{inspect(raw_orders)}
+          where inserted_at >= @start_at and inserted_at < @end_at
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace
+        use Favn.SQLAsset
+        use #{inspect(sql_provider)}
+
+        @materialized :table
+
+        query do
+          ~SQL[
+          select customer_id
+          from orders_in_window(@window_start, @window_end)
+          where country = @country
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    %{asset: asset_module}
+  end
+
+  defp compile_cross_connection_modules! do
+    root = Module.concat(__MODULE__, "Cross#{System.unique_integer([:positive])}")
+    other_namespace = Module.concat([root, Other, Sales])
+    gold_namespace = Module.concat([root, Gold, Sales])
+    other_asset = Module.concat(other_namespace, Orders)
+    cross_asset = Module.concat(gold_namespace, FctOrders)
+
+    Code.compile_string(
+      "defmodule #{inspect(other_namespace)} do\n  use Favn.Namespace, connection: :other_connection, catalog: :raw, schema: :sales\nend",
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :gold, schema: :sales\nend",
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(other_asset)} do
+        use Favn.Namespace
+        use Favn.Asset
+
+        @produces true
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(cross_asset)} do
+        use Favn.Namespace
+        use Favn.SQLAsset
+
+        @materialized :view
+
+        query do
+          ~SQL[
+          select *
+          from #{inspect(other_asset)}
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    %{cross: cross_asset}
+  end
+
+  defp events do
+    @events_table
+    |> :ets.tab2list()
+    |> Enum.sort_by(&elem(&1, 0))
+    |> Enum.map(&elem(&1, 1))
+  end
+end

--- a/test/sql_asset_runtime_test.exs
+++ b/test/sql_asset_runtime_test.exs
@@ -5,7 +5,9 @@ defmodule Favn.SQLAssetRuntimeTest do
   alias Favn.Connection.Loader
   alias Favn.Connection.Registry
   alias Favn.SQL.{Capabilities, Params, Result, WritePlan}
-  alias Favn.SQLAsset.Error
+  alias Favn.SQL.Error, as: SQLError
+  alias Favn.SQLAsset.Error, as: SQLAssetError
+  alias Favn.Window.{Key, Runtime}
 
   @events_table :sql_asset_runtime_test_events
 
@@ -47,8 +49,20 @@ defmodule Favn.SQLAssetRuntimeTest do
     @impl true
     def execute(:runtime_conn, statement, opts) do
       sql = IO.iodata_to_binary(statement)
-      record({:execute, sql, Keyword.get(opts, :params, [])})
-      {:ok, %Result{kind: :execute, command: sql, rows_affected: 1, metadata: %{}}}
+      params = Keyword.get(opts, :params, [])
+      record({:execute, sql, params})
+
+      if "FAIL" in params do
+        {:error,
+         %SQLError{
+           type: :execution_error,
+           operation: :execute,
+           connection: :sql_asset_runtime,
+           message: "forced execute failure"
+         }}
+      else
+        {:ok, %Result{kind: :execute, command: sql, rows_affected: 1, metadata: %{}}}
+      end
     end
 
     @impl true
@@ -57,8 +71,18 @@ defmodule Favn.SQLAssetRuntimeTest do
       params = Keyword.get(opts, :params, [])
       record({:query, sql, params})
 
-      {:ok,
-       %Result{kind: :query, command: sql, rows: [%{"ok" => true}], metadata: %{params: params}}}
+      if "FAIL" in params do
+        {:error,
+         %SQLError{
+           type: :execution_error,
+           operation: :query,
+           connection: :sql_asset_runtime,
+           message: "forced query failure"
+         }}
+      else
+        {:ok,
+         %Result{kind: :query, command: sql, rows: [%{"ok" => true}], metadata: %{params: params}}}
+      end
     end
 
     @impl true
@@ -122,6 +146,21 @@ defmodule Favn.SQLAssetRuntimeTest do
     refute Enum.any?(events(), fn event -> event == {:connect} end)
   end
 
+  test "render accepts compiled SQL module input without global asset registration" do
+    %{asset: asset_module} = compile_runtime_modules!()
+
+    assert {:ok, render} =
+             Favn.render(asset_module,
+               params: %{country: "NO"},
+               runtime: %{
+                 window_start: ~U[2025-01-01 00:00:00Z],
+                 window_end: ~U[2025-01-02 00:00:00Z]
+               }
+             )
+
+    assert render.asset_ref == {asset_module, :asset}
+  end
+
   test "preview returns executed preview statement and keeps canonical rendered SQL" do
     %{asset: asset_module} = compile_runtime_modules!()
 
@@ -160,6 +199,23 @@ defmodule Favn.SQLAssetRuntimeTest do
     assert explain.result.command == explain.statement
   end
 
+  test "render accepts runtime.window struct input" do
+    %{asset: asset_module} = compile_runtime_modules!()
+
+    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+
+    window_start = ~U[2025-01-01 00:00:00Z]
+    window_end = ~U[2025-01-02 00:00:00Z]
+    anchor_key = Key.new!(:day, window_start, "Etc/UTC")
+    window = Runtime.new!(:day, window_start, window_end, anchor_key, timezone: "Etc/UTC")
+
+    assert {:ok, render} =
+             Favn.render(asset_module, params: %{country: "NO"}, runtime: %{window: window})
+
+    assert render.runtime == window
+    assert Params.to_adapter_params(render.params) == [window_start, window_end, "NO"]
+  end
+
   test "materialize builds write plan with replace_existing semantics" do
     %{asset: asset_module} = compile_runtime_modules!()
 
@@ -185,7 +241,7 @@ defmodule Favn.SQLAssetRuntimeTest do
 
     assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
 
-    assert {:error, %Error{type: :missing_query_param}} =
+    assert {:error, %SQLAssetError{type: :missing_query_param}} =
              Favn.render(asset_module,
                runtime: %{
                  window_start: ~U[2025-01-01 00:00:00Z],
@@ -193,7 +249,7 @@ defmodule Favn.SQLAssetRuntimeTest do
                }
              )
 
-    assert {:error, %Error{type: :missing_runtime_input}} =
+    assert {:error, %SQLAssetError{type: :missing_runtime_input}} =
              Favn.render(asset_module, params: %{country: "NO"})
   end
 
@@ -202,7 +258,39 @@ defmodule Favn.SQLAssetRuntimeTest do
 
     assert :ok = Favn.TestSetup.setup_asset_modules([cross_asset], reload_graph?: true)
 
-    assert {:error, %Error{type: :cross_connection_asset_ref}} = Favn.render(cross_asset)
+    assert {:error, %SQLAssetError{type: :cross_connection_asset_ref}} = Favn.render(cross_asset)
+  end
+
+  test "preview, explain, and materialize normalize backend failures" do
+    %{asset: asset_module} = compile_runtime_modules!()
+
+    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+
+    opts = [
+      params: %{country: "FAIL"},
+      runtime: %{
+        window_start: ~U[2025-01-01 00:00:00Z],
+        window_end: ~U[2025-01-02 00:00:00Z]
+      }
+    ]
+
+    assert {:error, %SQLAssetError{type: :backend_execution_failed, phase: :preview}} =
+             Favn.preview(asset_module, opts)
+
+    assert {:error, %SQLAssetError{type: :backend_execution_failed, phase: :explain}} =
+             Favn.explain(asset_module, opts)
+
+    assert {:error, %SQLAssetError{type: :backend_execution_failed, phase: :materialize}} =
+             Favn.materialize(asset_module, opts)
+  end
+
+  test "nested defsql arguments support deferred asset refs resolved at render time" do
+    %{asset: asset_module} = compile_nested_deferred_modules!()
+
+    assert {:ok, render} = Favn.render(asset_module)
+
+    assert length(render.resolved_asset_refs) == 1
+    assert render.sql =~ "raw.sales.orders"
   end
 
   defp compile_runtime_modules! do
@@ -328,6 +416,84 @@ defmodule Favn.SQLAssetRuntimeTest do
     )
 
     %{cross: cross_asset}
+  end
+
+  defp compile_nested_deferred_modules! do
+    root = Module.concat(__MODULE__, "Deferred#{System.unique_integer([:positive])}")
+    raw_namespace = Module.concat([root, Raw, Sales])
+    gold_namespace = Module.concat([root, Gold, Sales])
+    sql_provider = Module.concat(root, SQL)
+    deferred_module = Module.concat(raw_namespace, Orders)
+    asset_module = Module.concat(gold_namespace, FctOrders)
+
+    Code.compile_string(
+      "defmodule #{inspect(raw_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :raw, schema: :sales\nend",
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :gold, schema: :sales\nend",
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_provider)} do
+        use Favn.SQL
+
+        defsql wrap_relation(source_relation) do
+          ~SQL[
+          select *
+          from @source_relation
+          ]
+        end
+
+        defsql nested_relation(source_relation) do
+          ~SQL[
+          select *
+          from wrap_relation(@source_relation)
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace
+        use Favn.SQLAsset
+        use #{inspect(sql_provider)}
+
+        @materialized :view
+
+        query do
+          ~SQL[
+          select *
+          from nested_relation(select * from #{inspect(deferred_module)})
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(deferred_module)} do
+        use Favn.Namespace
+        use Favn.Asset
+
+        @produces true
+
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    %{asset: asset_module}
   end
 
   defp events do

--- a/test/sql_asset_test.exs
+++ b/test/sql_asset_test.exs
@@ -152,7 +152,7 @@ defmodule Favn.SQLAssetTest do
     assert asset.ref == {asset_module, :asset}
   end
 
-  test "runtime execution returns an explicit not-implemented error for SQL assets" do
+  test "runtime execution returns explicit unsupported error for incremental SQL assets in Phase 4a" do
     asset_module = Module.concat(__MODULE__, "Runtime#{System.unique_integer([:positive])}")
 
     Code.compile_string(
@@ -161,7 +161,7 @@ defmodule Favn.SQLAssetTest do
         use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
         use Favn.SQLAsset
 
-        @materialized :table
+        @materialized {:incremental, strategy: :append}
 
         query do
           ~SQL[select 1 as id]
@@ -178,8 +178,8 @@ defmodule Favn.SQLAssetTest do
 
     assert run.status == :error
 
-    assert run.asset_results[{asset_module, :asset}].error.reason ==
-             :sql_asset_runtime_not_implemented
+    assert %Favn.SQLAsset.Error{type: :unsupported_materialization} =
+             run.asset_results[{asset_module, :asset}].error.reason
   end
 
   test "rejects missing materialized attribute" do


### PR DESCRIPTION
## Summary
- implement Phase 4a SQL runtime integration with new public helpers `Favn.render/2`, `Favn.preview/2`, `Favn.explain/2`, and `Favn.materialize/2` wired through `Favn.SQLAsset.Runtime`
- add a full SQL renderer (`Favn.SQLAsset.Renderer`) that expands SQL IR/`defsql`, resolves deferred asset refs at render time, enforces strict input checks, emits canonical positional params, and fails on cross-connection direct refs
- add render/runtime result and error structs (`Favn.SQL.Render`, `Favn.SQL.Params`, `Favn.SQL.Preview`, `Favn.SQL.Explain`, `Favn.SQL.MaterializationResult`, `Favn.SQLAsset.Error`) and extend write planning for view/table materialization with explicit `replace_existing?` semantics
- update runtime behavior and tests so SQL assets execute through the shared runtime path, incremental materialization returns explicit Phase 4a unsupported errors, and preview/explain/materialize semantics are covered by new integration tests
- refresh roadmap and architecture docs to split Phase 4a runtime integration from dedicated Phase 4b incremental work and document the Phase 4 API/binding/preview semantics

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`