### PR TITLE
Add compile-time SQL file support for SQL DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 - Plain Elixir functions become assets with metadata and dependencies.
 - Preferred single-asset authoring uses one module with `use Favn.Asset` and `def asset(ctx)`.
-- SQL assets can be authored as one module with `use Favn.SQLAsset`, `query do ... end`, and a real `~SQL""" ... """` sigil.
+- SQL assets can be authored as one module with `use Favn.SQLAsset`, `query do ... end` or `query file: "..."`, and a real `~SQL""" ... """` sigil.
 - Assets can optionally own warehouse relations through `@relation`.
 - Dependency graphs are discovered automatically from asset definitions.
 - Runs are planned deterministically and executed in dependency order.
@@ -111,10 +111,12 @@ Phase 4a runtime integration now includes:
 
 Favn SQL uses a real `~SQL` sigil as the single SQL body language.
 
-SQL assets declare their main query with `query do ... end`.
-Reusable SQL uses `defsql ... do ... end` through `Favn.SQL`.
+SQL assets declare their main query with `query do ... end` or `query file: "..."`.
+Reusable SQL uses `defsql ... do ... end` or `defsql ..., file: "..."` through `Favn.SQL`.
 
 Both asset queries and reusable SQL macros use the same `~SQL` body syntax and the same `@name` placeholder syntax for injected values.
+
+File-backed SQL is loaded at compile time only, tracked as an external compile resource, and compiled into the same SQL template IR as inline SQL.
 
 Implemented now:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -190,7 +190,11 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] explicit runtime guard for unsupported incremental strategies such as `:merge` and current `:replace`
   - [x] window-aware incremental execution and explicit lookback handling
 - [ ] Multi-asset SQL modules
-- [ ] SQL file support
+- [x] SQL file support
+  - [x] `query file: "..."` for SQL asset main queries
+  - [x] `defsql ..., file: "..."` for reusable SQL definitions
+  - [x] compile-time-only file loading with project-local path validation
+  - [x] `.sql` file diagnostics and Mix recompilation via external resource tracking
 - [x] Phase 5 relation-based SQL inference
   - [x] dependency inference from typed SQL relation references
   - [x] SQL asset dependency planning on the shared window-aware runtime model

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -74,6 +74,7 @@ lib/
     │   ├── relation_ref.ex
     │   ├── result.ex
     │   ├── session.ex
+    │   ├── source.ex
     │   ├── template.ex
     │   ├── write_plan.ex
     │   └── adapter/

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -202,8 +202,13 @@ defmodule Favn do
         end
       end
 
+  SQL assets support both inline `query do ... end` and file-backed
+  `query file: "..."` query definitions.
+
   The current SQL implementation keeps `~SQL` as the one SQL body language across
-  `query` and reusable `defsql` definitions. SQL authoring now includes one `@name`
+  inline `query` and inline reusable `defsql` definitions, while file-backed SQL
+  forms are loaded at compile time and normalized into the same compiled SQL source
+  and template IR model. SQL authoring now includes one `@name`
   placeholder model for SQL inputs, expression and relation SQL macros, direct asset
   references in relation position, and compile-time normalization into a dedicated SQL
   IR. Runtime helper APIs are available through `render/2`, `preview/2`, `explain/2`,

--- a/lib/favn/sql.ex
+++ b/lib/favn/sql.ex
@@ -9,6 +9,7 @@ defmodule Favn.SQL do
 
     * `use Favn.SQL`
     * `defsql ... do ... end`
+    * `defsql ..., file: "..."`
     * `~SQL\""" ... \"""`
   """
 
@@ -17,9 +18,13 @@ defmodule Favn.SQL do
   alias Favn.RelationRef
   alias Favn.SQL.Definition
   alias Favn.SQL.Definition.Param
-  alias Favn.SQL.{Error, Result, Session, WritePlan}
+  alias Favn.SQL.Error
   alias Favn.SQL.RelationRef, as: SQLRelationRef
+  alias Favn.SQL.Result
+  alias Favn.SQL.Session
+  alias Favn.SQL.Source
   alias Favn.SQL.Template
+  alias Favn.SQL.WritePlan
 
   @type opts :: keyword()
 
@@ -76,7 +81,35 @@ defmodule Favn.SQL do
       arity: arity,
       sql: sql,
       file: normalize_file(__CALLER__.file),
-      line: __CALLER__.line
+      line: __CALLER__.line,
+      sql_file: normalize_file(__CALLER__.file),
+      sql_line: __CALLER__.line
+    }
+
+    quote bind_quoted: [raw: Macro.escape(raw)] do
+      @favn_sql_raw_definitions raw
+      :ok
+    end
+  end
+
+  defmacro defsql({name, _meta, args_ast}, file: path)
+           when is_atom(name) and (is_list(args_ast) or is_nil(args_ast)) and is_binary(path) do
+    args = normalize_defsql_args!(args_ast || [], __CALLER__)
+    validate_reserved_arg_names!(args, __CALLER__)
+    arity = length(args)
+
+    source = Source.load_file!(__CALLER__, path, owner: "defsql")
+
+    raw = %{
+      module: __CALLER__.module,
+      name: name,
+      args: args,
+      arity: arity,
+      sql: source.sql,
+      file: normalize_file(__CALLER__.file),
+      line: __CALLER__.line,
+      sql_file: source.sql_file,
+      sql_line: source.sql_line
     }
 
     quote bind_quoted: [raw: Macro.escape(raw)] do
@@ -90,6 +123,22 @@ defmodule Favn.SQL do
       __CALLER__.file,
       __CALLER__.line,
       "defsql expects a function-style head, for example defsql my_macro(arg) do ... end"
+    )
+  end
+
+  defmacro defsql(_head, file: _path) do
+    compile_error!(
+      __CALLER__.file,
+      __CALLER__.line,
+      "defsql expects a function-style head, for example defsql my_macro(arg), file: \"sql/my_macro.sql\""
+    )
+  end
+
+  defmacro defsql(_head, opts) do
+    compile_error!(
+      __CALLER__.file,
+      __CALLER__.line,
+      "defsql expects either a do block or file: \"path/to/query.sql\", got: #{Macro.to_string(opts)}"
     )
   end
 
@@ -439,8 +488,10 @@ defmodule Favn.SQL do
           shape: if(inferred_root_kind == :query, do: :relation, else: :expression),
           sql: raw.sql,
           template: nil,
-          file: raw.file,
-          line: raw.line
+          file: raw.sql_file,
+          line: raw.sql_line,
+          declared_file: raw.file,
+          declared_line: raw.line
         }
       end)
 
@@ -533,9 +584,12 @@ defmodule Favn.SQL do
         :ok
 
       {{name, arity}, [definition | _rest]} ->
+        file = definition.declared_file || definition.file
+        line = definition.declared_line || definition.line
+
         compile_error!(
-          definition.file,
-          definition.line,
+          file,
+          line,
           "duplicate defsql #{name}/#{arity}; each defsql name/arity must be unique per module"
         )
     end)
@@ -550,10 +604,13 @@ defmodule Favn.SQL do
 
       {{name, arity}, definitions} ->
         providers = definitions |> Enum.map(&inspect(&1.module)) |> Enum.sort() |> Enum.join(", ")
+        first = hd(definitions)
+        file = first.declared_file || first.file
+        line = first.declared_line || first.line
 
         compile_error!(
-          hd(definitions).file,
-          hd(definitions).line,
+          file,
+          line,
           "duplicate visible defsql #{name}/#{arity} for #{inspect(owner_module)}; conflicting providers: #{providers}"
         )
     end)

--- a/lib/favn/sql/definition.ex
+++ b/lib/favn/sql/definition.ex
@@ -15,8 +15,32 @@ defmodule Favn.SQL.Definition do
     @type t :: %__MODULE__{name: atom(), index: non_neg_integer()}
   end
 
-  @enforce_keys [:module, :name, :arity, :params, :shape, :sql, :template, :file, :line]
-  defstruct [:module, :name, :arity, :params, :shape, :sql, :template, :file, :line]
+  @enforce_keys [
+    :module,
+    :name,
+    :arity,
+    :params,
+    :shape,
+    :sql,
+    :template,
+    :file,
+    :line,
+    :declared_file,
+    :declared_line
+  ]
+  defstruct [
+    :module,
+    :name,
+    :arity,
+    :params,
+    :shape,
+    :sql,
+    :template,
+    :file,
+    :line,
+    :declared_file,
+    :declared_line
+  ]
 
   @type t :: %__MODULE__{
           module: module(),
@@ -27,7 +51,9 @@ defmodule Favn.SQL.Definition do
           sql: String.t(),
           template: Template.t(),
           file: String.t(),
-          line: pos_integer()
+          line: pos_integer(),
+          declared_file: String.t(),
+          declared_line: pos_integer()
         }
 
   @spec key(t()) :: {atom(), non_neg_integer()}

--- a/lib/favn/sql/source.ex
+++ b/lib/favn/sql/source.ex
@@ -29,6 +29,8 @@ defmodule Favn.SQL.Source do
       )
     end
 
+    reject_symlink_path!(resolved_path, project_root, env, owner)
+
     if Path.extname(resolved_path) != ".sql" do
       compile_error!(
         env.file,
@@ -57,6 +59,53 @@ defmodule Favn.SQL.Source do
       sql_file: normalize_file(resolved_path),
       sql_line: 1
     }
+  end
+
+  defp reject_symlink_path!(resolved_path, project_root, env, owner) do
+    relative = Path.relative_to(resolved_path, project_root)
+
+    segments =
+      if relative == "." do
+        []
+      else
+        String.split(relative, "/", trim: true)
+      end
+
+    project_root
+    |> path_prefixes(segments)
+    |> Enum.each(fn path ->
+      case File.lstat(path) do
+        {:ok, %File.Stat{type: :symlink}} ->
+          compile_error!(
+            env.file,
+            env.line,
+            "#{owner} file path must not traverse symlinks, got: #{inspect(path)}"
+          )
+
+        {:ok, _stat} ->
+          :ok
+
+        {:error, :enoent} ->
+          :ok
+
+        {:error, reason} ->
+          compile_error!(
+            env.file,
+            env.line,
+            "failed to inspect #{owner} file path #{inspect(path)}: #{:file.format_error(reason)}"
+          )
+      end
+    end)
+  end
+
+  defp path_prefixes(base, segments) do
+    {paths, _current} =
+      Enum.reduce(segments, {[base], base}, fn segment, {acc, current} ->
+        next = Path.join(current, segment)
+        {[next | acc], next}
+      end)
+
+    Enum.reverse(paths)
   end
 
   defp within_project_root?(path, root) do

--- a/lib/favn/sql/source.ex
+++ b/lib/favn/sql/source.ex
@@ -1,0 +1,79 @@
+defmodule Favn.SQL.Source do
+  @moduledoc false
+
+  @spec load_file!(Macro.Env.t(), String.t(), keyword()) :: %{
+          sql: String.t(),
+          sql_file: String.t(),
+          sql_line: pos_integer()
+        }
+  def load_file!(%Macro.Env{} = env, authored_path, opts \\ []) when is_binary(authored_path) do
+    owner = Keyword.get(opts, :owner, "SQL")
+    owner_file = env.file |> to_string() |> Path.expand()
+    project_root = File.cwd!() |> Path.expand()
+
+    if Path.type(authored_path) == :absolute do
+      compile_error!(
+        env.file,
+        env.line,
+        "#{owner} file path must be relative, got: #{inspect(authored_path)}"
+      )
+    end
+
+    resolved_path = authored_path |> Path.expand(Path.dirname(owner_file)) |> Path.expand()
+
+    if not within_project_root?(resolved_path, project_root) do
+      compile_error!(
+        env.file,
+        env.line,
+        "#{owner} file path must resolve inside the project root, got: #{inspect(authored_path)}"
+      )
+    end
+
+    if Path.extname(resolved_path) != ".sql" do
+      compile_error!(
+        env.file,
+        env.line,
+        "#{owner} file path must end with .sql, got: #{inspect(authored_path)}"
+      )
+    end
+
+    sql =
+      case File.read(resolved_path) do
+        {:ok, content} ->
+          content
+
+        {:error, reason} ->
+          compile_error!(
+            env.file,
+            env.line,
+            "failed to read #{owner} file #{inspect(authored_path)} (resolved to #{inspect(resolved_path)}): #{:file.format_error(reason)}"
+          )
+      end
+
+    Module.put_attribute(env.module, :external_resource, resolved_path)
+
+    %{
+      sql: sql,
+      sql_file: normalize_file(resolved_path),
+      sql_line: 1
+    }
+  end
+
+  defp within_project_root?(path, root) do
+    canonical_path = Path.expand(path)
+    canonical_root = Path.expand(root)
+    root_prefix = canonical_root <> "/"
+
+    canonical_path == canonical_root or String.starts_with?(canonical_path, root_prefix)
+  end
+
+  defp normalize_file(file) do
+    file
+    |> to_string()
+    |> Path.relative_to_cwd()
+  end
+
+  defp compile_error!(file, line, description) do
+    raise CompileError, file: file, line: line, description: description
+  end
+end

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -5,7 +5,8 @@ defmodule Favn.SQLAsset do
   `Favn.SQLAsset` compiles one SQL-authored module into one canonical
   `%Favn.Asset{}` with ref `{Module, :asset}`.
 
-  SQL bodies are authored with `query do ... end` and a real `~SQL` sigil.
+  SQL bodies are authored with `query do ... end` or `query file: "..."`.
+  Inline SQL uses a real `~SQL` sigil.
   SQL compilation keeps the authored SQL source and a normalized SQL template IR
   so reusable SQL definitions and relation references can be validated at compile time.
   """
@@ -16,6 +17,7 @@ defmodule Favn.SQLAsset do
   alias Favn.RelationRef
   alias Favn.SQL
   alias Favn.SQL.Definition, as: SQLDefinition
+  alias Favn.SQL.Source
   alias Favn.SQL.Template
   alias Favn.SQLAsset.Definition
   alias Favn.SQLAsset.Materialization
@@ -95,12 +97,49 @@ defmodule Favn.SQLAsset do
       module: __CALLER__.module,
       file: normalize_file(__CALLER__.file),
       line: __CALLER__.line,
+      sql_file: normalize_file(__CALLER__.file),
+      sql_line: __CALLER__.line,
       sql: sql
     })
 
     quote do
       :ok
     end
+  end
+
+  defmacro query(file: path) when is_binary(path) do
+    raw_definition = Module.get_attribute(__CALLER__.module, :favn_sql_asset_raw)
+
+    if raw_definition do
+      compile_error!(
+        __CALLER__.file,
+        __CALLER__.line,
+        "Favn.SQLAsset modules can define only one query body"
+      )
+    end
+
+    source = Source.load_file!(__CALLER__, path, owner: "query")
+
+    Module.put_attribute(__CALLER__.module, :favn_sql_asset_raw, %{
+      module: __CALLER__.module,
+      file: normalize_file(__CALLER__.file),
+      line: __CALLER__.line,
+      sql_file: source.sql_file,
+      sql_line: source.sql_line,
+      sql: source.sql
+    })
+
+    quote do
+      :ok
+    end
+  end
+
+  defmacro query(opts) do
+    compile_error!(
+      __CALLER__.file,
+      __CALLER__.line,
+      "query expects either a do block or file: \"path/to/query.sql\", got: #{Macro.to_string(opts)}"
+    )
   end
 
   @doc false
@@ -170,8 +209,8 @@ defmodule Favn.SQLAsset do
     template =
       Template.compile!(raw_definition.sql,
         known_definitions: known_definitions,
-        file: raw_definition.file,
-        line: raw_definition.line,
+        file: raw_definition.sql_file,
+        line: raw_definition.sql_line,
         module: raw_definition.module,
         scope: :query,
         local_args: [],
@@ -258,7 +297,7 @@ defmodule Favn.SQLAsset do
     compile_error!(
       raw_definition.file,
       raw_definition.line,
-      "multiple @window attributes are not allowed; use at most one @window before query do ... end"
+      "multiple @window attributes are not allowed; use at most one @window before query"
     )
   end
 
@@ -291,7 +330,7 @@ defmodule Favn.SQLAsset do
     compile_error!(
       raw_definition.file,
       raw_definition.line,
-      "multiple @materialized attributes are not allowed; use exactly one @materialized before query do ... end"
+      "multiple @materialized attributes are not allowed; use exactly one @materialized before query"
     )
   end
 
@@ -442,7 +481,7 @@ defmodule Favn.SQLAsset do
       compile_error!(
         env.file,
         env.line,
-        "@depends/@meta/@window/@relation/@materialized on #{kind} #{name}/#{arity} requires query do ... end immediately below those attributes"
+        "@depends/@meta/@window/@relation/@materialized on #{kind} #{name}/#{arity} requires query immediately below those attributes"
       )
     else
       :ok

--- a/lib/favn/sql_asset/renderer.ex
+++ b/lib/favn/sql_asset/renderer.ex
@@ -124,7 +124,8 @@ defmodule Favn.SQLAsset.Renderer do
       local_args: %{},
       definition_catalog: definition_catalog,
       stack: [],
-      cache: %{}
+      cache: %{},
+      current_file: Map.get(definition.raw_asset || %{}, :sql_file, definition.asset.file)
     }
   end
 
@@ -177,6 +178,7 @@ defmodule Favn.SQLAsset.Renderer do
            asset_ref: env.asset_ref,
            span: span,
            line: span.start_line,
+           file: env.current_file,
            message: "failed to resolve local defsql argument @#{index}",
            stack: env.stack
          }}
@@ -190,7 +192,8 @@ defmodule Favn.SQLAsset.Renderer do
            env
            |> Map.put(:local_args, local_arg_map(arg_fragments))
            |> Map.put(:stack, [stack_frame(call, definition) | env.stack])
-           |> Map.put(:cache, next_env.cache),
+           |> Map.put(:cache, next_env.cache)
+           |> Map.put(:current_file, definition.file),
          {:ok, %Fragment{} = expanded, callee_env_after} <-
            render_nodes(definition.template.nodes, callee_env) do
       {:ok, expanded, %{env | cache: callee_env_after.cache}}
@@ -208,6 +211,7 @@ defmodule Favn.SQLAsset.Renderer do
            "failed to expand SQL definition #{call.definition.name}/#{call.definition.arity}",
          span: call.span,
          line: call.span.start_line,
+         file: env.current_file,
          stack: env.stack,
          cause: error
        }}
@@ -237,6 +241,7 @@ defmodule Favn.SQLAsset.Renderer do
            asset_ref: env.asset_ref,
            span: span,
            line: span.start_line,
+           file: env.current_file,
            message: "failed to find SQL definition #{name}/#{arity} during render",
            stack: env.stack,
            details: %{name: name, arity: arity}
@@ -294,14 +299,20 @@ defmodule Favn.SQLAsset.Renderer do
 
       :error ->
         with {:ok, relation_ref} <-
-               resolve_deferred_module(module, env.asset_ref, asset_ref.span, env.stack),
+               resolve_deferred_module(
+                 module,
+                 env.asset_ref,
+                 asset_ref.span,
+                 env.stack,
+                 env.current_file
+               ),
              :ok <- ensure_same_connection(asset_ref, relation_ref, env) do
           {:ok, relation_ref, %{env | cache: Map.put(env.cache, module, relation_ref)}}
         end
     end
   end
 
-  defp resolve_deferred_module(module, asset_ref, span, stack) do
+  defp resolve_deferred_module(module, asset_ref, span, stack, current_file) do
     case Code.ensure_compiled(module) do
       {:module, _compiled} ->
         case Compiler.compile_module_assets(module) do
@@ -316,6 +327,7 @@ defmodule Favn.SQLAsset.Renderer do
                asset_ref: asset_ref,
                span: span,
                line: span.start_line,
+               file: current_file,
                message:
                  "SQL asset reference #{inspect(module)} resolved, but it does not have a relation",
                stack: stack,
@@ -330,6 +342,7 @@ defmodule Favn.SQLAsset.Renderer do
                asset_ref: asset_ref,
                span: span,
                line: span.start_line,
+               file: current_file,
                message:
                  "invalid SQL asset reference #{inspect(module)}; expected a compiled single-asset module",
                stack: stack,
@@ -344,6 +357,7 @@ defmodule Favn.SQLAsset.Renderer do
                asset_ref: asset_ref,
                span: span,
                line: span.start_line,
+               file: current_file,
                message:
                  "SQL asset reference #{inspect(module)} could not be resolved at render time",
                stack: stack,
@@ -359,6 +373,7 @@ defmodule Favn.SQLAsset.Renderer do
            asset_ref: asset_ref,
            span: span,
            line: span.start_line,
+           file: current_file,
            message: "SQL asset reference #{inspect(module)} could not be resolved at render time",
            stack: stack,
            details: %{module: module}
@@ -386,6 +401,7 @@ defmodule Favn.SQLAsset.Renderer do
        asset_ref: env.asset_ref,
        span: span,
        line: span.start_line,
+       file: env.current_file,
        message:
          "SQL asset reference #{inspect(module)} resolves to connection #{inspect(relation_ref.connection)}, expected #{inspect(env.root_connection)}",
        stack: env.stack,
@@ -446,6 +462,7 @@ defmodule Favn.SQLAsset.Renderer do
        asset_ref: env.asset_ref,
        span: span,
        line: span.start_line,
+       file: env.current_file,
        message: "missing runtime SQL input :#{name} for #{inspect(env.asset_ref)}",
        stack: env.stack,
        details: %{name: name}
@@ -460,6 +477,7 @@ defmodule Favn.SQLAsset.Renderer do
        asset_ref: env.asset_ref,
        span: span,
        line: span.start_line,
+       file: env.current_file,
        message: "missing SQL param :#{name} for #{inspect(env.asset_ref)}",
        stack: env.stack,
        details: %{name: name}

--- a/test/sql_asset_test.exs
+++ b/test/sql_asset_test.exs
@@ -152,6 +152,58 @@ defmodule Favn.SQLAssetTest do
     assert asset.ref == {asset_module, :asset}
   end
 
+  test "supports file-backed query bodies" do
+    root = Module.concat(__MODULE__, "FileBacked#{System.unique_integer([:positive])}")
+    asset_module = Module.concat(root, Asset)
+    fixture = write_sql_fixture!("sql_asset_query.sql", "select @country as country")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
+        use Favn.SQLAsset
+
+        @materialized :view
+
+        query file: #{inspect(fixture.relative)}
+      end
+      """,
+      fixture.owner_file
+    )
+
+    assert {:ok, %Definition{} = definition} = SQLAssetCompiler.fetch_definition(asset_module)
+    assert definition.sql == "select @country as country"
+    assert String.ends_with?(definition.raw_asset.sql_file, "sql_asset_query.sql")
+    assert definition.raw_asset.sql_line == 1
+    assert definition.template.span.start_line == 1
+  end
+
+  test "reports SQL file diagnostics for file-backed query bodies" do
+    root = Module.concat(__MODULE__, "BadFileBacked#{System.unique_integer([:positive])}")
+    asset_module = Module.concat(root, Asset)
+    fixture = write_sql_fixture!("sql_asset_bad_query.sql", "select @1bad")
+
+    error =
+      assert_raise CompileError, fn ->
+        Code.compile_string(
+          """
+          defmodule #{inspect(asset_module)} do
+            use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
+            use Favn.SQLAsset
+
+            @materialized :view
+
+            query file: #{inspect(fixture.relative)}
+          end
+          """,
+          fixture.owner_file
+        )
+      end
+
+    assert String.ends_with?(to_string(error.file), "sql_asset_bad_query.sql")
+    assert error.line == 1
+  end
+
   test "rejects deferred incremental strategy :merge at compile time" do
     assert_raise CompileError, ~r/incremental strategy :merge is not supported in Phase 4b/, fn ->
       compile_sql_asset_module("""
@@ -379,5 +431,21 @@ defmodule Favn.SQLAssetTest do
     |> String.trim_trailing()
     |> String.split("\n")
     |> Enum.map_join("\n", &(padding <> &1))
+  end
+
+  defp write_sql_fixture!(file_name, body) do
+    uniq = "sql_asset_#{System.unique_integer([:positive])}"
+    base = Path.join(File.cwd!(), "tmp/favn_test_#{uniq}")
+    owner_dir = Path.join(base, "lib/my_app")
+    sql_dir = Path.join(base, "sql")
+
+    File.mkdir_p!(owner_dir)
+    File.mkdir_p!(sql_dir)
+
+    owner_file = Path.join(owner_dir, "asset.ex")
+    sql_file = Path.join(sql_dir, file_name)
+    File.write!(sql_file, body)
+
+    %{owner_file: owner_file, relative: "../../sql/#{file_name}"}
   end
 end

--- a/test/sql_dsl_test.exs
+++ b/test/sql_dsl_test.exs
@@ -431,6 +431,39 @@ defmodule Favn.SQLDSLTest do
     end
   end
 
+  test "rejects symlinked SQL files that resolve outside project root" do
+    unique = System.unique_integer([:positive])
+    module_name = Module.concat(__MODULE__, "SymlinkEscape#{unique}")
+    base = Path.join(File.cwd!(), "tmp/favn_test_symlink_escape_#{unique}")
+    owner_dir = Path.join(base, "lib/my_app")
+    sql_dir = Path.join(base, "sql")
+    owner_file = Path.join(owner_dir, "sql_provider.ex")
+    outside_file = Path.join(System.tmp_dir!(), "favn_outside_sql_#{unique}.sql")
+    symlink_file = Path.join(sql_dir, "outside.sql")
+
+    File.mkdir_p!(owner_dir)
+    File.mkdir_p!(sql_dir)
+    File.write!(outside_file, "select @amount_cents")
+    File.ln_s!(outside_file, symlink_file)
+
+    on_exit(fn ->
+      _ = File.rm(outside_file)
+    end)
+
+    assert_raise CompileError, ~r/must not traverse symlinks/, fn ->
+      Code.compile_string(
+        """
+        defmodule #{inspect(module_name)} do
+          use Favn.SQL
+
+          defsql bad(amount_cents), file: "../../sql/outside.sql"
+        end
+        """,
+        owner_file
+      )
+    end
+  end
+
   defp write_sql_fixture!(file_name, body, root_key \\ nil) do
     key = root_key || "sql_dsl_#{System.unique_integer([:positive])}"
     base = Path.join(File.cwd!(), "tmp/favn_test_#{key}")

--- a/test/sql_dsl_test.exs
+++ b/test/sql_dsl_test.exs
@@ -314,4 +314,136 @@ defmodule Favn.SQLDSLTest do
                    )
                  end
   end
+
+  test "supports file-backed defsql definitions" do
+    root = Module.concat(__MODULE__, "FileBacked#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    asset_module = Module.concat(root, Asset)
+    root_key = "sql_dsl_shared_#{System.unique_integer([:positive])}"
+
+    cents_fixture =
+      write_sql_fixture!(
+        "cents_to_dollars.sql",
+        "cast((@amount_cents / 100.0) as numeric(16, 2))",
+        root_key
+      )
+
+    orders_fixture =
+      write_sql_fixture!(
+        "orders_in_window.sql",
+        """
+        select order_id, total_amount_cents
+        from sales.orders
+        where inserted_at >= @start_at and inserted_at < @end_at
+        """,
+        root_key
+      )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(sql_module)} do
+        use Favn.SQL
+
+        defsql cents_to_dollars(amount_cents), file: #{inspect(cents_fixture.relative)}
+        defsql orders_in_window(start_at, end_at), file: #{inspect(orders_fixture.relative)}
+      end
+      """,
+      cents_fixture.owner_file
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
+        use Favn.SQLAsset
+        use #{inspect(sql_module)}
+
+        @materialized :view
+
+        query do
+          ~SQL[
+          select cents_to_dollars(total_amount_cents)
+          from orders_in_window(@window_start, @window_end)
+          ]
+        end
+      end
+      """,
+      "test/dynamic_sql_dsl_test.exs"
+    )
+
+    definitions = sql_module.__favn_sql_definitions__()
+
+    assert Enum.any?(definitions, fn definition ->
+             definition.name == :cents_to_dollars and
+               String.ends_with?(definition.file, "cents_to_dollars.sql")
+           end)
+
+    assert Enum.any?(definitions, fn definition ->
+             definition.name == :orders_in_window and
+               String.ends_with?(definition.file, "orders_in_window.sql")
+           end)
+
+    assert {:ok, %Favn.SQLAsset.Definition{} = definition} =
+             SQLAssetCompiler.fetch_definition(asset_module)
+
+    assert Enum.any?(Template.calls(definition.template), fn %Template.Call{} = call ->
+             call.definition.name == :orders_in_window and call.context == :relation
+           end)
+  end
+
+  test "reports SQL file diagnostics for file-backed defsql" do
+    root = Module.concat(__MODULE__, "BadFileBacked#{System.unique_integer([:positive])}")
+    sql_module = Module.concat(root, SQL)
+    fixture = write_sql_fixture!("bad_defsql.sql", "@country + @missing")
+
+    error =
+      assert_raise CompileError, fn ->
+        Code.compile_string(
+          """
+          defmodule #{inspect(sql_module)} do
+            use Favn.SQL
+
+            defsql bad_filter(country), file: #{inspect(fixture.relative)}
+          end
+          """,
+          fixture.owner_file
+        )
+      end
+
+    assert String.ends_with?(to_string(error.file), "bad_defsql.sql")
+    assert error.line == 1
+  end
+
+  test "rejects file-backed SQL paths outside project root" do
+    module_name = Module.concat(__MODULE__, "PathEscape#{System.unique_integer([:positive])}")
+
+    assert_raise CompileError, ~r/must resolve inside the project root/, fn ->
+      Code.compile_string(
+        """
+        defmodule #{inspect(module_name)} do
+          use Favn.SQL
+
+          defsql bad(amount_cents), file: "../../../../outside.sql"
+        end
+        """,
+        "/tmp/favn_outside/lib/path_escape.ex"
+      )
+    end
+  end
+
+  defp write_sql_fixture!(file_name, body, root_key \\ nil) do
+    key = root_key || "sql_dsl_#{System.unique_integer([:positive])}"
+    base = Path.join(File.cwd!(), "tmp/favn_test_#{key}")
+    owner_dir = Path.join(base, "lib/my_app")
+    sql_dir = Path.join(base, "sql")
+
+    File.mkdir_p!(owner_dir)
+    File.mkdir_p!(sql_dir)
+
+    owner_file = Path.join(owner_dir, "sql_provider.ex")
+    sql_file = Path.join(sql_dir, file_name)
+    File.write!(sql_file, body)
+
+    %{owner_file: owner_file, relative: "../../sql/#{file_name}"}
+  end
 end


### PR DESCRIPTION
## Summary
- Add compile-time file-backed SQL loading for both SQL assets (`query file: \"...\"`) and reusable SQL macros (`defsql ..., file: \"...\"`) while keeping inline SQL forms unchanged.
- Keep file-backed SQL on the same canonical compilation/runtime path by compiling loaded SQL into the existing template IR, adding source metadata for `.sql` diagnostics, and tracking SQL files via `@external_resource` for recompilation.
- Extend docs/roadmap coverage and add focused tests for file-backed query/defsql authoring, SQL-file diagnostics, and project-root path validation.

## Validation
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`