### PR TITLE
Implement phase 5 SQL relation dependency inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,9 +135,15 @@ Not supported yet for direct SQL asset refs:
 - arbitrary nested dialect syntax
 - plain relation names inferred from raw text
 
-Planned next:
+Implemented in Phase 5:
 
-- relation-based dependency inference in a later separate phase
+- relation-based dependency inference from typed SQL relation references
+- additive merge of explicit + inferred dependencies with provenance metadata
+- relation ownership diagnostics (unmanaged warnings, ambiguous ownership errors)
+
+Planned later:
+
+- registered external source/dependency identities to replace unmanaged warnings with explicit registrations
 
 Favn explicitly avoids fake sigils, Jinja-style templating, arbitrary Elixir interpolation inside SQL, and string stitching as the normal authoring workflow.
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -1218,6 +1218,7 @@ Future continuation (not in Phase 5):
 
 * register typed external sources/dependencies so unmanaged warnings can resolve into explicit registered external identities
 * expose public lineage/provenance inspection APIs on top of retained dependency metadata
+* expand CTE inference coverage for nested/subquery-local `with` scopes and lock behavior with focused tests
 
 ### Phase 6 — generated assets / multi-assets
 

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Phase 1 and Phase 2 implemented.
+Phase 1, Phase 2, Phase 3, Phase 4a, Phase 4b, and Phase 5 implemented.
 
 This document defines the target long-term asset authoring direction for Favn and the phased path to implement it safely.
 
@@ -1195,6 +1195,8 @@ Write-plan naming rule for Phase 4a:
 
 ### Phase 5 — relation-based inference
 
+Status: implemented in current codebase.
+
 Deliver:
 
 * controlled dependency inference from SQL relation usage
@@ -1202,6 +1204,20 @@ Deliver:
 * diagnostics and validation
 
 This phase improves ergonomics without changing the core model.
+
+Implemented shape:
+
+* infer dependencies from typed SQL IR relation references
+* merge explicit and inferred dependencies with provenance retained on canonical `%Favn.Asset{}` metadata
+* resolve through the relation ownership index during registry build
+* surface unmanaged relations as warnings
+* fail on ambiguous owners, unresolved direct asset refs, and cross-connection direct asset refs
+* feed merged dependency edges into the existing shared graph/planner/runtime model
+
+Future continuation (not in Phase 5):
+
+* register typed external sources/dependencies so unmanaged warnings can resolve into explicit registered external identities
+* expose public lineage/provenance inspection APIs on top of retained dependency metadata
 
 ### Phase 6 — generated assets / multi-assets
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -182,6 +182,7 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] SQL asset dependency planning on the shared window-aware runtime model
   - [x] additive explicit + inferred dependency merge with provenance metadata
   - [x] unmanaged external relation warnings and ambiguous ownership errors
+  - [ ] follow-up hardening: nested/subquery `WITH` CTE alias exclusion tests for relation inference
 
 ---
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -177,9 +177,11 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] window-aware incremental execution and explicit lookback handling
 - [ ] Multi-asset SQL modules
 - [ ] SQL file support
-- [ ] Phase 5 relation-based SQL inference
-  - [ ] dependency inference from typed SQL relation references
-  - [ ] SQL asset dependency planning on the shared window-aware runtime model
+- [x] Phase 5 relation-based SQL inference
+  - [x] dependency inference from typed SQL relation references
+  - [x] SQL asset dependency planning on the shared window-aware runtime model
+  - [x] additive explicit + inferred dependency merge with provenance metadata
+  - [x] unmanaged external relation warnings and ambiguous ownership errors
 
 ---
 
@@ -194,8 +196,10 @@ Goal: make single-node production usage reliable and inspectable.
 - [ ] Concurrency controls
 - [ ] Run deduplication / run keys
 - [ ] Improved failure recovery
+- [ ] Registered source/external dependency model (typed relation identities)
 - [ ] Materialization history tracking
 - [ ] Asset and window state inspection
+- [ ] Asset dependency provenance and relation-lineage inspection APIs
 - [ ] Better rerun and replay ergonomics
 - [ ] Stronger test coverage for runtime, scheduler, windowing, and SQL execution
 - [ ] Operator-facing graph and run inspection foundation

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -8,14 +8,19 @@ lib/
 └── favn/
     ├── application.ex
     ├── asset.ex
+    ├── diagnostic.ex
     ├── assets.ex
     ├── namespace.ex
     ├── relation_ref.ex
     ├── assets/
     │   ├── compiler.ex
+    │   ├── dependency_inference.ex
     │   ├── graph_index.ex
     │   ├── planner.ex
     │   └── registry.ex
+    ├── asset/
+    │   ├── dependency.ex
+    │   └── relation_input.ex
     ├── connection.ex
     ├── connection/
     │   ├── definition.ex
@@ -81,6 +86,7 @@ lib/
     │   ├── error.ex
     │   ├── input.ex
     │   ├── materialization.ex
+    │   ├── relation_usage.ex
     │   ├── renderer.ex
     │   └── runtime.ex
     ├── scheduler/

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -23,6 +23,7 @@ test/
 ├── scheduler_test.exs
 ├── sql_asset_test.exs
 ├── sql_asset_runtime_test.exs
+├── sql_dependency_inference_test.exs
 ├── sql_template_asset_ref_test.exs
 ├── sql_template_ir_test.exs
 ├── sql_dsl_test.exs

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -205,7 +205,9 @@ defmodule Favn do
   placeholder model for SQL inputs, expression and relation SQL macros, direct asset
   references in relation position, and compile-time normalization into a dedicated SQL
   IR. Runtime helper APIs are available through `render/2`, `preview/2`, `explain/2`,
-  and `materialize/2`.
+  and `materialize/2`. SQL relation references discovered from the typed SQL IR are
+  now also used to infer additive asset dependencies through the registry ownership
+  index, with diagnostics retained on canonical asset metadata.
 
   Compact multi-asset style uses `Favn.Assets`:
 

--- a/lib/favn/asset.ex
+++ b/lib/favn/asset.ex
@@ -20,6 +20,9 @@ defmodule Favn.Asset do
   has normalized authoring-friendly input into runtime-ready values.
   """
 
+  alias Favn.Asset.Dependency
+  alias Favn.Asset.RelationInput
+  alias Favn.Diagnostic
   alias Favn.Ref
   alias Favn.RelationRef
   alias Favn.SQLAsset.Materialization
@@ -121,9 +124,12 @@ defmodule Favn.Asset do
           line: pos_integer(),
           meta: map(),
           depends_on: [Ref.t()],
+          dependencies: [Dependency.t()],
           window_spec: Spec.t() | nil,
           produces: RelationRef.t() | nil,
-          materialization: Favn.SQLAsset.Materialization.t() | nil
+          materialization: Favn.SQLAsset.Materialization.t() | nil,
+          relation_inputs: [RelationInput.t()],
+          diagnostics: [Diagnostic.t()]
         }
 
   @typedoc """
@@ -143,9 +149,12 @@ defmodule Favn.Asset do
     type: :elixir,
     meta: %{},
     depends_on: [],
+    dependencies: [],
     window_spec: nil,
     produces: nil,
-    materialization: nil
+    materialization: nil,
+    relation_inputs: [],
+    diagnostics: []
   ]
 
   @doc """

--- a/lib/favn/asset/dependency.ex
+++ b/lib/favn/asset/dependency.ex
@@ -1,0 +1,18 @@
+defmodule Favn.Asset.Dependency do
+  @moduledoc """
+  Canonical dependency edge metadata for one asset.
+  """
+
+  alias Favn.Asset.RelationInput
+
+  @enforce_keys [:asset_ref, :provenance]
+  defstruct [:asset_ref, provenance: [], relation_inputs: []]
+
+  @type provenance :: :explicit | :inferred_sql_relation | :inferred_sql_asset_ref
+
+  @type t :: %__MODULE__{
+          asset_ref: Favn.Ref.t(),
+          provenance: [provenance()],
+          relation_inputs: [RelationInput.t()]
+        }
+end

--- a/lib/favn/asset/relation_input.ex
+++ b/lib/favn/asset/relation_input.ex
@@ -1,0 +1,31 @@
+defmodule Favn.Asset.RelationInput do
+  @moduledoc """
+  Typed SQL relation input discovered from normalized SQL IR.
+  """
+
+  alias Favn.RelationRef
+  alias Favn.SQL.Template.Span
+
+  @enforce_keys [:kind]
+  defstruct [
+    :kind,
+    :relation_ref,
+    :raw,
+    :asset_ref,
+    :resolution,
+    :span
+  ]
+
+  @type kind :: :plain_relation | :direct_asset_ref
+
+  @type resolution :: :resolved | :deferred | nil
+
+  @type t :: %__MODULE__{
+          kind: kind(),
+          relation_ref: RelationRef.t() | nil,
+          raw: String.t() | nil,
+          asset_ref: Favn.Ref.t() | nil,
+          resolution: resolution(),
+          span: Span.t() | nil
+        }
+end

--- a/lib/favn/assets/dependency_inference.ex
+++ b/lib/favn/assets/dependency_inference.ex
@@ -126,12 +126,15 @@ defmodule Favn.Assets.DependencyInference do
          _relation_owner_entries
        ) do
     with {:ok, dependency_ref, relation_ref} <- resolve_direct_asset_ref(asset, input),
-         :ok <- ensure_direct_asset_registered(catalog, dependency_ref, asset, input),
          :ok <- ensure_same_connection(asset, input, relation_ref) do
       if dependency_ref == asset.ref do
         {:ok, :no_dependency, []}
       else
-        {:ok, dependency_ref, :inferred_sql_asset_ref, []}
+        if Map.has_key?(catalog.assets_by_ref, dependency_ref) do
+          {:ok, dependency_ref, :inferred_sql_asset_ref, []}
+        else
+          {:ok, :no_dependency, []}
+        end
       end
     else
       {:error, %Diagnostic{} = diagnostic} ->
@@ -280,23 +283,5 @@ defmodule Favn.Assets.DependencyInference do
        span: input.span,
        details: %{}
      }}
-  end
-
-  defp ensure_direct_asset_registered(catalog, dependency_ref, asset, input) do
-    if Map.has_key?(catalog.assets_by_ref, dependency_ref) do
-      :ok
-    else
-      {:error,
-       %Diagnostic{
-         severity: :error,
-         stage: :registry,
-         code: :unresolved_direct_asset_ref,
-         message:
-           "direct SQL asset reference #{inspect(input.raw)} for #{inspect(asset.ref)} resolves to #{inspect(dependency_ref)}, but that asset is not registered",
-         asset_ref: asset.ref,
-         span: input.span,
-         details: %{dependency_ref: dependency_ref}
-       }}
-    end
   end
 end

--- a/lib/favn/assets/dependency_inference.ex
+++ b/lib/favn/assets/dependency_inference.ex
@@ -1,0 +1,302 @@
+defmodule Favn.Assets.DependencyInference do
+  @moduledoc false
+
+  alias Favn.Asset
+  alias Favn.Asset.Dependency
+  alias Favn.Asset.RelationInput
+  alias Favn.Assets.Compiler
+  alias Favn.Diagnostic
+  alias Favn.RelationRef
+
+  @type error :: {:dependency_inference_error, Favn.Ref.t(), Diagnostic.t()}
+
+  @spec infer(%{
+          assets: [Asset.t()],
+          assets_by_ref: %{Favn.Ref.t() => Asset.t()},
+          relation_owners: %{RelationRef.t() => Favn.Ref.t()}
+        }) ::
+          {:ok,
+           %{
+             assets: [Asset.t()],
+             assets_by_ref: %{Favn.Ref.t() => Asset.t()},
+             relation_owners: %{RelationRef.t() => Favn.Ref.t()},
+             diagnostics: [Diagnostic.t()]
+           }}
+          | {:error, error()}
+  def infer(catalog) do
+    relation_owner_entries = Map.to_list(catalog.relation_owners)
+
+    catalog.assets
+    |> Enum.reduce_while({:ok, [], %{}, []}, fn %Asset{} = asset,
+                                                {:ok, assets_acc, by_ref_acc, diagnostics_acc} ->
+      case infer_asset(asset, catalog, relation_owner_entries) do
+        {:ok, inferred_asset} ->
+          merged_diagnostics = diagnostics_acc ++ inferred_asset.diagnostics
+
+          {:cont,
+           {:ok, [inferred_asset | assets_acc],
+            Map.put(by_ref_acc, inferred_asset.ref, inferred_asset), merged_diagnostics}}
+
+        {:error, %Diagnostic{} = diagnostic} ->
+          {:halt, {:error, {:dependency_inference_error, asset.ref, diagnostic}}}
+      end
+    end)
+    |> case do
+      {:ok, assets, assets_by_ref, diagnostics} ->
+        {:ok,
+         catalog
+         |> Map.put(:assets, Enum.reverse(assets))
+         |> Map.put(:assets_by_ref, assets_by_ref)
+         |> Map.put(:diagnostics, diagnostics)}
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp infer_asset(%Asset{} = asset, catalog, relation_owner_entries) do
+    initial_dependencies = explicit_dependency_map(asset)
+
+    asset.relation_inputs
+    |> Enum.reduce_while({:ok, initial_dependencies, []}, fn input,
+                                                             {:ok, dependency_map, diagnostics} ->
+      case infer_input_dependency(asset, input, catalog, relation_owner_entries) do
+        {:ok, :no_dependency, new_diagnostics} ->
+          {:cont, {:ok, dependency_map, diagnostics ++ new_diagnostics}}
+
+        {:ok, dependency_ref, dependency_provenance, new_diagnostics} ->
+          updated_map =
+            add_dependency(dependency_map, dependency_ref, dependency_provenance, input)
+
+          {:cont, {:ok, updated_map, diagnostics ++ new_diagnostics}}
+
+        {:error, %Diagnostic{} = diagnostic} ->
+          {:halt, {:error, diagnostic}}
+      end
+    end)
+    |> case do
+      {:ok, dependency_map, diagnostics} ->
+        dependencies =
+          dependency_map
+          |> Map.values()
+          |> Enum.sort_by(& &1.asset_ref)
+
+        depends_on = Enum.map(dependencies, & &1.asset_ref)
+
+        {:ok,
+         %{asset | dependencies: dependencies, depends_on: depends_on, diagnostics: diagnostics}}
+
+      {:error, %Diagnostic{} = diagnostic} ->
+        {:error, diagnostic}
+    end
+  end
+
+  defp explicit_dependency_map(%Asset{} = asset) do
+    Enum.reduce(asset.depends_on, %{}, fn ref, acc ->
+      Map.put(acc, ref, %Dependency{asset_ref: ref, provenance: [:explicit], relation_inputs: []})
+    end)
+  end
+
+  defp infer_input_dependency(
+         asset,
+         %RelationInput{kind: :plain_relation, relation_ref: relation_ref} = input,
+         _catalog,
+         relation_owner_entries
+       ) do
+    case matching_owners(relation_ref, relation_owner_entries) do
+      [] ->
+        {:ok, :no_dependency, [unmanaged_relation_warning(asset, input)]}
+
+      [{_owner_relation, dependency_ref}] ->
+        if dependency_ref == asset.ref do
+          {:ok, :no_dependency, []}
+        else
+          {:ok, dependency_ref, :inferred_sql_relation, []}
+        end
+
+      owners ->
+        {:error, ambiguous_relation_error(asset, input, owners)}
+    end
+  end
+
+  defp infer_input_dependency(
+         asset,
+         %RelationInput{kind: :direct_asset_ref} = input,
+         catalog,
+         _relation_owner_entries
+       ) do
+    with {:ok, dependency_ref, relation_ref} <- resolve_direct_asset_ref(asset, input),
+         :ok <- ensure_direct_asset_registered(catalog, dependency_ref, asset, input),
+         :ok <- ensure_same_connection(asset, input, relation_ref) do
+      if dependency_ref == asset.ref do
+        {:ok, :no_dependency, []}
+      else
+        {:ok, dependency_ref, :inferred_sql_asset_ref, []}
+      end
+    else
+      {:error, %Diagnostic{} = diagnostic} ->
+        {:error, diagnostic}
+    end
+  end
+
+  defp add_dependency(map, dependency_ref, provenance, %RelationInput{} = relation_input) do
+    Map.update(
+      map,
+      dependency_ref,
+      %Dependency{
+        asset_ref: dependency_ref,
+        provenance: [provenance],
+        relation_inputs: [relation_input]
+      },
+      fn existing ->
+        %Dependency{} = existing
+
+        %{
+          existing
+          | provenance: (existing.provenance ++ [provenance]) |> Enum.uniq() |> Enum.sort(),
+            relation_inputs: existing.relation_inputs ++ [relation_input]
+        }
+      end
+    )
+  end
+
+  defp matching_owners(%RelationRef{} = relation_ref, relation_owner_entries) do
+    Enum.filter(relation_owner_entries, fn {owner_relation, _owner_ref} ->
+      relation_matches?(relation_ref, owner_relation)
+    end)
+  end
+
+  defp relation_matches?(%RelationRef{} = input, %RelationRef{} = owner) do
+    owner.connection == input.connection and
+      owner.name == input.name and
+      field_matches?(input.catalog, owner.catalog) and
+      field_matches?(input.schema, owner.schema)
+  end
+
+  defp field_matches?(nil, _value), do: true
+  defp field_matches?(left, right), do: left == right
+
+  defp unmanaged_relation_warning(asset, %RelationInput{} = input) do
+    %Diagnostic{
+      severity: :warning,
+      stage: :registry,
+      code: :unmanaged_relation_reference,
+      message:
+        "SQL relation #{inspect(input.raw || input.relation_ref)} used by #{inspect(asset.ref)} is not owned by a registered asset",
+      asset_ref: asset.ref,
+      span: input.span,
+      details: %{relation_ref: input.relation_ref}
+    }
+  end
+
+  defp ambiguous_relation_error(asset, %RelationInput{} = input, owners) do
+    %Diagnostic{
+      severity: :error,
+      stage: :registry,
+      code: :ambiguous_relation_owner,
+      message:
+        "SQL relation #{inspect(input.raw || input.relation_ref)} used by #{inspect(asset.ref)} resolves to multiple owned relations",
+      asset_ref: asset.ref,
+      span: input.span,
+      details: %{relation_ref: input.relation_ref, owners: owners}
+    }
+  end
+
+  defp resolve_direct_asset_ref(_asset, %RelationInput{
+         asset_ref: {module, :asset} = asset_ref,
+         relation_ref: relation_ref,
+         resolution: :resolved
+       })
+       when is_atom(module) do
+    {:ok, asset_ref, relation_ref}
+  end
+
+  defp resolve_direct_asset_ref(asset, %RelationInput{
+         asset_ref: {module, :asset},
+         resolution: :deferred,
+         span: span
+       })
+       when is_atom(module) do
+    case Compiler.compile_module_assets(module) do
+      {:ok, [%Asset{produces: %RelationRef{} = relation_ref}]} ->
+        {:ok, {module, :asset}, relation_ref}
+
+      _other ->
+        {:error,
+         %Diagnostic{
+           severity: :error,
+           stage: :registry,
+           code: :unresolved_direct_asset_ref,
+           message:
+             "direct SQL asset reference #{inspect(module)} used by #{inspect(asset.ref)} could not be resolved",
+           asset_ref: asset.ref,
+           span: span,
+           details: %{module: module}
+         }}
+    end
+  end
+
+  defp resolve_direct_asset_ref(asset, %RelationInput{} = input) do
+    {:error,
+     %Diagnostic{
+       severity: :error,
+       stage: :registry,
+       code: :unresolved_direct_asset_ref,
+       message:
+         "direct SQL asset reference #{inspect(input.raw)} used by #{inspect(asset.ref)} could not be resolved",
+       asset_ref: asset.ref,
+       span: input.span,
+       details: %{input: input}
+     }}
+  end
+
+  defp ensure_same_connection(asset, input, %RelationRef{connection: connection}) do
+    if connection == asset.produces.connection do
+      :ok
+    else
+      {:error,
+       %Diagnostic{
+         severity: :error,
+         stage: :registry,
+         code: :cross_connection_direct_asset_ref,
+         message:
+           "direct SQL asset reference #{inspect(input.raw)} for #{inspect(asset.ref)} resolves to connection #{inspect(connection)}, expected #{inspect(asset.produces.connection)}",
+         asset_ref: asset.ref,
+         span: input.span,
+         details: %{expected_connection: asset.produces.connection, actual_connection: connection}
+       }}
+    end
+  end
+
+  defp ensure_same_connection(asset, input, nil) do
+    {:error,
+     %Diagnostic{
+       severity: :error,
+       stage: :registry,
+       code: :unresolved_direct_asset_ref,
+       message:
+         "direct SQL asset reference #{inspect(input.raw)} for #{inspect(asset.ref)} did not resolve a produced relation",
+       asset_ref: asset.ref,
+       span: input.span,
+       details: %{}
+     }}
+  end
+
+  defp ensure_direct_asset_registered(catalog, dependency_ref, asset, input) do
+    if Map.has_key?(catalog.assets_by_ref, dependency_ref) do
+      :ok
+    else
+      {:error,
+       %Diagnostic{
+         severity: :error,
+         stage: :registry,
+         code: :unresolved_direct_asset_ref,
+         message:
+           "direct SQL asset reference #{inspect(input.raw)} for #{inspect(asset.ref)} resolves to #{inspect(dependency_ref)}, but that asset is not registered",
+         asset_ref: asset.ref,
+         span: input.span,
+         details: %{dependency_ref: dependency_ref}
+       }}
+    end
+  end
+end

--- a/lib/favn/assets/registry.ex
+++ b/lib/favn/assets/registry.ex
@@ -14,8 +14,11 @@ defmodule Favn.Assets.Registry do
 
   alias Favn.Asset
   alias Favn.Assets.Compiler
+  alias Favn.Assets.DependencyInference
+  alias Favn.Diagnostic
   alias Favn.Ref
   alias Favn.RelationRef
+  require Logger
 
   @catalog_key {__MODULE__, :catalog}
 
@@ -26,11 +29,13 @@ defmodule Favn.Assets.Registry do
           {:invalid_asset_module, module()}
           | {:duplicate_asset, Favn.asset_ref()}
           | {:duplicate_relation_owner, RelationRef.t(), Favn.asset_ref(), Favn.asset_ref()}
+          | DependencyInference.error()
 
   @type catalog :: %{
           assets: [Asset.t()],
           assets_by_ref: %{Ref.t() => Asset.t()},
-          relation_owners: %{RelationRef.t() => Ref.t()}
+          relation_owners: %{RelationRef.t() => Ref.t()},
+          diagnostics: [Diagnostic.t()]
         }
 
   @doc """
@@ -62,6 +67,7 @@ defmodule Favn.Assets.Registry do
   @spec load() :: :ok | {:error, error()}
   def load do
     with {:ok, catalog} <- build_catalog() do
+      log_catalog_warnings(catalog)
       :persistent_term.put(@catalog_key, catalog)
       :ok
     end
@@ -99,7 +105,7 @@ defmodule Favn.Assets.Registry do
   def build_catalog(modules) when is_list(modules) do
     modules
     |> Enum.reduce_while(
-      {:ok, %{assets: [], assets_by_ref: %{}, relation_owners: %{}}},
+      {:ok, %{assets: [], assets_by_ref: %{}, relation_owners: %{}, diagnostics: []}},
       fn module, {:ok, catalog} ->
         case Compiler.compile_module_assets(module) do
           {:ok, assets} ->
@@ -114,8 +120,13 @@ defmodule Favn.Assets.Registry do
       end
     )
     |> case do
-      {:ok, catalog} -> {:ok, %{catalog | assets: Enum.reverse(catalog.assets)}}
-      {:error, _reason} = error -> error
+      {:ok, catalog} ->
+        catalog = %{catalog | assets: Enum.reverse(catalog.assets)}
+
+        DependencyInference.infer(catalog)
+
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -180,5 +191,13 @@ defmodule Favn.Assets.Registry do
          ref: ref
        }) do
     Map.put(relation_owners, relation_ref, ref)
+  end
+
+  defp log_catalog_warnings(%{diagnostics: diagnostics}) when is_list(diagnostics) do
+    diagnostics
+    |> Enum.filter(&(&1.severity == :warning))
+    |> Enum.each(fn diagnostic ->
+      Logger.warning(diagnostic.message)
+    end)
   end
 end

--- a/lib/favn/diagnostic.ex
+++ b/lib/favn/diagnostic.ex
@@ -1,0 +1,31 @@
+defmodule Favn.Diagnostic do
+  @moduledoc """
+  Normalized diagnostic emitted by compile, registry, or runtime phases.
+  """
+
+  alias Favn.SQL.Template.Span
+
+  @enforce_keys [:severity, :stage, :code, :message]
+  defstruct [
+    :severity,
+    :stage,
+    :code,
+    :message,
+    :asset_ref,
+    :span,
+    details: %{}
+  ]
+
+  @type severity :: :info | :warning | :error
+  @type stage :: :compile | :registry | :render | :planner | :runtime
+
+  @type t :: %__MODULE__{
+          severity: severity(),
+          stage: stage(),
+          code: atom(),
+          message: String.t(),
+          asset_ref: Favn.Ref.t() | nil,
+          span: Span.t() | nil,
+          details: map()
+        }
+end

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -138,7 +138,19 @@ defmodule Favn.SQL.Template do
           }
   end
 
-  @type ir_node :: Text.t() | Placeholder.t() | Call.t() | AssetRef.t()
+  defmodule Relation do
+    @moduledoc false
+    @enforce_keys [:raw, :segments, :span]
+    defstruct [:raw, :segments, :span]
+
+    @type t :: %__MODULE__{
+            raw: String.t(),
+            segments: [String.t()],
+            span: Favn.SQL.Template.Span.t()
+          }
+  end
+
+  @type ir_node :: Text.t() | Placeholder.t() | Call.t() | AssetRef.t() | Relation.t()
 
   @enforce_keys [:source, :root_kind, :nodes, :span, :requires]
   defstruct [:source, :root_kind, :nodes, :span, :requires]
@@ -243,6 +255,9 @@ defmodule Favn.SQL.Template do
   @spec asset_refs(t()) :: [AssetRef.t()]
   def asset_refs(%__MODULE__{nodes: nodes}), do: collect_asset_refs(nodes)
 
+  @spec relation_refs(t()) :: [Relation.t()]
+  def relation_refs(%__MODULE__{nodes: nodes}), do: collect_relation_refs(nodes)
+
   @spec calls(t()) :: [Call.t()]
   def calls(%__MODULE__{nodes: nodes}), do: collect_calls(nodes)
 
@@ -269,6 +284,14 @@ defmodule Favn.SQL.Template do
   defp collect_calls(nodes) do
     Enum.flat_map(nodes, fn
       %Call{} = call -> [call | Enum.flat_map(call.args, &collect_calls(&1.nodes))]
+      _other -> []
+    end)
+  end
+
+  defp collect_relation_refs(nodes) do
+    Enum.flat_map(nodes, fn
+      %Relation{} = relation_ref -> [relation_ref]
+      %Call{args: args} -> Enum.flat_map(args, &collect_relation_refs(&1.nodes))
       _other -> []
     end)
   end
@@ -466,12 +489,38 @@ defmodule Favn.SQL.Template do
       call_candidate?(word, tail, state) ->
         parse_call(word, tail, state, context, acc)
 
+      relation_ref_candidate?(word, tail, state) ->
+        parse_relation_ref(word, tail, state, acc)
+
       true ->
         next_state =
           advance_state(state, String.to_charlist(word))
           |> update_relation_context(String.downcase(word))
 
         parse_nodes(tail, next_state, [text_node(word, state.position, next_state.position) | acc])
+    end
+  end
+
+  defp parse_relation_ref(word, tail, state, acc) do
+    {segments, tail_after_relation} = read_relation_chain(tail, [word])
+
+    if length(segments) in 1..3 do
+      raw = Enum.join(segments, ".")
+
+      next_state =
+        advance_state(state, String.to_charlist(raw))
+        |> Map.put(:relation_entry?, false)
+        |> Map.put(:join_prefix, nil)
+
+      node = build_relation_ref(raw, segments, state, next_state)
+      parse_nodes(tail_after_relation, next_state, [node | acc])
+    else
+      raw = Enum.join(segments, ".")
+      next_state = advance_state(state, String.to_charlist(raw))
+
+      parse_nodes(tail_after_relation, next_state, [
+        text_node(raw, state.position, next_state.position) | acc
+      ])
     end
   end
 
@@ -788,6 +837,10 @@ defmodule Favn.SQL.Template do
     }
   end
 
+  defp build_relation_ref(raw, segments, state, next_state) do
+    %Relation{raw: raw, segments: segments, span: span(state.position, next_state.position)}
+  end
+
   defp classify_placeholder_source(name, _state) when name in @reserved_runtime_inputs,
     do: :runtime
 
@@ -812,6 +865,13 @@ defmodule Favn.SQL.Template do
       state.relation_entry? and
       String.match?(word, ~r/^[A-Z][A-Za-z0-9_]*$/) and
       List.first(tail) == ?.
+  end
+
+  defp relation_ref_candidate?(word, tail, state) do
+    state.statement_kind not in [:update, :merge] and
+      state.relation_entry? and
+      String.match?(word, ~r/^[a-z_][A-Za-z0-9_]*$/) and
+      peek_nonspace_char(tail) != ?(
   end
 
   defp call_candidate?(word, tail, state) do
@@ -1041,6 +1101,20 @@ defmodule Favn.SQL.Template do
   end
 
   defp read_alias_chain(rest, segments), do: {segments, rest}
+
+  defp read_relation_chain([?. | rest], segments) do
+    case rest do
+      [char | _tail]
+      when (char >= ?a and char <= ?z) or (char >= ?A and char <= ?Z) or char == ?_ ->
+        {segment, tail_after_segment} = read_identifier(rest)
+        read_relation_chain(tail_after_segment, segments ++ [segment])
+
+      _other ->
+        {segments, [?. | rest]}
+    end
+  end
+
+  defp read_relation_chain(rest, segments), do: {segments, rest}
 
   defp uppercase_alias_segments?(segments),
     do: Enum.all?(segments, &String.match?(&1, ~r/^[A-Z][A-Za-z0-9_]*$/))

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -6,6 +6,7 @@ defmodule Favn.SQL.Template do
   alias Favn.Assets.Compiler
   alias Favn.RelationRef
   alias Favn.SQL.Definition
+  alias MapSet
 
   @reserved_runtime_inputs [:window_start, :window_end]
   @join_prefixes ["inner", "left", "right", "full", "cross"]
@@ -225,7 +226,13 @@ defmodule Favn.SQL.Template do
       paren_depth: 0,
       statement_kind: top_level_statement_kind(root_kind),
       scope: scope,
-      root_kind: root_kind
+      root_kind: root_kind,
+      cte_names: MapSet.new(),
+      cte_active?: false,
+      cte_expect_alias?: false,
+      cte_waiting_query?: false,
+      cte_query_depth: nil,
+      cte_ready_for_next?: false
     }
 
     {nodes, end_state} = parse_nodes(String.to_charlist(sql), parser_state, [])
@@ -410,7 +417,17 @@ defmodule Favn.SQL.Template do
     parse_identifier(chars, state, acc)
   end
 
+  defp parse_nodes([?, | rest], state, acc) do
+    next_state =
+      state
+      |> advance_state(~c",")
+      |> maybe_continue_cte_sequence_after_comma()
+
+    parse_nodes(rest, next_state, [text_node(",", state.position, next_state.position) | acc])
+  end
+
   defp parse_nodes([char | rest], state, acc) when char not in [?(, ?), ?;] do
+    state = maybe_close_cte_sequence(state, char)
     {next_state, text} = consume_single_char(char, state)
     parse_nodes(rest, next_state, [text_node(text, state.position, next_state.position) | acc])
   end
@@ -422,6 +439,7 @@ defmodule Favn.SQL.Template do
       |> Map.put(:paren_depth, state.paren_depth + 1)
       |> Map.put(:relation_entry?, false)
       |> Map.put(:join_prefix, nil)
+      |> maybe_enter_cte_query()
 
     parse_nodes(rest, next_state, [text_node("(", state.position, next_state.position) | acc])
   end
@@ -433,6 +451,7 @@ defmodule Favn.SQL.Template do
       |> Map.put(:paren_depth, max(state.paren_depth - 1, 0))
       |> Map.put(:relation_entry?, false)
       |> Map.put(:join_prefix, nil)
+      |> maybe_exit_cte_query(state)
 
     parse_nodes(rest, next_state, [text_node(")", state.position, next_state.position) | acc])
   end
@@ -444,6 +463,12 @@ defmodule Favn.SQL.Template do
       |> Map.put(:relation_entry?, false)
       |> Map.put(:join_prefix, nil)
       |> Map.put(:statement_kind, top_level_statement_kind(state.root_kind))
+      |> Map.put(:cte_names, MapSet.new())
+      |> Map.put(:cte_active?, false)
+      |> Map.put(:cte_expect_alias?, false)
+      |> Map.put(:cte_waiting_query?, false)
+      |> Map.put(:cte_query_depth, nil)
+      |> Map.put(:cte_ready_for_next?, false)
 
     parse_nodes(rest, next_state, [text_node(";", state.position, next_state.position) | acc])
   end
@@ -480,6 +505,7 @@ defmodule Favn.SQL.Template do
 
   defp parse_identifier(chars, state, acc) do
     {word, tail} = read_identifier(chars)
+    state = update_cte_state_for_identifier(state, word)
     context = if state.relation_entry?, do: :relation, else: :expression
 
     cond do
@@ -871,7 +897,12 @@ defmodule Favn.SQL.Template do
     state.statement_kind not in [:update, :merge] and
       state.relation_entry? and
       String.match?(word, ~r/^[a-z_][A-Za-z0-9_]*$/) and
+      not cte_name?(state, word) and
       peek_nonspace_char(tail) != ?(
+  end
+
+  defp cte_name?(state, word) do
+    MapSet.member?(state.cte_names, String.downcase(word))
   end
 
   defp call_candidate?(word, tail, state) do
@@ -1168,6 +1199,106 @@ defmodule Favn.SQL.Template do
         join_prefix: nil,
         statement_kind: update_statement_kind(state.statement_kind, word, state.paren_depth)
     }
+
+  defp update_cte_state_for_identifier(state, word) do
+    lower_word = String.downcase(word)
+
+    state
+    |> maybe_finalize_cte_after_query_identifier()
+    |> transition_cte_identifier(lower_word)
+  end
+
+  defp maybe_finalize_cte_after_query_identifier(state) do
+    if state.cte_ready_for_next? and state.paren_depth == 0 and not state.cte_expect_alias? do
+      state
+      |> Map.put(:cte_active?, false)
+      |> Map.put(:cte_waiting_query?, false)
+      |> Map.put(:cte_query_depth, nil)
+      |> Map.put(:cte_ready_for_next?, false)
+    else
+      state
+    end
+  end
+
+  defp transition_cte_identifier(%{paren_depth: 0} = state, "with") do
+    state
+    |> Map.put(:cte_names, MapSet.new())
+    |> Map.put(:cte_active?, true)
+    |> Map.put(:cte_expect_alias?, true)
+    |> Map.put(:cte_waiting_query?, false)
+    |> Map.put(:cte_query_depth, nil)
+    |> Map.put(:cte_ready_for_next?, false)
+  end
+
+  defp transition_cte_identifier(
+         %{cte_active?: true, cte_expect_alias?: true, paren_depth: 0} = state,
+         "recursive"
+       ),
+       do: state
+
+  defp transition_cte_identifier(
+         %{cte_active?: true, cte_expect_alias?: true, paren_depth: 0} = state,
+         alias_name
+       ) do
+    state
+    |> Map.put(:cte_names, MapSet.put(state.cte_names, alias_name))
+    |> Map.put(:cte_expect_alias?, false)
+  end
+
+  defp transition_cte_identifier(
+         %{cte_active?: true, cte_expect_alias?: false, paren_depth: 0} = state,
+         "as"
+       ) do
+    Map.put(state, :cte_waiting_query?, true)
+  end
+
+  defp transition_cte_identifier(state, _word), do: state
+
+  defp maybe_enter_cte_query(state) do
+    if state.cte_active? and state.cte_waiting_query? and state.paren_depth > 0 and
+         is_nil(state.cte_query_depth) do
+      state
+      |> Map.put(:cte_query_depth, state.paren_depth)
+      |> Map.put(:cte_waiting_query?, false)
+      |> Map.put(:cte_ready_for_next?, false)
+    else
+      state
+    end
+  end
+
+  defp maybe_exit_cte_query(state, previous_state) do
+    if state.cte_active? and not is_nil(previous_state.cte_query_depth) and
+         previous_state.paren_depth == previous_state.cte_query_depth do
+      state
+      |> Map.put(:cte_query_depth, nil)
+      |> Map.put(:cte_ready_for_next?, true)
+    else
+      state
+    end
+  end
+
+  defp maybe_continue_cte_sequence_after_comma(state) do
+    if state.cte_active? and state.cte_ready_for_next? and state.paren_depth == 0 do
+      state
+      |> Map.put(:cte_expect_alias?, true)
+      |> Map.put(:cte_ready_for_next?, false)
+    else
+      state
+    end
+  end
+
+  defp maybe_close_cte_sequence(state, char) do
+    if state.cte_active? and state.cte_ready_for_next? and state.paren_depth == 0 and
+         char not in [32, 9, 10, 13] do
+      state
+      |> Map.put(:cte_active?, false)
+      |> Map.put(:cte_waiting_query?, false)
+      |> Map.put(:cte_query_depth, nil)
+      |> Map.put(:cte_ready_for_next?, false)
+    else
+      state
+    end
+  end
 
   defp top_level_statement_kind(:query), do: :query
   defp top_level_statement_kind(:expression), do: :expression

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -19,6 +19,7 @@ defmodule Favn.SQLAsset do
   alias Favn.SQL.Template
   alias Favn.SQLAsset.Definition
   alias Favn.SQLAsset.Materialization
+  alias Favn.SQLAsset.RelationUsage
   alias Favn.SQLAsset.Runtime
   alias Favn.Window.Spec
 
@@ -177,6 +178,8 @@ defmodule Favn.SQLAsset do
         enforce_query_root: true
       )
 
+    relation_inputs = RelationUsage.collect(raw_definition.module, template)
+
     asset = %Asset{
       module: raw_definition.module,
       name: :asset,
@@ -189,6 +192,7 @@ defmodule Favn.SQLAsset do
       line: raw_definition.line,
       meta: meta,
       depends_on: depends_on,
+      relation_inputs: relation_inputs,
       window_spec: window_spec,
       produces: produces,
       materialization: materialization
@@ -199,6 +203,7 @@ defmodule Favn.SQLAsset do
       asset: asset,
       sql: raw_definition.sql,
       template: template,
+      relation_inputs: relation_inputs,
       sql_definitions: Map.values(known_definitions),
       materialization: materialization,
       raw_asset: raw_definition

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -178,7 +178,8 @@ defmodule Favn.SQLAsset do
         enforce_query_root: true
       )
 
-    relation_inputs = RelationUsage.collect(raw_definition.module, template)
+    relation_inputs =
+      RelationUsage.collect(raw_definition.module, template, Map.values(known_definitions))
 
     asset = %Asset{
       module: raw_definition.module,

--- a/lib/favn/sql_asset/definition.ex
+++ b/lib/favn/sql_asset/definition.ex
@@ -4,6 +4,7 @@ defmodule Favn.SQLAsset.Definition do
   """
 
   alias Favn.Asset
+  alias Favn.Asset.RelationInput
   alias Favn.SQL
   alias Favn.SQLAsset.Materialization
 
@@ -14,6 +15,7 @@ defmodule Favn.SQLAsset.Definition do
     :sql,
     :template,
     :materialization,
+    relation_inputs: [],
     sql_definitions: [],
     raw_asset: nil
   ]
@@ -24,6 +26,7 @@ defmodule Favn.SQLAsset.Definition do
           sql: String.t(),
           template: SQL.Template.t(),
           materialization: Materialization.t(),
+          relation_inputs: [RelationInput.t()],
           sql_definitions: [SQL.Definition.t()],
           raw_asset: map() | nil
         }

--- a/lib/favn/sql_asset/relation_usage.ex
+++ b/lib/favn/sql_asset/relation_usage.ex
@@ -1,0 +1,82 @@
+defmodule Favn.SQLAsset.RelationUsage do
+  @moduledoc false
+
+  alias Favn.Asset.RelationInput
+  alias Favn.Namespace
+  alias Favn.RelationRef
+  alias Favn.SQL.Template
+
+  @spec collect(module(), Template.t()) :: [RelationInput.t()]
+  def collect(module, %Template{} = template) when is_atom(module) do
+    defaults = Namespace.resolve(module)
+    connection = Map.get(defaults, :connection)
+    catalog = Map.get(defaults, :catalog)
+    schema = Map.get(defaults, :schema)
+
+    plain_relation_inputs =
+      template
+      |> Template.relation_refs()
+      |> Enum.map(fn relation_ref ->
+        to_plain_relation_input(relation_ref, connection, catalog, schema)
+      end)
+
+    direct_asset_inputs =
+      template
+      |> Template.asset_refs()
+      |> Enum.map(&to_direct_asset_input/1)
+
+    plain_relation_inputs ++ direct_asset_inputs
+  end
+
+  defp to_plain_relation_input(
+         %Template.Relation{raw: raw, segments: segments, span: span},
+         connection,
+         catalog,
+         schema
+       ) do
+    relation_ref =
+      case segments do
+        [name] ->
+          RelationRef.new!(%{
+            connection: connection,
+            catalog: catalog,
+            schema: schema,
+            name: name
+          })
+
+        [schema_name, name] ->
+          RelationRef.new!(%{
+            connection: connection,
+            catalog: catalog,
+            schema: schema_name,
+            name: name
+          })
+
+        [catalog_name, schema_name, name] ->
+          RelationRef.new!(%{
+            connection: connection,
+            catalog: catalog_name,
+            schema: schema_name,
+            name: name
+          })
+      end
+
+    %RelationInput{
+      kind: :plain_relation,
+      raw: raw,
+      relation_ref: relation_ref,
+      span: span
+    }
+  end
+
+  defp to_direct_asset_input(%Template.AssetRef{} = asset_ref) do
+    %RelationInput{
+      kind: :direct_asset_ref,
+      raw: inspect(asset_ref.module),
+      relation_ref: asset_ref.produced_relation,
+      asset_ref: asset_ref.asset_ref,
+      resolution: asset_ref.resolution,
+      span: asset_ref.span
+    }
+  end
+end

--- a/lib/favn/sql_asset/relation_usage.ex
+++ b/lib/favn/sql_asset/relation_usage.ex
@@ -4,14 +4,38 @@ defmodule Favn.SQLAsset.RelationUsage do
   alias Favn.Asset.RelationInput
   alias Favn.Namespace
   alias Favn.RelationRef
+  alias Favn.SQL.Definition, as: SQLDefinition
   alias Favn.SQL.Template
+  alias Favn.SQL.Template.Call
 
-  @spec collect(module(), Template.t()) :: [RelationInput.t()]
-  def collect(module, %Template{} = template) when is_atom(module) do
+  @spec collect(module(), Template.t(), [SQLDefinition.t()]) :: [RelationInput.t()]
+  def collect(module, %Template{} = template, sql_definitions \\ []) when is_atom(module) do
+    definition_catalog =
+      sql_definitions
+      |> Enum.map(fn %SQLDefinition{} = definition ->
+        {SQLDefinition.key(definition), definition}
+      end)
+      |> Map.new()
+
+    root_defaults = Namespace.resolve(module)
+
+    {inputs, _visited} =
+      collect_template(module, template, definition_catalog, %{}, root_defaults)
+
+    inputs
+  end
+
+  defp collect_template(
+         module,
+         %Template{} = template,
+         definition_catalog,
+         visited,
+         root_defaults
+       ) do
     defaults = Namespace.resolve(module)
-    connection = Map.get(defaults, :connection)
-    catalog = Map.get(defaults, :catalog)
-    schema = Map.get(defaults, :schema)
+    connection = Map.get(defaults, :connection) || Map.get(root_defaults, :connection)
+    catalog = Map.get(defaults, :catalog) || Map.get(root_defaults, :catalog)
+    schema = Map.get(defaults, :schema) || Map.get(root_defaults, :schema)
 
     plain_relation_inputs =
       template
@@ -25,7 +49,37 @@ defmodule Favn.SQLAsset.RelationUsage do
       |> Template.asset_refs()
       |> Enum.map(&to_direct_asset_input/1)
 
-    plain_relation_inputs ++ direct_asset_inputs
+    {nested_inputs, visited_after_calls} =
+      template
+      |> Template.calls()
+      |> Enum.reduce({[], visited}, fn %Call{definition: definition_ref}, {acc, visited_acc} ->
+        key = {definition_ref.name, definition_ref.arity}
+
+        case Map.fetch(definition_catalog, key) do
+          {:ok, %SQLDefinition{} = definition} ->
+            id = {definition.module, definition.name, definition.arity}
+
+            if Map.has_key?(visited_acc, id) do
+              {acc, visited_acc}
+            else
+              {definition_inputs, visited_after_definition} =
+                collect_template(
+                  definition.module,
+                  definition.template,
+                  definition_catalog,
+                  Map.put(visited_acc, id, true),
+                  root_defaults
+                )
+
+              {acc ++ definition_inputs, visited_after_definition}
+            end
+
+          :error ->
+            {acc, visited_acc}
+        end
+      end)
+
+    {plain_relation_inputs ++ direct_asset_inputs ++ nested_inputs, visited_after_calls}
   end
 
   defp to_plain_relation_input(

--- a/lib/favn/sql_asset/renderer.ex
+++ b/lib/favn/sql_asset/renderer.ex
@@ -5,7 +5,7 @@ defmodule Favn.SQLAsset.Renderer do
   alias Favn.RelationRef
   alias Favn.SQL.Definition, as: SQLDefinition
   alias Favn.SQL.{ParamBinding, Params, Render, Template}
-  alias Favn.SQL.Template.{AssetRef, Call, Placeholder, Text}
+  alias Favn.SQL.Template.{AssetRef, Call, Placeholder, Relation, Text}
   alias Favn.SQLAsset.{Definition, Error}
   alias Favn.Window.Runtime
 
@@ -145,6 +145,8 @@ defmodule Favn.SQLAsset.Renderer do
   end
 
   defp render_node(%Text{sql: sql}, env), do: {:ok, %Fragment{sql: sql}, env}
+
+  defp render_node(%Relation{raw: raw}, env), do: {:ok, %Fragment{sql: raw}, env}
 
   defp render_node(%Placeholder{source: :runtime, name: name, span: span}, env) do
     case Map.fetch(env.runtime_values, name) do

--- a/test/sql_asset_runtime_test.exs
+++ b/test/sql_asset_runtime_test.exs
@@ -469,11 +469,12 @@ defmodule Favn.SQLAssetRuntimeTest do
   end
 
   test "render fails hard for cross-connection direct asset refs" do
-    %{cross: cross_asset} = compile_cross_connection_modules!()
+    %{cross: cross_asset, other: other_asset} = compile_cross_connection_modules!()
 
-    assert :ok = Favn.TestSetup.setup_asset_modules([cross_asset], reload_graph?: true)
+    assert {:error, {:dependency_inference_error, {^cross_asset, :asset}, diagnostic}} =
+             Favn.Assets.Registry.build_catalog([other_asset, cross_asset])
 
-    assert {:error, %SQLAssetError{type: :cross_connection_asset_ref}} = Favn.render(cross_asset)
+    assert diagnostic.code == :cross_connection_direct_asset_ref
   end
 
   test "preview, explain, and materialize normalize backend failures" do
@@ -630,7 +631,7 @@ defmodule Favn.SQLAssetRuntimeTest do
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 
-    %{cross: cross_asset}
+    %{cross: cross_asset, other: other_asset}
   end
 
   defp compile_nested_deferred_modules! do

--- a/test/sql_dependency_inference_test.exs
+++ b/test/sql_dependency_inference_test.exs
@@ -125,6 +125,146 @@ defmodule Favn.SQLDependencyInferenceTest do
     assert {:error, {:cycle, _cycle}} = GraphIndex.build_index(catalog.assets)
   end
 
+  test "infers dependency from relation ref inside defsql body" do
+    root = Module.concat(__MODULE__, "Defsql#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    raw_orders = Module.concat(root, RawOrders)
+    consumer = Module.concat(root, Consumer)
+
+    compile_elixir_asset!(raw_orders, "raw_orders")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql orders_in_window(start_at, end_at) do
+          ~SQL[
+          select *
+          from silver.sales.raw_orders
+          where inserted_at >= @start_at and inserted_at < @end_at
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(consumer)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+        use #{inspect(sql_module)}
+
+        @materialized :view
+
+        query do
+          ~SQL[select * from orders_in_window(@window_start, @window_end)]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    :ok = Favn.TestSetup.setup_asset_modules([raw_orders, consumer], reload_graph?: true)
+
+    assert {:ok, asset} = Favn.get_asset(consumer)
+    assert asset.depends_on == [{raw_orders, :asset}]
+  end
+
+  test "infers dependency from nested defsql relation chain" do
+    root = Module.concat(__MODULE__, "NestedDefsql#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    raw_orders = Module.concat(root, RawOrders)
+    consumer = Module.concat(root, Consumer)
+
+    compile_elixir_asset!(raw_orders, "raw_orders")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql raw_orders_relation(start_at) do
+          ~SQL[select * from silver.sales.raw_orders where inserted_at >= @start_at]
+        end
+
+        defsql wrapped_orders(start_at) do
+          ~SQL[select * from raw_orders_relation(@start_at)]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(consumer)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+        use #{inspect(sql_module)}
+
+        @materialized :view
+
+        query do
+          ~SQL[select * from wrapped_orders(@window_start)]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    :ok = Favn.TestSetup.setup_asset_modules([raw_orders, consumer], reload_graph?: true)
+
+    assert {:ok, asset} = Favn.get_asset(consumer)
+    assert asset.depends_on == [{raw_orders, :asset}]
+  end
+
+  test "infers direct asset refs used inside defsql body" do
+    root = Module.concat(__MODULE__, "DefsqlAssetRef#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    raw_orders = Module.concat(root, RawOrders)
+    consumer = Module.concat(root, Consumer)
+
+    compile_elixir_asset!(raw_orders, "raw_orders")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql raw_orders_relation(start_at) do
+          ~SQL[select * from #{inspect(raw_orders)} where inserted_at >= @start_at]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(consumer)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+        use #{inspect(sql_module)}
+
+        @materialized :view
+
+        query do
+          ~SQL[select * from raw_orders_relation(@window_start)]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    :ok = Favn.TestSetup.setup_asset_modules([raw_orders, consumer], reload_graph?: true)
+
+    assert {:ok, asset} = Favn.get_asset(consumer)
+    assert asset.depends_on == [{raw_orders, :asset}]
+  end
+
   test "fails catalog build for cross-connection direct asset ref" do
     root = Module.concat(__MODULE__, "CrossConn#{System.unique_integer([:positive])}")
     upstream = Module.concat(root, Upstream)

--- a/test/sql_dependency_inference_test.exs
+++ b/test/sql_dependency_inference_test.exs
@@ -1,0 +1,215 @@
+defmodule Favn.SQLDependencyInferenceTest do
+  use ExUnit.Case
+
+  alias Favn.Assets.GraphIndex
+  alias Favn.Assets.Registry
+
+  setup do
+    state = Favn.TestSetup.capture_state()
+
+    on_exit(fn ->
+      Favn.TestSetup.restore_state(state, reload_graph?: true)
+    end)
+
+    :ok
+  end
+
+  test "infers dependency from SQL plain relation reference" do
+    root = Module.concat(__MODULE__, "Infer#{System.unique_integer([:positive])}")
+    raw_orders = Module.concat(root, RawOrders)
+    fct_orders = Module.concat(root, FctOrders)
+
+    compile_elixir_asset!(raw_orders, "raw_orders")
+    compile_sql_asset!(fct_orders, "select * from silver.sales.raw_orders")
+
+    :ok = Favn.TestSetup.setup_asset_modules([raw_orders, fct_orders], reload_graph?: true)
+
+    assert {:ok, asset} = Favn.get_asset(fct_orders)
+    assert asset.depends_on == [{raw_orders, :asset}]
+
+    assert [%Favn.Asset.Dependency{asset_ref: {^raw_orders, :asset}, provenance: provenance}] =
+             asset.dependencies
+
+    assert Enum.sort(provenance) == [:inferred_sql_relation]
+  end
+
+  test "dedupes explicit and inferred dependency and retains provenance" do
+    root = Module.concat(__MODULE__, "Dedupe#{System.unique_integer([:positive])}")
+    raw_orders = Module.concat(root, RawOrders)
+    fct_orders = Module.concat(root, FctOrders)
+
+    compile_elixir_asset!(raw_orders, "raw_orders")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(fct_orders)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+
+        @depends #{inspect(raw_orders)}
+        @materialized :view
+
+        query do
+          ~SQL[select * from silver.sales.raw_orders]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    :ok = Favn.TestSetup.setup_asset_modules([raw_orders, fct_orders], reload_graph?: true)
+
+    assert {:ok, asset} = Favn.get_asset(fct_orders)
+    assert asset.depends_on == [{raw_orders, :asset}]
+
+    assert [%Favn.Asset.Dependency{asset_ref: {^raw_orders, :asset}, provenance: provenance}] =
+             asset.dependencies
+
+    assert Enum.sort(provenance) == [:explicit, :inferred_sql_relation]
+  end
+
+  test "emits warning diagnostic for unmanaged SQL relation" do
+    root = Module.concat(__MODULE__, "Unmanaged#{System.unique_integer([:positive])}")
+    fct_orders = Module.concat(root, FctOrders)
+
+    compile_sql_asset!(fct_orders, "select * from ext_orders")
+
+    assert {:ok, catalog} = Registry.build_catalog([fct_orders])
+    [asset] = catalog.assets
+
+    assert Enum.any?(asset.diagnostics, fn diagnostic ->
+             diagnostic.code == :unmanaged_relation_reference and diagnostic.severity == :warning
+           end)
+  end
+
+  test "fails catalog build for ambiguous relation ownership" do
+    root = Module.concat(__MODULE__, "Ambiguous#{System.unique_integer([:positive])}")
+    owner_a = Module.concat(root, OwnerA)
+    owner_b = Module.concat(root, OwnerB)
+    consumer = Module.concat(root, Consumer)
+
+    compile_elixir_asset_with_schema!(owner_a, "orders", :sales)
+    compile_elixir_asset_with_schema!(owner_b, "orders", :marketing)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(consumer)} do
+        use Favn.Namespace, connection: :warehouse
+        use Favn.SQLAsset
+
+        @materialized :view
+
+        query do
+          ~SQL[select * from orders]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    assert {:error, {:dependency_inference_error, {^consumer, :asset}, diagnostic}} =
+             Registry.build_catalog([owner_a, owner_b, consumer])
+
+    assert diagnostic.code == :ambiguous_relation_owner
+  end
+
+  test "cycle detection includes inferred edges" do
+    root = Module.concat(__MODULE__, "Cycle#{System.unique_integer([:positive])}")
+    a = Module.concat(root, A)
+    b = Module.concat(root, B)
+
+    compile_sql_asset!(a, "select * from b")
+    compile_sql_asset!(b, "select * from a")
+
+    assert {:ok, catalog} = Registry.build_catalog([a, b])
+    assert {:error, {:cycle, _cycle}} = GraphIndex.build_index(catalog.assets)
+  end
+
+  test "fails catalog build for cross-connection direct asset ref" do
+    root = Module.concat(__MODULE__, "CrossConn#{System.unique_integer([:positive])}")
+    upstream = Module.concat(root, Upstream)
+    consumer = Module.concat(root, Consumer)
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(upstream)} do
+        use Favn.Namespace, connection: :other, catalog: :silver, schema: :sales
+        use Favn.Asset
+
+        @produces true
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(consumer)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+
+        @materialized :view
+
+        query do
+          ~SQL[select * from #{inspect(upstream)}]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    assert {:error, {:dependency_inference_error, {^consumer, :asset}, diagnostic}} =
+             Registry.build_catalog([upstream, consumer])
+
+    assert diagnostic.code == :cross_connection_direct_asset_ref
+  end
+
+  defp compile_elixir_asset!(module, table_name) do
+    Code.compile_string(
+      """
+      defmodule #{inspect(module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :silver, schema: :sales
+        use Favn.Asset
+
+        @produces name: #{inspect(table_name)}
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+  end
+
+  defp compile_elixir_asset_with_schema!(module, table_name, schema_name) do
+    Code.compile_string(
+      """
+      defmodule #{inspect(module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :silver, schema: #{inspect(schema_name)}
+        use Favn.Asset
+
+        @produces name: #{inspect(table_name)}
+        def asset(_ctx), do: :ok
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+  end
+
+  defp compile_sql_asset!(module, sql) do
+    Code.compile_string(
+      """
+      defmodule #{inspect(module)} do
+        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.SQLAsset
+
+        @materialized :view
+
+        query do
+          ~SQL[#{sql}]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+  end
+end

--- a/test/sql_template_asset_ref_test.exs
+++ b/test/sql_template_asset_ref_test.exs
@@ -56,6 +56,31 @@ defmodule Favn.SQLTemplateAssetRefTest do
     assert Template.asset_refs(template) == []
   end
 
+  test "captures plain relation refs in relation positions" do
+    sql = """
+    select *
+    from silver.sales.orders o
+    join sales.customers c on c.id = o.customer_id
+    """
+
+    template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+
+    assert Enum.map(Template.relation_refs(template), & &1.raw) == [
+             "silver.sales.orders",
+             "sales.customers"
+           ]
+  end
+
+  test "does not treat table function syntax as plain relation ref" do
+    sql = """
+    select *
+    from read_parquet('orders.parquet')
+    """
+
+    template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+    assert Template.relation_refs(template) == []
+  end
+
   test "does not support update from and merge into asset refs" do
     update_sql = """
     update silver.sales.orders as o

--- a/test/sql_template_asset_ref_test.exs
+++ b/test/sql_template_asset_ref_test.exs
@@ -130,6 +130,33 @@ defmodule Favn.SQLTemplateAssetRefTest do
     assert Template.asset_refs(with_merge_template) == []
   end
 
+  test "does not treat CTE names as relation refs" do
+    sql = """
+    with recent_orders as (
+      select * from silver.sales.orders
+    )
+    select *
+    from recent_orders
+    """
+
+    template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+
+    assert Enum.map(Template.relation_refs(template), & &1.raw) == ["silver.sales.orders"]
+  end
+
+  test "CTE name shadowing owned relation name is not treated as relation ref" do
+    sql = """
+    with orders as (
+      select 1 as order_id
+    )
+    select *
+    from orders
+    """
+
+    template = Template.compile!(sql, file: "test/sql_template_asset_ref_test.exs", line: 1)
+    assert Template.relation_refs(template) == []
+  end
+
   test "keeps unresolved module references as deferred asset refs" do
     template =
       Template.compile!(


### PR DESCRIPTION
## Summary
- implement Phase 5 relation-based SQL dependency inference from typed SQL template relation refs and direct SQL asset refs
- merge explicit and inferred dependencies onto canonical assets with provenance metadata, and resolve diagnostics at registry build time
- update planner-facing behavior through existing merged `depends_on`, add coverage for inference/ambiguity/cross-connection/cycle cases, and sync roadmap/docs for completed Phase 5 plus future external-source follow-up

## Validation
- mix format
- mix compile --warnings-as-errors
- mix test
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected