### PR TITLE
Add v0.4 MultiAsset generated Elixir DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@
 
 - Plain Elixir functions become assets with metadata and dependencies.
 - Preferred single-asset authoring uses one module with `use Favn.Asset` and `def asset(ctx)`.
+- Advanced repetitive extraction authoring uses `use Favn.MultiAsset` with `asset :name do ... end` declarations and one shared `def asset(ctx)`.
 - SQL assets can be authored as one module with `use Favn.SQLAsset`, `query do ... end` or `query file: "..."`, and a real `~SQL""" ... """` sigil.
 - Assets can optionally own warehouse relations through `@relation`.
 - Dependency graphs are discovered automatically from asset definitions.
@@ -57,6 +58,41 @@ end
 - `@relation`
 
 Single-asset modules compile to one canonical `%Favn.Asset{}` with ref `{Module, :asset}`.
+
+## Advanced generated Elixir DSL
+
+`Favn.MultiAsset` is an advanced Elixir DSL for repetitive extraction assets.
+One module declares many generated assets with familiar metadata attributes while sharing one runtime `asset/1` function.
+
+```elixir
+defmodule MyApp.Raw.Shopify do
+  use Favn.MultiAsset
+
+  defaults do
+    meta owner: "data-platform", category: :shopify, tags: [:raw]
+
+    rest do
+      primary_key "id"
+      paginator :cursor, cursor_path: "links.next"
+      incremental cursor: "updated_at", start_param: "updated_at_min"
+      extra page_size: 250
+    end
+  end
+
+  @doc "Extract orders"
+  @relation true
+  asset :orders do
+    rest do
+      path "/orders.json"
+      data_path "orders"
+    end
+  end
+
+  def asset(ctx), do: MyApp.Shopify.Client.extract(ctx.asset.config, ctx)
+end
+```
+
+Generated assets compile into canonical `%Favn.Asset{}` refs like `{MyApp.Raw.Shopify, :orders}` and expose merged runtime config through `ctx.asset.config`.
 
 ## Preferred single-asset SQL DSL
 
@@ -301,7 +337,7 @@ config :favn,
 
 Key settings:
 
-- `asset_modules`: modules that define assets with `use Favn.Asset`, `use Favn.SQLAsset`, or `use Favn.Assets`.
+- `asset_modules`: modules that define assets with `use Favn.Asset`, `use Favn.MultiAsset`, `use Favn.SQLAsset`, or `use Favn.Assets`.
 - `pipeline_modules`: pipeline modules discovered by the scheduler runtime.
 - `:pubsub_name`: PubSub server name used for run event broadcasting.
 - `:scheduler`: trigger scheduler runtime options (`enabled`, `default_timezone`, `tick_ms`). `enabled` defaults to `true`; `tick_ms` defaults to `15_000`.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -190,6 +190,7 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] explicit runtime guard for unsupported incremental strategies such as `:merge` and current `:replace`
   - [x] window-aware incremental execution and explicit lookback handling
 - [ ] Multi-asset SQL modules
+- [x] Generated multi-asset Elixir DSL for repetitive extraction assets (`Favn.MultiAsset`)
 - [x] SQL file support
   - [x] `query file: "..."` for SQL asset main queries
   - [x] `defsql ..., file: "..."` for reusable SQL definitions

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -11,6 +11,7 @@ lib/
     ├── diagnostic.ex
     ├── assets.ex
     ├── namespace.ex
+    ├── multi_asset.ex
     ├── relation_ref.ex
     ├── assets/
     │   ├── compiler.ex

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -11,6 +11,7 @@ test/
 ├── favn_test.exs
 ├── freshness_test.exs
 ├── graph_index_test.exs
+├── multi_asset_test.exs
 ├── pipeline_sqlite_smoke_test.exs
 ├── pipeline_test.exs
 ├── planner_test.exs

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -31,6 +31,7 @@ defmodule Favn do
   Assets can be authored with:
 
     * `use Favn.Asset` (preferred single-asset module DSL)
+    * `use Favn.MultiAsset` (advanced generated multi-asset Elixir DSL)
     * `use Favn.Assets` (compact multi-asset module DSL)
 
   At compile time,
@@ -218,7 +219,35 @@ defmodule Favn do
   with `WITH` are excluded lexically from relation inference, including nested
   subquery scopes.
 
-  Compact multi-asset style uses `Favn.Assets`:
+  Advanced generated multi-asset extraction style uses `Favn.MultiAsset`:
+
+      defmodule MyApp.Raw.Shopify do
+        use Favn.MultiAsset
+
+        defaults do
+          meta owner: "data-platform", category: :shopify, tags: [:raw]
+
+          rest do
+            primary_key "id"
+            paginator :cursor, cursor_path: "links.next"
+          end
+        end
+
+        @doc "Extract orders"
+        @relation true
+        asset :orders do
+          rest do
+            path "/orders.json"
+            data_path "orders"
+          end
+        end
+
+        def asset(ctx) do
+          MyApp.Shopify.Client.extract(ctx.asset.config, ctx)
+        end
+      end
+
+  Compact multi-asset function style uses `Favn.Assets`:
 
   A simplified example:
 
@@ -308,7 +337,7 @@ defmodule Favn do
   A consumer application typically sets Favn up in four steps:
 
     1. add `:favn` as a dependency in `mix.exs`
-    2. define one or more asset modules with `use Favn.Asset` and/or `use Favn.Assets`
+    2. define one or more asset modules with `use Favn.Asset`, `use Favn.MultiAsset`, and/or `use Favn.Assets`
     3. register those modules under `config :favn, asset_modules: [...]`
     4. start the host application normally
 

--- a/lib/favn/asset.ex
+++ b/lib/favn/asset.ex
@@ -115,6 +115,7 @@ defmodule Favn.Asset do
   @type t :: %__MODULE__{
           module: module(),
           name: atom(),
+          entrypoint: atom() | nil,
           ref: Ref.t(),
           arity: non_neg_integer(),
           type: :elixir | :sql | :source,
@@ -125,6 +126,7 @@ defmodule Favn.Asset do
           meta: map(),
           depends_on: [Ref.t()],
           dependencies: [Dependency.t()],
+          config: map(),
           window_spec: Spec.t() | nil,
           relation: RelationRef.t() | nil,
           materialization: Favn.SQLAsset.Materialization.t() | nil,
@@ -140,6 +142,7 @@ defmodule Favn.Asset do
   defstruct [
     :module,
     :name,
+    :entrypoint,
     :ref,
     :arity,
     :title,
@@ -150,6 +153,7 @@ defmodule Favn.Asset do
     meta: %{},
     depends_on: [],
     dependencies: [],
+    config: %{},
     window_spec: nil,
     relation: nil,
     materialization: nil,
@@ -172,6 +176,8 @@ defmodule Favn.Asset do
   def validate!(%__MODULE__{} = asset) do
     meta = normalize_meta!(asset.meta)
     validate_depends_on!(asset.depends_on)
+    validate_entrypoint!(asset.entrypoint)
+    validate_config!(asset.config)
     validate_window_spec!(asset.window_spec)
     validate_relation!(asset.relation)
     validate_type!(asset.type)
@@ -257,6 +263,19 @@ defmodule Favn.Asset do
           "asset depends_on must be a list of Favn.Ref values, got: #{inspect(depends_on)}"
   end
 
+  defp validate_entrypoint!(entrypoint) when is_atom(entrypoint) or is_nil(entrypoint), do: :ok
+
+  defp validate_entrypoint!(entrypoint) do
+    raise ArgumentError,
+          "asset entrypoint must be an atom or nil, got: #{inspect(entrypoint)}"
+  end
+
+  defp validate_config!(config) when is_map(config), do: :ok
+
+  defp validate_config!(config) do
+    raise ArgumentError, "asset config must be a map, got: #{inspect(config)}"
+  end
+
   defp validate_window_spec!(nil), do: :ok
 
   defp validate_window_spec!(%Spec{} = spec) do
@@ -336,6 +355,7 @@ defmodule Favn.Asset do
     asset = %__MODULE__{
       module: raw_asset.module,
       name: :asset,
+      entrypoint: :asset,
       ref: Ref.new(raw_asset.module, :asset),
       arity: 1,
       type: :elixir,
@@ -345,6 +365,7 @@ defmodule Favn.Asset do
       line: raw_asset.line,
       meta: meta,
       depends_on: depends_on,
+      config: %{},
       window_spec: window_spec
     }
 

--- a/lib/favn/assets.ex
+++ b/lib/favn/assets.ex
@@ -178,6 +178,7 @@ defmodule Favn.Assets do
     asset = %Asset{
       module: raw_asset.module,
       name: raw_asset.name,
+      entrypoint: raw_asset.name,
       ref: Ref.new(raw_asset.module, raw_asset.name),
       arity: raw_asset.arity,
       doc: raw_asset.doc,
@@ -186,6 +187,7 @@ defmodule Favn.Assets do
       title: title,
       meta: meta,
       depends_on: depends_on,
+      config: %{},
       window_spec: window_spec
     }
 

--- a/lib/favn/multi_asset.ex
+++ b/lib/favn/multi_asset.ex
@@ -1,0 +1,665 @@
+defmodule Favn.MultiAsset do
+  @moduledoc """
+  Advanced Elixir DSL for compiling one module into many canonical assets.
+
+  `Favn.MultiAsset` keeps the shared `%Favn.Asset{}` model and runtime contract,
+  while allowing repetitive extraction patterns to share one `asset/1` runtime
+  entrypoint and per-asset compile-time config.
+  """
+
+  alias Favn.Asset
+  alias Favn.Ref
+  alias Favn.Window.Spec
+
+  @doc false
+  defmacro __using__(_opts) do
+    quote do
+      Module.register_attribute(__MODULE__, :depends, accumulate: true)
+      Module.register_attribute(__MODULE__, :meta, persist: false)
+      Module.register_attribute(__MODULE__, :relation, accumulate: true)
+      Module.register_attribute(__MODULE__, :window, accumulate: true)
+      Module.register_attribute(__MODULE__, :favn_multi_asset_defaults_raw, persist: true)
+
+      Module.register_attribute(__MODULE__, :favn_multi_assets_raw, persist: true)
+      Module.register_attribute(__MODULE__, :favn_multi_asset_decls, persist: true)
+
+      Module.register_attribute(__MODULE__, :favn_multi_asset_runtime_count, persist: false)
+      Module.register_attribute(__MODULE__, :favn_multi_asset_generating, persist: false)
+
+      @favn_multi_asset_runtime_count 0
+      @favn_multi_assets_raw []
+      @favn_multi_asset_decls []
+
+      @on_definition Favn.MultiAsset
+      @before_compile Favn.MultiAsset
+
+      import Favn.MultiAsset, only: [defaults: 1, asset: 2]
+    end
+  end
+
+  @doc false
+  def __on_definition__(env, kind, name, args, _guards, _body) do
+    arity = length(args || [])
+
+    generated_definition? =
+      Module.get_attribute(env.module, :favn_multi_asset_generating) == true and
+        kind == :def and
+        name in [:__favn_assets__, :__favn_assets_raw__]
+
+    if generated_definition? do
+      :ok
+    else
+      case {kind, name, arity} do
+        {:def, :asset, 1} ->
+          increment_runtime_count!(env)
+
+        {:defp, name, 1} when name != :asset ->
+          if is_generated_decl_name?(name) do
+            capture_generated_asset_definition!(env, name)
+          else
+            validate_no_stray_asset_attributes!(env, kind, name, arity)
+          end
+
+        {:def, :asset, _other_arity} ->
+          compile_error!(
+            env.file,
+            env.line,
+            "Favn.MultiAsset requires exactly one public asset/1 function"
+          )
+
+        {:defp, :asset, _arity} ->
+          compile_error!(
+            env.file,
+            env.line,
+            "Favn.MultiAsset requires a public def asset(ctx)"
+          )
+
+        {kind, _name, _arity} when kind in [:def, :defp] ->
+          validate_no_stray_asset_attributes!(env, kind, name, arity)
+
+        _ ->
+          :ok
+      end
+    end
+  end
+
+  @doc false
+  defmacro defaults(do: block) do
+    current = Module.get_attribute(__CALLER__.module, :favn_multi_asset_defaults_raw)
+
+    if current do
+      compile_error!(
+        __CALLER__.file,
+        __CALLER__.line,
+        "multiple defaults blocks are not allowed; use at most one defaults do ... end"
+      )
+    end
+
+    defaults = normalize_defaults_block!(block, __CALLER__)
+    Module.put_attribute(__CALLER__.module, :favn_multi_asset_defaults_raw, defaults)
+
+    quote do
+      :ok
+    end
+  end
+
+  defmacro asset(name, do: block) do
+    if not is_atom(name) do
+      compile_error!(
+        __CALLER__.file,
+        __CALLER__.line,
+        "asset name must be an atom, got: #{Macro.to_string(name)}"
+      )
+    end
+
+    asset_rest = normalize_asset_block!(block, __CALLER__, name)
+
+    raw_decl = %{
+      name: name,
+      file: normalize_file(__CALLER__.file),
+      line: __CALLER__.line,
+      rest: asset_rest
+    }
+
+    decl_fun = decl_fun_name(name)
+
+    quote do
+      @favn_multi_asset_decls [
+        {unquote(decl_fun), unquote(Macro.escape(raw_decl))} | @favn_multi_asset_decls
+      ]
+
+      defp unquote(decl_fun)(_ctx), do: :ok
+      :ok
+    end
+  end
+
+  @doc false
+  defmacro __before_compile__(env) do
+    runtime_count = Module.get_attribute(env.module, :favn_multi_asset_runtime_count) || 0
+
+    if runtime_count != 1 do
+      compile_error!(
+        env.file,
+        env.line,
+        "Favn.MultiAsset modules must define exactly one public asset/1 function"
+      )
+    end
+
+    raw_assets =
+      env.module
+      |> Module.get_attribute(:favn_multi_assets_raw)
+      |> Enum.reverse()
+
+    if raw_assets == [] do
+      compile_error!(
+        env.file,
+        env.line,
+        "Favn.MultiAsset modules must declare at least one asset :name do ... end"
+      )
+    end
+
+    _ = validate_unique_names!(raw_assets)
+    assets = Enum.map(raw_assets, &build_asset!/1)
+
+    Module.put_attribute(env.module, :favn_multi_asset_generating, true)
+
+    quote do
+      @doc false
+      @spec __favn_assets__() :: [Favn.Asset.t()]
+      def __favn_assets__, do: unquote(Macro.escape(assets))
+
+      @doc false
+      def __favn_assets_raw__, do: unquote(Macro.escape(raw_assets))
+    end
+  end
+
+  defp increment_runtime_count!(env) do
+    count = Module.get_attribute(env.module, :favn_multi_asset_runtime_count) || 0
+    Module.put_attribute(env.module, :favn_multi_asset_runtime_count, count + 1)
+  end
+
+  defp is_generated_decl_name?(name) when is_atom(name) do
+    name
+    |> Atom.to_string()
+    |> String.starts_with?("__favn_multi_asset_decl__")
+  end
+
+  defp decl_fun_name(name) when is_atom(name),
+    do: String.to_atom("__favn_multi_asset_decl__#{name}")
+
+  defp capture_generated_asset_definition!(env, decl_fun) do
+    decl = fetch_decl!(env.module, decl_fun, env)
+
+    depends = env.module |> fetch_accum_attribute(:depends) |> Enum.reverse()
+    meta = Module.get_attribute(env.module, :meta)
+    window = env.module |> fetch_accum_attribute(:window) |> Enum.reverse()
+    relation = env.module |> fetch_accum_attribute(:relation) |> Enum.reverse()
+    doc = normalize_doc(Module.get_attribute(env.module, :doc))
+
+    validate_relation_attr!(relation, env)
+
+    Module.delete_attribute(env.module, :depends)
+    Module.delete_attribute(env.module, :meta)
+    Module.delete_attribute(env.module, :window)
+    Module.delete_attribute(env.module, :relation)
+    clear_doc!(env.module, env.line)
+
+    defaults =
+      Module.get_attribute(env.module, :favn_multi_asset_defaults_raw) ||
+        %{meta: %{}, window_spec: nil, rest: nil}
+
+    merged_meta =
+      defaults.meta
+      |> Map.merge(normalize_meta!(meta, env))
+
+    merged_window = normalize_window!(window, env) || defaults.window_spec
+    merged_rest = merge_rest(defaults.rest, decl.rest)
+    merged_config = if is_nil(merged_rest), do: %{}, else: %{rest: merged_rest}
+
+    raw_asset = %{
+      module: env.module,
+      name: decl.name,
+      entrypoint: :asset,
+      arity: 1,
+      doc: doc,
+      file: decl.file,
+      line: decl.line,
+      depends: depends,
+      meta: merged_meta,
+      window_spec: merged_window,
+      relation: relation,
+      config: merged_config
+    }
+
+    raw_assets = Module.get_attribute(env.module, :favn_multi_assets_raw) || []
+    Module.put_attribute(env.module, :favn_multi_assets_raw, [raw_asset | raw_assets])
+  end
+
+  defp fetch_decl!(module, decl_fun, env) do
+    decls = Module.get_attribute(module, :favn_multi_asset_decls) || []
+
+    case Enum.find(decls, fn {name, _decl} -> name == decl_fun end) do
+      {_name, decl} ->
+        decl
+
+      nil ->
+        compile_error!(env.file, env.line, "internal error: missing declaration for #{decl_fun}")
+    end
+  end
+
+  defp validate_unique_names!(raw_assets) do
+    raw_assets
+    |> Enum.group_by(& &1.name)
+    |> Enum.each(fn {name, assets} ->
+      case assets do
+        [_single] ->
+          :ok
+
+        [first | _rest] ->
+          compile_error!(
+            first.file,
+            first.line,
+            "duplicate asset name #{inspect(name)}; asset names must be unique within a module"
+          )
+      end
+    end)
+
+    raw_assets
+  end
+
+  defp build_asset!(raw_asset) do
+    depends_on = normalize_depends!(raw_asset.depends, raw_asset)
+
+    asset = %Asset{
+      module: raw_asset.module,
+      name: raw_asset.name,
+      entrypoint: raw_asset.entrypoint,
+      ref: Ref.new(raw_asset.module, raw_asset.name),
+      arity: raw_asset.arity,
+      type: :elixir,
+      title: nil,
+      doc: raw_asset.doc,
+      file: raw_asset.file,
+      line: raw_asset.line,
+      meta: raw_asset.meta,
+      depends_on: depends_on,
+      config: raw_asset.config,
+      window_spec: raw_asset.window_spec
+    }
+
+    try do
+      Asset.validate!(asset)
+    rescue
+      error in ArgumentError ->
+        compile_error!(raw_asset.file, raw_asset.line, error.message)
+    end
+  end
+
+  defp normalize_defaults_block!(block, env) do
+    {meta, window_spec, rest, rest_count} =
+      block_expressions(block)
+      |> Enum.reduce({%{}, nil, nil, 0}, fn expression, {meta, window_spec, rest, rest_count} ->
+        case expression do
+          {:meta, _meta, [meta_ast]} ->
+            {normalize_meta!(eval_quoted!(meta_ast, env), env), window_spec, rest, rest_count}
+
+          {:window, _meta, [window_ast]} ->
+            {meta, normalize_window_value!(eval_quoted!(window_ast, env), env), rest, rest_count}
+
+          {:rest, _meta, [[do: rest_block]]} ->
+            if rest_count > 0 do
+              compile_error!(
+                env.file,
+                env.line,
+                "multiple rest blocks are not allowed inside defaults"
+              )
+            end
+
+            {meta, window_spec, normalize_rest_block!(rest_block, env), rest_count + 1}
+
+          other ->
+            compile_error!(
+              env.file,
+              env.line,
+              "defaults only supports meta, window, and rest blocks; got: #{Macro.to_string(other)}"
+            )
+        end
+      end)
+
+    _ = rest_count
+    %{meta: meta, window_spec: window_spec, rest: rest}
+  end
+
+  defp normalize_asset_block!(block, env, name) do
+    {rest, rest_count} =
+      block_expressions(block)
+      |> Enum.reduce({nil, 0}, fn expression, {_rest, rest_count} ->
+        case expression do
+          {:rest, _meta, [[do: rest_block]]} ->
+            if rest_count > 0 do
+              compile_error!(
+                env.file,
+                env.line,
+                "multiple rest blocks are not allowed inside asset #{inspect(name)}"
+              )
+            end
+
+            {normalize_rest_block!(rest_block, env), rest_count + 1}
+
+          other ->
+            compile_error!(
+              env.file,
+              env.line,
+              "asset blocks only support rest do ... end in v0.4; got: #{Macro.to_string(other)}"
+            )
+        end
+      end)
+
+    _ = rest_count
+    rest
+  end
+
+  defp normalize_rest_block!(block, env) do
+    block_expressions(block)
+    |> Enum.reduce(%{}, fn expression, acc ->
+      case expression do
+        {:path, _meta, [value_ast]} ->
+          put_unique_rest_slot!(
+            acc,
+            :path,
+            normalize_binary!(eval_quoted!(value_ast, env), :path, env),
+            env
+          )
+
+        {:data_path, _meta, [value_ast]} ->
+          put_unique_rest_slot!(
+            acc,
+            :data_path,
+            normalize_binary!(eval_quoted!(value_ast, env), :data_path, env),
+            env
+          )
+
+        {:params, _meta, [value_ast]} ->
+          put_unique_rest_slot!(
+            acc,
+            :params,
+            normalize_map_like!(eval_quoted!(value_ast, env), "rest.params", env),
+            env
+          )
+
+        {:primary_key, _meta, [value_ast]} ->
+          put_unique_rest_slot!(
+            acc,
+            :primary_key,
+            normalize_binary!(eval_quoted!(value_ast, env), :primary_key, env),
+            env
+          )
+
+        {:paginator, _meta, [kind_ast, opts_ast]} ->
+          kind = eval_quoted!(kind_ast, env)
+
+          if not is_atom(kind) do
+            compile_error!(
+              env.file,
+              env.line,
+              "rest.paginator kind must be an atom, got: #{inspect(kind)}"
+            )
+          end
+
+          opts = normalize_map_like!(eval_quoted!(opts_ast, env), "rest.paginator options", env)
+
+          put_unique_rest_slot!(acc, :paginator, Map.put(opts, :kind, kind), env)
+
+        {:incremental, _meta, [opts_ast]} ->
+          opts = normalize_map_like!(eval_quoted!(opts_ast, env), "rest.incremental options", env)
+          put_unique_rest_slot!(acc, :incremental, Map.put_new(opts, :kind, :cursor), env)
+
+        {:method, _meta, [value_ast]} ->
+          value = eval_quoted!(value_ast, env)
+
+          if not (is_atom(value) or is_binary(value)) do
+            compile_error!(
+              env.file,
+              env.line,
+              "rest.method must be an atom or string, got: #{inspect(value)}"
+            )
+          end
+
+          put_unique_rest_slot!(acc, :method, value, env)
+
+        {:extra, _meta, [value_ast]} ->
+          put_unique_rest_slot!(
+            acc,
+            :extra,
+            normalize_map_like!(eval_quoted!(value_ast, env), "rest.extra", env),
+            env
+          )
+
+        other ->
+          compile_error!(
+            env.file,
+            env.line,
+            "rest only supports path, data_path, params, primary_key, paginator, incremental, method, and extra; got: #{Macro.to_string(other)}"
+          )
+      end
+    end)
+  end
+
+  defp put_unique_rest_slot!(acc, key, value, env) do
+    if Map.has_key?(acc, key) do
+      compile_error!(env.file, env.line, "multiple rest.#{key} entries are not allowed")
+    end
+
+    Map.put(acc, key, value)
+  end
+
+  defp normalize_depends!(depends, raw_asset) do
+    Enum.map(depends, fn
+      name when is_atom(name) ->
+        Ref.new(raw_asset.module, name)
+
+      {module, name} when is_atom(module) and is_atom(name) ->
+        Ref.new(module, name)
+
+      dependency ->
+        compile_error!(
+          raw_asset.file,
+          raw_asset.line,
+          "invalid @depends entry #{inspect(dependency)}; expected :asset_name or {Module, :asset_name}"
+        )
+    end)
+  end
+
+  defp normalize_meta!(meta, _env) when is_nil(meta), do: %{}
+
+  defp normalize_meta!(meta, env) do
+    Asset.normalize_meta!(meta)
+  rescue
+    error in ArgumentError ->
+      compile_error!(env.file, env.line, error.message)
+  end
+
+  defp normalize_window!([], _env), do: nil
+  defp normalize_window!([%Spec{} = spec], _env), do: spec
+
+  defp normalize_window!([_a, _b | _rest], env) do
+    compile_error!(
+      env.file,
+      env.line,
+      "multiple @window attributes are not allowed; use at most one @window per asset declaration"
+    )
+  end
+
+  defp normalize_window!(value, env) do
+    compile_error!(
+      env.file,
+      env.line,
+      "invalid @window value #{inspect(value)}; expected Favn.Window spec like Favn.Window.daily()"
+    )
+  end
+
+  defp normalize_window_value!(%Spec{} = spec, _env), do: spec
+
+  defp normalize_window_value!(value, env) do
+    compile_error!(
+      env.file,
+      env.line,
+      "invalid defaults window value #{inspect(value)}; expected Favn.Window spec like Favn.Window.daily()"
+    )
+  end
+
+  defp validate_relation_attr!([], _env), do: :ok
+
+  defp validate_relation_attr!([relation], env) do
+    valid? =
+      relation == true or (is_list(relation) and Keyword.keyword?(relation)) or is_map(relation)
+
+    if valid? do
+      :ok
+    else
+      compile_error!(
+        env.file,
+        env.line,
+        "invalid @relation value #{inspect(relation)}; expected true, a keyword list, or a map"
+      )
+    end
+  end
+
+  defp validate_relation_attr!([_a, _b | _rest], env) do
+    compile_error!(
+      env.file,
+      env.line,
+      "multiple @relation attributes are not allowed; use at most one @relation per asset declaration"
+    )
+  end
+
+  defp validate_no_stray_asset_attributes!(env, kind, name, arity) do
+    depends = fetch_accum_attribute(env.module, :depends)
+    meta = Module.get_attribute(env.module, :meta)
+    window = fetch_accum_attribute(env.module, :window)
+    relation = fetch_accum_attribute(env.module, :relation)
+    doc = normalize_doc(Module.get_attribute(env.module, :doc))
+
+    if depends != [] or not is_nil(meta) or window != [] or relation != [] or not is_nil(doc) do
+      Module.delete_attribute(env.module, :depends)
+      Module.delete_attribute(env.module, :meta)
+      Module.delete_attribute(env.module, :window)
+      Module.delete_attribute(env.module, :relation)
+      clear_doc!(env.module, env.line)
+
+      compile_error!(
+        env.file,
+        env.line,
+        "@doc/@depends/@meta/@window/@relation on #{kind} #{name}/#{arity} requires asset :name do immediately below those attributes"
+      )
+    else
+      :ok
+    end
+  end
+
+  defp merge_rest(nil, nil), do: nil
+  defp merge_rest(nil, asset_rest) when is_map(asset_rest), do: asset_rest
+  defp merge_rest(default_rest, nil) when is_map(default_rest), do: default_rest
+
+  defp merge_rest(default_rest, asset_rest) do
+    merged = Map.merge(default_rest, asset_rest)
+    merged = merge_nested_map(merged, default_rest, asset_rest, :params)
+    merged = merge_nested_map(merged, default_rest, asset_rest, :extra)
+
+    if map_size(merged) == 0 do
+      nil
+    else
+      merged
+    end
+  end
+
+  defp merge_nested_map(merged, defaults, overrides, key) do
+    default_map = Map.get(defaults, key)
+    override_map = Map.get(overrides, key)
+
+    map =
+      case {default_map, override_map} do
+        {nil, nil} -> nil
+        {nil, override_map} -> override_map
+        {default_map, nil} -> default_map
+        {default_map, override_map} -> Map.merge(default_map, override_map)
+      end
+
+    if is_nil(map) do
+      Map.delete(merged, key)
+    else
+      Map.put(merged, key, map)
+    end
+  end
+
+  defp normalize_map_like!(value, label, env) when is_list(value) do
+    if Keyword.keyword?(value) do
+      Map.new(value)
+    else
+      compile_error!(
+        env.file,
+        env.line,
+        "#{label} must be a keyword list or map, got: #{inspect(value)}"
+      )
+    end
+  end
+
+  defp normalize_map_like!(value, _label, _env) when is_map(value), do: value
+
+  defp normalize_map_like!(value, label, env) do
+    compile_error!(
+      env.file,
+      env.line,
+      "#{label} must be a keyword list or map, got: #{inspect(value)}"
+    )
+  end
+
+  defp normalize_binary!(value, _field, _env) when is_binary(value), do: value
+
+  defp normalize_binary!(value, field, env) do
+    compile_error!(
+      env.file,
+      env.line,
+      "rest.#{field} must be a string, got: #{inspect(value)}"
+    )
+  end
+
+  defp eval_quoted!(ast, env) do
+    {value, _bindings} = Code.eval_quoted(ast, [], env)
+    value
+  rescue
+    error in [CompileError, SyntaxError, ArgumentError] ->
+      compile_error!(env.file, env.line, Exception.message(error))
+  end
+
+  defp block_expressions({:__block__, _meta, expressions}), do: expressions
+  defp block_expressions(nil), do: []
+  defp block_expressions(expression), do: [expression]
+
+  defp fetch_accum_attribute(module, attribute) do
+    case Module.get_attribute(module, attribute) do
+      nil -> []
+      value when is_list(value) -> value
+    end
+  end
+
+  defp normalize_doc({_line, false}), do: nil
+  defp normalize_doc({_line, doc}) when is_binary(doc), do: doc
+  defp normalize_doc(false), do: nil
+  defp normalize_doc(doc) when is_binary(doc), do: doc
+  defp normalize_doc(_), do: nil
+
+  defp normalize_file(file) do
+    file
+    |> to_string()
+    |> Path.relative_to_cwd()
+  end
+
+  defp compile_error!(file, line, description) do
+    raise CompileError, file: file, line: line, description: description
+  end
+
+  defp clear_doc!(module, line) do
+    Module.put_attribute(module, :doc, {line, false})
+  end
+end

--- a/lib/favn/multi_asset.ex
+++ b/lib/favn/multi_asset.ex
@@ -8,7 +8,9 @@ defmodule Favn.MultiAsset do
   """
 
   alias Favn.Asset
+  alias Favn.Namespace
   alias Favn.Ref
+  alias Favn.RelationRef
   alias Favn.Window.Spec
 
   @doc false
@@ -51,6 +53,7 @@ defmodule Favn.MultiAsset do
     else
       case {kind, name, arity} do
         {:def, :asset, 1} ->
+          validate_no_stray_asset_attributes!(env, kind, name, arity)
           increment_runtime_count!(env)
 
         {:defp, name, 1} when name != :asset ->
@@ -85,6 +88,8 @@ defmodule Favn.MultiAsset do
 
   @doc false
   defmacro defaults(do: block) do
+    ensure_no_pending_attributes!(__CALLER__)
+
     current = Module.get_attribute(__CALLER__.module, :favn_multi_asset_defaults_raw)
 
     if current do
@@ -98,7 +103,10 @@ defmodule Favn.MultiAsset do
     defaults = normalize_defaults_block!(block, __CALLER__)
     Module.put_attribute(__CALLER__.module, :favn_multi_asset_defaults_raw, defaults)
 
+    marker_fun = defaults_marker_fun_name(__CALLER__.line)
+
     quote do
+      defp unquote(marker_fun)(), do: :ok
       :ok
     end
   end
@@ -145,6 +153,8 @@ defmodule Favn.MultiAsset do
       )
     end
 
+    ensure_no_pending_attributes!(env)
+
     raw_assets =
       env.module
       |> Module.get_attribute(:favn_multi_assets_raw)
@@ -159,7 +169,8 @@ defmodule Favn.MultiAsset do
     end
 
     _ = validate_unique_names!(raw_assets)
-    assets = Enum.map(raw_assets, &build_asset!/1)
+    assets = raw_assets |> Enum.map(&build_asset!/1) |> resolve_relations!(env.module, env)
+    _ = ensure_unique_relation_owners!(assets, env)
 
     Module.put_attribute(env.module, :favn_multi_asset_generating, true)
 
@@ -186,6 +197,9 @@ defmodule Favn.MultiAsset do
 
   defp decl_fun_name(name) when is_atom(name),
     do: String.to_atom("__favn_multi_asset_decl__#{name}")
+
+  defp defaults_marker_fun_name(line),
+    do: String.to_atom("__favn_multi_asset_defaults_marker__#{line}")
 
   defp capture_generated_asset_definition!(env, decl_fun) do
     decl = fetch_decl!(env.module, decl_fun, env)
@@ -456,7 +470,15 @@ defmodule Favn.MultiAsset do
   defp normalize_depends!(depends, raw_asset) do
     Enum.map(depends, fn
       name when is_atom(name) ->
-        Ref.new(raw_asset.module, name)
+        if module_atom?(name) do
+          compile_error!(
+            raw_asset.file,
+            raw_asset.line,
+            "invalid @depends entry #{inspect(name)}; expected :asset_name or {Module, :asset_name}; module shorthand is not supported in Favn.MultiAsset"
+          )
+        else
+          Ref.new(raw_asset.module, name)
+        end
 
       {module, name} when is_atom(module) and is_atom(name) ->
         Ref.new(module, name)
@@ -468,6 +490,109 @@ defmodule Favn.MultiAsset do
           "invalid @depends entry #{inspect(dependency)}; expected :asset_name or {Module, :asset_name}"
         )
     end)
+  end
+
+  defp resolve_relations!(assets, module, env) do
+    defaults = Namespace.resolve_relation(module)
+
+    Enum.map(assets, fn %Asset{} = asset ->
+      inferred_name = asset.name
+
+      relation =
+        case fetch_raw_relation(module, asset.name) do
+          nil ->
+            asset.relation
+
+          true ->
+            RelationRef.new!(Map.put(defaults, :name, inferred_name))
+
+          attrs when is_list(attrs) ->
+            if Keyword.keyword?(attrs) do
+              attrs
+              |> Map.new()
+              |> merge_relation_attrs(defaults, inferred_name)
+              |> RelationRef.new!()
+            else
+              compile_error!(
+                env.file,
+                env.line,
+                "invalid @relation value #{inspect(attrs)}; expected true, a keyword list, or a map"
+              )
+            end
+
+          attrs when is_map(attrs) ->
+            attrs
+            |> merge_relation_attrs(defaults, inferred_name)
+            |> RelationRef.new!()
+
+          other ->
+            compile_error!(
+              env.file,
+              env.line,
+              "invalid @relation value #{inspect(other)}; expected true, a keyword list, or a map"
+            )
+        end
+
+      %{asset | relation: relation}
+    end)
+  rescue
+    error in ArgumentError ->
+      compile_error!(env.file, env.line, error.message)
+  end
+
+  defp fetch_raw_relation(module, name) do
+    with entries when is_list(entries) <- Module.get_attribute(module, :favn_multi_assets_raw),
+         %{relation: relation} <- Enum.find(entries, &(&1.name == name)) do
+      case relation do
+        [] -> nil
+        [value] -> value
+      end
+    else
+      _ -> nil
+    end
+  end
+
+  defp merge_relation_attrs(attrs, defaults, asset_name) when is_map(attrs) do
+    attrs =
+      if has_explicit_name?(attrs) do
+        attrs
+      else
+        Map.put(attrs, :name, asset_name)
+      end
+
+    defaults
+    |> maybe_drop_default_key(attrs, [:catalog], [:database, "database"])
+    |> maybe_drop_default_key(attrs, [:name], [:table, "table", :name, "name"])
+    |> Map.merge(attrs)
+  end
+
+  defp has_explicit_name?(attrs) do
+    Enum.any?([:name, "name", :table, "table"], &Map.has_key?(attrs, &1))
+  end
+
+  defp maybe_drop_default_key(defaults, attrs, canonical_keys, authored_keys) do
+    if Enum.any?(authored_keys, &Map.has_key?(attrs, &1)) do
+      Enum.reduce(canonical_keys, defaults, &Map.delete(&2, &1))
+    else
+      defaults
+    end
+  end
+
+  defp ensure_unique_relation_owners!(assets, env) do
+    assets
+    |> Enum.reject(&is_nil(&1.relation))
+    |> Enum.group_by(& &1.relation)
+    |> Enum.each(fn {relation_ref, owners} ->
+      case owners do
+        [_single] ->
+          :ok
+
+        _many ->
+          compile_error!(env.file, env.line, "duplicate relation #{inspect(relation_ref)}")
+      end
+    end)
+
+    assets
   end
 
   defp normalize_meta!(meta, _env) when is_nil(meta), do: %{}
@@ -554,6 +679,39 @@ defmodule Favn.MultiAsset do
       )
     else
       :ok
+    end
+  end
+
+  defp ensure_no_pending_attributes!(env) do
+    depends = fetch_accum_attribute(env.module, :depends)
+    meta = Module.get_attribute(env.module, :meta)
+    window = fetch_accum_attribute(env.module, :window)
+    relation = fetch_accum_attribute(env.module, :relation)
+    pending_doc? = pending_doc?(env.module)
+
+    if depends != [] or not is_nil(meta) or window != [] or relation != [] or pending_doc? do
+      Module.delete_attribute(env.module, :depends)
+      Module.delete_attribute(env.module, :meta)
+      Module.delete_attribute(env.module, :window)
+      Module.delete_attribute(env.module, :relation)
+      clear_doc!(env.module, env.line)
+
+      compile_error!(
+        env.file,
+        env.line,
+        "@doc/@meta/@depends/@window/@relation must be attached to an immediately following asset :name do"
+      )
+    else
+      :ok
+    end
+  end
+
+  defp pending_doc?(module) do
+    case Module.get_attribute(module, :doc) do
+      nil -> false
+      false -> false
+      {_line, false} -> false
+      _ -> true
     end
   end
 
@@ -661,5 +819,11 @@ defmodule Favn.MultiAsset do
 
   defp clear_doc!(module, line) do
     Module.put_attribute(module, :doc, {line, false})
+  end
+
+  defp module_atom?(module) when is_atom(module) do
+    module
+    |> Atom.to_string()
+    |> String.starts_with?("Elixir.")
   end
 end

--- a/lib/favn/run/context.ex
+++ b/lib/favn/run/context.ex
@@ -10,7 +10,7 @@ defmodule Favn.Run.Context do
           run_id: String.t(),
           target_refs: [Ref.t()],
           current_ref: Ref.t(),
-          asset: %{ref: Ref.t(), relation: Favn.RelationRef.t() | nil},
+          asset: %{ref: Ref.t(), relation: Favn.RelationRef.t() | nil, config: map()},
           params: map(),
           window: Runtime.t() | nil,
           pipeline: map() | nil,

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -819,7 +819,7 @@ defmodule Favn.Runtime.Coordinator do
       run_id: state.run_id,
       target_refs: state.target_refs,
       current_ref: step.ref,
-      asset: %{ref: step.ref, relation: asset.relation},
+      asset: %{ref: step.ref, relation: asset.relation, config: asset.config},
       params: state.params,
       window: step.runtime_window,
       pipeline: state.pipeline_context,

--- a/lib/favn/runtime/executor/local.ex
+++ b/lib/favn/runtime/executor/local.ex
@@ -39,7 +39,9 @@ defmodule Favn.Runtime.Executor.Local do
   end
 
   defp invoke(asset, %Context{} = ctx) do
-    case apply(asset.module, asset.name, [ctx]) do
+    entrypoint = asset.entrypoint || asset.name
+
+    case apply(asset.module, entrypoint, [ctx]) do
       :ok ->
         {:ok, %{}}
 

--- a/lib/favn/source.ex
+++ b/lib/favn/source.ex
@@ -65,6 +65,7 @@ defmodule Favn.Source do
     asset = %Asset{
       module: env.module,
       name: :asset,
+      entrypoint: nil,
       ref: Ref.new(env.module, :asset),
       arity: 0,
       type: :source,
@@ -75,6 +76,7 @@ defmodule Favn.Source do
       meta: meta || %{},
       depends_on: [],
       dependencies: [],
+      config: %{},
       window_spec: nil,
       relation: nil,
       materialization: nil,

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -223,6 +223,7 @@ defmodule Favn.SQLAsset do
     asset = %Asset{
       module: raw_definition.module,
       name: :asset,
+      entrypoint: :asset,
       ref: Ref.new(raw_definition.module, :asset),
       arity: 1,
       type: :sql,
@@ -232,6 +233,7 @@ defmodule Favn.SQLAsset do
       line: raw_definition.line,
       meta: meta,
       depends_on: depends_on,
+      config: %{},
       relation_inputs: relation_inputs,
       window_spec: window_spec,
       relation: relation,

--- a/test/multi_asset_test.exs
+++ b/test/multi_asset_test.exs
@@ -2,7 +2,6 @@ defmodule Favn.MultiAssetTest do
   use ExUnit.Case, async: false
 
   alias Favn.Asset
-  alias Favn.Assets.Compiler
   alias Favn.RelationRef
   alias Favn.Run.Context
   alias Favn.Runtime.Executor.Local
@@ -127,7 +126,7 @@ defmodule Favn.MultiAssetTest do
              mod == module_name
            end)
 
-    assert {:ok, [orders, customers]} = Compiler.compile_module_assets(module_name)
+    [orders, customers] = module_name.__favn_assets__()
 
     assert orders.relation == %RelationRef{
              connection: :warehouse,
@@ -353,6 +352,65 @@ defmodule Favn.MultiAssetTest do
       def asset(_ctx), do: :ok
       """)
     end
+
+    assert_raise CompileError,
+                 ~r/module shorthand is not supported in Favn.MultiAsset/,
+                 fn ->
+                   compile_test_module("""
+                   use Favn.MultiAsset
+
+                   @depends #{inspect(Favn.AssetsTest.Upstream)}
+                   asset :orders do
+                     rest do
+                       path "/orders.json"
+                       data_path "orders"
+                     end
+                   end
+
+                   def asset(_ctx), do: :ok
+                   """)
+                 end
+
+    assert_raise CompileError,
+                 ~r/requires asset :name do immediately below/,
+                 fn ->
+                   compile_test_module("""
+                   use Favn.MultiAsset
+
+                   @doc "should-not-attach"
+                   defaults do
+                     meta owner: "x"
+                   end
+
+                   asset :orders do
+                     rest do
+                       path "/orders.json"
+                       data_path "orders"
+                     end
+                   end
+
+                   def asset(_ctx), do: :ok
+                   """)
+                 end
+
+    assert_raise CompileError,
+                 ~r/requires asset :name do immediately below/,
+                 fn ->
+                   compile_test_module("""
+                   use Favn.MultiAsset
+
+                   asset :orders do
+                     rest do
+                       path "/orders.json"
+                       data_path "orders"
+                     end
+                   end
+
+                   @meta owner: "late"
+
+                   def asset(_ctx), do: :ok
+                   """)
+                 end
   end
 
   defp compile_test_module(module_body) do

--- a/test/multi_asset_test.exs
+++ b/test/multi_asset_test.exs
@@ -1,0 +1,369 @@
+defmodule Favn.MultiAssetTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Asset
+  alias Favn.Assets.Compiler
+  alias Favn.RelationRef
+  alias Favn.Run.Context
+  alias Favn.Runtime.Executor.Local
+
+  test "compiles generated canonical assets with merged defaults and rest config" do
+    module_name = Module.concat(__MODULE__, "Shopify#{System.unique_integer([:positive])}")
+
+    source = """
+    defmodule #{inspect(module_name)} do
+      use Favn.MultiAsset
+
+      defaults do
+        meta owner: "data-platform", category: :shopify, tags: [:raw]
+        window Favn.Window.daily(lookback: 1)
+
+        rest do
+          primary_key "id"
+          paginator :cursor, cursor_path: "links.next"
+          incremental cursor: "updated_at", start_param: "updated_at_min"
+          extra page_size: 250
+        end
+      end
+
+      @doc "Extract orders"
+      @meta tags: [:orders]
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+          params status: "any"
+          extra include_metafields: true
+        end
+      end
+
+      @doc "Extract customers"
+      asset :customers do
+        rest do
+          path "/customers.json"
+          data_path "customers"
+        end
+      end
+
+      def asset(ctx), do: {:ok, %{rest: ctx.asset.config[:rest]}}
+    end
+    """
+
+    assert Enum.any?(Code.compile_string(source, "test/dynamic_multi_asset_test.exs"), fn {mod, _} ->
+             mod == module_name
+           end)
+
+    [orders, customers] = module_name.__favn_assets__()
+
+    assert %Asset{name: :orders, entrypoint: :asset, ref: {^module_name, :orders}} = orders
+
+    assert %Asset{name: :customers, entrypoint: :asset, ref: {^module_name, :customers}} =
+             customers
+
+    assert orders.meta == %{owner: "data-platform", category: :shopify, tags: [:orders]}
+    assert customers.meta == %{owner: "data-platform", category: :shopify, tags: [:raw]}
+
+    assert orders.window_spec == %Favn.Window.Spec{kind: :day, lookback: 1, timezone: "Etc/UTC"}
+
+    assert customers.window_spec == %Favn.Window.Spec{
+             kind: :day,
+             lookback: 1,
+             timezone: "Etc/UTC"
+           }
+
+    assert orders.config == %{
+             rest: %{
+               primary_key: "id",
+               paginator: %{kind: :cursor, cursor_path: "links.next"},
+               incremental: %{kind: :cursor, cursor: "updated_at", start_param: "updated_at_min"},
+               extra: %{page_size: 250, include_metafields: true},
+               path: "/orders.json",
+               data_path: "orders",
+               params: %{status: "any"}
+             }
+           }
+
+    assert customers.config == %{
+             rest: %{
+               primary_key: "id",
+               paginator: %{kind: :cursor, cursor_path: "links.next"},
+               incremental: %{kind: :cursor, cursor: "updated_at", start_param: "updated_at_min"},
+               extra: %{page_size: 250},
+               path: "/customers.json",
+               data_path: "customers"
+             }
+           }
+  end
+
+  test "relation defaults and @relation true infer generated asset names" do
+    module_name = Module.concat(__MODULE__, "Produces#{System.unique_integer([:positive])}")
+
+    source = """
+    defmodule #{inspect(module_name)} do
+      use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :shopify]
+      use Favn.MultiAsset
+
+      @relation true
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+        end
+      end
+
+      @relation true
+      asset :customers do
+        rest do
+          path "/customers.json"
+          data_path "customers"
+        end
+      end
+
+      def asset(_ctx), do: :ok
+    end
+    """
+
+    assert Enum.any?(Code.compile_string(source, "test/dynamic_multi_asset_test.exs"), fn {mod, _} ->
+             mod == module_name
+           end)
+
+    assert {:ok, [orders, customers]} = Compiler.compile_module_assets(module_name)
+
+    assert orders.relation == %RelationRef{
+             connection: :warehouse,
+             catalog: "raw",
+             schema: "shopify",
+             name: "orders"
+           }
+
+    assert customers.relation == %RelationRef{
+             connection: :warehouse,
+             catalog: "raw",
+             schema: "shopify",
+             name: "customers"
+           }
+  end
+
+  test "runtime executor invokes shared entrypoint and keeps generated ref" do
+    module_name = Module.concat(__MODULE__, "Runtime#{System.unique_integer([:positive])}")
+
+    source = """
+    defmodule #{inspect(module_name)} do
+      use Favn.MultiAsset
+
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+        end
+      end
+
+      def asset(ctx), do: {:ok, %{seen_ref: ctx.asset.ref, seen_config: ctx.asset.config}}
+    end
+    """
+
+    assert Enum.any?(Code.compile_string(source, "test/dynamic_multi_asset_test.exs"), fn {mod, _} ->
+             mod == module_name
+           end)
+
+    [asset] = module_name.__favn_assets__()
+
+    ctx = %Context{
+      run_id: "run",
+      target_refs: [asset.ref],
+      current_ref: asset.ref,
+      asset: %{ref: asset.ref, relation: nil, config: asset.config},
+      params: %{},
+      window: nil,
+      run_started_at: DateTime.utc_now(),
+      stage: 0,
+      attempt: 1,
+      max_attempts: 1
+    }
+
+    step_ref = {asset.ref, nil}
+
+    assert {:ok, %{exec_ref: exec_ref}} = Local.start_step(asset, ctx, self(), step_ref)
+
+    assert_receive {:executor_step_result, ^exec_ref, ^step_ref, {:ok, result_meta}}
+    assert result_meta.seen_ref == asset.ref
+    assert result_meta.seen_config == asset.config
+  end
+
+  test "supports local and tuple @depends refs" do
+    module_name = Module.concat(__MODULE__, "Depends#{System.unique_integer([:positive])}")
+
+    source = """
+    defmodule #{inspect(module_name)} do
+      use Favn.MultiAsset
+
+      asset :upstream do
+        rest do
+          path "/upstream.json"
+          data_path "upstream"
+        end
+      end
+
+      @depends :upstream
+      @depends {#{inspect(Favn.AssetsTest.Upstream)}, :source_rows}
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+        end
+      end
+
+      def asset(_ctx), do: :ok
+    end
+    """
+
+    assert Enum.any?(Code.compile_string(source, "test/dynamic_multi_asset_test.exs"), fn {mod, _} ->
+             mod == module_name
+           end)
+
+    [_upstream, orders] = module_name.__favn_assets__()
+
+    assert orders.depends_on == [
+             {module_name, :upstream},
+             {Favn.AssetsTest.Upstream, :source_rows}
+           ]
+  end
+
+  test "rejects invalid declarations and stray attributes" do
+    assert_raise CompileError, ~r/must define exactly one public asset\/1 function/, fn ->
+      compile_test_module("""
+      use Favn.MultiAsset
+
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+        end
+      end
+      """)
+    end
+
+    assert_raise CompileError, ~r/requires exactly one public asset\/1 function/, fn ->
+      compile_test_module("""
+      use Favn.MultiAsset
+
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+        end
+      end
+
+      def asset(_ctx, _opts), do: :ok
+      """)
+    end
+
+    assert_raise CompileError, ~r/requires a public def asset\(ctx\)/, fn ->
+      compile_test_module("""
+      use Favn.MultiAsset
+
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+        end
+      end
+
+      defp asset(_ctx), do: :ok
+      """)
+    end
+
+    assert_raise CompileError, ~r/duplicate asset name/, fn ->
+      compile_test_module("""
+      use Favn.MultiAsset
+
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+        end
+      end
+
+      asset :orders do
+        rest do
+          path "/orders-2.json"
+          data_path "orders"
+        end
+      end
+
+      def asset(_ctx), do: :ok
+      """)
+    end
+
+    assert_raise CompileError, ~r/multiple defaults blocks are not allowed/, fn ->
+      compile_test_module("""
+      use Favn.MultiAsset
+
+      defaults do
+        meta owner: "a"
+      end
+
+      defaults do
+        meta owner: "b"
+      end
+
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+        end
+      end
+
+      def asset(_ctx), do: :ok
+      """)
+    end
+
+    assert_raise CompileError,
+                 ~r/requires asset :name do immediately below/,
+                 fn ->
+                   compile_test_module("""
+                   use Favn.MultiAsset
+
+                   @meta owner: "data"
+                   def helper(_ctx), do: :ok
+
+                   asset :orders do
+                     rest do
+                       path "/orders.json"
+                       data_path "orders"
+                     end
+                   end
+
+                   def asset(_ctx), do: :ok
+                   """)
+                 end
+
+    assert_raise CompileError, ~r/rest.extra must be a keyword list or map/, fn ->
+      compile_test_module("""
+      use Favn.MultiAsset
+
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+          extra :bad
+        end
+      end
+
+      def asset(_ctx), do: :ok
+      """)
+    end
+  end
+
+  defp compile_test_module(module_body) do
+    module_name = Module.concat(__MODULE__, "Invalid#{System.unique_integer([:positive])}")
+
+    source = """
+    defmodule #{inspect(module_name)} do
+      #{module_body}
+    end
+    """
+
+    Code.compile_string(source, "test/dynamic_multi_asset_test.exs")
+  end
+end


### PR DESCRIPTION
## Summary
- Add `Favn.MultiAsset` as an advanced generated Elixir DSL that compiles one module into many canonical `%Favn.Asset{}` refs while keeping one shared public `asset/1` runtime entrypoint.
- Add default/per-asset `rest` config DSL with deterministic merge semantics, strict compile-time validations, and familiar metadata attachment (`@doc`, `@meta`, `@depends`, `@window`, `@relation`) to the immediately following `asset :name do` declaration.
- Extend canonical/runtime plumbing with `%Favn.Asset{entrypoint, config}` plus `ctx.asset.config`, and update runtime invocation to execute `asset.entrypoint` so generated refs like `{Module, :orders}` run through shared `asset/1`.
- Add `test/multi_asset_test.exs` and update docs (`README.md`, `lib/favn.ex`, `docs/FEATURES.md`, `docs/lib_structure.md`, `docs/test_structure.md`) to document the new authoring mode and structure changes.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`