### PR TITLE
Harden nested WITH CTE alias exclusion in SQL inference

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,7 @@ Implemented in Phase 5:
 - relation-based dependency inference from typed SQL relation references
 - additive merge of explicit + inferred dependencies with provenance metadata
 - relation ownership diagnostics (unmanaged warnings, ambiguous ownership errors)
+- lexical CTE alias exclusion for relation inference across top-level and nested subqueries
 
 Planned later:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -196,7 +196,7 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] SQL asset dependency planning on the shared window-aware runtime model
   - [x] additive explicit + inferred dependency merge with provenance metadata
   - [x] unmanaged external relation warnings and ambiguous ownership errors
-  - [ ] follow-up hardening: nested/subquery `WITH` CTE alias exclusion tests for relation inference
+  - [x] follow-up hardening: nested/subquery `WITH` CTE alias exclusion tests for relation inference
 
 ---
 

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -209,7 +209,9 @@ defmodule Favn do
   IR. Runtime helper APIs are available through `render/2`, `preview/2`, `explain/2`,
   and `materialize/2`. SQL relation references discovered from the typed SQL IR are
   now also used to infer additive asset dependencies through the registry ownership
-  index, with diagnostics retained on canonical asset metadata.
+  index, with diagnostics retained on canonical asset metadata. CTE aliases declared
+  with `WITH` are excluded lexically from relation inference, including nested
+  subquery scopes.
 
   Compact multi-asset style uses `Favn.Assets`:
 

--- a/lib/favn/sql/template.ex
+++ b/lib/favn/sql/template.ex
@@ -227,12 +227,7 @@ defmodule Favn.SQL.Template do
       statement_kind: top_level_statement_kind(root_kind),
       scope: scope,
       root_kind: root_kind,
-      cte_names: MapSet.new(),
-      cte_active?: false,
-      cte_expect_alias?: false,
-      cte_waiting_query?: false,
-      cte_query_depth: nil,
-      cte_ready_for_next?: false
+      cte_scopes: []
     }
 
     {nodes, end_state} = parse_nodes(String.to_charlist(sql), parser_state, [])
@@ -452,6 +447,7 @@ defmodule Favn.SQL.Template do
       |> Map.put(:relation_entry?, false)
       |> Map.put(:join_prefix, nil)
       |> maybe_exit_cte_query(state)
+      |> pop_expired_cte_scopes()
 
     parse_nodes(rest, next_state, [text_node(")", state.position, next_state.position) | acc])
   end
@@ -463,12 +459,7 @@ defmodule Favn.SQL.Template do
       |> Map.put(:relation_entry?, false)
       |> Map.put(:join_prefix, nil)
       |> Map.put(:statement_kind, top_level_statement_kind(state.root_kind))
-      |> Map.put(:cte_names, MapSet.new())
-      |> Map.put(:cte_active?, false)
-      |> Map.put(:cte_expect_alias?, false)
-      |> Map.put(:cte_waiting_query?, false)
-      |> Map.put(:cte_query_depth, nil)
-      |> Map.put(:cte_ready_for_next?, false)
+      |> Map.put(:cte_scopes, [])
 
     parse_nodes(rest, next_state, [text_node(";", state.position, next_state.position) | acc])
   end
@@ -897,12 +888,16 @@ defmodule Favn.SQL.Template do
     state.statement_kind not in [:update, :merge] and
       state.relation_entry? and
       String.match?(word, ~r/^[a-z_][A-Za-z0-9_]*$/) and
-      not cte_name?(state, word) and
+      not visible_cte_name?(state, word) and
       peek_nonspace_char(tail) != ?(
   end
 
-  defp cte_name?(state, word) do
-    MapSet.member?(state.cte_names, String.downcase(word))
+  defp visible_cte_name?(state, word) do
+    alias_name = String.downcase(word)
+
+    Enum.any?(state.cte_scopes, fn scope ->
+      MapSet.member?(scope.names, alias_name)
+    end)
   end
 
   defp call_candidate?(word, tail, state) do
@@ -1209,95 +1204,116 @@ defmodule Favn.SQL.Template do
   end
 
   defp maybe_finalize_cte_after_query_identifier(state) do
-    if state.cte_ready_for_next? and state.paren_depth == 0 and not state.cte_expect_alias? do
-      state
-      |> Map.put(:cte_active?, false)
-      |> Map.put(:cte_waiting_query?, false)
-      |> Map.put(:cte_query_depth, nil)
-      |> Map.put(:cte_ready_for_next?, false)
-    else
-      state
-    end
+    update_top_cte_scope(state, fn scope ->
+      if scope.active? and scope.ready_for_next? and state.paren_depth == scope.boundary_depth and
+           not scope.expect_alias? do
+        %{
+          scope
+          | active?: false,
+            waiting_query?: false,
+            query_depth: nil,
+            ready_for_next?: false
+        }
+      else
+        scope
+      end
+    end)
   end
 
-  defp transition_cte_identifier(%{paren_depth: 0} = state, "with") do
-    state
-    |> Map.put(:cte_names, MapSet.new())
-    |> Map.put(:cte_active?, true)
-    |> Map.put(:cte_expect_alias?, true)
-    |> Map.put(:cte_waiting_query?, false)
-    |> Map.put(:cte_query_depth, nil)
-    |> Map.put(:cte_ready_for_next?, false)
+  defp transition_cte_identifier(state, "with"), do: push_cte_scope(state, state.paren_depth)
+
+  defp transition_cte_identifier(state, word) do
+    update_top_cte_scope(state, fn scope ->
+      cond do
+        scope.active? and scope.expect_alias? and state.paren_depth == scope.boundary_depth and
+            word == "recursive" ->
+          scope
+
+        scope.active? and scope.expect_alias? and state.paren_depth == scope.boundary_depth ->
+          %{scope | names: MapSet.put(scope.names, word), expect_alias?: false}
+
+        scope.active? and not scope.expect_alias? and state.paren_depth == scope.boundary_depth and
+            word == "as" ->
+          %{scope | waiting_query?: true}
+
+        true ->
+          scope
+      end
+    end)
   end
-
-  defp transition_cte_identifier(
-         %{cte_active?: true, cte_expect_alias?: true, paren_depth: 0} = state,
-         "recursive"
-       ),
-       do: state
-
-  defp transition_cte_identifier(
-         %{cte_active?: true, cte_expect_alias?: true, paren_depth: 0} = state,
-         alias_name
-       ) do
-    state
-    |> Map.put(:cte_names, MapSet.put(state.cte_names, alias_name))
-    |> Map.put(:cte_expect_alias?, false)
-  end
-
-  defp transition_cte_identifier(
-         %{cte_active?: true, cte_expect_alias?: false, paren_depth: 0} = state,
-         "as"
-       ) do
-    Map.put(state, :cte_waiting_query?, true)
-  end
-
-  defp transition_cte_identifier(state, _word), do: state
 
   defp maybe_enter_cte_query(state) do
-    if state.cte_active? and state.cte_waiting_query? and state.paren_depth > 0 and
-         is_nil(state.cte_query_depth) do
-      state
-      |> Map.put(:cte_query_depth, state.paren_depth)
-      |> Map.put(:cte_waiting_query?, false)
-      |> Map.put(:cte_ready_for_next?, false)
-    else
-      state
-    end
+    update_top_cte_scope(state, fn scope ->
+      if scope.active? and scope.waiting_query? and state.paren_depth > scope.boundary_depth and
+           is_nil(scope.query_depth) do
+        %{scope | query_depth: state.paren_depth, waiting_query?: false, ready_for_next?: false}
+      else
+        scope
+      end
+    end)
   end
 
   defp maybe_exit_cte_query(state, previous_state) do
-    if state.cte_active? and not is_nil(previous_state.cte_query_depth) and
-         previous_state.paren_depth == previous_state.cte_query_depth do
-      state
-      |> Map.put(:cte_query_depth, nil)
-      |> Map.put(:cte_ready_for_next?, true)
-    else
-      state
-    end
+    update_top_cte_scope(state, fn scope ->
+      if scope.active? and not is_nil(scope.query_depth) and
+           previous_state.paren_depth == scope.query_depth do
+        %{scope | query_depth: nil, ready_for_next?: true}
+      else
+        scope
+      end
+    end)
   end
 
   defp maybe_continue_cte_sequence_after_comma(state) do
-    if state.cte_active? and state.cte_ready_for_next? and state.paren_depth == 0 do
-      state
-      |> Map.put(:cte_expect_alias?, true)
-      |> Map.put(:cte_ready_for_next?, false)
-    else
-      state
-    end
+    update_top_cte_scope(state, fn scope ->
+      if scope.active? and scope.ready_for_next? and state.paren_depth == scope.boundary_depth do
+        %{scope | expect_alias?: true, ready_for_next?: false}
+      else
+        scope
+      end
+    end)
   end
 
   defp maybe_close_cte_sequence(state, char) do
-    if state.cte_active? and state.cte_ready_for_next? and state.paren_depth == 0 and
-         char not in [32, 9, 10, 13] do
-      state
-      |> Map.put(:cte_active?, false)
-      |> Map.put(:cte_waiting_query?, false)
-      |> Map.put(:cte_query_depth, nil)
-      |> Map.put(:cte_ready_for_next?, false)
-    else
-      state
+    update_top_cte_scope(state, fn scope ->
+      if scope.active? and scope.ready_for_next? and state.paren_depth == scope.boundary_depth and
+           char not in [32, 9, 10, 13] do
+        %{
+          scope
+          | active?: false,
+            waiting_query?: false,
+            query_depth: nil,
+            ready_for_next?: false
+        }
+      else
+        scope
+      end
+    end)
+  end
+
+  defp push_cte_scope(state, boundary_depth) do
+    scope = %{
+      boundary_depth: boundary_depth,
+      names: MapSet.new(),
+      active?: true,
+      expect_alias?: true,
+      waiting_query?: false,
+      query_depth: nil,
+      ready_for_next?: false
+    }
+
+    %{state | cte_scopes: [scope | state.cte_scopes]}
+  end
+
+  defp update_top_cte_scope(state, fun) do
+    case state.cte_scopes do
+      [scope | rest] -> %{state | cte_scopes: [fun.(scope) | rest]}
+      [] -> state
     end
+  end
+
+  defp pop_expired_cte_scopes(state) do
+    %{state | cte_scopes: Enum.reject(state.cte_scopes, &(&1.boundary_depth > state.paren_depth))}
   end
 
   defp top_level_statement_kind(:query), do: :query

--- a/test/sql_dependency_inference_test.exs
+++ b/test/sql_dependency_inference_test.exs
@@ -305,6 +305,112 @@ defmodule Favn.SQLDependencyInferenceTest do
     assert diagnostic.code == :cross_connection_direct_asset_ref
   end
 
+  test "ignores nested CTE aliases while inferring relation dependencies" do
+    root = Module.concat(__MODULE__, "NestedCTE#{System.unique_integer([:positive])}")
+    raw_orders = Module.concat(root, RawOrders)
+    customers = Module.concat(root, Customers)
+    consumer = Module.concat(root, Consumer)
+
+    compile_elixir_asset!(raw_orders, "raw_orders")
+    compile_elixir_asset!(customers, "customers")
+
+    compile_sql_asset!(
+      consumer,
+      """
+      with raw_orders as (
+        select * from silver.sales.raw_orders
+      )
+      select *
+      from raw_orders
+      join (
+        with customers as (
+          select * from silver.sales.customers
+        )
+        select * from customers
+      ) nested_customers on true
+      """
+    )
+
+    :ok =
+      Favn.TestSetup.setup_asset_modules([raw_orders, customers, consumer], reload_graph?: true)
+
+    assert {:ok, asset} = Favn.get_asset(consumer)
+
+    assert asset.depends_on == [{customers, :asset}, {raw_orders, :asset}]
+
+    refute Enum.any?(asset.diagnostics, fn diagnostic ->
+             diagnostic.code == :unmanaged_relation_reference
+           end)
+  end
+
+  test "ignores CTE aliases inside nested defsql relation chain" do
+    root = Module.concat(__MODULE__, "NestedDefsqlCTE#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    raw_orders = Module.concat(root, RawOrders)
+    customers = Module.concat(root, Customers)
+    consumer = Module.concat(root, Consumer)
+
+    compile_elixir_asset!(raw_orders, "raw_orders")
+    compile_elixir_asset!(customers, "customers")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql filtered_orders(start_at) do
+          ~SQL[
+          with scoped_orders as (
+            select * from silver.sales.raw_orders
+          )
+          select *
+          from scoped_orders
+          where inserted_at >= @start_at
+            and exists (
+            with scoped_customers as (
+              select customer_id from silver.sales.customers
+            )
+            select 1 from scoped_customers
+          )
+          ]
+        end
+
+        defsql wrapped_orders(start_at) do
+          ~SQL[select * from filtered_orders(@start_at)]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(consumer)} do
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
+        use Favn.SQLAsset
+        use #{inspect(sql_module)}
+
+        @materialized :view
+
+        query do
+          ~SQL[select * from wrapped_orders(@window_start)]
+        end
+      end
+      """,
+      "test/dynamic_sql_dependency_inference_test.exs"
+    )
+
+    :ok =
+      Favn.TestSetup.setup_asset_modules([raw_orders, customers, consumer], reload_graph?: true)
+
+    assert {:ok, asset} = Favn.get_asset(consumer)
+    assert asset.depends_on == [{customers, :asset}, {raw_orders, :asset}]
+
+    refute Enum.any?(asset.diagnostics, fn diagnostic ->
+             diagnostic.code == :unmanaged_relation_reference
+           end)
+  end
+
   defp compile_elixir_asset!(module, table_name) do
     Code.compile_string(
       """

--- a/test/sql_dependency_inference_test.exs
+++ b/test/sql_dependency_inference_test.exs
@@ -343,6 +343,36 @@ defmodule Favn.SQLDependencyInferenceTest do
            end)
   end
 
+  test "ignores multi-CTE sibling aliases in end-to-end dependency inference" do
+    root = Module.concat(__MODULE__, "SiblingCTE#{System.unique_integer([:positive])}")
+    raw_orders = Module.concat(root, RawOrders)
+    consumer = Module.concat(root, Consumer)
+
+    compile_elixir_asset!(raw_orders, "raw_orders")
+
+    compile_sql_asset!(
+      consumer,
+      """
+      with a as (
+        select * from silver.sales.raw_orders
+      ),
+      b as (
+        select * from a
+      )
+      select * from b
+      """
+    )
+
+    :ok = Favn.TestSetup.setup_asset_modules([raw_orders, consumer], reload_graph?: true)
+
+    assert {:ok, asset} = Favn.get_asset(consumer)
+    assert asset.depends_on == [{raw_orders, :asset}]
+
+    refute Enum.any?(asset.diagnostics, fn diagnostic ->
+             diagnostic.code == :unmanaged_relation_reference
+           end)
+  end
+
   test "ignores CTE aliases inside nested defsql relation chain" do
     root = Module.concat(__MODULE__, "NestedDefsqlCTE#{System.unique_integer([:positive])}")
     sql_module = Module.concat(root, SQL)

--- a/test/sql_template_ir_test.exs
+++ b/test/sql_template_ir_test.exs
@@ -371,6 +371,89 @@ defmodule Favn.SQLTemplateIRTest do
              Template.asset_refs(template)
   end
 
+  test "excludes nested derived-table CTE aliases from relation refs" do
+    template =
+      Template.compile!(
+        """
+        select *
+        from (
+          with local_orders as (
+            select * from silver.sales.orders
+          )
+          select * from local_orders
+        ) as derived
+        join silver.sales.customers c on true
+        """,
+        file: "test/sql_template_ir_test.exs",
+        line: 1
+      )
+
+    assert Enum.map(Template.relation_refs(template), & &1.raw) == [
+             "silver.sales.orders",
+             "silver.sales.customers"
+           ]
+  end
+
+  test "excludes nested exists and in CTE aliases from relation refs" do
+    template =
+      Template.compile!(
+        """
+        select *
+        from silver.sales.orders o
+        where exists (
+          with recursive seeded as (
+            select * from silver.sales.events
+          ),
+          linked as (
+            select * from seeded
+          )
+          select 1 from linked
+        )
+        and o.customer_id in (
+          with ids as (
+            select customer_id from silver.sales.customers
+          )
+          select customer_id from ids
+        )
+        """,
+        file: "test/sql_template_ir_test.exs",
+        line: 1
+      )
+
+    assert Enum.map(Template.relation_refs(template), & &1.raw) == [
+             "silver.sales.orders",
+             "silver.sales.events",
+             "silver.sales.customers"
+           ]
+  end
+
+  test "keeps lexical CTE shadowing local while resuming outer relation inference" do
+    template =
+      Template.compile!(
+        """
+        with orders as (
+          select 1 as id
+        )
+        select *
+        from orders
+        where exists (
+          with orders as (
+            select * from silver.sales.orders
+          )
+          select 1 from orders
+        )
+        join sales.orders as external_orders on true
+        """,
+        file: "test/sql_template_ir_test.exs",
+        line: 1
+      )
+
+    assert Enum.map(Template.relation_refs(template), & &1.raw) == [
+             "silver.sales.orders",
+             "sales.orders"
+           ]
+  end
+
   test "treats semicolon inside parentheses as ordinary text" do
     template =
       Template.compile!(


### PR DESCRIPTION
## Summary
- replace top-level-only CTE tracking in `Favn.SQL.Template` with lexical nested CTE scopes keyed by parser depth
- exclude CTE aliases from plain relation inference across derived tables, `exists`/`in` subqueries, `WITH RECURSIVE`, and nested `defsql` relation traversal
- add focused IR and end-to-end dependency inference coverage, and mark the Phase 5 follow-up hardening task complete in roadmap/docs

## Validation
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`