### PR TITLE
Add typed external relational sources with unified relation DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 - Plain Elixir functions become assets with metadata and dependencies.
 - Preferred single-asset authoring uses one module with `use Favn.Asset` and `def asset(ctx)`.
 - SQL assets can be authored as one module with `use Favn.SQLAsset`, `query do ... end`, and a real `~SQL""" ... """` sigil.
-- Assets can optionally own produced warehouse relations through `@produces`.
+- Assets can optionally own warehouse relations through `@relation`.
 - Dependency graphs are discovered automatically from asset definitions.
 - Runs are planned deterministically and executed in dependency order.
 - Runtime state and run events are exposed through a small public API.
@@ -35,14 +35,14 @@ Phase 2 introduces `Favn.Asset` as the preferred one-module-per-asset DSL:
 
 ```elixir
 defmodule MyWarehouse.Raw.Sales.Orders do
-  use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+  use Favn.Namespace, relation: [connection: :warehouse, catalog: "raw", schema: "sales"]
   use Favn.Asset
 
   @doc "Extract raw orders from upstream API"
   @meta owner: "data-platform", category: :sales, tags: [:raw]
-  @produces true
+  @relation true
   def asset(ctx) do
-    _target = ctx.asset.produces
+    _target = ctx.asset.relation
     :ok
   end
 end
@@ -54,7 +54,7 @@ end
 - `@meta`
 - `@depends` (module shorthand `@depends MyApp.UpstreamAsset` only for single-asset modules; use tuple refs for multi-asset modules)
 - `@window`
-- `@produces`
+- `@relation`
 
 Single-asset modules compile to one canonical `%Favn.Asset{}` with ref `{Module, :asset}`.
 
@@ -64,7 +64,7 @@ Phase 3 introduces `Favn.SQLAsset` as the preferred one-module-per-asset SQL DSL
 
 ```elixir
 defmodule MyWarehouse.Gold.Sales.FctOrders do
-  use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+  use Favn.Namespace, relation: [connection: :warehouse, catalog: "gold", schema: "sales"]
   use Favn.SQLAsset
 
   @doc "Gold fact table for orders"
@@ -93,9 +93,9 @@ end
 - `@depends`
 - `@window`
 - `@materialized`
-- `@produces`
+- `@relation`
 
-SQL assets compile into the same canonical `%Favn.Asset{}` shape as Elixir assets, including ref `{Module, :asset}` and inferred produced relation ownership.
+SQL assets compile into the same canonical `%Favn.Asset{}` shape as Elixir assets, including ref `{Module, :asset}` and inferred relation ownership.
 
 Phase 4a runtime integration now includes:
 
@@ -192,11 +192,11 @@ defmodule MyApp.SalesAssets do
 end
 ```
 
-Produced relation ownership can be declared separately from logical dependencies:
+Relation ownership can be declared separately from logical dependencies:
 
 ```elixir
 defmodule MyApp.Warehouse.Raw.Sales do
-  use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+  use Favn.Namespace, relation: [connection: :warehouse, catalog: "raw", schema: "sales"]
 end
 
 defmodule MyApp.Warehouse.Raw.Sales.Assets do
@@ -204,9 +204,9 @@ defmodule MyApp.Warehouse.Raw.Sales.Assets do
   use Favn.Assets
 
   @asset true
-  @produces true
+  @relation true
   def orders(ctx) do
-    ctx.asset.produces
+    ctx.asset.relation
     :ok
   end
 end
@@ -413,7 +413,7 @@ def daily_sales(ctx), do: :ok
 Runtime context now includes:
 
 - `ctx.window` (concrete execution window for the current node)
-- `ctx.asset.ref` and `ctx.asset.produces`
+- `ctx.asset.ref` and `ctx.asset.relation`
 - `ctx.pipeline.anchor_window` (run-level requested window intent)
 - `ctx.pipeline.run_kind` (`:pipeline` or `:pipeline_backfill`)
 - `ctx.pipeline.resolved_refs` (deterministic resolved target refs snapshot)

--- a/docs/ASSET_SQL_PLAN.md
+++ b/docs/ASSET_SQL_PLAN.md
@@ -55,7 +55,7 @@ Favn already has a strong canonical runtime model:
 The new SQL direction revealed a cleaner overall design:
 
 * SQL assets feel much more natural as one module per asset
-* produced relation inference becomes straightforward
+* relation inference becomes straightforward
 * module namespace can carry connection/catalog/schema defaults
 * plain SQL can stay plain SQL
 
@@ -89,7 +89,7 @@ SQL bodies should stay as standard SQL as much as possible.
 
 Elixir and SQL assets must compile into the same canonical `%Favn.Asset{}` shape.
 
-### 5. Shared produced relation model
+### 5. Shared relation model
 
 Both Elixir and SQL assets must be able to declare or infer the relation they materialize.
 
@@ -119,15 +119,15 @@ Example:
 
 ```elixir
 defmodule MyWarehouse do
-  use Favn.Namespace, connection: :warehouse
+  use Favn.Namespace, relation: [connection: :warehouse]
 end
 
 defmodule MyWarehouse.Raw do
-  use Favn.Namespace, catalog: "raw"
+  use Favn.Namespace, relation: [catalog: "raw"]
 end
 
 defmodule MyWarehouse.Raw.Sales do
-  use Favn.Namespace, schema: "sales"
+  use Favn.Namespace, relation: [schema: "sales"]
 end
 
 defmodule MyWarehouse.Raw.Sales.Orders do
@@ -135,11 +135,11 @@ defmodule MyWarehouse.Raw.Sales.Orders do
 
   @doc "Extract raw orders from upstream API"
   @meta owner: "data-platform", category: :sales, tags: [:raw]
-  @produces true
+  @relation true
   @window Favn.Window.daily(on: :order_date, lookback: 1)
 
   def asset(ctx) do
-    target = ctx.asset.produces
+    target = ctx.asset.relation
     # => %Favn.RelationRef{
     #      connection: :warehouse,
     #      catalog: "raw",
@@ -156,10 +156,10 @@ defmodule MyWarehouse.Raw.Sales.Customers do
 
   @doc "Extract raw customers from upstream API with asset name override"
   @meta owner: "data-platform", category: :sales, tags: [:raw]
-  @produces name: "crm_customers"
+  @relation name: "crm_customers"
 
   def asset(ctx) do
-    ctx.asset.produces
+    ctx.asset.relation
     :ok
   end
 end
@@ -171,7 +171,7 @@ It keeps Elixir asset authoring aligned with the SQL asset direction:
 
 * one module
 * one obvious asset
-* one obvious produced relation
+* one obvious relation
 * one obvious runtime entrypoint
 * easy IEx usage
 
@@ -182,7 +182,7 @@ A `Favn.Asset` module should compile to one canonical asset.
 Likely rules:
 
 * module defines exactly one public asset function, likely `def asset(ctx)`
-* `@doc`, `@meta`, `@depends`, `@window`, and `@produces` attach to that asset
+* `@doc`, `@meta`, `@depends`, `@window`, and `@relation` attach to that asset
 * module-level defaults such as `connection`, `catalog`, and `schema` may be used for relation ownership
 
 ### Relation defaults inside `Favn.Asset`
@@ -201,26 +201,26 @@ Example:
 
 or equivalent canonical ref shape.
 
-### `@produces`
+### `@relation`
 
-`@produces` should express **physical relation ownership**.
+`@relation` should express **physical relation ownership**.
 
 Example:
 
 ```elixir
-@produces true
+@relation true
 ```
 
 or:
 
 ```elixir
-@produces name: :orders
+@relation name: :orders
 ```
 
 or:
 
 ```elixir
-@produces connection: :warehouse, catalog: :raw, schema: :sales, name: :orders
+@relation connection: :warehouse, catalog: :raw, schema: :sales, name: :orders
 ```
 
 This must remain separate from `@depends`.
@@ -239,7 +239,7 @@ It remains useful when:
 
 ### Required extension to `Favn.Assets`
 
-`Favn.Assets` must be extended with produced relation support so Elixir assets can participate in relation ownership and SQL dependency linking.
+`Favn.Assets` must be extended with relation support so Elixir assets can participate in relation ownership and SQL dependency linking.
 
 Example:
 
@@ -253,15 +253,15 @@ defmodule MyApp.RawAssets do
   schema :sales
 
   @asset true
-  @produces true
+  @relation true
   def orders(ctx) do
-    target = ctx.asset.produces
+    target = ctx.asset.relation
     :ok
   end
 
   @asset true
   @depends :orders
-  @produces name: :stg_orders
+  @relation name: :stg_orders
   def stage_orders(ctx) do
     :ok
   end
@@ -271,10 +271,10 @@ end
 ### Meaning
 
 * `@depends` stays logical dependency
-* `@produces` becomes relation ownership
+* `@relation` becomes relation ownership
 * module defaults reduce repetition
 
-This change is required so SQL assets can later infer dependencies from Elixir-produced warehouse relations.
+This change is required so SQL assets can later infer dependencies from Elixir-warehouse relations.
 
 ---
 
@@ -354,15 +354,15 @@ end
 * one SQL asset module = one asset
 * SQL body remains normal SQL authored through a real `~SQL` sigil
 * metadata uses familiar Favn conventions
-* produced relation is normally inferred from namespace/module path
-* explicit override via `@produces` is allowed
+* relation is normally inferred from namespace/module path
+* explicit override via `@relation` is allowed
 
-### Explicit produced relation override
+### Explicit relation override
 
 Example:
 
 ```elixir
-@produces schema: "mart", name: "fact_orders"
+@relation schema: "mart", name: "fact_orders"
 ```
 
 ### SQL authoring principle
@@ -387,9 +387,9 @@ The SQL text should stay as close to standard SQL as possible so ordinary SQL ed
 
 ---
 
-## Shared produced relation model
+## Shared relation model
 
-A shared produced relation model is the bridge between Elixir assets and SQL assets.
+A shared relation model is the bridge between Elixir assets and SQL assets.
 
 This is required so a SQL asset can read a warehouse relation produced by an Elixir asset, and Favn can understand that relationship.
 
@@ -449,13 +449,13 @@ This keeps relation identifiers SQL-safe and avoids atom leakage.
 
 Extend `%Favn.Asset{}` with:
 
-* `produces :: Favn.RelationRef.t() | nil`
+* `relation :: Favn.RelationRef.t() | nil`
 
 This should be a first-class field on the canonical asset struct, not loose metadata.
 
 ### Why
 
-Produced relation ownership is:
+Relation ownership is:
 
 * structural
 * indexable
@@ -464,9 +464,9 @@ Produced relation ownership is:
 
 ---
 
-## `@produces` semantics
+## `@relation` semantics
 
-`@produces` means:
+`@relation` means:
 
 > this asset owns or materializes this relation
 
@@ -479,27 +479,27 @@ These two concepts must remain separate.
 ### Recommended accepted forms
 
 ```elixir
-@produces true
+@relation true
 ```
 
 ```elixir
-@produces name: :orders
+@relation name: :orders
 ```
 
 ```elixir
-@produces connection: :warehouse, catalog: :raw, schema: :sales, name: :orders
+@relation connection: :warehouse, catalog: :raw, schema: :sales, name: :orders
 ```
 
 ### Inference rules
 
 Recommended behavior:
 
-* no `@produces` means the asset does not declare a produced relation
-* `@produces true` means:
+* no `@relation` means the asset does not declare a relation
+* `@relation true` means:
 
   * use module defaults or namespace defaults
   * infer `name` if possible from function name or module leaf
-* partial `@produces` values merge on top of defaults
+* partial `@relation` values merge on top of defaults
 
 ### Validation rules
 
@@ -514,9 +514,9 @@ Recommended behavior:
 
 ## Runtime context exposure
 
-The resolved produced relation should be passed into runtime context as:
+The resolved relation should be passed into runtime context as:
 
-* `ctx.asset.produces`
+* `ctx.asset.relation`
 
 This should be a `%Favn.RelationRef{}`.
 
@@ -550,7 +550,7 @@ This index is needed for:
 
 ### Uniqueness rule
 
-No two assets may claim the same produced relation.
+No two assets may claim the same relation.
 
 If two assets compile to the same canonical `%Favn.RelationRef{}`, compilation or startup must fail.
 
@@ -577,10 +577,10 @@ defmodule MyWarehouse.Raw.Sales.Orders do
   schema :sales
 
   @doc "Extract raw orders from upstream API"
-  @produces connection: :warehouse catalog: "raw" schema: "sales" name: "orders"
+  @relation connection: :warehouse catalog: "raw" schema: "sales" name: "orders"
 
   def asset(ctx) do
-    target = ctx.asset.produces
+    target = ctx.asset.relation
     :ok
   end
 end
@@ -588,7 +588,7 @@ end
 
 A downstream SQL asset may read `raw.sales.orders`, and Favn can connect that relation back to the Elixir producer asset via the relation ownership index.
 
-This is why `@produces` is required as a first-class concept.
+This is why `@relation` is required as a first-class concept.
 
 ---
 
@@ -668,7 +668,7 @@ Target helper capabilities include:
 * explain query
 * materialize asset output
 * inspect resolved connection
-* inspect resolved produced relation
+* inspect resolved relation
 
 Recommended public APIs:
 
@@ -755,7 +755,7 @@ Relevant shared runtime concepts should include:
 
 * `ctx.window`
 * `ctx.pipeline.anchor_window`
-* `ctx.asset.produces`
+* `ctx.asset.relation`
 
 ---
 
@@ -775,7 +775,7 @@ Plain SQL remains the preferred path.
 
 ### Do not overload `@depends`
 
-Logical dependency and produced relation ownership remain separate concepts.
+Logical dependency and relation ownership remain separate concepts.
 
 ### Do not put scheduling into asset DSLs
 
@@ -809,16 +809,16 @@ This is the intended intuitive warehouse-oriented structure.
 
 ## Phased implementation plan
 
-### Phase 1 — shared produced relation foundation
+### Phase 1 — shared relation foundation
 
 Deliver:
 
 * [x] `Favn.RelationRef`
-* [x] `%Favn.Asset{produces: ...}`
+* [x] `%Favn.Asset{relation: ...}`
 * [x] namespace config inheritance
 * [x] `Favn.Assets` support for:
-  * `@produces`
-  * `ctx.asset.produces`
+  * `@relation`
+  * `ctx.asset.relation`
 * [x] validation and normalization
 * [x] relation ownership uniqueness checks
 * [x] relation ownership index
@@ -837,7 +837,7 @@ Deliver:
   * [x] `@meta`
   * [x] `@depends`
   * [x] `@window`
-  * [x] `@produces`
+  * [x] `@relation`
   * [x] relation defaults through `Favn.Namespace`
 * [x] compilation into one canonical `%Favn.Asset{}`
 
@@ -852,7 +852,7 @@ Implemented semantics:
 
   * `Some.Module` (only when `Some.Module` uses `Favn.Asset`, normalized to `{Some.Module, :asset}`)
   * `{Some.Module, :asset_name}`
-* `@produces true` relation-name inference for single-asset modules uses module leaf `Macro.underscore/1`
+* `@relation true` relation-name inference for single-asset modules uses module leaf `Macro.underscore/1`
 
   * `MyWarehouse.Raw.Sales.Orders` -> `"orders"`
   * `MyWarehouse.Gold.Sales.FctOrders` -> `"fct_orders"`
@@ -871,8 +871,8 @@ Deliver:
   * [x] `@depends`
   * [x] `@window`
   * [x] `@materialized`
-  * [x] optional `@produces` override
-* [x] produced relation inference from namespace/module path
+  * [x] optional `@relation` override
+* [x] relation inference from namespace/module path
 * [x] compilation into one canonical `%Favn.Asset{}`
 
 This phase establishes the SQL asset authoring model.
@@ -894,8 +894,8 @@ Implemented semantics:
   * `:view`
   * `:table`
   * `{:incremental, strategy: :append | :replace | :delete_insert | :merge, unique_key: [...]}`
-* SQL assets infer their produced relation from `Favn.Namespace` defaults plus module leaf `Macro.underscore/1`
-* SQL assets require a resolved produced relation with a connection name
+* SQL assets infer their relation from `Favn.Namespace` defaults plus module leaf `Macro.underscore/1`
+* SQL assets require a resolved relation with a connection name
 * `~SQL` stays plain SQL and currently rejects interpolation/modifiers in phase 3
 * SQL modules expose the existing asset compiler seam via `__favn_asset_compiler__/0`
 * generated `asset/1` currently returns `{:error, :sql_asset_runtime_not_implemented}` until phase 4 runtime execution lands
@@ -1081,7 +1081,7 @@ Phase 3 validates:
 * `defsql` call arity matches the declared reusable SQL definition
 * duplicate visible imported/local reusable SQL definitions are compile-time errors
 * cyclic reusable SQL definitions are compile-time errors
-* compiled asset references must resolve to single-asset modules with produced relations
+* compiled asset references must resolve to single-asset modules with relations
 * unresolved asset references stay as deferred symbolic refs in the SQL IR
 * obvious relation-only positions such as `from` / `join` do not receive known expression macros
 * obvious expression positions do not receive known relation macros
@@ -1150,7 +1150,7 @@ Deliver:
 
 * SQL execution through shared runtime
 * render/preview/explain/materialize helper APIs
-* inspectable resolved connection and produced relation
+* inspectable resolved connection and relation
 * strict render result struct with final SQL, canonical bound params, and diagnostics metadata
 * pure `render/2` semantics with no backend calls or session creation
 * backend-neutral positional bindings from renderer, with adapter-side placeholder rewriting when needed
@@ -1241,12 +1241,12 @@ Resolved in Phase 2.
 * canonical internal ref remains `{module, :asset}`
 * public convenience module lookup is supported by `Favn.get_asset(module)` for single-asset modules
 
-### 2. Produced relation name inference
+### 2. Relation name inference
 
 Resolved in Phase 2.
 
 * default inference uses module leaf `Macro.underscore/1`
-* custom naming should be explicit via `@produces name: ...` when needed
+* custom naming should be explicit via `@relation name: ...` when needed
 
 ### 3. `Favn.Asset` function naming
 
@@ -1271,8 +1271,8 @@ Adopt the following target direction for Favn:
 * `Favn.Asset` as the preferred single-module Elixir asset DSL
 * `Favn.SQLAsset` as the preferred single-module SQL asset DSL
 * `Favn.Namespace` for inherited configuration
-* shared produced relation model via `Favn.RelationRef`
-* extension of `Favn.Assets` with `@produces` and relation defaults
+* shared relation model via `Favn.RelationRef`
+* extension of `Favn.Assets` with `@relation` and relation defaults
 * relation ownership index as the bridge between Elixir and SQL assets
 * explicit dependencies first, inferred dependencies later
 * plain SQL bodies, not custom SQL templating

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Current release: v0.3.0**
+**Current release: v0.4.0**
 
 ## Current Focus
 
@@ -22,7 +22,8 @@ Near-term priority is a practical path to real usage:
 ## Terminology
 
 - **Asset** — a Favn executable unit
-- **Source** — an external relation Favn reads from but does not build
+- **Source** — an external relation declared via `Favn.Source`, used in lineage but not executed
+- **Relation** — warehouse identity: connection, catalog, schema, name
 - **Connection** — reusable backend configuration used by assets and pipelines
 - **Adapter** — implementation for a backend such as DuckDB, Snowflake, or Databricks
 
@@ -120,26 +121,26 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
 - [x] DuckDB adapter foundation (duckdbex-backed connect/query/introspection/materialization baseline)
   - [x] Appender-backed table writes preserve normal `WritePlan` create semantics
   - [x] Appender lifecycle cleanup is explicit on failure paths
-- [x] Phase 1 shared produced relation foundation
+- [x] Phase 1 shared relation foundation
   - [x] `Favn.RelationRef`
-  - [x] `%Favn.Asset{produces: ...}`
-  - [x] `Favn.Namespace` config inheritance for `connection` / `catalog` / `schema`
-  - [x] `Favn.Assets` support for `@produces`
-  - [x] runtime exposure through `ctx.asset.produces`
+  - [x] `%Favn.Asset{relation: ...}`
+  - [x] `Favn.Namespace` config inheritance for `connection` / `catalog` / `schema` via grouped `relation:` key
+  - [x] `Favn.Assets` support for `@relation`
+  - [x] runtime exposure through `ctx.asset.relation`
   - [x] relation normalization and validation (`database`/`table` aliases included)
-  - [x] relation ownership uniqueness checks
-  - [x] relation ownership index in the registry catalog
+  - [x] relation uniqueness checks
+  - [x] relation index in the registry catalog
 - [x] Phase 2 single-asset Elixir DSL (`Favn.Asset`)
   - [x] one-module-per-asset `def asset(ctx)` convention
-  - [x] `@doc`, `@meta`, `@depends`, `@window`, `@produces`
+  - [x] `@doc`, `@meta`, `@depends`, `@window`, `@relation`
   - [x] relation default inheritance via `Favn.Namespace`
   - [x] canonical compile output as one `%Favn.Asset{ref: {Module, :asset}}`
   - [x] module dependency shorthand normalization (`@depends Some.AssetModule`)
-  - [x] `@produces true` relation-name inference from module leaf (`Macro.underscore/1`)
+  - [x] `@relation true` relation-name inference from module leaf (`Macro.underscore/1`)
   - [x] module convenience lookup via `Favn.get_asset(module)` for single-asset modules
 - [x] Phase 3 single-asset SQL DSL (`Favn.SQLAsset`)
   - [x] one-module-per-asset SQL DSL with `query do ... end` and a real `~SQL""" ... """` sigil
-  - [x] `@doc`, `@meta`, `@depends`, `@window`, `@materialized`, `@produces`
+  - [x] `@doc`, `@meta`, `@depends`, `@window`, `@materialized`, `@relation`
   - [x] relation default inheritance via `Favn.Namespace`
   - [x] canonical compile output as one `%Favn.Asset{ref: {Module, :asset}}`
   - [x] module convenience lookup via `Favn.get_asset(module)` for single-asset modules
@@ -158,7 +159,15 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] reusable SQL cycle detection
   - [x] deferred symbolic asset refs for not-yet-compiled modules
 - [ ] DuckDB adapter hardening for runtime execution
-- [ ] Typed source identities
+- [x] Typed external relational sources
+  - [x] Unified `relation` DSL naming
+  - [x] `Favn.Source` DSL for external relations
+  - [x] `@relation` in `Favn.Asset` (renamed from `@produces`)
+  - [x] `@relation` in `Favn.SQLAsset` (with inference by default)
+  - [x] `Favn.Namespace` grouped relation defaults: `relation: [connection: ..., catalog: ..., schema: ...]`
+  - [x] Relation-based dependency inference with registered sources
+  - [x] `%Favn.Asset{type: :source}` for non-materializing sources
+  - [x] Removed `@produces` legacy naming
 - [x] Phase 4a runtime integration for SQL assets
   - [x] SQL execution through shared runtime
   - [x] SQL helper APIs (`Favn.render/2`, `Favn.preview/2`, `Favn.explain/2`, `Favn.materialize/2`)
@@ -197,7 +206,7 @@ Goal: make single-node production usage reliable and inspectable.
 - [ ] Concurrency controls
 - [ ] Run deduplication / run keys
 - [ ] Improved failure recovery
-- [ ] Registered source/external dependency model (typed relation identities)
+- [x] Registered source/external dependency model (typed relation identities)
 - [ ] Materialization history tracking
 - [ ] Asset and window state inspection
 - [ ] Asset dependency provenance and relation-lineage inspection APIs

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Current release: v0.4.0**
+**Current release: v0.3.0**
 
 ## Current Focus
 

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -48,10 +48,10 @@ defmodule Favn do
   introspect and orchestrate the workflow later.
 
   Asset modules can also inherit relation defaults from `Favn.Namespace` and declare owned
-  relations with `@produces`. Produced relation ownership is distinct from `@depends`:
+  relations with `@relation`. Relation ownership is distinct from `@depends`:
 
       defmodule MyApp.Warehouse.Raw.Sales do
-        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
       end
 
       defmodule MyApp.Warehouse.Raw.Sales.Assets do
@@ -59,9 +59,9 @@ defmodule Favn do
         use Favn.Assets
 
         @asset true
-        @produces true
+        @relation true
         def orders(ctx) do
-          ctx.asset.produces
+          ctx.asset.relation
           :ok
         end
       end
@@ -172,19 +172,19 @@ defmodule Favn do
   Preferred one-module-per-asset style uses `Favn.Asset`:
 
       defmodule MyApp.Raw.Sales.Orders do
-        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
         use Favn.Asset
 
         @doc "Extract raw orders"
         @meta owner: "data-platform", category: :sales, tags: [:raw]
-        @produces true
+        @relation true
         def asset(ctx), do: :ok
       end
 
   Preferred one-module-per-asset SQL style uses `Favn.SQLAsset`:
 
       defmodule MyApp.Gold.Sales.FctOrders do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
 
         @doc "Build the gold fact table for orders"

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -41,7 +41,7 @@ defmodule Favn do
     * documentation
     * metadata (`owner`, `category`, `tags`)
     * dependency references
-    * optional produced relation ownership
+    * optional relation ownership
     * source file and line
 
   This keeps the workflow definition close to the business logic while still allowing Favn to

--- a/lib/favn/asset.ex
+++ b/lib/favn/asset.ex
@@ -12,7 +12,7 @@ defmodule Favn.Asset do
 
         @doc "Extract raw orders"
         @meta owner: "data-platform", category: :sales, tags: [:raw]
-        @produces true
+        @relation true
         def asset(ctx), do: :ok
       end
 
@@ -33,7 +33,7 @@ defmodule Favn.Asset do
     quote do
       Module.register_attribute(__MODULE__, :depends, accumulate: true)
       Module.register_attribute(__MODULE__, :meta, persist: false)
-      Module.register_attribute(__MODULE__, :produces, accumulate: true)
+      Module.register_attribute(__MODULE__, :relation, accumulate: true)
       Module.register_attribute(__MODULE__, :window, accumulate: true)
       Module.register_attribute(__MODULE__, :favn_single_asset_raw, persist: false)
 
@@ -84,7 +84,7 @@ defmodule Favn.Asset do
       Module.get_attribute(env.module, :depends),
       Module.get_attribute(env.module, :meta),
       Module.get_attribute(env.module, :window),
-      Module.get_attribute(env.module, :produces)
+      Module.get_attribute(env.module, :relation)
     } do
       {[], nil, [], []} ->
         :ok
@@ -93,7 +93,7 @@ defmodule Favn.Asset do
         compile_error!(
           env.file,
           env.line,
-          "@depends/@meta/@window/@produces must be attached to def asset(ctx)"
+          "@depends/@meta/@window/@relation must be attached to def asset(ctx)"
         )
     end
 
@@ -117,7 +117,7 @@ defmodule Favn.Asset do
           name: atom(),
           ref: Ref.t(),
           arity: non_neg_integer(),
-          type: :elixir | :sql,
+          type: :elixir | :sql | :source,
           title: String.t() | nil,
           doc: String.t() | nil,
           file: String.t(),
@@ -126,7 +126,7 @@ defmodule Favn.Asset do
           depends_on: [Ref.t()],
           dependencies: [Dependency.t()],
           window_spec: Spec.t() | nil,
-          produces: RelationRef.t() | nil,
+          relation: RelationRef.t() | nil,
           materialization: Favn.SQLAsset.Materialization.t() | nil,
           relation_inputs: [RelationInput.t()],
           diagnostics: [Diagnostic.t()]
@@ -151,7 +151,7 @@ defmodule Favn.Asset do
     depends_on: [],
     dependencies: [],
     window_spec: nil,
-    produces: nil,
+    relation: nil,
     materialization: nil,
     relation_inputs: [],
     diagnostics: []
@@ -173,7 +173,7 @@ defmodule Favn.Asset do
     meta = normalize_meta!(asset.meta)
     validate_depends_on!(asset.depends_on)
     validate_window_spec!(asset.window_spec)
-    validate_produces!(asset.produces)
+    validate_relation!(asset.relation)
     validate_type!(asset.type)
     validate_materialization!(asset.materialization)
 
@@ -271,18 +271,18 @@ defmodule Favn.Asset do
           "asset window_spec must be a Favn.Window.Spec or nil, got: #{inspect(value)}"
   end
 
-  defp validate_produces!(nil), do: :ok
-  defp validate_produces!(%RelationRef{} = relation_ref), do: RelationRef.validate!(relation_ref)
+  defp validate_relation!(nil), do: :ok
+  defp validate_relation!(%RelationRef{} = relation_ref), do: RelationRef.validate!(relation_ref)
 
-  defp validate_produces!(value) do
+  defp validate_relation!(value) do
     raise ArgumentError,
-          "asset produces must be a Favn.RelationRef or nil, got: #{inspect(value)}"
+          "asset relation must be a Favn.RelationRef or nil, got: #{inspect(value)}"
   end
 
-  defp validate_type!(type) when type in [:elixir, :sql], do: :ok
+  defp validate_type!(type) when type in [:elixir, :sql, :source], do: :ok
 
   defp validate_type!(value) do
-    raise ArgumentError, "asset type must be :elixir or :sql, got: #{inspect(value)}"
+    raise ArgumentError, "asset type must be :elixir, :sql, or :source, got: #{inspect(value)}"
   end
 
   defp validate_materialization!(nil), do: :ok
@@ -306,13 +306,13 @@ defmodule Favn.Asset do
     depends = env.module |> Module.get_attribute(:depends) |> Enum.reverse()
     meta = Module.get_attribute(env.module, :meta)
     window = env.module |> Module.get_attribute(:window) |> Enum.reverse()
-    produces = env.module |> Module.get_attribute(:produces) |> Enum.reverse()
-    validate_produces_attr!(produces, env)
+    relation = env.module |> Module.get_attribute(:relation) |> Enum.reverse()
+    validate_relation_attr!(relation, env)
 
     Module.delete_attribute(env.module, :depends)
     Module.delete_attribute(env.module, :meta)
     Module.delete_attribute(env.module, :window)
-    Module.delete_attribute(env.module, :produces)
+    Module.delete_attribute(env.module, :relation)
 
     Module.put_attribute(env.module, :favn_single_asset_raw, %{
       module: env.module,
@@ -324,7 +324,7 @@ defmodule Favn.Asset do
       depends: depends,
       meta: meta,
       window: window,
-      produces: produces
+      relation: relation
     })
   end
 
@@ -414,11 +414,11 @@ defmodule Favn.Asset do
     )
   end
 
-  defp validate_produces_attr!([], _env), do: :ok
+  defp validate_relation_attr!([], _env), do: :ok
 
-  defp validate_produces_attr!([produces], env) do
+  defp validate_relation_attr!([relation], env) do
     valid? =
-      produces == true or (is_list(produces) and Keyword.keyword?(produces)) or is_map(produces)
+      relation == true or (is_list(relation) and Keyword.keyword?(relation)) or is_map(relation)
 
     if valid? do
       :ok
@@ -426,16 +426,16 @@ defmodule Favn.Asset do
       compile_error!(
         env.file,
         env.line,
-        "invalid @produces value #{inspect(produces)}; expected true, a keyword list, or a map"
+        "invalid @relation value #{inspect(relation)}; expected true, a keyword list, or a map"
       )
     end
   end
 
-  defp validate_produces_attr!([_a, _b | _rest], env) do
+  defp validate_relation_attr!([_a, _b | _rest], env) do
     compile_error!(
       env.file,
       env.line,
-      "multiple @produces attributes are not allowed; use at most one @produces for def asset(ctx)"
+      "multiple @relation attributes are not allowed; use at most one @relation for def asset(ctx)"
     )
   end
 
@@ -443,18 +443,18 @@ defmodule Favn.Asset do
     depends = Module.get_attribute(env.module, :depends)
     meta = Module.get_attribute(env.module, :meta)
     window = Module.get_attribute(env.module, :window)
-    produces = Module.get_attribute(env.module, :produces)
+    relation = Module.get_attribute(env.module, :relation)
 
-    if depends != [] or not is_nil(meta) or window != [] or produces != [] do
+    if depends != [] or not is_nil(meta) or window != [] or relation != [] do
       Module.delete_attribute(env.module, :depends)
       Module.delete_attribute(env.module, :meta)
       Module.delete_attribute(env.module, :window)
-      Module.delete_attribute(env.module, :produces)
+      Module.delete_attribute(env.module, :relation)
 
       compile_error!(
         env.file,
         env.line,
-        "@depends/@meta/@window/@produces on #{kind} #{name}/#{arity} requires def asset(ctx) immediately below those attributes"
+        "@depends/@meta/@window/@relation on #{kind} #{name}/#{arity} requires def asset(ctx) immediately below those attributes"
       )
     else
       :ok

--- a/lib/favn/assets.ex
+++ b/lib/favn/assets.ex
@@ -29,7 +29,7 @@ defmodule Favn.Assets do
       Module.register_attribute(__MODULE__, :asset, persist: false)
       Module.register_attribute(__MODULE__, :depends, accumulate: true)
       Module.register_attribute(__MODULE__, :meta, persist: false)
-      Module.register_attribute(__MODULE__, :produces, accumulate: true)
+      Module.register_attribute(__MODULE__, :relation, accumulate: true)
       Module.register_attribute(__MODULE__, :window, accumulate: true)
       Module.register_attribute(__MODULE__, :favn_assets_raw, accumulate: true)
 
@@ -64,12 +64,12 @@ defmodule Favn.Assets do
                 |> Module.get_attribute(:window)
                 |> Enum.reverse()
 
-              produces = env.module |> Module.get_attribute(:produces) |> Enum.reverse()
-              validate_produces_attr!(produces, env)
+              relation = env.module |> Module.get_attribute(:relation) |> Enum.reverse()
+              validate_relation_attr!(relation, env)
               Module.delete_attribute(env.module, :depends)
               Module.delete_attribute(env.module, :meta)
               Module.delete_attribute(env.module, :window)
-              Module.delete_attribute(env.module, :produces)
+              Module.delete_attribute(env.module, :relation)
 
               Module.put_attribute(env.module, :favn_assets_raw, %{
                 module: env.module,
@@ -82,7 +82,7 @@ defmodule Favn.Assets do
                 depends: depends,
                 meta: meta,
                 window: window,
-                produces: produces
+                relation: relation
               })
             else
               compile_error!(
@@ -116,7 +116,7 @@ defmodule Favn.Assets do
       Module.get_attribute(env.module, :depends),
       Module.get_attribute(env.module, :meta),
       Module.get_attribute(env.module, :window),
-      Module.get_attribute(env.module, :produces)
+      Module.get_attribute(env.module, :relation)
     } do
       {[], nil, [], []} ->
         :ok
@@ -125,7 +125,7 @@ defmodule Favn.Assets do
         compile_error!(
           env.file,
           env.line,
-          "@depends/@meta/@window/@produces must be attached to an immediately following @asset function"
+          "@depends/@meta/@window/@relation must be attached to an immediately following @asset function"
         )
     end
 
@@ -241,11 +241,11 @@ defmodule Favn.Assets do
     )
   end
 
-  defp validate_produces_attr!([], _env), do: :ok
+  defp validate_relation_attr!([], _env), do: :ok
 
-  defp validate_produces_attr!([produces], env) do
+  defp validate_relation_attr!([relation], env) do
     valid? =
-      produces == true or (is_list(produces) and Keyword.keyword?(produces)) or is_map(produces)
+      relation == true or (is_list(relation) and Keyword.keyword?(relation)) or is_map(relation)
 
     if valid? do
       :ok
@@ -253,16 +253,16 @@ defmodule Favn.Assets do
       compile_error!(
         env.file,
         env.line,
-        "invalid @produces value #{inspect(produces)}; expected true, a keyword list, or a map"
+        "invalid @relation value #{inspect(relation)}; expected true, a keyword list, or a map"
       )
     end
   end
 
-  defp validate_produces_attr!([_a, _b | _rest], env) do
+  defp validate_relation_attr!([_a, _b | _rest], env) do
     compile_error!(
       env.file,
       env.line,
-      "multiple @produces attributes are not allowed; use at most one @produces per @asset function"
+      "multiple @relation attributes are not allowed; use at most one @relation per @asset function"
     )
   end
 
@@ -298,20 +298,20 @@ defmodule Favn.Assets do
     depends = Module.get_attribute(env.module, :depends)
     meta = Module.get_attribute(env.module, :meta)
     window = Module.get_attribute(env.module, :window)
-    produces = Module.get_attribute(env.module, :produces)
+    relation = Module.get_attribute(env.module, :relation)
 
-    if depends != [] or not is_nil(meta) or window != [] or produces != [] do
+    if depends != [] or not is_nil(meta) or window != [] or relation != [] do
       Module.delete_attribute(env.module, :depends)
       Module.delete_attribute(env.module, :meta)
       Module.delete_attribute(env.module, :window)
-      Module.delete_attribute(env.module, :produces)
+      Module.delete_attribute(env.module, :relation)
 
       arity = length(args || [])
 
       compile_error!(
         env.file,
         env.line,
-        "@depends/@meta/@window/@produces on #{kind} #{name}/#{arity} requires @asset immediately above that function"
+        "@depends/@meta/@window/@relation on #{kind} #{name}/#{arity} requires @asset immediately above that function"
       )
     else
       :ok

--- a/lib/favn/assets/compiler.ex
+++ b/lib/favn/assets/compiler.ex
@@ -78,7 +78,7 @@ defmodule Favn.Assets.Compiler do
       {:ok, assets} ->
         try do
           validate_single_asset_depends_shorthand!(module)
-          resolve_produced_relations(assets, module)
+          resolve_relations(assets, module)
         rescue
           error in ArgumentError -> {:error, {:invalid_compiled_assets, error.message}}
         end
@@ -134,8 +134,8 @@ defmodule Favn.Assets.Compiler do
     end
   end
 
-  defp resolve_produced_relations(assets, module) do
-    defaults = Namespace.resolve(module)
+  defp resolve_relations(assets, module) do
+    defaults = Namespace.resolve_relation(module)
 
     try do
       assets = Enum.map(assets, &resolve_relation(&1, defaults))

--- a/lib/favn/assets/compiler.ex
+++ b/lib/favn/assets/compiler.ex
@@ -138,7 +138,7 @@ defmodule Favn.Assets.Compiler do
     defaults = Namespace.resolve(module)
 
     try do
-      assets = Enum.map(assets, &resolve_produced_relation(&1, defaults))
+      assets = Enum.map(assets, &resolve_relation(&1, defaults))
       ensure_unique_relation_owners!(assets)
       {:ok, assets}
     rescue
@@ -146,13 +146,13 @@ defmodule Favn.Assets.Compiler do
     end
   end
 
-  defp resolve_produced_relation(%Asset{} = asset, defaults) do
+  defp resolve_relation(%Asset{} = asset, defaults) do
     inferred_name = inferred_relation_name(asset)
 
-    produces =
-      case fetch_raw_produces(asset.module, asset.name) do
+    relation =
+      case fetch_raw_relation(asset.module, asset.name) do
         nil ->
-          asset.produces
+          asset.relation
 
         true ->
           RelationRef.new!(Map.put(defaults, :name, inferred_name))
@@ -161,31 +161,31 @@ defmodule Favn.Assets.Compiler do
           if Keyword.keyword?(attrs) do
             attrs
             |> Map.new()
-            |> merge_produces_attrs(defaults, inferred_name)
+            |> merge_relation_attrs(defaults, inferred_name)
             |> RelationRef.new!()
           else
             raise ArgumentError,
-                  "invalid @produces value #{inspect(attrs)}; expected true, a keyword list, or a map"
+                  "invalid @relation value #{inspect(attrs)}; expected true, a keyword list, or a map"
           end
 
         attrs when is_map(attrs) ->
           attrs
-          |> merge_produces_attrs(defaults, inferred_name)
+          |> merge_relation_attrs(defaults, inferred_name)
           |> RelationRef.new!()
 
         other ->
           raise ArgumentError,
-                "invalid @produces value #{inspect(other)}; expected true, a keyword list, or a map"
+                "invalid @relation value #{inspect(other)}; expected true, a keyword list, or a map"
       end
 
-    %{asset | produces: produces}
+    %{asset | relation: relation}
   end
 
-  defp fetch_raw_produces(module, name) do
+  defp fetch_raw_relation(module, name) do
     with true <- function_exported?(module, :__favn_assets_raw__, 0),
          entries when is_list(entries) <- module.__favn_assets_raw__(),
-         %{produces: produces} <- Enum.find(entries, &(&1.name == name)) do
-      case produces do
+         %{relation: relation} <- Enum.find(entries, &(&1.name == name)) do
+      case relation do
         [] -> nil
         [value] -> value
       end
@@ -194,7 +194,7 @@ defmodule Favn.Assets.Compiler do
     end
   end
 
-  defp merge_produces_attrs(attrs, defaults, asset_name) when is_map(attrs) do
+  defp merge_relation_attrs(attrs, defaults, asset_name) when is_map(attrs) do
     attrs =
       if has_explicit_name?(attrs) do
         attrs
@@ -222,12 +222,12 @@ defmodule Favn.Assets.Compiler do
 
   defp ensure_unique_relation_owners!(assets) do
     assets
-    |> Enum.reject(&is_nil(&1.produces))
-    |> Enum.group_by(& &1.produces)
+    |> Enum.reject(&is_nil(&1.relation))
+    |> Enum.group_by(& &1.relation)
     |> Enum.each(fn {relation_ref, owners} ->
       case owners do
         [_single] -> :ok
-        _many -> raise ArgumentError, "duplicate produced relation #{inspect(relation_ref)}"
+        _many -> raise ArgumentError, "duplicate relation #{inspect(relation_ref)}"
       end
     end)
   end

--- a/lib/favn/assets/dependency_inference.ex
+++ b/lib/favn/assets/dependency_inference.ex
@@ -221,7 +221,7 @@ defmodule Favn.Assets.DependencyInference do
        })
        when is_atom(module) do
     case Compiler.compile_module_assets(module) do
-      {:ok, [%Asset{produces: %RelationRef{} = relation_ref}]} ->
+      {:ok, [%Asset{relation: %RelationRef{} = relation_ref}]} ->
         {:ok, {module, :asset}, relation_ref}
 
       _other ->
@@ -254,7 +254,7 @@ defmodule Favn.Assets.DependencyInference do
   end
 
   defp ensure_same_connection(asset, input, %RelationRef{connection: connection}) do
-    if connection == asset.produces.connection do
+    if connection == asset.relation.connection do
       :ok
     else
       {:error,
@@ -263,10 +263,10 @@ defmodule Favn.Assets.DependencyInference do
          stage: :registry,
          code: :cross_connection_direct_asset_ref,
          message:
-           "direct SQL asset reference #{inspect(input.raw)} for #{inspect(asset.ref)} resolves to connection #{inspect(connection)}, expected #{inspect(asset.produces.connection)}",
+           "direct SQL asset reference #{inspect(input.raw)} for #{inspect(asset.ref)} resolves to connection #{inspect(connection)}, expected #{inspect(asset.relation.connection)}",
          asset_ref: asset.ref,
          span: input.span,
-         details: %{expected_connection: asset.produces.connection, actual_connection: connection}
+         details: %{expected_connection: asset.relation.connection, actual_connection: connection}
        }}
     end
   end

--- a/lib/favn/assets/dependency_inference.ex
+++ b/lib/favn/assets/dependency_inference.ex
@@ -278,7 +278,7 @@ defmodule Favn.Assets.DependencyInference do
        stage: :registry,
        code: :unresolved_direct_asset_ref,
        message:
-         "direct SQL asset reference #{inspect(input.raw)} for #{inspect(asset.ref)} did not resolve a produced relation",
+         "direct SQL asset reference #{inspect(input.raw)} for #{inspect(asset.ref)} did not resolve a relation",
        asset_ref: asset.ref,
        span: input.span,
        details: %{}

--- a/lib/favn/assets/planner.ex
+++ b/lib/favn/assets/planner.ex
@@ -54,7 +54,7 @@ defmodule Favn.Assets.Planner do
          target_refs: target_refs,
          target_node_keys: build_target_node_keys(target_refs, graph.ref_nodes),
          dependencies: dependencies,
-         nodes: build_nodes(graph, stage_map),
+         nodes: build_nodes(graph, stage_map, projected_index.assets_by_ref),
          topo_order: projected_index.topo_order,
          stages: build_stages(projected_index, ref_stage_map),
          node_stages: build_node_stages(graph, stage_map, projected_index.topo_rank)
@@ -313,19 +313,24 @@ defmodule Favn.Assets.Planner do
     end)
   end
 
-  defp build_nodes(graph, stage_map) do
+  defp build_nodes(graph, stage_map, assets_by_ref) do
     graph.nodes
     |> Enum.sort_by(&node_key_sort_key(&1.node_key))
     |> Enum.reduce(%{}, fn node, acc ->
+      asset = Map.fetch!(assets_by_ref, node.ref)
+
       full_node =
         Map.merge(node, %{
           stage: Map.fetch!(stage_map, node.node_key),
-          action: :run
+          action: node_action(asset)
         })
 
       Map.put(acc, full_node.node_key, full_node)
     end)
   end
+
+  defp node_action(%{type: :source}), do: :observe
+  defp node_action(_asset), do: :run
 
   defp build_stages(index, stage_map) do
     index.topo_order

--- a/lib/favn/assets/registry.ex
+++ b/lib/favn/assets/registry.ex
@@ -169,10 +169,10 @@ defmodule Favn.Assets.Registry do
     end
   end
 
-  defp ensure_unique_relation_owner(_catalog, %Asset{produces: nil}), do: :ok
+  defp ensure_unique_relation_owner(_catalog, %Asset{relation: nil}), do: :ok
 
   defp ensure_unique_relation_owner(catalog, %Asset{
-         produces: %RelationRef{} = relation_ref,
+         relation: %RelationRef{} = relation_ref,
          ref: ref
        }) do
     case Map.fetch(catalog.relation_owners, relation_ref) do
@@ -184,10 +184,10 @@ defmodule Favn.Assets.Registry do
     end
   end
 
-  defp put_relation_owner(relation_owners, %Asset{produces: nil}), do: relation_owners
+  defp put_relation_owner(relation_owners, %Asset{relation: nil}), do: relation_owners
 
   defp put_relation_owner(relation_owners, %Asset{
-         produces: %RelationRef{} = relation_ref,
+         relation: %RelationRef{} = relation_ref,
          ref: ref
        }) do
     Map.put(relation_owners, relation_ref, ref)

--- a/lib/favn/namespace.ex
+++ b/lib/favn/namespace.ex
@@ -69,40 +69,46 @@ defmodule Favn.Namespace do
   end
 
   def normalize_config!(opts) when is_map(opts) do
-    relation_defaults =
-      case Map.fetch(opts, :relation) do
-        {:ok, defaults} when is_map(defaults) ->
-          Enum.reduce(defaults, %{}, fn {key, value}, acc ->
-            canonical_key = normalize_key!(key)
-            Map.put(acc, canonical_key, normalize_value!(canonical_key, value))
-          end)
-
-        {:ok, defaults} when is_list(defaults) and defaults != [] ->
-          Enum.reduce(defaults, %{}, fn {key, value}, acc ->
-            canonical_key = normalize_key!(key)
-            Map.put(acc, canonical_key, normalize_value!(canonical_key, value))
-          end)
-
-        :error ->
-          %{}
-      end
-
-    flat_defaults =
-      Enum.reduce([:connection, :catalog, :schema], %{}, fn key, acc ->
-        case Map.fetch(opts, key) do
-          {:ok, value} ->
-            Map.put(acc, key, normalize_value!(key, value))
-
-          :error ->
-            acc
-        end
-      end)
-
-    Map.merge(flat_defaults, relation_defaults)
+    relation_defaults = normalize_relation_defaults!(Map.get(opts, :relation, %{}))
+    validate_no_legacy_keys!(Map.delete(opts, :relation))
+    relation_defaults
   end
 
   def normalize_config!(opts) do
     raise ArgumentError, "namespace config must be a keyword list or map, got: #{inspect(opts)}"
+  end
+
+  defp normalize_relation_defaults!(defaults) when defaults in [%{}, []], do: %{}
+
+  defp normalize_relation_defaults!(defaults) when is_map(defaults) do
+    Enum.reduce(defaults, %{}, fn {key, value}, acc ->
+      canonical_key = normalize_key!(key)
+      Map.put(acc, canonical_key, normalize_value!(canonical_key, value))
+    end)
+  end
+
+  defp normalize_relation_defaults!(defaults) when is_list(defaults) do
+    if Keyword.keyword?(defaults) do
+      defaults
+      |> Map.new()
+      |> normalize_relation_defaults!()
+    else
+      raise ArgumentError,
+            "namespace relation config must be a keyword list or map, got: #{inspect(defaults)}"
+    end
+  end
+
+  defp normalize_relation_defaults!(defaults) do
+    raise ArgumentError,
+          "namespace relation config must be a keyword list or map, got: #{inspect(defaults)}"
+  end
+
+  defp validate_no_legacy_keys!(opts_without_relation) when map_size(opts_without_relation) == 0,
+    do: :ok
+
+  defp validate_no_legacy_keys!(opts_without_relation) do
+    raise ArgumentError,
+          "namespace config contains unsupported key(s) #{inspect(Map.keys(opts_without_relation))}; use relation: [connection: ..., catalog: ..., schema: ...]"
   end
 
   defp namespace_config(module) do

--- a/lib/favn/namespace.ex
+++ b/lib/favn/namespace.ex
@@ -2,7 +2,21 @@ defmodule Favn.Namespace do
   @moduledoc """
   Namespace config carrier for inherited asset relation defaults.
 
-  Phase 1 supports `:connection`, `:catalog`, and `:schema` inheritance.
+  Supports grouped `relation: [connection: ..., catalog: ..., schema: ...]` for relation defaults.
+
+  Example:
+
+      defmodule MyApp do
+        use Favn.Namespace, relation: [connection: :warehouse]
+      end
+
+      defmodule MyApp.Raw do
+        use Favn.Namespace, relation: [catalog: "raw"]
+      end
+
+      defmodule MyApp.Raw.Stripe do
+        use Favn.Namespace, relation: [schema: "stripe"]
+      end
   """
 
   @supported_keys [:connection, :catalog, :schema]
@@ -33,6 +47,16 @@ defmodule Favn.Namespace do
     end)
   end
 
+  @doc """
+  Resolve relation defaults for a module by merging ancestor namespaces.
+
+  Returns a map with `:connection`, `:catalog`, and `:schema` keys for relation construction.
+  """
+  @spec resolve_relation(module()) :: map()
+  def resolve_relation(module) when is_atom(module) do
+    resolve(module)
+  end
+
   @doc false
   @spec normalize_config!(keyword() | map()) :: map()
   def normalize_config!(opts) when is_list(opts) do
@@ -45,10 +69,36 @@ defmodule Favn.Namespace do
   end
 
   def normalize_config!(opts) when is_map(opts) do
-    Enum.reduce(opts, %{}, fn {key, value}, acc ->
-      canonical_key = normalize_key!(key)
-      Map.put(acc, canonical_key, normalize_value!(canonical_key, value))
-    end)
+    relation_defaults =
+      case Map.fetch(opts, :relation) do
+        {:ok, defaults} when is_map(defaults) ->
+          Enum.reduce(defaults, %{}, fn {key, value}, acc ->
+            canonical_key = normalize_key!(key)
+            Map.put(acc, canonical_key, normalize_value!(canonical_key, value))
+          end)
+
+        {:ok, defaults} when is_list(defaults) and defaults != [] ->
+          Enum.reduce(defaults, %{}, fn {key, value}, acc ->
+            canonical_key = normalize_key!(key)
+            Map.put(acc, canonical_key, normalize_value!(canonical_key, value))
+          end)
+
+        :error ->
+          %{}
+      end
+
+    flat_defaults =
+      Enum.reduce([:connection, :catalog, :schema], %{}, fn key, acc ->
+        case Map.fetch(opts, key) do
+          {:ok, value} ->
+            Map.put(acc, key, normalize_value!(key, value))
+
+          :error ->
+            acc
+        end
+      end)
+
+    Map.merge(flat_defaults, relation_defaults)
   end
 
   def normalize_config!(opts) do

--- a/lib/favn/namespace.ex
+++ b/lib/favn/namespace.ex
@@ -33,10 +33,12 @@ defmodule Favn.Namespace do
   end
 
   @doc """
-  Resolve namespace config for a module by merging ancestor namespaces.
+  Resolve relation defaults for a module by merging ancestor namespaces.
+
+  Returns a map with `:connection`, `:catalog`, and `:schema` keys for relation construction.
   """
-  @spec resolve(module()) :: map()
-  def resolve(module) when is_atom(module) do
+  @spec resolve_relation(module()) :: map()
+  def resolve_relation(module) when is_atom(module) do
     module
     |> ancestors()
     |> Enum.reduce(%{}, fn ancestor, acc ->
@@ -45,16 +47,6 @@ defmodule Favn.Namespace do
         config -> Map.merge(acc, config)
       end
     end)
-  end
-
-  @doc """
-  Resolve relation defaults for a module by merging ancestor namespaces.
-
-  Returns a map with `:connection`, `:catalog`, and `:schema` keys for relation construction.
-  """
-  @spec resolve_relation(module()) :: map()
-  def resolve_relation(module) when is_atom(module) do
-    resolve(module)
   end
 
   @doc false

--- a/lib/favn/plan.ex
+++ b/lib/favn/plan.ex
@@ -17,7 +17,7 @@ defmodule Favn.Plan do
   @typedoc """
   Execution action for one planned node.
   """
-  @type action :: :run
+  @type action :: :run | :observe
 
   @typedoc """
   One planned node keyed by canonical ref.

--- a/lib/favn/run/context.ex
+++ b/lib/favn/run/context.ex
@@ -10,7 +10,7 @@ defmodule Favn.Run.Context do
           run_id: String.t(),
           target_refs: [Ref.t()],
           current_ref: Ref.t(),
-          asset: %{ref: Ref.t(), produces: Favn.RelationRef.t() | nil},
+          asset: %{ref: Ref.t(), relation: Favn.RelationRef.t() | nil},
           params: map(),
           window: Runtime.t() | nil,
           pipeline: map() | nil,

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -35,7 +35,7 @@ defmodule Favn.Runtime.Coordinator do
   def handle_cast(:start_run, %{state: state} = data) do
     with {:ok, state} <- apply_run_transition(state, :start),
          {:ok, state} <- maybe_schedule_timeout(state),
-         {:ok, state} <- emit_step_ready_for_sources(state),
+         {:ok, state} <- emit_initial_ready_steps(state),
          {:ok, state} <- dispatch_ready_work(state),
          {:ok, state} <- maybe_finalize_terminal(state) do
       {:noreply, %{data | state: state}}
@@ -673,19 +673,19 @@ defmodule Favn.Runtime.Coordinator do
     end
   end
 
-  defp emit_step_ready_for_sources(%State{} = state) do
-    source_keys =
+  defp emit_initial_ready_steps(%State{} = state) do
+    ready_keys =
       state.steps
       |> Enum.filter(fn {_node_key, step} -> step.status == :ready end)
       |> Enum.map(&elem(&1, 0))
       |> Enum.sort()
 
     events =
-      Enum.map(source_keys, fn node_key ->
+      Enum.map(ready_keys, fn node_key ->
         {:step_ready, node_key}
       end)
 
-    emit_events(%{state | ready_queue: source_keys}, events)
+    emit_events(%{state | ready_queue: ready_keys}, events)
   end
 
   defp emit_events(%State{} = state, events) when is_list(events) do

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -792,7 +792,7 @@ defmodule Favn.Runtime.Coordinator do
       run_id: state.run_id,
       target_refs: state.target_refs,
       current_ref: step.ref,
-      asset: %{ref: step.ref, produces: asset.produces},
+      asset: %{ref: step.ref, relation: asset.relation},
       params: state.params,
       window: step.runtime_window,
       pipeline: state.pipeline_context,

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -200,12 +200,39 @@ defmodule Favn.Runtime.Coordinator do
     with {:ok, state} <- apply_step_transition(state, &StepTransitions.start_step(&1, node_key)),
          step <- Map.fetch!(state.steps, node_key),
          {:ok, asset} <- Favn.Assets.Registry.get_asset(step.ref),
-         {:ok, handle} <- start_executor_step(state, node_key, asset) do
-      {:ok, put_execution_handle(state, node_key, handle)}
+         node <- Map.fetch!(state.plan.nodes, node_key),
+         {:ok, state} <- start_node_execution(state, node_key, node, asset) do
+      {:ok, state}
     else
       {:error, reason} ->
         normalized = %{kind: :error, reason: reason, stacktrace: [], class: :executor_error}
         handle_step_error(state, node_key, normalized)
+    end
+  end
+
+  defp start_node_execution(
+         %State{} = state,
+         node_key,
+         %{action: :observe},
+         %Favn.Asset{} = asset
+       ) do
+    complete_step_transition(
+      state,
+      fn next_state ->
+        StepTransitions.complete_success(next_state, node_key, %{
+          observed: true,
+          relation: asset.relation
+        })
+      end,
+      :observe,
+      node_key,
+      :success
+    )
+  end
+
+  defp start_node_execution(%State{} = state, node_key, %{action: :run}, %Favn.Asset{} = asset) do
+    with {:ok, handle} <- start_executor_step(state, node_key, asset) do
+      {:ok, put_execution_handle(state, node_key, handle)}
     end
   end
 

--- a/lib/favn/source.ex
+++ b/lib/favn/source.ex
@@ -1,0 +1,193 @@
+defmodule Favn.Source do
+  @moduledoc """
+  External relational source DSL for declaring upstream data relations.
+
+  Represents a relation in an external data warehouse that Favn can read from
+  and reason about, but does not materialize or execute.
+
+      defmodule MyApp.Raw.Stripe.Charges do
+        use Favn.Source
+
+        @relation true
+      end
+
+  The `@relation` attribute is required and follows the same inference rules as `Favn.Asset`.
+
+  Supported attributes:
+  - `@doc` - documentation
+  - `@meta` - metadata such as owner, category, tags
+  - `@relation` - the external relation identity (required)
+  """
+
+  alias Favn.Namespace
+  alias Favn.Ref
+  alias Favn.RelationRef
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      Module.register_attribute(__MODULE__, :meta, persist: false)
+      Module.register_attribute(__MODULE__, :relation, accumulate: true)
+      Module.register_attribute(__MODULE__, :favn_source_raw, persist: false)
+
+      @on_definition Favn.Source
+      @before_compile Favn.Source
+    end
+  end
+
+  @doc false
+  def __on_definition__(env, kind, name, args, _guards, _body) do
+    arity = length(args || [])
+
+    cond do
+      kind in [:def, :defp] and name == :source and arity == 1 ->
+        compile_error!(
+          env.file,
+          env.line,
+          "Favn.Source does not define a source/1 function; use @relation to declare the external relation"
+        )
+
+      kind in [:def, :defp] ->
+        validate_no_stray_source_attributes!(env, kind, name, arity)
+
+      true ->
+        :ok
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    relation = Module.get_attribute(env.module, :relation) |> Enum.reverse()
+
+    if relation == [] do
+      compile_error!(
+        env.file,
+        env.line,
+        "Favn.Source modules require @relation attribute"
+      )
+    end
+
+    raw_sources = build_sources!(env.module, relation)
+
+    quote do
+      @doc false
+      @spec __favn_assets__() :: [Favn.Asset.t()]
+      def __favn_assets__, do: unquote(Macro.escape(raw_sources))
+
+      @doc false
+      def __favn_assets_raw__, do: unquote(Macro.escape(raw_sources))
+
+      @doc false
+      def __favn_single_asset__, do: true
+
+      @doc false
+      def __favn_source__, do: true
+    end
+  end
+
+  defp build_sources!(module, [relation]) do
+    defaults = Namespace.resolve(module)
+    inferred_name = inferred_relation_name(module)
+
+    relation_ref =
+      case relation do
+        true ->
+          RelationRef.new!(Map.put(defaults, :name, inferred_name))
+
+        attrs when is_list(attrs) ->
+          if Keyword.keyword?(attrs) do
+            attrs
+            |> Map.new()
+            |> merge_relation_attrs(defaults, inferred_name)
+            |> RelationRef.new!()
+          else
+            raise ArgumentError,
+                  "invalid @relation value #{inspect(attrs)}; expected true, a keyword list, or a map"
+          end
+
+        attrs when is_map(attrs) ->
+          attrs
+          |> merge_relation_attrs(defaults, inferred_name)
+          |> RelationRef.new!()
+
+        other ->
+          raise ArgumentError,
+                "invalid @relation value #{inspect(other)}; expected true, a keyword list, or a map"
+      end
+
+    %Favn.Asset{
+      module: module,
+      name: :source,
+      ref: Ref.new(module, :source),
+      arity: 0,
+      type: :source,
+      title: nil,
+      doc: nil,
+      file: nil,
+      line: 0,
+      meta: %{},
+      depends_on: [],
+      dependencies: [],
+      window_spec: nil,
+      relation: relation_ref,
+      materialization: nil,
+      relation_inputs: [],
+      diagnostics: []
+    }
+  end
+
+  defp inferred_relation_name(module) do
+    module
+    |> Module.split()
+    |> List.last()
+    |> Macro.underscore()
+  end
+
+  defp merge_relation_attrs(attrs, defaults, inferred_name) when is_map(attrs) do
+    attrs =
+      if has_explicit_name?(attrs) do
+        attrs
+      else
+        Map.put(attrs, :name, inferred_name)
+      end
+
+    defaults
+    |> maybe_drop_default_key(attrs, [:catalog], [:database, "database"])
+    |> maybe_drop_default_key(attrs, [:name], [:table, "table", :name, "name"])
+    |> Map.merge(attrs)
+  end
+
+  defp has_explicit_name?(attrs) do
+    Enum.any?([:name, "name", :table, "table"], &Map.has_key?(attrs, &1))
+  end
+
+  defp maybe_drop_default_key(defaults, attrs, canonical_keys, authored_keys) do
+    if Enum.any?(authored_keys, &Map.has_key?(attrs, &1)) do
+      Enum.reduce(canonical_keys, defaults, &Map.delete(&2, &1))
+    else
+      defaults
+    end
+  end
+
+  defp validate_no_stray_source_attributes!(env, kind, name, arity) do
+    meta = Module.get_attribute(env.module, :meta)
+    relation = Module.get_attribute(env.module, :relation)
+
+    if not is_nil(meta) or relation != [] do
+      Module.delete_attribute(env.module, :meta)
+      Module.delete_attribute(env.module, :relation)
+
+      compile_error!(
+        env.file,
+        env.line,
+        "invalid #{kind} #{name}/#{arity} in Favn.Source module; only @doc and @relation allowed"
+      )
+    else
+      :ok
+    end
+  end
+
+  defp compile_error!(file, line, description) do
+    raise CompileError, file: file, line: line, description: description
+  end
+end

--- a/lib/favn/source.ex
+++ b/lib/favn/source.ex
@@ -27,28 +27,8 @@ defmodule Favn.Source do
     quote do
       Module.register_attribute(__MODULE__, :meta, persist: false)
       Module.register_attribute(__MODULE__, :relation, accumulate: true)
-      Module.register_attribute(__MODULE__, :favn_source_generating, persist: false)
 
-      @on_definition Favn.Source
       @before_compile Favn.Source
-    end
-  end
-
-  @doc false
-  def __on_definition__(env, kind, name, args, _guards, _body) do
-    arity = length(args || [])
-
-    generated_definition? =
-      Module.get_attribute(env.module, :favn_source_generating) == true and
-        kind == :def and
-        name in [:__favn_assets__, :__favn_assets_raw__, :__favn_single_asset__, :__favn_source__]
-
-    if kind in [:def, :defp] and not generated_definition? do
-      compile_error!(
-        env.file,
-        env.line,
-        "Favn.Source modules are declarative and cannot define #{kind} #{name}/#{arity}"
-      )
     end
   end
 
@@ -66,6 +46,7 @@ defmodule Favn.Source do
       )
     end
 
+    validate_no_user_definitions!(env)
     validate_relation_attr!(relation, env)
 
     raw_asset = %{
@@ -101,9 +82,7 @@ defmodule Favn.Source do
       diagnostics: []
     }
 
-    ensure_valid_asset!(asset, env)
-
-    Module.put_attribute(env.module, :favn_source_generating, true)
+    asset = ensure_valid_asset!(asset, env)
 
     quote do
       @doc false
@@ -144,9 +123,32 @@ defmodule Favn.Source do
     )
   end
 
+  defp validate_no_user_definitions!(env) do
+    definitions =
+      env.module
+      |> Module.definitions_in()
+      |> Enum.reject(&allowed_generated_definition?/1)
+
+    case definitions do
+      [] ->
+        :ok
+
+      definitions ->
+        formatted = Enum.map_join(definitions, ", ", fn {name, arity} -> "#{name}/#{arity}" end)
+
+        compile_error!(
+          env.file,
+          env.line,
+          "Favn.Source modules are declarative and cannot define functions; found: #{formatted}"
+        )
+    end
+  end
+
+  defp allowed_generated_definition?({:__favn_namespace_config__, 0}), do: true
+  defp allowed_generated_definition?(_definition), do: false
+
   defp ensure_valid_asset!(%Asset{} = asset, env) do
-    _ = Asset.validate!(asset)
-    :ok
+    Asset.validate!(asset)
   rescue
     error in ArgumentError -> compile_error!(env.file, env.line, error.message)
   end

--- a/lib/favn/source.ex
+++ b/lib/favn/source.ex
@@ -27,6 +27,7 @@ defmodule Favn.Source do
     quote do
       Module.register_attribute(__MODULE__, :meta, persist: false)
       Module.register_attribute(__MODULE__, :relation, accumulate: true)
+      Module.register_attribute(__MODULE__, :favn_source_generating, persist: false)
 
       @on_definition Favn.Source
       @before_compile Favn.Source
@@ -37,7 +38,12 @@ defmodule Favn.Source do
   def __on_definition__(env, kind, name, args, _guards, _body) do
     arity = length(args || [])
 
-    if kind in [:def, :defp] do
+    generated_definition? =
+      Module.get_attribute(env.module, :favn_source_generating) == true and
+        kind == :def and
+        name in [:__favn_assets__, :__favn_assets_raw__, :__favn_single_asset__, :__favn_source__]
+
+    if kind in [:def, :defp] and not generated_definition? do
       compile_error!(
         env.file,
         env.line,
@@ -96,6 +102,8 @@ defmodule Favn.Source do
     }
 
     ensure_valid_asset!(asset, env)
+
+    Module.put_attribute(env.module, :favn_source_generating, true)
 
     quote do
       @doc false

--- a/lib/favn/source.ex
+++ b/lib/favn/source.ex
@@ -19,16 +19,14 @@ defmodule Favn.Source do
   - `@relation` - the external relation identity (required)
   """
 
-  alias Favn.Namespace
+  alias Favn.Asset
   alias Favn.Ref
-  alias Favn.RelationRef
 
   @doc false
   defmacro __using__(_opts) do
     quote do
       Module.register_attribute(__MODULE__, :meta, persist: false)
       Module.register_attribute(__MODULE__, :relation, accumulate: true)
-      Module.register_attribute(__MODULE__, :favn_source_raw, persist: false)
 
       @on_definition Favn.Source
       @before_compile Favn.Source
@@ -39,25 +37,20 @@ defmodule Favn.Source do
   def __on_definition__(env, kind, name, args, _guards, _body) do
     arity = length(args || [])
 
-    cond do
-      kind in [:def, :defp] and name == :source and arity == 1 ->
-        compile_error!(
-          env.file,
-          env.line,
-          "Favn.Source does not define a source/1 function; use @relation to declare the external relation"
-        )
-
-      kind in [:def, :defp] ->
-        validate_no_stray_source_attributes!(env, kind, name, arity)
-
-      true ->
-        :ok
+    if kind in [:def, :defp] do
+      compile_error!(
+        env.file,
+        env.line,
+        "Favn.Source modules are declarative and cannot define #{kind} #{name}/#{arity}"
+      )
     end
   end
 
   @doc false
   defmacro __before_compile__(env) do
     relation = Module.get_attribute(env.module, :relation) |> Enum.reverse()
+    meta = Module.get_attribute(env.module, :meta)
+    doc = normalize_doc(Module.get_attribute(env.module, :doc))
 
     if relation == [] do
       compile_error!(
@@ -67,15 +60,50 @@ defmodule Favn.Source do
       )
     end
 
-    raw_sources = build_sources!(env.module, relation)
+    validate_relation_attr!(relation, env)
+
+    raw_asset = %{
+      module: env.module,
+      name: :asset,
+      arity: 0,
+      doc: doc,
+      file: normalize_file(env.file),
+      line: env.line,
+      depends: [],
+      meta: meta,
+      window: [],
+      relation: relation
+    }
+
+    asset = %Asset{
+      module: env.module,
+      name: :asset,
+      ref: Ref.new(env.module, :asset),
+      arity: 0,
+      type: :source,
+      title: nil,
+      doc: doc,
+      file: normalize_file(env.file),
+      line: env.line,
+      meta: meta || %{},
+      depends_on: [],
+      dependencies: [],
+      window_spec: nil,
+      relation: nil,
+      materialization: nil,
+      relation_inputs: [],
+      diagnostics: []
+    }
+
+    ensure_valid_asset!(asset, env)
 
     quote do
       @doc false
       @spec __favn_assets__() :: [Favn.Asset.t()]
-      def __favn_assets__, do: unquote(Macro.escape(raw_sources))
+      def __favn_assets__, do: [unquote(Macro.escape(asset))]
 
       @doc false
-      def __favn_assets_raw__, do: unquote(Macro.escape(raw_sources))
+      def __favn_assets_raw__, do: [unquote(Macro.escape(raw_asset))]
 
       @doc false
       def __favn_single_asset__, do: true
@@ -85,106 +113,46 @@ defmodule Favn.Source do
     end
   end
 
-  defp build_sources!(module, [relation]) do
-    defaults = Namespace.resolve(module)
-    inferred_name = inferred_relation_name(module)
+  defp validate_relation_attr!([relation], env) do
+    valid? =
+      relation == true or (is_list(relation) and Keyword.keyword?(relation)) or is_map(relation)
 
-    relation_ref =
-      case relation do
-        true ->
-          RelationRef.new!(Map.put(defaults, :name, inferred_name))
-
-        attrs when is_list(attrs) ->
-          if Keyword.keyword?(attrs) do
-            attrs
-            |> Map.new()
-            |> merge_relation_attrs(defaults, inferred_name)
-            |> RelationRef.new!()
-          else
-            raise ArgumentError,
-                  "invalid @relation value #{inspect(attrs)}; expected true, a keyword list, or a map"
-          end
-
-        attrs when is_map(attrs) ->
-          attrs
-          |> merge_relation_attrs(defaults, inferred_name)
-          |> RelationRef.new!()
-
-        other ->
-          raise ArgumentError,
-                "invalid @relation value #{inspect(other)}; expected true, a keyword list, or a map"
-      end
-
-    %Favn.Asset{
-      module: module,
-      name: :source,
-      ref: Ref.new(module, :source),
-      arity: 0,
-      type: :source,
-      title: nil,
-      doc: nil,
-      file: nil,
-      line: 0,
-      meta: %{},
-      depends_on: [],
-      dependencies: [],
-      window_spec: nil,
-      relation: relation_ref,
-      materialization: nil,
-      relation_inputs: [],
-      diagnostics: []
-    }
-  end
-
-  defp inferred_relation_name(module) do
-    module
-    |> Module.split()
-    |> List.last()
-    |> Macro.underscore()
-  end
-
-  defp merge_relation_attrs(attrs, defaults, inferred_name) when is_map(attrs) do
-    attrs =
-      if has_explicit_name?(attrs) do
-        attrs
-      else
-        Map.put(attrs, :name, inferred_name)
-      end
-
-    defaults
-    |> maybe_drop_default_key(attrs, [:catalog], [:database, "database"])
-    |> maybe_drop_default_key(attrs, [:name], [:table, "table", :name, "name"])
-    |> Map.merge(attrs)
-  end
-
-  defp has_explicit_name?(attrs) do
-    Enum.any?([:name, "name", :table, "table"], &Map.has_key?(attrs, &1))
-  end
-
-  defp maybe_drop_default_key(defaults, attrs, canonical_keys, authored_keys) do
-    if Enum.any?(authored_keys, &Map.has_key?(attrs, &1)) do
-      Enum.reduce(canonical_keys, defaults, &Map.delete(&2, &1))
-    else
-      defaults
-    end
-  end
-
-  defp validate_no_stray_source_attributes!(env, kind, name, arity) do
-    meta = Module.get_attribute(env.module, :meta)
-    relation = Module.get_attribute(env.module, :relation)
-
-    if not is_nil(meta) or relation != [] do
-      Module.delete_attribute(env.module, :meta)
-      Module.delete_attribute(env.module, :relation)
-
+    if not valid? do
       compile_error!(
         env.file,
         env.line,
-        "invalid #{kind} #{name}/#{arity} in Favn.Source module; only @doc and @relation allowed"
+        "invalid @relation value #{inspect(relation)}; expected true, a keyword list, or a map"
       )
-    else
-      :ok
     end
+
+    :ok
+  end
+
+  defp validate_relation_attr!(_relation, env) do
+    compile_error!(
+      env.file,
+      env.line,
+      "multiple @relation attributes are not allowed; use at most one @relation"
+    )
+  end
+
+  defp ensure_valid_asset!(%Asset{} = asset, env) do
+    _ = Asset.validate!(asset)
+    :ok
+  rescue
+    error in ArgumentError -> compile_error!(env.file, env.line, error.message)
+  end
+
+  defp normalize_doc({_line, false}), do: nil
+  defp normalize_doc({_line, doc}) when is_binary(doc), do: doc
+  defp normalize_doc(false), do: nil
+  defp normalize_doc(doc) when is_binary(doc), do: doc
+  defp normalize_doc(_), do: nil
+
+  defp normalize_file(file) do
+    file
+    |> to_string()
+    |> Path.relative_to_cwd()
   end
 
   defp compile_error!(file, line, description) do

--- a/lib/favn/sql/materialization_planner.ex
+++ b/lib/favn/sql/materialization_planner.ex
@@ -130,9 +130,9 @@ defmodule Favn.SQL.MaterializationPlanner do
   defp target_exists?(%Session{} = session, %Render{} = render) do
     ref =
       RelationRef.new!(%{
-        catalog: render.produced_relation.catalog,
-        schema: render.produced_relation.schema,
-        name: render.produced_relation.name
+        catalog: render.relation.catalog,
+        schema: render.relation.schema,
+        name: render.relation.name
       })
 
     case SQL.get_relation(session, ref) do
@@ -179,9 +179,9 @@ defmodule Favn.SQL.MaterializationPlanner do
 
     ref =
       RelationRef.new!(%{
-        catalog: render.produced_relation.catalog,
-        schema: render.produced_relation.schema,
-        name: render.produced_relation.name
+        catalog: render.relation.catalog,
+        schema: render.relation.schema,
+        name: render.relation.name
       })
 
     with {:ok, columns} <- SQL.columns(session, ref),
@@ -250,9 +250,9 @@ defmodule Favn.SQL.MaterializationPlanner do
 
   defp relation(%Render{} = render, type) do
     %Favn.SQL.Relation{
-      catalog: render.produced_relation.catalog,
-      schema: render.produced_relation.schema,
-      name: render.produced_relation.name,
+      catalog: render.relation.catalog,
+      schema: render.relation.schema,
+      name: render.relation.name,
       type: type,
       metadata: %{}
     }

--- a/lib/favn/sql/render.ex
+++ b/lib/favn/sql/render.ex
@@ -50,11 +50,11 @@ defmodule Favn.SQL.Render do
   alias Favn.SQL.Params
   alias Favn.Window.Runtime
 
-  @enforce_keys [:asset_ref, :connection, :produced_relation, :materialization, :sql, :params]
+  @enforce_keys [:asset_ref, :connection, :relation, :materialization, :sql, :params]
   defstruct [
     :asset_ref,
     :connection,
-    :produced_relation,
+    :relation,
     :materialization,
     :sql,
     :params,
@@ -66,7 +66,7 @@ defmodule Favn.SQL.Render do
   @type t :: %__MODULE__{
           asset_ref: Favn.asset_ref(),
           connection: atom(),
-          produced_relation: RelationRef.t(),
+          relation: RelationRef.t(),
           materialization: Favn.SQLAsset.Materialization.t(),
           sql: String.t(),
           params: Params.t(),

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -967,14 +967,14 @@ defmodule Favn.SQL.Template do
   defp validate_compiled_asset_module!(module, file, line) do
     if function_exported?(module, :__favn_single_asset__, 0) and module.__favn_single_asset__() do
       case Compiler.compile_module_assets(module) do
-        {:ok, [%{produces: %RelationRef{} = produces}]} ->
-          {:resolved, produces}
+        {:ok, [%{relation: %RelationRef{} = relation}]} ->
+          {:resolved, relation}
 
-        {:ok, [%{produces: nil}]} ->
+        {:ok, [%{relation: nil}]} ->
           compile_error!(
             file,
             line,
-            "SQL asset reference #{inspect(module)} does not resolve to a produced relation"
+            "SQL asset reference #{inspect(module)} does not resolve to a relation"
           )
 
         {:ok, [_asset | _rest]} ->

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -127,13 +127,13 @@ defmodule Favn.SQL.Template do
 
   defmodule AssetRef do
     @moduledoc false
-    @enforce_keys [:module, :asset_ref, :produced_relation, :resolution, :span]
-    defstruct [:module, :asset_ref, :produced_relation, :resolution, :span]
+    @enforce_keys [:module, :asset_ref, :relation, :resolution, :span]
+    defstruct [:module, :asset_ref, :relation, :resolution, :span]
 
     @type t :: %__MODULE__{
             module: module(),
             asset_ref: {module(), :asset},
-            produced_relation: RelationRef.t() | nil,
+            relation: RelationRef.t() | nil,
             resolution: :resolved | :deferred,
             span: Favn.SQL.Template.Span.t()
           }
@@ -851,13 +851,13 @@ defmodule Favn.SQL.Template do
   end
 
   defp build_asset_ref(module, state, next_state) do
-    {resolution, produced_relation} =
+    {resolution, relation} =
       resolve_asset_reference(module, state.file, state.position.line, state.module)
 
     %AssetRef{
       module: module,
       asset_ref: {module, :asset},
-      produced_relation: produced_relation,
+      relation: relation,
       resolution: resolution,
       span: span(state.position, next_state.position)
     }

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -363,7 +363,7 @@ defmodule Favn.SQLAsset do
     do: materialization
 
   defp normalize_relation!(raw_definition, inferred_name) do
-    defaults = Namespace.resolve(raw_definition.module)
+    defaults = Namespace.resolve_relation(raw_definition.module)
 
     relation_attrs =
       case raw_definition.relation do

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -28,7 +28,7 @@ defmodule Favn.SQLAsset do
     quote do
       Module.register_attribute(__MODULE__, :depends, accumulate: true)
       Module.register_attribute(__MODULE__, :meta, persist: false)
-      Module.register_attribute(__MODULE__, :produces, accumulate: true)
+      Module.register_attribute(__MODULE__, :relation, accumulate: true)
       Module.register_attribute(__MODULE__, :window, accumulate: true)
       Module.register_attribute(__MODULE__, :materialized, accumulate: true)
       Module.register_attribute(__MODULE__, :favn_sql_asset_raw, persist: false)
@@ -121,7 +121,7 @@ defmodule Favn.SQLAsset do
       |> Map.put(:depends, env.module |> fetch_accum_attribute(:depends) |> Enum.reverse())
       |> Map.put(:meta, Module.get_attribute(env.module, :meta))
       |> Map.put(:window, env.module |> fetch_accum_attribute(:window) |> Enum.reverse())
-      |> Map.put(:produces, env.module |> fetch_accum_attribute(:produces) |> Enum.reverse())
+      |> Map.put(:relation, env.module |> fetch_accum_attribute(:relation) |> Enum.reverse())
       |> Map.put(
         :materialized,
         env.module |> fetch_accum_attribute(:materialized) |> Enum.reverse()
@@ -164,7 +164,7 @@ defmodule Favn.SQLAsset do
     materialization =
       normalize_materialized!(raw_definition.materialized, window_spec, raw_definition)
 
-    produces = normalize_produces!(raw_definition, inferred_relation_name(raw_definition.module))
+    relation = normalize_relation!(raw_definition, inferred_relation_name(raw_definition.module))
     known_definitions = fetch_sql_definitions!(raw_definition)
 
     template =
@@ -195,7 +195,7 @@ defmodule Favn.SQLAsset do
       depends_on: depends_on,
       relation_inputs: relation_inputs,
       window_spec: window_spec,
-      produces: produces,
+      relation: relation,
       materialization: materialization
     }
 
@@ -362,11 +362,11 @@ defmodule Favn.SQLAsset do
   defp validate_incremental_materialized!(materialization, _window_spec, _raw_definition),
     do: materialization
 
-  defp normalize_produces!(raw_definition, inferred_name) do
+  defp normalize_relation!(raw_definition, inferred_name) do
     defaults = Namespace.resolve(raw_definition.module)
 
-    produces_attrs =
-      case raw_definition.produces do
+    relation_attrs =
+      case raw_definition.relation do
         [] ->
           %{}
 
@@ -380,7 +380,7 @@ defmodule Favn.SQLAsset do
             compile_error!(
               raw_definition.file,
               raw_definition.line,
-              "invalid @produces value #{inspect(attrs)}; expected true, a keyword list, or a map"
+              "invalid @relation value #{inspect(attrs)}; expected true, a keyword list, or a map"
             )
           end
 
@@ -391,58 +391,58 @@ defmodule Favn.SQLAsset do
           compile_error!(
             raw_definition.file,
             raw_definition.line,
-            "multiple @produces attributes are not allowed; use at most one @produces before query do ... end"
+            "multiple @relation attributes are not allowed; use at most one @relation before query do ... end"
           )
 
         [other] ->
           compile_error!(
             raw_definition.file,
             raw_definition.line,
-            "invalid @produces value #{inspect(other)}; expected true, a keyword list, or a map"
+            "invalid @relation value #{inspect(other)}; expected true, a keyword list, or a map"
           )
       end
 
     defaults
-    |> maybe_drop_default_key(produces_attrs, [:catalog], [:database, "database"])
-    |> maybe_drop_default_key(produces_attrs, [:name], [:table, "table", :name, "name"])
-    |> Map.merge(produces_attrs)
+    |> maybe_drop_default_key(relation_attrs, [:catalog], [:database, "database"])
+    |> maybe_drop_default_key(relation_attrs, [:name], [:table, "table", :name, "name"])
+    |> Map.merge(relation_attrs)
     |> maybe_put_inferred_name(inferred_name)
     |> RelationRef.new!()
-    |> ensure_sql_relation_connection!(raw_definition)
+    |> ensure_sql_relation!(raw_definition)
   rescue
     error in ArgumentError ->
       compile_error!(raw_definition.file, raw_definition.line, error.message)
   end
 
-  defp ensure_sql_relation_connection!(%RelationRef{connection: nil}, raw_definition) do
+  defp ensure_sql_relation!(%RelationRef{connection: nil}, raw_definition) do
     compile_error!(
       raw_definition.file,
       raw_definition.line,
-      "SQL assets require a connection through Favn.Namespace or @produces"
+      "SQL assets require a connection through Favn.Namespace or @relation"
     )
   end
 
-  defp ensure_sql_relation_connection!(%RelationRef{} = relation_ref, _raw_definition),
+  defp ensure_sql_relation!(%RelationRef{} = relation_ref, _raw_definition),
     do: relation_ref
 
   defp validate_no_stray_asset_attributes!(env, kind, name, arity) do
     depends = fetch_accum_attribute(env.module, :depends)
     meta = Module.get_attribute(env.module, :meta)
     window = fetch_accum_attribute(env.module, :window)
-    produces = fetch_accum_attribute(env.module, :produces)
+    relation = fetch_accum_attribute(env.module, :relation)
     materialized = fetch_accum_attribute(env.module, :materialized)
 
-    if depends != [] or not is_nil(meta) or window != [] or produces != [] or materialized != [] do
+    if depends != [] or not is_nil(meta) or window != [] or relation != [] or materialized != [] do
       Module.delete_attribute(env.module, :depends)
       Module.delete_attribute(env.module, :meta)
       Module.delete_attribute(env.module, :window)
-      Module.delete_attribute(env.module, :produces)
+      Module.delete_attribute(env.module, :relation)
       Module.delete_attribute(env.module, :materialized)
 
       compile_error!(
         env.file,
         env.line,
-        "@depends/@meta/@window/@produces/@materialized on #{kind} #{name}/#{arity} requires query do ... end immediately below those attributes"
+        "@depends/@meta/@window/@relation/@materialized on #{kind} #{name}/#{arity} requires query do ... end immediately below those attributes"
       )
     else
       :ok

--- a/lib/favn/sql_asset/error.ex
+++ b/lib/favn/sql_asset/error.ex
@@ -26,7 +26,7 @@ defmodule Favn.SQLAsset.Error do
           | :missing_runtime_input
           | :missing_query_param
           | :unresolved_asset_ref
-          | :invalid_produced_relation
+          | :invalid_relation
           | :cross_connection_asset_ref
           | :defsql_expansion_failed
           | :binding_failure

--- a/lib/favn/sql_asset/relation_usage.ex
+++ b/lib/favn/sql_asset/relation_usage.ex
@@ -17,7 +17,7 @@ defmodule Favn.SQLAsset.RelationUsage do
       end)
       |> Map.new()
 
-    root_defaults = Namespace.resolve(module)
+    root_defaults = Namespace.resolve_relation(module)
 
     {inputs, _visited} =
       collect_template(module, template, definition_catalog, %{}, root_defaults)
@@ -32,7 +32,7 @@ defmodule Favn.SQLAsset.RelationUsage do
          visited,
          root_defaults
        ) do
-    defaults = Namespace.resolve(module)
+    defaults = Namespace.resolve_relation(module)
     connection = Map.get(defaults, :connection) || Map.get(root_defaults, :connection)
     catalog = Map.get(defaults, :catalog) || Map.get(root_defaults, :catalog)
     schema = Map.get(defaults, :schema) || Map.get(root_defaults, :schema)
@@ -127,7 +127,7 @@ defmodule Favn.SQLAsset.RelationUsage do
     %RelationInput{
       kind: :direct_asset_ref,
       raw: inspect(asset_ref.module),
-      relation_ref: asset_ref.produced_relation,
+      relation_ref: asset_ref.relation,
       asset_ref: asset_ref.asset_ref,
       resolution: asset_ref.resolution,
       span: asset_ref.span

--- a/lib/favn/sql_asset/renderer.ex
+++ b/lib/favn/sql_asset/renderer.ex
@@ -28,7 +28,7 @@ defmodule Favn.SQLAsset.Renderer do
        %Render{
          asset_ref: definition.asset.ref,
          connection: definition.asset.relation.connection,
-         produced_relation: definition.asset.relation,
+         relation: definition.asset.relation,
          materialization: definition.materialization,
          sql: fragment.sql,
          params: normalized_params,
@@ -276,7 +276,7 @@ defmodule Favn.SQLAsset.Renderer do
   end
 
   defp resolve_asset_ref(
-         %AssetRef{resolution: :resolved, produced_relation: %RelationRef{} = relation_ref} =
+         %AssetRef{resolution: :resolved, relation: %RelationRef{} = relation_ref} =
            asset_ref,
          env
        ) do
@@ -311,7 +311,7 @@ defmodule Favn.SQLAsset.Renderer do
           {:ok, [%{relation: nil}]} ->
             {:error,
              %Error{
-               type: :invalid_produced_relation,
+               type: :invalid_relation,
                phase: :render,
                asset_ref: asset_ref,
                span: span,
@@ -325,7 +325,7 @@ defmodule Favn.SQLAsset.Renderer do
           {:ok, _many} ->
             {:error,
              %Error{
-               type: :invalid_produced_relation,
+               type: :invalid_relation,
                phase: :render,
                asset_ref: asset_ref,
                span: span,

--- a/lib/favn/sql_asset/renderer.ex
+++ b/lib/favn/sql_asset/renderer.ex
@@ -27,8 +27,8 @@ defmodule Favn.SQLAsset.Renderer do
       {:ok,
        %Render{
          asset_ref: definition.asset.ref,
-         connection: definition.asset.produces.connection,
-         produced_relation: definition.asset.produces,
+         connection: definition.asset.relation.connection,
+         produced_relation: definition.asset.relation,
          materialization: definition.materialization,
          sql: fragment.sql,
          params: normalized_params,
@@ -118,7 +118,7 @@ defmodule Favn.SQLAsset.Renderer do
   defp base_env(definition, params, runtime_inputs, definition_catalog) do
     %{
       asset_ref: definition.asset.ref,
-      root_connection: definition.asset.produces.connection,
+      root_connection: definition.asset.relation.connection,
       params: params,
       runtime_values: runtime_inputs.runtime_values,
       local_args: %{},
@@ -305,10 +305,10 @@ defmodule Favn.SQLAsset.Renderer do
     case Code.ensure_compiled(module) do
       {:module, _compiled} ->
         case Compiler.compile_module_assets(module) do
-          {:ok, [%{produces: %RelationRef{} = relation_ref}]} ->
+          {:ok, [%{relation: %RelationRef{} = relation_ref}]} ->
             {:ok, relation_ref}
 
-          {:ok, [%{produces: nil}]} ->
+          {:ok, [%{relation: nil}]} ->
             {:error,
              %Error{
                type: :invalid_produced_relation,
@@ -317,7 +317,7 @@ defmodule Favn.SQLAsset.Renderer do
                span: span,
                line: span.start_line,
                message:
-                 "SQL asset reference #{inspect(module)} resolved, but it does not produce a relation",
+                 "SQL asset reference #{inspect(module)} resolved, but it does not have a relation",
                stack: stack,
                details: %{module: module}
              }}

--- a/test/asset_test.exs
+++ b/test/asset_test.exs
@@ -19,7 +19,7 @@ defmodule Favn.AssetTest do
     assert asset.title == nil
     assert asset.depends_on == []
     assert asset.doc == nil
-    assert asset.produces == nil
+    assert asset.relation == nil
   end
 
   test "stores the canonical metadata shape" do
@@ -34,7 +34,7 @@ defmodule Favn.AssetTest do
       title: "Fact Sales",
       meta: %{owner: "analytics", category: :finance, tags: [:warehouse, "finance"]},
       depends_on: [Ref.new(Example.Assets, :normalize_orders)],
-      produces: %RelationRef{
+      relation: %RelationRef{
         connection: :warehouse,
         catalog: "gold",
         schema: "sales",
@@ -53,7 +53,7 @@ defmodule Favn.AssetTest do
     assert asset.meta == %{owner: "analytics", category: :finance, tags: [:warehouse, "finance"]}
     assert asset.depends_on == [{Example.Assets, :normalize_orders}]
 
-    assert asset.produces == %RelationRef{
+    assert asset.relation == %RelationRef{
              connection: :warehouse,
              catalog: "gold",
              schema: "sales",
@@ -73,22 +73,22 @@ defmodule Favn.AssetTest do
       title: "Fact Sales",
       meta: %{owner: "analytics", category: :finance, tags: [:warehouse, "finance"]},
       depends_on: [Ref.new(Example.Assets, :normalize_orders)],
-      produces: %RelationRef{name: "fact_sales"}
+      relation: %RelationRef{name: "fact_sales"}
     }
 
     assert Asset.validate!(asset) == asset
   end
 
-  test "validate!/1 rejects invalid produces values" do
-    assert_raise ArgumentError, ~r/asset produces must be a Favn\.RelationRef or nil/, fn ->
+  test "validate!/1 rejects invalid relation values" do
+    assert_raise ArgumentError, ~r/asset relation must be a Favn\.RelationRef or nil/, fn ->
       Asset.validate!(%Asset{
         module: Example.Assets,
-        name: :bad_produces,
-        ref: Ref.new(Example.Assets, :bad_produces),
+        name: :bad_relation,
+        ref: Ref.new(Example.Assets, :bad_relation),
         arity: 0,
         file: "lib/example/assets.ex",
         line: 10,
-        produces: %{name: "bad"}
+        relation: %{name: "bad"}
       })
     end
   end

--- a/test/assets_test.exs
+++ b/test/assets_test.exs
@@ -57,7 +57,7 @@ defmodule Favn.AssetsTest do
            meta: %{category: :sql},
            depends_on: [],
            window_spec: Favn.Window.daily(),
-           produces: %Favn.RelationRef{name: "compiled_sql_asset"}
+           relation: %Favn.RelationRef{name: "compiled_sql_asset"}
          }
        ]}
     end
@@ -77,7 +77,7 @@ defmodule Favn.AssetsTest do
            arity: 1,
            file: "lib/sql_assets.ex",
            line: 1,
-           produces: %{name: "bad"}
+           relation: %{name: "bad"}
          }
        ]}
     end
@@ -95,7 +95,7 @@ defmodule Favn.AssetsTest do
     assert extract.doc == "Extract raw orders"
     assert extract.meta == %{}
     assert extract.depends_on == []
-    assert extract.produces == nil
+    assert extract.relation == nil
 
     assert normalize.depends_on == [{Favn.AssetsTest.Sample, :extract_orders}]
     assert normalize.meta == %{owner: "data", tags: [:sales, "warehouse"]}
@@ -110,10 +110,10 @@ defmodule Favn.AssetsTest do
     assert fact.meta == %{owner: "analytics", category: :sales, tags: [:view]}
     assert fact.depends_on == [{Favn.AssetsTest.Upstream, :source_rows}]
     assert fact.window_spec == nil
-    assert fact.produces == nil
+    assert fact.relation == nil
   end
 
-  test "captures @produces with namespace defaults and runtime name inference" do
+  test "captures @relation with namespace defaults and runtime name inference" do
     module_name = Module.concat(__MODULE__, "Produces#{System.unique_integer([:positive])}")
 
     source = """
@@ -122,11 +122,11 @@ defmodule Favn.AssetsTest do
       use Favn.Assets
 
       @asset true
-      @produces true
+      @relation true
       def orders(_ctx), do: :ok
 
       @asset true
-      @produces database: :silver, table: :daily_orders
+      @relation database: :silver, table: :daily_orders
       def stage_orders(_ctx), do: :ok
     end
     """
@@ -137,14 +137,14 @@ defmodule Favn.AssetsTest do
 
     assert {:ok, [orders, stage_orders]} = Compiler.compile_module_assets(module_name)
 
-    assert orders.produces == %RelationRef{
+    assert orders.relation == %RelationRef{
              connection: :warehouse,
              catalog: "raw",
              schema: "sales",
              name: "orders"
            }
 
-    assert stage_orders.produces == %RelationRef{
+    assert stage_orders.relation == %RelationRef{
              connection: :warehouse,
              catalog: "silver",
              schema: "sales",
@@ -164,9 +164,9 @@ defmodule Favn.AssetsTest do
       @meta owner: "data-platform", category: :sales, tags: [:raw]
       @depends {Favn.AssetsTest.Upstream, :source_rows}
       @window Favn.Window.daily(lookback: 2)
-      @produces true
+      @relation true
       def asset(ctx) do
-        _target = ctx.asset.produces
+        _target = ctx.asset.relation
         :ok
       end
     end
@@ -186,7 +186,7 @@ defmodule Favn.AssetsTest do
 
     assert asset.meta == %{owner: "data-platform", category: :sales, tags: [:raw]}
 
-    assert asset.produces == %RelationRef{
+    assert asset.relation == %RelationRef{
              connection: :warehouse,
              catalog: "raw",
              schema: "sales",
@@ -201,7 +201,7 @@ defmodule Favn.AssetsTest do
     defmodule #{inspect(module_name)} do
       use Favn.Asset
 
-      @produces true
+      @relation true
       def asset(_ctx), do: :ok
     end
     """
@@ -210,7 +210,7 @@ defmodule Favn.AssetsTest do
              mod == module_name
            end)
 
-    assert {:ok, [%Asset{produces: %RelationRef{name: name}}]} =
+    assert {:ok, [%Asset{relation: %RelationRef{name: name}}]} =
              Compiler.compile_module_assets(module_name)
 
     assert name =~ ~r/^fct_orders\d+$/
@@ -300,14 +300,14 @@ defmodule Favn.AssetsTest do
         use Favn.Assets
 
         @asset true
-        @produces true
+        @relation true
         def orders(_ctx), do: :ok
       end
       """,
       "test/dynamic_assets_test.exs"
     )
 
-    assert {:ok, [%Asset{produces: %RelationRef{} = produces}]} =
+    assert {:ok, [%Asset{relation: %RelationRef{} = produces}]} =
              Compiler.compile_module_assets(assets)
 
     assert produces == %RelationRef{
@@ -330,7 +330,7 @@ defmodule Favn.AssetsTest do
         use Favn.Assets
 
         @asset true
-        @produces true
+        @relation true
         def orders(_ctx), do: :ok
       end
       """,
@@ -352,7 +352,7 @@ defmodule Favn.AssetsTest do
       "test/dynamic_assets_test.exs"
     )
 
-    assert {:ok, [%Asset{produces: %RelationRef{} = produces}]} =
+    assert {:ok, [%Asset{relation: %RelationRef{} = produces}]} =
              Compiler.compile_module_assets(assets)
 
     assert produces == %RelationRef{
@@ -507,23 +507,23 @@ defmodule Favn.AssetsTest do
       """)
     end
 
-    assert_raise CompileError, ~r/invalid @produces value/, fn ->
+    assert_raise CompileError, ~r/invalid @relation value/, fn ->
       compile_test_module("""
       use Favn.Assets
 
       @asset true
-      @produces :bad
+      @relation :bad
       def bad_produces(_ctx), do: :ok
       """)
     end
 
-    assert_raise CompileError, ~r/multiple @produces attributes are not allowed/, fn ->
+    assert_raise CompileError, ~r/multiple @relation attributes are not allowed/, fn ->
       compile_test_module("""
       use Favn.Assets
 
       @asset true
-      @produces true
-      @produces name: :orders
+      @relation true
+      @relation name: :orders
       def duplicate_produces(_ctx), do: :ok
       """)
     end
@@ -539,11 +539,11 @@ defmodule Favn.AssetsTest do
                  use Favn.Assets
 
                  @asset true
-                 @produces true
+                 @relation true
                  def orders(_ctx), do: :ok
 
                  @asset true
-                 @produces name: :orders
+                 @relation name: :orders
                  def duplicate_orders(_ctx), do: :ok
                end
                """,
@@ -555,13 +555,13 @@ defmodule Favn.AssetsTest do
     assert {:error, {:invalid_compiled_assets, message}} =
              Compiler.compile_module_assets(duplicate_module)
 
-    assert message =~ "duplicate produced relation"
+    assert message =~ "duplicate relation"
 
     assert_raise CompileError, ~r/requires @asset immediately above/, fn ->
       compile_test_module("""
       use Favn.Assets
 
-      @produces true
+      @relation true
       def helper(_ctx), do: :ok
       """)
     end
@@ -576,7 +576,7 @@ defmodule Favn.AssetsTest do
                  use Favn.Assets
 
                  @asset true
-                 @produces %{"database" => "raw", :catalog => "silver", "name" => "orders"}
+                 @relation %{"database" => "raw", :catalog => "silver", "name" => "orders"}
                  def duplicate_catalog_keys(_ctx), do: :ok
                end
                """,
@@ -600,7 +600,7 @@ defmodule Favn.AssetsTest do
                  use Favn.Assets
 
                  @asset true
-                 @produces %{"table" => "orders", :name => "other_orders"}
+                 @relation %{"table" => "orders", :name => "other_orders"}
                  def duplicate_name_keys(_ctx), do: :ok
                end
                """,
@@ -739,14 +739,14 @@ defmodule Favn.AssetsTest do
         use Favn.Assets
 
         @asset true
-        @produces %{"name" => "orders"}
+        @relation %{"name" => "orders"}
         def ignored_name_inference(_ctx), do: :ok
       end
       """,
       "test/dynamic_assets_test.exs"
     )
 
-    assert {:ok, [%Asset{produces: %RelationRef{name: "orders"} = produces}]} =
+    assert {:ok, [%Asset{relation: %RelationRef{name: "orders"} = produces}]} =
              Compiler.compile_module_assets(module_name)
 
     assert produces.catalog == nil

--- a/test/assets_test.exs
+++ b/test/assets_test.exs
@@ -307,10 +307,10 @@ defmodule Favn.AssetsTest do
       "test/dynamic_assets_test.exs"
     )
 
-    assert {:ok, [%Asset{relation: %RelationRef{} = produces}]} =
+    assert {:ok, [%Asset{relation: %RelationRef{} = relation}]} =
              Compiler.compile_module_assets(assets)
 
-    assert produces == %RelationRef{
+    assert relation == %RelationRef{
              connection: :warehouse,
              catalog: "raw",
              schema: "sales",
@@ -318,7 +318,7 @@ defmodule Favn.AssetsTest do
            }
   end
 
-  test "produced relation inheritance is compile-order independent" do
+  test "relation inheritance is compile-order independent" do
     root = Module.concat(__MODULE__, "OrderRoot#{System.unique_integer([:positive])}")
     raw = Module.concat(root, Raw)
     sales = Module.concat(raw, Sales)
@@ -352,10 +352,10 @@ defmodule Favn.AssetsTest do
       "test/dynamic_assets_test.exs"
     )
 
-    assert {:ok, [%Asset{relation: %RelationRef{} = produces}]} =
+    assert {:ok, [%Asset{relation: %RelationRef{} = relation}]} =
              Compiler.compile_module_assets(assets)
 
-    assert produces == %RelationRef{
+    assert relation == %RelationRef{
              connection: :warehouse,
              catalog: "raw",
              schema: "sales",
@@ -513,7 +513,7 @@ defmodule Favn.AssetsTest do
 
       @asset true
       @relation :bad
-      def bad_produces(_ctx), do: :ok
+      def bad_relation(_ctx), do: :ok
       """)
     end
 
@@ -524,7 +524,7 @@ defmodule Favn.AssetsTest do
       @asset true
       @relation true
       @relation name: :orders
-      def duplicate_produces(_ctx), do: :ok
+      def duplicate_relation(_ctx), do: :ok
       """)
     end
 
@@ -713,7 +713,7 @@ defmodule Favn.AssetsTest do
     assert [%Favn.Asset{name: :compiled_sql_asset, module: ^module_name}] = catalog.assets
   end
 
-  test "asset compiler seam rejects invalid canonical produced relation shapes" do
+  test "asset compiler seam rejects invalid canonical relation shapes" do
     module_name = Module.concat(__MODULE__, "BadCompiler#{System.unique_integer([:positive])}")
 
     source = """
@@ -730,7 +730,7 @@ defmodule Favn.AssetsTest do
              Compiler.compile_module_assets(module_name)
   end
 
-  test "supports string-key produces maps without name inference collisions" do
+  test "supports string-key relation maps without name inference collisions" do
     module_name = Module.concat(__MODULE__, "StringKeys#{System.unique_integer([:positive])}")
 
     Code.compile_string(
@@ -746,11 +746,11 @@ defmodule Favn.AssetsTest do
       "test/dynamic_assets_test.exs"
     )
 
-    assert {:ok, [%Asset{relation: %RelationRef{name: "orders"} = produces}]} =
+    assert {:ok, [%Asset{relation: %RelationRef{name: "orders"} = relation}]} =
              Compiler.compile_module_assets(module_name)
 
-    assert produces.catalog == nil
-    assert produces.schema == nil
+    assert relation.catalog == nil
+    assert relation.schema == nil
   end
 
   defp compile_test_module(body) do

--- a/test/assets_test.exs
+++ b/test/assets_test.exs
@@ -118,7 +118,7 @@ defmodule Favn.AssetsTest do
 
     source = """
     defmodule #{inspect(module_name)} do
-      use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+      use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
       use Favn.Assets
 
       @asset true
@@ -157,7 +157,7 @@ defmodule Favn.AssetsTest do
 
     source = """
     defmodule #{inspect(module_name)} do
-      use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+      use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
       use Favn.Asset
 
       @doc "Extract raw orders"
@@ -280,17 +280,17 @@ defmodule Favn.AssetsTest do
     assets = Module.concat(sales, Assets)
 
     Code.compile_string(
-      "defmodule #{inspect(root)} do\n  use Favn.Namespace, connection: :warehouse\nend",
+      "defmodule #{inspect(root)} do\n  use Favn.Namespace, relation: [connection: :warehouse]\nend",
       "test/dynamic_assets_test.exs"
     )
 
     Code.compile_string(
-      "defmodule #{inspect(raw)} do\n  use Favn.Namespace, catalog: :raw\nend",
+      "defmodule #{inspect(raw)} do\n  use Favn.Namespace, relation: [catalog: :raw]\nend",
       "test/dynamic_assets_test.exs"
     )
 
     Code.compile_string(
-      "defmodule #{inspect(sales)} do\n  use Favn.Namespace, schema: :sales\nend",
+      "defmodule #{inspect(sales)} do\n  use Favn.Namespace, relation: [schema: :sales]\nend",
       "test/dynamic_assets_test.exs"
     )
 
@@ -338,17 +338,17 @@ defmodule Favn.AssetsTest do
     )
 
     Code.compile_string(
-      "defmodule #{inspect(root)} do\n  use Favn.Namespace, connection: :warehouse\nend",
+      "defmodule #{inspect(root)} do\n  use Favn.Namespace, relation: [connection: :warehouse]\nend",
       "test/dynamic_assets_test.exs"
     )
 
     Code.compile_string(
-      "defmodule #{inspect(raw)} do\n  use Favn.Namespace, catalog: :raw\nend",
+      "defmodule #{inspect(raw)} do\n  use Favn.Namespace, relation: [catalog: :raw]\nend",
       "test/dynamic_assets_test.exs"
     )
 
     Code.compile_string(
-      "defmodule #{inspect(sales)} do\n  use Favn.Namespace, schema: :sales\nend",
+      "defmodule #{inspect(sales)} do\n  use Favn.Namespace, relation: [schema: :sales]\nend",
       "test/dynamic_assets_test.exs"
     )
 
@@ -535,7 +535,7 @@ defmodule Favn.AssetsTest do
              Code.compile_string(
                """
                defmodule #{inspect(duplicate_module)} do
-                 use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+                 use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
                  use Favn.Assets
 
                  @asset true

--- a/test/favn_test.exs
+++ b/test/favn_test.exs
@@ -143,7 +143,7 @@ defmodule FavnTest do
     Code.compile_string(
       """
       defmodule #{inspect(owner_a)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
         use Favn.Assets
 
         @asset true
@@ -157,7 +157,7 @@ defmodule FavnTest do
     Code.compile_string(
       """
       defmodule #{inspect(owner_b)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
         use Favn.Assets
 
         @asset true

--- a/test/favn_test.exs
+++ b/test/favn_test.exs
@@ -147,7 +147,7 @@ defmodule FavnTest do
         use Favn.Assets
 
         @asset true
-        @produces true
+        @relation true
         def orders(_ctx), do: :ok
       end
       """,
@@ -161,7 +161,7 @@ defmodule FavnTest do
         use Favn.Assets
 
         @asset true
-        @produces name: :orders
+        @relation name: :orders
         def duplicate_orders(_ctx), do: :ok
       end
       """,

--- a/test/pipeline_test.exs
+++ b/test/pipeline_test.exs
@@ -282,7 +282,7 @@ defmodule Favn.PipelineTest do
     Code.compile_string(
       """
       defmodule #{inspect(module_name)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
         use Favn.Assets
 
         alias Favn.Test.Fixtures.Assets.Pipeline.CtxRecorder

--- a/test/pipeline_test.exs
+++ b/test/pipeline_test.exs
@@ -276,7 +276,7 @@ defmodule Favn.PipelineTest do
     assert ctx.pipeline.trigger == %{kind: :manual, requested_by: :api}
   end
 
-  test "run_asset/2 projects produced relation ownership to ctx.asset.produces" do
+  test "run_asset/2 projects produced relation ownership to ctx.asset.relation" do
     module_name = Module.concat(__MODULE__, "ProducesAssets#{System.unique_integer([:positive])}")
 
     Code.compile_string(
@@ -288,7 +288,7 @@ defmodule Favn.PipelineTest do
         alias Favn.Test.Fixtures.Assets.Pipeline.CtxRecorder
 
         @asset true
-        @produces true
+        @relation true
         def orders(ctx) do
           CtxRecorder.record(ctx)
           :ok
@@ -310,7 +310,7 @@ defmodule Favn.PipelineTest do
 
     assert ctx.asset.ref == {module_name, :orders}
 
-    assert ctx.asset.produces == %Favn.RelationRef{
+    assert ctx.asset.relation == %Favn.RelationRef{
              connection: :warehouse,
              catalog: "raw",
              schema: "sales",

--- a/test/pipeline_test.exs
+++ b/test/pipeline_test.exs
@@ -276,7 +276,7 @@ defmodule Favn.PipelineTest do
     assert ctx.pipeline.trigger == %{kind: :manual, requested_by: :api}
   end
 
-  test "run_asset/2 projects produced relation ownership to ctx.asset.relation" do
+  test "run_asset/2 projects relation ownership to ctx.asset.relation" do
     module_name = Module.concat(__MODULE__, "ProducesAssets#{System.unique_integer([:positive])}")
 
     Code.compile_string(

--- a/test/sql_asset_runtime_test.exs
+++ b/test/sql_asset_runtime_test.exs
@@ -347,9 +347,12 @@ defmodule Favn.SQLAssetRuntimeTest do
   end
 
   test "incremental append bootstraps when target relation does not exist" do
-    %{asset: asset_module} = compile_incremental_runtime_modules!(:append)
+    %{asset: asset_module, source: source_module} = compile_incremental_runtime_modules!(:append)
 
-    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+    assert :ok =
+             Favn.TestSetup.setup_asset_modules([source_module, asset_module],
+               reload_graph?: true
+             )
 
     assert {:ok, output} =
              Favn.materialize(asset_module,
@@ -371,11 +374,15 @@ defmodule Favn.SQLAssetRuntimeTest do
   end
 
   test "incremental delete_insert uses transaction and window delete scope" do
-    %{asset: asset_module} = compile_incremental_runtime_modules!(:delete_insert)
+    %{asset: asset_module, source: source_module} =
+      compile_incremental_runtime_modules!(:delete_insert)
 
     Application.put_env(:favn, :sql_asset_runtime_target_exists, true)
 
-    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+    assert :ok =
+             Favn.TestSetup.setup_asset_modules([source_module, asset_module],
+               reload_graph?: true
+             )
 
     assert {:ok, output} =
              Favn.materialize(asset_module,
@@ -408,11 +415,14 @@ defmodule Favn.SQLAssetRuntimeTest do
   end
 
   test "incremental lookback widens query input window params" do
-    %{asset: asset_module} = compile_incremental_runtime_modules!(:append)
+    %{asset: asset_module, source: source_module} = compile_incremental_runtime_modules!(:append)
 
     Application.put_env(:favn, :sql_asset_runtime_target_exists, true)
 
-    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+    assert :ok =
+             Favn.TestSetup.setup_asset_modules([source_module, asset_module],
+               reload_graph?: true
+             )
 
     assert {:ok, output} =
              Favn.materialize(asset_module,
@@ -437,9 +447,12 @@ defmodule Favn.SQLAssetRuntimeTest do
   end
 
   test "incremental materialize requires runtime window struct" do
-    %{asset: asset_module} = compile_incremental_runtime_modules!(:append)
+    %{asset: asset_module, source: source_module} = compile_incremental_runtime_modules!(:append)
 
-    assert :ok = Favn.TestSetup.setup_asset_modules([asset_module], reload_graph?: true)
+    assert :ok =
+             Favn.TestSetup.setup_asset_modules([source_module, asset_module],
+               reload_graph?: true
+             )
 
     assert {:error, %SQLAssetError{type: :materialization_planning_failed}} =
              Favn.materialize(asset_module,
@@ -714,11 +727,30 @@ defmodule Favn.SQLAssetRuntimeTest do
 
   defp compile_incremental_runtime_modules!(strategy) do
     root = Module.concat(__MODULE__, "Incremental#{System.unique_integer([:positive])}")
+    raw_namespace = Module.concat([root, Raw, Sales])
     gold_namespace = Module.concat([root, Gold, Sales])
+    raw_orders = Module.concat(raw_namespace, Orders)
     asset_module = Module.concat(gold_namespace, FctOrders)
 
     Code.compile_string(
+      "defmodule #{inspect(raw_namespace)} do\n  use Favn.Namespace, relation: [connection: :sql_asset_runtime, catalog: :raw, schema: :sales]\nend",
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
       "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, relation: [connection: :sql_asset_runtime, catalog: :gold, schema: :sales]\nend",
+      "test/dynamic_sql_asset_runtime_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(raw_orders)} do
+        use Favn.Namespace
+        use Favn.Source
+
+        @relation true
+      end
+      """,
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 
@@ -750,7 +782,7 @@ defmodule Favn.SQLAssetRuntimeTest do
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 
-    %{asset: asset_module}
+    %{asset: asset_module, source: raw_orders}
   end
 
   defp runtime_window(start_at, end_at) do

--- a/test/sql_asset_runtime_test.exs
+++ b/test/sql_asset_runtime_test.exs
@@ -518,12 +518,12 @@ defmodule Favn.SQLAssetRuntimeTest do
     asset_module = Module.concat(gold_namespace, FctOrders)
 
     Code.compile_string(
-      "defmodule #{inspect(raw_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :raw, schema: :sales\nend",
+      "defmodule #{inspect(raw_namespace)} do\n  use Favn.Namespace, relation: [connection: :sql_asset_runtime, catalog: :raw, schema: :sales]\nend",
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 
     Code.compile_string(
-      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :gold, schema: :sales\nend",
+      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, relation: [connection: :sql_asset_runtime, catalog: :gold, schema: :sales]\nend",
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 
@@ -590,12 +590,12 @@ defmodule Favn.SQLAssetRuntimeTest do
     cross_asset = Module.concat(gold_namespace, FctOrders)
 
     Code.compile_string(
-      "defmodule #{inspect(other_namespace)} do\n  use Favn.Namespace, connection: :other_connection, catalog: :raw, schema: :sales\nend",
+      "defmodule #{inspect(other_namespace)} do\n  use Favn.Namespace, relation: [connection: :other_connection, catalog: :raw, schema: :sales]\nend",
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 
     Code.compile_string(
-      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :gold, schema: :sales\nend",
+      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, relation: [connection: :sql_asset_runtime, catalog: :gold, schema: :sales]\nend",
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 
@@ -643,12 +643,12 @@ defmodule Favn.SQLAssetRuntimeTest do
     asset_module = Module.concat(gold_namespace, FctOrders)
 
     Code.compile_string(
-      "defmodule #{inspect(raw_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :raw, schema: :sales\nend",
+      "defmodule #{inspect(raw_namespace)} do\n  use Favn.Namespace, relation: [connection: :sql_asset_runtime, catalog: :raw, schema: :sales]\nend",
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 
     Code.compile_string(
-      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :gold, schema: :sales\nend",
+      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, relation: [connection: :sql_asset_runtime, catalog: :gold, schema: :sales]\nend",
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 
@@ -718,7 +718,7 @@ defmodule Favn.SQLAssetRuntimeTest do
     asset_module = Module.concat(gold_namespace, FctOrders)
 
     Code.compile_string(
-      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, connection: :sql_asset_runtime, catalog: :gold, schema: :sales\nend",
+      "defmodule #{inspect(gold_namespace)} do\n  use Favn.Namespace, relation: [connection: :sql_asset_runtime, catalog: :gold, schema: :sales]\nend",
       "test/dynamic_sql_asset_runtime_test.exs"
     )
 

--- a/test/sql_asset_runtime_test.exs
+++ b/test/sql_asset_runtime_test.exs
@@ -533,7 +533,7 @@ defmodule Favn.SQLAssetRuntimeTest do
         use Favn.Namespace
         use Favn.Asset
 
-        @produces true
+        @relation true
 
         def asset(_ctx), do: :ok
       end
@@ -605,7 +605,7 @@ defmodule Favn.SQLAssetRuntimeTest do
         use Favn.Namespace
         use Favn.Asset
 
-        @produces true
+        @relation true
         def asset(_ctx), do: :ok
       end
       """,
@@ -701,7 +701,7 @@ defmodule Favn.SQLAssetRuntimeTest do
         use Favn.Namespace
         use Favn.Asset
 
-        @produces true
+        @relation true
 
         def asset(_ctx), do: :ok
       end

--- a/test/sql_asset_test.exs
+++ b/test/sql_asset_test.exs
@@ -68,7 +68,7 @@ defmodule Favn.SQLAssetTest do
 
     assert asset.window_spec == %Favn.Window.Spec{kind: :day, lookback: 2, timezone: "Etc/UTC"}
 
-    assert asset.produces == %Favn.RelationRef{
+    assert asset.relation == %Favn.RelationRef{
              connection: :warehouse,
              catalog: "gold",
              schema: "sales",
@@ -103,7 +103,7 @@ defmodule Favn.SQLAssetTest do
 
         @depends #{inspect(upstream)}
         @materialized :table
-        @produces schema: :mart, table: :fact_orders
+        @relation schema: :mart, table: :fact_orders
         query do
           ~SQL[select * from silver.sales.stg_orders]
         end
@@ -116,7 +116,7 @@ defmodule Favn.SQLAssetTest do
 
     assert asset.depends_on == [{upstream, :asset}]
 
-    assert asset.produces == %Favn.RelationRef{
+    assert asset.relation == %Favn.RelationRef{
              connection: :warehouse,
              catalog: "silver",
              schema: "mart",
@@ -232,7 +232,7 @@ defmodule Favn.SQLAssetTest do
 
   test "rejects missing connection for produced SQL relation" do
     assert_raise CompileError,
-                 ~r/SQL assets require a connection through Favn\.Namespace or @produces/,
+                 ~r/SQL assets require a connection through Favn\.Namespace or @relation/,
                  fn ->
                    compile_sql_asset_module("""
                    use Favn.SQLAsset
@@ -307,14 +307,14 @@ defmodule Favn.SQLAssetTest do
   end
 
   test "rejects multiple produces attributes with a controlled compile error" do
-    assert_raise CompileError, ~r/multiple @produces attributes are not allowed/, fn ->
+    assert_raise CompileError, ~r/multiple @relation attributes are not allowed/, fn ->
       compile_sql_asset_module("""
       use Favn.Namespace, connection: :warehouse
       use Favn.SQLAsset
 
       @materialized :view
-      @produces true
-      @produces name: :orders
+      @relation true
+      @relation name: :orders
 
       query do
         ~SQL[select 1]

--- a/test/sql_asset_test.exs
+++ b/test/sql_asset_test.exs
@@ -80,7 +80,7 @@ defmodule Favn.SQLAssetTest do
     assert definition.materialization == asset.materialization
   end
 
-  test "supports explicit depends and produces overrides for SQL assets" do
+  test "supports explicit depends and relation overrides for SQL assets" do
     upstream = Module.concat(__MODULE__, "Upstream#{System.unique_integer([:positive])}")
     asset_module = Module.concat(__MODULE__, "SqlDepends#{System.unique_integer([:positive])}")
 
@@ -306,7 +306,7 @@ defmodule Favn.SQLAssetTest do
     assert message =~ "single-asset module"
   end
 
-  test "rejects multiple produces attributes with a controlled compile error" do
+  test "rejects multiple relation attributes with a controlled compile error" do
     assert_raise CompileError, ~r/multiple @relation attributes are not allowed/, fn ->
       compile_sql_asset_module("""
       use Favn.Namespace, relation: [connection: :warehouse]

--- a/test/sql_asset_test.exs
+++ b/test/sql_asset_test.exs
@@ -23,17 +23,17 @@ defmodule Favn.SQLAssetTest do
     asset_module = Module.concat(sales, FctOrders)
 
     Code.compile_string(
-      "defmodule #{inspect(root)} do\n  use Favn.Namespace, connection: :warehouse\nend",
+      "defmodule #{inspect(root)} do\n  use Favn.Namespace, relation: [connection: :warehouse]\nend",
       "test/dynamic_sql_asset_test.exs"
     )
 
     Code.compile_string(
-      "defmodule #{inspect(gold)} do\n  use Favn.Namespace, catalog: :gold\nend",
+      "defmodule #{inspect(gold)} do\n  use Favn.Namespace, relation: [catalog: :gold]\nend",
       "test/dynamic_sql_asset_test.exs"
     )
 
     Code.compile_string(
-      "defmodule #{inspect(sales)} do\n  use Favn.Namespace, schema: :sales\nend",
+      "defmodule #{inspect(sales)} do\n  use Favn.Namespace, relation: [schema: :sales]\nend",
       "test/dynamic_sql_asset_test.exs"
     )
 
@@ -98,7 +98,7 @@ defmodule Favn.SQLAssetTest do
     Code.compile_string(
       """
       defmodule #{inspect(asset_module)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :silver, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :silver, schema: :sales]
         use Favn.SQLAsset
 
         @depends #{inspect(upstream)}
@@ -130,7 +130,7 @@ defmodule Favn.SQLAssetTest do
     Code.compile_string(
       """
       defmodule #{inspect(asset_module)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
 
         @doc "Facade SQL asset"
@@ -155,7 +155,7 @@ defmodule Favn.SQLAssetTest do
   test "rejects deferred incremental strategy :merge at compile time" do
     assert_raise CompileError, ~r/incremental strategy :merge is not supported in Phase 4b/, fn ->
       compile_sql_asset_module("""
-      use Favn.Namespace, connection: :warehouse
+      use Favn.Namespace, relation: [connection: :warehouse]
       use Favn.SQLAsset
 
       @window Favn.Window.daily()
@@ -173,7 +173,7 @@ defmodule Favn.SQLAssetTest do
                  ~r/incremental materialization unique_key is reserved for future :merge semantics/,
                  fn ->
                    compile_sql_asset_module("""
-                   use Favn.Namespace, connection: :warehouse
+                   use Favn.Namespace, relation: [connection: :warehouse]
                    use Favn.SQLAsset
 
                    @window Favn.Window.daily()
@@ -189,7 +189,7 @@ defmodule Favn.SQLAssetTest do
   test "rejects delete_insert without window_column" do
     assert_raise CompileError, ~r/incremental :delete_insert requires :window_column/, fn ->
       compile_sql_asset_module("""
-      use Favn.Namespace, connection: :warehouse
+      use Favn.Namespace, relation: [connection: :warehouse]
       use Favn.SQLAsset
 
       @window Favn.Window.daily()
@@ -205,7 +205,7 @@ defmodule Favn.SQLAssetTest do
   test "rejects incremental materialization without @window" do
     assert_raise CompileError, ~r/incremental SQL materialization requires @window/, fn ->
       compile_sql_asset_module("""
-      use Favn.Namespace, connection: :warehouse
+      use Favn.Namespace, relation: [connection: :warehouse]
       use Favn.SQLAsset
 
       @materialized {:incremental, strategy: :append}
@@ -220,7 +220,7 @@ defmodule Favn.SQLAssetTest do
   test "rejects missing materialized attribute" do
     assert_raise CompileError, ~r/Favn\.SQLAsset requires one @materialized attribute/, fn ->
       compile_sql_asset_module("""
-      use Favn.Namespace, connection: :warehouse
+      use Favn.Namespace, relation: [connection: :warehouse]
       use Favn.SQLAsset
 
       query do
@@ -252,7 +252,7 @@ defmodule Favn.SQLAssetTest do
 
       Code.compile_string(
         "defmodule #{inspect(module_name)} do\n" <>
-          "  use Favn.Namespace, connection: :warehouse\n" <>
+          "  use Favn.Namespace, relation: [connection: :warehouse]\n" <>
           "  use Favn.SQLAsset\n\n" <>
           "  @materialized :view\n" <>
           "  query do\n" <>
@@ -267,7 +267,7 @@ defmodule Favn.SQLAssetTest do
   test "rejects plain string query bodies" do
     assert_raise CompileError, ~r/query body must contain a ~SQL literal/, fn ->
       compile_sql_asset_module("""
-      use Favn.Namespace, connection: :warehouse
+      use Favn.Namespace, relation: [connection: :warehouse]
       use Favn.SQLAsset
 
       @materialized :view
@@ -285,7 +285,7 @@ defmodule Favn.SQLAssetTest do
     Code.compile_string(
       """
       defmodule #{inspect(asset_module)} do
-        use Favn.Namespace, connection: :warehouse
+        use Favn.Namespace, relation: [connection: :warehouse]
         use Favn.SQLAsset
 
         @depends #{inspect(Favn.AssetsTest.Upstream)}
@@ -309,7 +309,7 @@ defmodule Favn.SQLAssetTest do
   test "rejects multiple produces attributes with a controlled compile error" do
     assert_raise CompileError, ~r/multiple @relation attributes are not allowed/, fn ->
       compile_sql_asset_module("""
-      use Favn.Namespace, connection: :warehouse
+      use Favn.Namespace, relation: [connection: :warehouse]
       use Favn.SQLAsset
 
       @materialized :view
@@ -330,7 +330,7 @@ defmodule Favn.SQLAssetTest do
     Code.compile_string(
       """
       defmodule #{inspect(asset_module)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
 
         @depends #{inspect(upstream)}

--- a/test/sql_dependency_inference_test.exs
+++ b/test/sql_dependency_inference_test.exs
@@ -43,7 +43,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(fct_orders)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
 
         @depends #{inspect(raw_orders)}
@@ -94,7 +94,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(consumer)} do
-        use Favn.Namespace, connection: :warehouse
+        use Favn.Namespace, relation: [connection: :warehouse]
         use Favn.SQLAsset
 
         @materialized :view
@@ -153,7 +153,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(consumer)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
         use #{inspect(sql_module)}
 
@@ -201,7 +201,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(consumer)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
         use #{inspect(sql_module)}
 
@@ -245,7 +245,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(consumer)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
         use #{inspect(sql_module)}
 
@@ -273,7 +273,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(upstream)} do
-        use Favn.Namespace, connection: :other, catalog: :silver, schema: :sales
+        use Favn.Namespace, relation: [connection: :other, catalog: :silver, schema: :sales]
         use Favn.Asset
 
         @relation true
@@ -286,7 +286,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(consumer)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
 
         @materialized :view
@@ -309,7 +309,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(module)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :silver, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :silver, schema: :sales]
         use Favn.Asset
 
         @relation name: #{inspect(table_name)}
@@ -324,7 +324,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(module)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :silver, schema: #{inspect(schema_name)}
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :silver, schema: #{inspect(schema_name)}]
         use Favn.Asset
 
         @relation name: #{inspect(table_name)}
@@ -339,7 +339,7 @@ defmodule Favn.SQLDependencyInferenceTest do
     Code.compile_string(
       """
       defmodule #{inspect(module)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
 
         @materialized :view

--- a/test/sql_dependency_inference_test.exs
+++ b/test/sql_dependency_inference_test.exs
@@ -276,7 +276,7 @@ defmodule Favn.SQLDependencyInferenceTest do
         use Favn.Namespace, connection: :other, catalog: :silver, schema: :sales
         use Favn.Asset
 
-        @produces true
+        @relation true
         def asset(_ctx), do: :ok
       end
       """,
@@ -312,7 +312,7 @@ defmodule Favn.SQLDependencyInferenceTest do
         use Favn.Namespace, connection: :warehouse, catalog: :silver, schema: :sales
         use Favn.Asset
 
-        @produces name: #{inspect(table_name)}
+        @relation name: #{inspect(table_name)}
         def asset(_ctx), do: :ok
       end
       """,
@@ -327,7 +327,7 @@ defmodule Favn.SQLDependencyInferenceTest do
         use Favn.Namespace, connection: :warehouse, catalog: :silver, schema: #{inspect(schema_name)}
         use Favn.Asset
 
-        @produces name: #{inspect(table_name)}
+        @relation name: #{inspect(table_name)}
         def asset(_ctx), do: :ok
       end
       """,

--- a/test/sql_dsl_test.exs
+++ b/test/sql_dsl_test.exs
@@ -28,7 +28,7 @@ defmodule Favn.SQLDSLTest do
         use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
         use Favn.Asset
 
-        @produces true
+        @relation true
 
         def asset(_ctx), do: :ok
       end
@@ -185,7 +185,7 @@ defmodule Favn.SQLDSLTest do
         use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
         use Favn.Asset
 
-        @produces true
+        @relation true
 
         def asset(_ctx), do: :ok
       end

--- a/test/sql_dsl_test.exs
+++ b/test/sql_dsl_test.exs
@@ -25,7 +25,7 @@ defmodule Favn.SQLDSLTest do
     Code.compile_string(
       """
       defmodule #{inspect(raw_orders)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
         use Favn.Asset
 
         @relation true
@@ -63,7 +63,7 @@ defmodule Favn.SQLDSLTest do
     Code.compile_string(
       """
       defmodule #{inspect(asset_module)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.SQLAsset
         use #{inspect(sql_module)}
 
@@ -154,7 +154,7 @@ defmodule Favn.SQLDSLTest do
                    Code.compile_string(
                      """
                      defmodule #{inspect(asset_module)} do
-                       use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+                       use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
                        use Favn.SQLAsset
                        use #{inspect(sql_module)}
 
@@ -182,7 +182,7 @@ defmodule Favn.SQLDSLTest do
     Code.compile_string(
       """
       defmodule #{inspect(raw_orders)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
         use Favn.Asset
 
         @relation true
@@ -216,7 +216,7 @@ defmodule Favn.SQLDSLTest do
                    Code.compile_string(
                      """
                      defmodule #{inspect(asset_module)} do
-                       use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+                       use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
                        use Favn.SQLAsset
                        use #{inspect(sql_module)}
 
@@ -254,7 +254,7 @@ defmodule Favn.SQLDSLTest do
                    Code.compile_string(
                      """
                      defmodule #{inspect(asset_module)} do
-                       use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+                       use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
                        use Favn.SQLAsset
 
                         @materialized :view
@@ -297,7 +297,7 @@ defmodule Favn.SQLDSLTest do
                    Code.compile_string(
                      """
                      defmodule #{inspect(asset_module)} do
-                       use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+                       use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
                        use Favn.SQLAsset
                        use #{inspect(sql_module)}
 

--- a/test/sql_template_asset_ref_test.exs
+++ b/test/sql_template_asset_ref_test.exs
@@ -203,7 +203,7 @@ defmodule Favn.SQLTemplateAssetRefTest do
     )
 
     assert_raise CompileError,
-                 ~r/does not resolve to a produced relation/,
+                 ~r/does not resolve to a relation/,
                  fn ->
                    Template.compile!(
                      "select * from #{inspect(no_produces)}",
@@ -233,7 +233,7 @@ defmodule Favn.SQLTemplateAssetRefTest do
         use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
         use Favn.Asset
 
-        @produces true
+        @relation true
 
         def asset(_ctx), do: :ok
       end

--- a/test/sql_template_asset_ref_test.exs
+++ b/test/sql_template_asset_ref_test.exs
@@ -230,7 +230,7 @@ defmodule Favn.SQLTemplateAssetRefTest do
     Code.compile_string(
       """
       defmodule #{inspect(module)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.Asset
 
         @relation true

--- a/test/sql_template_asset_ref_test.exs
+++ b/test/sql_template_asset_ref_test.exs
@@ -188,12 +188,12 @@ defmodule Favn.SQLTemplateAssetRefTest do
                  end
   end
 
-  test "raises for compiled single-asset module without produced relation" do
-    no_produces = Module.concat(__MODULE__, "NoProduces#{System.unique_integer([:positive])}")
+  test "raises for compiled single-asset module without relation" do
+    no_relation = Module.concat(__MODULE__, "NoRelation#{System.unique_integer([:positive])}")
 
     Code.compile_string(
       """
-      defmodule #{inspect(no_produces)} do
+      defmodule #{inspect(no_relation)} do
         use Favn.Asset
 
         def asset(_ctx), do: :ok
@@ -206,7 +206,7 @@ defmodule Favn.SQLTemplateAssetRefTest do
                  ~r/does not resolve to a relation/,
                  fn ->
                    Template.compile!(
-                     "select * from #{inspect(no_produces)}",
+                     "select * from #{inspect(no_relation)}",
                      file: "test/sql_template_asset_ref_test.exs",
                      line: 1
                    )

--- a/test/sql_template_ir_test.exs
+++ b/test/sql_template_ir_test.exs
@@ -171,7 +171,7 @@ defmodule Favn.SQLTemplateIRTest do
         use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
         use Favn.Asset
 
-        @produces true
+        @relation true
 
         def asset(_ctx), do: :ok
       end
@@ -396,7 +396,7 @@ defmodule Favn.SQLTemplateIRTest do
         use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
         use Favn.Asset
 
-        @produces true
+        @relation true
 
         def asset(_ctx), do: :ok
       end

--- a/test/sql_template_ir_test.exs
+++ b/test/sql_template_ir_test.exs
@@ -168,7 +168,7 @@ defmodule Favn.SQLTemplateIRTest do
     Code.compile_string(
       """
       defmodule #{inspect(raw_orders)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :raw, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
         use Favn.Asset
 
         @relation true
@@ -273,7 +273,7 @@ defmodule Favn.SQLTemplateIRTest do
       Code.compile_string(
         """
         defmodule #{inspect(asset_module)} do
-          use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+          use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
           use Favn.SQLAsset
           use #{inspect(sql_a)}
           use #{inspect(sql_b)}
@@ -393,7 +393,7 @@ defmodule Favn.SQLTemplateIRTest do
     Code.compile_string(
       """
       defmodule #{inspect(module)} do
-        use Favn.Namespace, connection: :warehouse, catalog: :gold, schema: :sales
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
         use Favn.Asset
 
         @relation true


### PR DESCRIPTION
## Summary

Implements the typed external relational sources feature with a unified `relation` DSL:

- Renamed `@produces` → `@relation` across all DSLs
- Added new `Favn.Source` module for declaring external relations
- Updated `Favn.Namespace` to use grouped `relation: [connection: ..., catalog: ..., schema: ...]` syntax
- Added `:source` asset type for non-materializing external relations
- Updated dependency inference to work with registered sources

## Changes

### Core changes:
- `lib/favn/asset.ex`: `produces` → `relation`, added `:source` type
- `lib/favn/namespace.ex`: Grouped `relation: [...]` syntax
- `lib/favn/source.ex`: New DSL for external relations
- `lib/favn/sql_asset.ex`: `@relation` with inference
- Updated all caller modules

## Example

```elixir
defmodule MyApp do
  use Favn.Namespace, relation: [connection: :warehouse]
end

defmodule MyApp.Raw.Stripe.Charges do
  use Favn.Source
  @relation true
end

defmodule MyApp.Silver.Stripe.StgCharges do
  use Favn.SQLAsset
  @materialized :table

  query do
    ~SQL"""
    select * from raw.stripe.charges
    """
  end
end
```

- All tests pass (304 tests + 14 doctests)
- `mix credo --strict` passes
- `mix dialyzer` passes