### PR TITLE
Refactor public docs for agent-friendly DSL guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ config :favn,
 
 ```elixir
 Favn.list_assets()
-{:ok, run_id} = Favn.run_asset(MyApp.Raw.Sales.Orders)
+{:ok, run_id} = Favn.run_asset({MyApp.Raw.Sales.Orders, :asset})
 {:ok, run} = Favn.await_run(run_id)
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,45 +1,37 @@
 <div align="center">
   <img src="docs/images/favn-logo-transparent.png" alt="Favn logo" width="300" />
   <p><strong>Asset-first orchestration for Elixir</strong></p>
-  <p>Define business logic as assets. Let Favn discover dependencies, plan runs, and execute deterministic workflows.</p>
+  <p>Define assets close to the business logic. Let Favn discover dependencies, plan runs, and execute deterministic workflows.</p>
 </div>
 
-<p align="center">
-  <strong>Status:</strong> Not recommended for production. API and DSL may change.
-</p>
+## What Favn Is
 
-<p align="center">
-  <a href="#quickstart">Quickstart</a> •
-  <a href="#configuration">Configuration</a> •
-  <a href="#current-limitations">Current limitations</a> •
-  <a href="#roadmap-and-release-focus">Roadmap</a> •
-  <a href="#installation">Installation</a> • 
-  <a href="/docs/FEATURES.md">Features</a> • 
-  <a href="/lib/favn.ex">Docs</a>
+Favn is an Elixir library for defining, inspecting, and orchestrating data assets.
+It favors normal Elixir modules, explicit metadata, and dependency-driven execution over large framework-specific abstractions.
 
-</p>
+## Status
 
-## Favn at a glance
+Favn `v0.4.0` is complete.
 
-- Plain Elixir functions become assets with metadata and dependencies.
-- Preferred single-asset authoring uses one module with `use Favn.Asset` and `def asset(ctx)`.
-- Advanced repetitive extraction authoring uses `use Favn.MultiAsset` with `asset :name do ... end` declarations and one shared `def asset(ctx)`.
-- SQL assets can be authored as one module with `use Favn.SQLAsset`, `query do ... end` or `query file: "..."`, and a real `~SQL""" ... """` sigil.
-- Assets can optionally own warehouse relations through `@relation`.
-- Dependency graphs are discovered automatically from asset definitions.
-- Runs are planned deterministically and executed in dependency order.
-- Runtime state and run events are exposed through a small public API.
+- Private development project
+- Breaking changes are still allowed before `v1.0`
+- SQL assets, connections, schedules, pipelines, and windowing are available
 
-## Preferred single-asset DSL
+## Choose Your DSL
 
-Phase 2 introduces `Favn.Asset` as the preferred one-module-per-asset DSL:
+- `Favn.Asset`: preferred single-asset Elixir DSL
+- `Favn.SQLAsset`: preferred single-asset SQL DSL
+- `Favn.MultiAsset`: repetitive extraction assets with shared runtime logic
+- `Favn.Assets`: compact multi-asset function DSL; still supported, but use `Favn.Asset` for new single-asset modules
+
+## Quickstart
 
 ```elixir
-defmodule MyWarehouse.Raw.Sales.Orders do
+defmodule MyApp.Raw.Sales.Orders do
   use Favn.Namespace, relation: [connection: :warehouse, catalog: "raw", schema: "sales"]
   use Favn.Asset
 
-  @doc "Extract raw orders from upstream API"
+  @doc "Extract raw orders"
   @meta owner: "data-platform", category: :sales, tags: [:raw]
   @relation true
   def asset(ctx) do
@@ -49,567 +41,57 @@ defmodule MyWarehouse.Raw.Sales.Orders do
 end
 ```
 
-`Favn.Asset` supports:
-
-- `@doc`
-- `@meta`
-- `@depends` (module shorthand `@depends MyApp.UpstreamAsset` only for single-asset modules; use tuple refs for multi-asset modules)
-- `@window`
-- `@relation`
-
-Single-asset modules compile to one canonical `%Favn.Asset{}` with ref `{Module, :asset}`.
-
-## Advanced generated Elixir DSL
-
-`Favn.MultiAsset` is an advanced Elixir DSL for repetitive extraction assets.
-One module declares many generated assets with familiar metadata attributes while sharing one runtime `asset/1` function.
-
-```elixir
-defmodule MyApp.Raw.Shopify do
-  use Favn.MultiAsset
-
-  defaults do
-    meta owner: "data-platform", category: :shopify, tags: [:raw]
-
-    rest do
-      primary_key "id"
-      paginator :cursor, cursor_path: "links.next"
-      incremental cursor: "updated_at", start_param: "updated_at_min"
-      extra page_size: 250
-    end
-  end
-
-  @doc "Extract orders"
-  @relation true
-  asset :orders do
-    rest do
-      path "/orders.json"
-      data_path "orders"
-    end
-  end
-
-  def asset(ctx), do: MyApp.Shopify.Client.extract(ctx.asset.config, ctx)
-end
-```
-
-Generated assets compile into canonical `%Favn.Asset{}` refs like `{MyApp.Raw.Shopify, :orders}` and expose merged runtime config through `ctx.asset.config`.
-
-## Preferred single-asset SQL DSL
-
-Phase 3 introduces `Favn.SQLAsset` as the preferred one-module-per-asset SQL DSL:
-
-```elixir
-defmodule MyWarehouse.Gold.Sales.FctOrders do
-  use Favn.Namespace, relation: [connection: :warehouse, catalog: "gold", schema: "sales"]
-  use Favn.SQLAsset
-
-  @doc "Gold fact table for orders"
-  @meta owner: "analytics", category: :sales, tags: [:gold]
-  @depends MyWarehouse.Silver.Sales.StgOrders
-  @window Favn.Window.daily(lookback: 2)
-  @materialized {:incremental, strategy: :delete_insert, window_column: :order_date}
-
-  query do
-    ~SQL"""
-    select
-      order_id,
-      customer_id,
-      order_date,
-      total_amount
-    from silver.sales.stg_orders
-    """
-  end
-end
-```
-
-`Favn.SQLAsset` currently supports:
-
-- `@doc`
-- `@meta`
-- `@depends`
-- `@window`
-- `@materialized`
-- `@relation`
-
-SQL assets compile into the same canonical `%Favn.Asset{}` shape as Elixir assets, including ref `{Module, :asset}` and inferred relation ownership.
-
-Phase 4a runtime integration now includes:
-
-- `Favn.render/2`
-- `Favn.preview/2`
-- `Favn.explain/2`
-- `Favn.materialize/2`
-
-`render/2` is backend/session free and emits canonical rendered SQL plus backend-neutral positional bindings.
-`preview/2` returns both canonical rendered SQL (`preview.render.sql`) and the actual executed preview statement (`preview.statement`).
-
-## SQL DSL direction
-
-Favn SQL uses a real `~SQL` sigil as the single SQL body language.
-
-SQL assets declare their main query with `query do ... end` or `query file: "..."`.
-Reusable SQL uses `defsql ... do ... end` or `defsql ..., file: "..."` through `Favn.SQL`.
-
-Both asset queries and reusable SQL macros use the same `~SQL` body syntax and the same `@name` placeholder syntax for injected values.
-
-File-backed SQL is loaded at compile time only, tracked as an external compile resource, and compiled into the same SQL template IR as inline SQL.
-
-Implemented now:
-
-- real `~SQL` sigil
-- `query do ... end`
-- reusable `defsql ... do ... end` via `Favn.SQL`
-- one `@name` placeholder model for runtime inputs and reusable SQL arguments
-- ordered scanner-based SQL IR with parsed placeholders, reusable SQL calls, and asset refs
-- expression SQL macros and relation SQL macros
-- direct asset references in relation position, such as `from MyApp.Raw.Sales.Orders`
-- compile-time validation for duplicate visible SQL definitions and reusable SQL cycles
-
-Not supported yet for direct SQL asset refs:
-
-- dialect-specific table functions
-- `update ... from`
-- `merge into`
-- arbitrary nested dialect syntax
-- plain relation names inferred from raw text
-
-Implemented in Phase 5:
-
-- relation-based dependency inference from typed SQL relation references
-- additive merge of explicit + inferred dependencies with provenance metadata
-- relation ownership diagnostics (unmanaged warnings, ambiguous ownership errors)
-- lexical CTE alias exclusion for relation inference across top-level and nested subqueries
-
-Planned later:
-
-- registered external source/dependency identities to replace unmanaged warnings with explicit registrations
-
-Favn explicitly avoids fake sigils, Jinja-style templating, arbitrary Elixir interpolation inside SQL, and string stitching as the normal authoring workflow.
-
-Placeholder rules:
-
-- in `query` bodies, non-reserved `@name` placeholders resolve from runtime params
-- in `defsql` bodies, non-reserved `@name` placeholders must match declared arguments
-
-## Introduction
-
-Favn is an asset-first orchestration library for Elixir.
-
-It helps you define business logic as simple, well-documented functions, automatically discover their relationships, and reliably execute them as deterministic workflows.
-
-Favn means to hold or embrace—reflecting its role in keeping your workflows connected and reliable.
-
-Instead of building pipelines manually, you describe your system through assets and their dependencies. Favn takes care of planning, execution, and coordination—ensuring that everything runs in the correct order, at the right time, and on the right machine.
-
-Designed for the BEAM, Favn scales from a single node to distributed systems where work is executed in parallel across available resources.
-
-Favn is built to be:
-- predictable — deterministic runs based on explicit dependencies  
-- reliable — execution you can trust in production  
-- observable — clear insight into runs, state, and flow  
-- ergonomic — simple APIs with strong documentation at the center  
-- agent-friendly — easy for both humans and AI to understand, use, and extend  
-
-Whether you're building ETL pipelines, system integrations, workflows, or AI-driven processes, Favn acts as the layer that holds everything together and ensures it runs as expected.
-
-Favn doesn’t just run your workflows. It takes care of them.
-
-## Quickstart
-
-Define an asset module:
-
-```elixir
-defmodule MyApp.SalesAssets do
-  use Favn.Assets
-
-  @asset true
-  def extract_orders(_ctx), do: :ok
-
-  @asset true
-  @depends :extract_orders
-  def build_daily_report(_ctx), do: :ok
-end
-```
-
-Relation ownership can be declared separately from logical dependencies:
-
-```elixir
-defmodule MyApp.Warehouse.Raw.Sales do
-  use Favn.Namespace, relation: [connection: :warehouse, catalog: "raw", schema: "sales"]
-end
-
-defmodule MyApp.Warehouse.Raw.Sales.Assets do
-  use Favn.Namespace
-  use Favn.Assets
-
-  @asset true
-  @relation true
-  def orders(ctx) do
-    ctx.asset.relation
-    :ok
-  end
-end
-```
-
-Register the module and run a target asset:
-
 ```elixir
 # config/config.exs
 import Config
 
 config :favn,
-  asset_modules: [MyApp.SalesAssets]
+  asset_modules: [MyApp.Raw.Sales.Orders]
 ```
 
 ```elixir
-# from your app runtime / iex
-{:ok, run_id} = Favn.run_asset({MyApp.SalesAssets, :build_daily_report}, dependencies: :all)
+Favn.list_assets()
+{:ok, run_id} = Favn.run_asset(MyApp.Raw.Sales.Orders)
 {:ok, run} = Favn.await_run(run_id)
 ```
 
-Backfill a windowed asset or pipeline over a range (single submitted run):
+## Install And Configure
+
+Favn is currently installed from Git:
 
 ```elixir
-range = %{
-  kind: :day,
-  start_at: DateTime.from_naive!(~N[2025-01-01 00:00:00], "Etc/UTC"),
-  end_at: DateTime.from_naive!(~N[2025-01-04 00:00:00], "Etc/UTC"),
-  timezone: "Etc/UTC"
-}
-
-{:ok, run_id} = Favn.backfill_asset({MyApp.SalesAssets, :build_daily_report}, range: range)
-{:ok, run} = Favn.await_run(run_id)
-
-# provenance persisted on run snapshots
-run.backfill.range
-run.backfill.anchor_ranges
-run.pipeline.backfill_range
-```
-
-Freshness policy helpers over persisted window/node results:
-
-```elixir
-{:ok, freshness} =
-  Favn.check_asset_freshness({MyApp.SalesAssets, :build_daily_report},
-    window_key: hd(run.plan.target_node_keys) |> elem(1),
-    max_age_seconds: 3_600
-  )
-```
-
-
-## New in v0.2 DSL shape
-
-v0.2 has been refactored to the following authoring contract and attribute order:
-
-```elixir
-@asset "Asset Name"
-@meta owner: "data-platform", category: :sales, tags: [:daily]
-@window Favn.Window.daily(lookback: 1)
-@doc "What this asset does"
-@depends {:MyApp.UpstreamAssets, :upstream_asset}
-@spec asset_name(map()) :: :ok | {:ok, map()} | {:error, term()}
-def asset_name(ctx) do
-  :ok
+defp deps do
+  [
+    {:favn, git: "https://github.com/eirhop/favn.git", tag: "v0.4.0"}
+  ]
 end
 ```
 
-Notes:
-- Use one `@depends` entry per declaration; repeat `@depends` for multiple dependencies.
-- Use `@window` when an asset should execute against a runtime-resolved window.
-- `@uses` is deferred and intentionally out of scope for this refactor.
-- Missing `@doc`/`@spec` is allowed (UI will simply have less metadata).
-
-## Configuration
-
-Favn is configured through the `:favn` application environment:
+Minimal config:
 
 ```elixir
 import Config
 
 config :favn,
-  asset_modules: [MyApp.SalesAssets],
-  pipeline_modules: [MyApp.Pipelines.DailySales],
-  pubsub_name: MyApp.PubSub,
-  scheduler: [enabled: true, default_timezone: "Etc/UTC"],
-  storage_adapter: Favn.Storage.Adapter.Memory,
-  storage_adapter_opts: []
+  asset_modules: [MyApp.Raw.Sales.Orders]
 ```
 
-Key settings:
+Add `pipeline_modules`, `connections`, `scheduler`, `storage_adapter`, and `storage_adapter_opts` as your app grows.
 
-- `asset_modules`: modules that define assets with `use Favn.Asset`, `use Favn.MultiAsset`, `use Favn.SQLAsset`, or `use Favn.Assets`.
-- `pipeline_modules`: pipeline modules discovered by the scheduler runtime.
-- `:pubsub_name`: PubSub server name used for run event broadcasting.
-- `:scheduler`: trigger scheduler runtime options (`enabled`, `default_timezone`, `tick_ms`). `enabled` defaults to `true`; `tick_ms` defaults to `15_000`.
-- `:storage_adapter`: storage adapter module (must persist both runs and scheduler state).
-- `:storage_adapter_opts`: options passed to the configured storage adapter.
+## AI Agent Start Point
 
-Custom adapters are supported. To integrate cleanly, implement the full `Favn.Storage.Adapter`
-contract, including run persistence callbacks and scheduler-state callbacks.
+Put this in `AGENTS.md`:
 
-SQLite durable storage (single-node) can be configured with:
-
-```elixir
-import Config
-
-config :favn,
-  storage_adapter: Favn.Storage.Adapter.SQLite,
-  storage_adapter_opts: [
-    database: "/var/lib/my_app/favn.db",
-    busy_timeout: 5_000,
-    pool_size: 1
-  ]
+```text
+When working in this repository, always start by reading the moduledoc for Favn.AgentGuide.
 ```
 
-SQLite ordering notes:
-
-- `runs.updated_seq` is allocated from a dedicated `favn_counters` row (`run_write_order`)
-  inside the same transaction that persists the run snapshot.
-- `list_runs` remains ordered by latest persisted write:
-  `updated_seq DESC, updated_at_us DESC, id DESC`.
-
-## Current limitations
-
-- The default run store is node-local in-memory storage.
-- Public run execution is asynchronous by default (`Favn.run_asset/2` returns a run id).
-- Independent ready steps execute in parallel within a run, bounded by `max_concurrency`.
-- Run events are best-effort pubsub notifications.
-
-## SQL connection foundation (v0.4)
-
-The first SQL foundation step is documented in:
-
-- [`docs/CONNECTION_FOUNDATION_ARCHITECTURE.md`](docs/CONNECTION_FOUNDATION_ARCHITECTURE.md)
-- [`docs/SQL_ADAPTER_ARCHITECTURE.md`](docs/SQL_ADAPTER_ARCHITECTURE.md)
-- [`docs/sql_adapter_scope.md`](docs/sql_adapter_scope.md) (includes the DuckDB/duckdbex v0.4 implementation request and risk gates)
-
-The architecture and current implementation provide:
-
-- `Favn.Connection` definition providers
-- schema-driven runtime config merge/validation
-- boot-time connection loading with fail-fast validation
-- redacted public lookup APIs on `Favn`
-
-This foundation is the base contract that `Favn.SQL.Adapter` work builds on.
-
-The internal SQL runtime contract now includes:
-
-- `Favn.SQL.Adapter` as the backend behaviour boundary
-- `Favn.SQL` as the runtime facade starting from `%Favn.Connection.Resolved{}`
-- `Favn.SQL.Adapter.DuckDB` as the first internal DuckDB runtime adapter backed by `duckdbex`
-- DuckDB appender-backed table writes now preserve normal table create semantics, run inside explicit transactions, and close/release appender handles on all paths
-- DuckDB runtime errors are normalized to `%Favn.SQL.Error{}` with retryability metadata and rollback-failure surfacing
-
-DuckDB runtime constraints in v0.4:
-
-- single-node operation is the supported model
-- concurrent reads and writes are supported within a single process, with optimistic conflict handling
-- external concurrent writers can still conflict; those conflicts surface as normalized retryable execution errors
-- `duckdbex` is an internal implementation detail and is kept replaceable for later extraction to a first-party package (planned direction: `favn_duckdb`)
-
-## Runtime behavior in this release
-
-- **Planning and orchestration**: Favn plans dependency-aware runs with deterministic topological stages and orchestrates execution through a run-scoped coordinator with bounded parallel step dispatch per run.
-- **Run lifecycle**: runtime orchestration now uses explicit internal run and step state machines; public run status includes `:running | :ok | :error | :cancelled | :timed_out`.
-- **Step retries**: failed steps can be retried with deterministic step-level policy (`retry` option on `Favn.run_asset/2`) without restarting the run.
-- **Execution boundary**: one-step asset invocation is isolated behind an asynchronous runtime executor boundary.
-- **Storage facade contract**: run retrieval/listing APIs normalize storage failures to one of:
-  - `:not_found`
-  - `:invalid_opts`
-  - `{:store_error, reason}`
-- **Checkpoint persistence policy**: runtime checkpoints are required; if snapshot persistence fails, `Favn.run_asset/2` returns `{:error, {:storage_persist_failed, reason}}`.
-- **Event delivery**: run events are published as best-effort observability signals and do not affect run correctness.
-- **Internal telemetry**: runtime boundaries emit machine-oriented `:telemetry` events under `[:favn, :runtime, ...]` for operators and future external exporters.
-- **Logger correlation metadata**: runtime coordinator/executor processes attach lightweight metadata (`run_id`, `ref`, `stage`, `attempt`) for human diagnostics without treating logs as telemetry.
-
-## Runtime windowing foundation (in progress)
-
-v0.3 introduces shared runtime windowing primitives intended for both Elixir
-assets now and SQL assets later.
-
-Current foundation modules:
-
-- `Favn.Window`
-- `Favn.Window.Spec`
-- `Favn.Window.Anchor`
-- `Favn.Window.Runtime`
-- `Favn.Window.Key`
-
-These modules establish canonical window data types and deterministic
-window-key encoding/decoding. Planner/runtime/storage integration lands in
-subsequent v0.3 slices.
-
-Current runtime internals now key step state by `{asset_ref, window_key}`
-The plan model also includes `target_node_keys` so runtime target completion
-checks are node-key-based rather than ref scans.
-It also includes `node_stages` so runtime recovery/promotion logic can iterate
-stages by node key.
-Planner v1 now expands windowed assets into concrete `{asset_ref, window_key}`
-nodes from an optional `anchor_window` (hour/day/month with lookback).
-`resume_from_failure` reruns now support duplicate refs when node-keyed
-persisted run results are available.
-
-Asset modules can now attach window specs directly on assets:
-
-```elixir
-@asset true
-@window Favn.Window.daily(lookback: 1)
-def daily_sales(ctx), do: :ok
-```
-
-Runtime context now includes:
-
-- `ctx.window` (concrete execution window for the current node)
-- `ctx.asset.ref` and `ctx.asset.relation`
-- `ctx.pipeline.anchor_window` (run-level requested window intent)
-- `ctx.pipeline.run_kind` (`:pipeline` or `:pipeline_backfill`)
-- `ctx.pipeline.resolved_refs` (deterministic resolved target refs snapshot)
-- `ctx.pipeline.deps` (resolved dependency mode used for planning)
-
-## Guarantees in this release
-
-- **Run lifecycle semantics**
-  - `Favn.run_asset/2` returns `{:ok, run_id}` when a run is submitted.
-  - Step admission order is deterministic for equally-ready refs; completion order is naturally non-deterministic under parallel execution.
-  - `Favn.cancel_run/1` requests cancellation and returns a cancellation acknowledgement tuple.
-  - `Favn.await_run/2` returns `{:ok, %Favn.Run{status: :ok}}` on success or `{:error, %Favn.Run{status: :error | :cancelled | :timed_out}}` on non-success terminal outcomes.
-  - Failed runs preserve structured failure context in both `run.error` and `run.asset_results[ref].error`.
-  - `Favn.get_run/1` returns the latest stored run state for an ID.
-- **Storage error contract**
-  - `Favn.get_run/1` and `Favn.list_runs/1` return storage errors only as `:not_found`, `:invalid_opts`, or `{:store_error, reason}`.
-  - Adapter-specific raw errors are wrapped as `{:store_error, reason}`.
-- **Event delivery scope**
-  - `Favn.subscribe_run/1` and `Favn.unsubscribe_run/1` manage PubSub subscriptions for run topics.
-  - Event delivery is best-effort; missing subscribers or publish failures do not change run success/failure outcomes.
-  - Events use a stable envelope schema (`schema_version`, `event_type`, `entity`, `run_id`, `sequence`, `emitted_at`, `status`, `data`, optional `ref`/`stage`).
-  - `status` is the **internal runtime** run/step status at emission time (not `%Favn.Run{}` public status).
-
-## Not guaranteed yet / non-goals
-
-- Durable distributed execution guarantees across nodes.
-- Exactly-once event delivery, replay, or durable event logs.
-- Persistent storage guarantees beyond the configured adapter behavior (default adapter is in-memory and node-local).
-- Global concurrency fairness across runs and retries.
-
-## v0.3 pipeline DSL direction (foundation PR)
-
-The first v0.3 pipeline foundation slice keeps pipelines as a composition layer on top of the existing asset graph planner.
-
-- Pipelines are **not** a second graph/planning DSL.
-- Pipeline selection resolves to asset refs and then uses dependency-based planning.
-- Initial DSL is intentionally small and user-friendly:
-  - `asset`
-  - `assets`
-  - `select`
-  - `deps`
-  - `schedule`
-  - `window`
-  - `source`
-  - `outputs`
-
-Pipeline `partition` has been removed; use `window` for runtime window intent.
-
-Selection authoring supports both:
-
-- shorthand (`asset` / `assets`) for common cases
-- `select do ... end` for flexible selection (module/tag/category/ref style criteria)
-
-Inside `select do ... end`, selectors are additive (union-based), not intersection-based.
-That means each selector contributes refs to one combined target set before dedupe/sort.
-
-A pipeline definition should use either shorthand selection or `select`, but not both in the same definition.
-
-Schedule authoring now supports both:
-
-- reusable named schedules in modules that `use Favn.Triggers.Schedules`
-- inline schedule definitions directly inside `pipeline ... do`
-
-Pipeline schedule references use explicit refs:
-
-- `schedule {MyApp.Schedules, :daily_oslo}`
-- `schedule cron: "0 2 * * *", timezone: "Europe/Oslo", missed: :skip, overlap: :forbid`
-
-Schedule DSL validation is strict at authoring time:
-
-- cron must be a valid 5-field cron expression
-- when both cron day-of-month and day-of-week are restricted, evaluation uses standard OR semantics
-- timezone must be a known zoneinfo identifier
-
-Deferred from the first v0.3 pipeline foundation PR:
-
-- schedule/polling runtime engines
-- API-triggered execution surface
-- DB-managed pipeline installations/runtime overrides
-- source/output runtime binding behaviors
-- multi-output runtime fan-out behavior
-
-Planned later: a `where` clause for richer asset filtering/querying. `where` is intended as a filtering layer only and must not replace dependency-based graph planning.
-
-### Pipeline foundation API (v0.3)
-
-The first v0.3 implementation adds manual pipeline planning/runs:
-
-- `Favn.plan_pipeline(MyApp.Pipelines.DailySales)`
-- `Favn.run_pipeline(MyApp.Pipelines.DailySales, params: %{requested_by: "operator"})`
-
-Execution model guidance:
-
-- `run_pipeline/2` is the primary operator-facing execution entrypoint.
-- `run_asset/2` is a lower-level primitive for simple assets, tests, debugging, and development flows.
-- In operator workflows, prefer selecting/running a pipeline (and narrow to a single asset with `deps: :none` when needed).
-- `run_asset/2` can also take explicit manual pipeline provenance/context when needed:
-  `Favn.run_asset(ref, pipeline_context: %{...})`.
-
-Assets can read pipeline-aware fields from `ctx.pipeline` during pipeline-triggered runs (for example pipeline identity, config, trigger metadata, and runtime params).
-`ctx.params` remains the generic run params map, while `ctx.pipeline.params` exposes the pipeline-trigger params/provenance payload.
-
-### Stable operator actions (v0.3)
-
-v0.3 includes stable operator actions for:
-
-- `run` (`run_asset/2`, `run_pipeline/2`)
-- `cancel` (`cancel_run/1`)
-- `rerun` (`rerun_run/2`)
-
-Rerun behavior:
-
-- rerun is run-id based and supports two modes:
-  - `:resume_from_failure` (default)
-  - `:exact_replay` (explicit)
-- both modes use persisted execution intent from the source run
-- rerun is allowed for terminal runs (`:ok | :error | :cancelled | :timed_out`)
-- reruns persist lineage metadata (`replay_mode`, `rerun_of_run_id`, `parent_run_id`, `root_run_id`, `lineage_depth`)
-
-## Roadmap and release focus
-
-- Add durable production-ready storage adapters with stronger operational guarantees.
-- Expand run query capabilities for richer operator UIs.
-- Improve event observability integrations (telemetry/export pipelines).
-- Land orchestration-layer fundamentals for v1 (pipeline composition + manual execution first, then API/schedule/polling/freshness and installed runtime config via `ctx`).
-- Add release packaging/versioning via Hex.
-
-## Installation
-
-Favn is not published on Hex yet.
-
-Install it from the GitHub repository by adding `favn` to your list of
-dependencies in `mix.exs`:
-
-```elixir
-def deps do
-  [
-    {:favn, git: "https://github.com/eirhop/favn.git", tag: "v0.3.0"}
-  ]
-end
-```
-
-Once Favn is published on Hex, the dependency can move to a normal versioned
-package declaration:
-
-```elixir
-def deps do
-  [
-    {:favn, "~> 0.3.0"}
-  ]
-end
-```
+## Read Next
+
+- `Favn`: public runtime and operator API facade
+- `Favn.AgentGuide`: routing guide for AI agents and new contributors
+- `Favn.Asset`: single-asset Elixir authoring
+- `Favn.SQLAsset`: single-asset SQL authoring
+- `Favn.MultiAsset`: repetitive extraction authoring
+- `Favn.Pipeline`: pipeline composition
+- `docs/FEATURES.md`: roadmap and feature status

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-**Current release: v0.3.0**
+**Current release: v0.4.0**
 
 ## Current Focus
 
@@ -109,7 +109,7 @@ Goal: make Favn usable for scheduled and windowed asset execution.
 
 ## v0.4.0 — SQL Foundation and DuckDB
 
-**Status: Planned**
+**Status: Released**
 
 Goal: first complete SQL workflow on top of the shared runtime window model.
 
@@ -201,6 +201,7 @@ Goal: first complete SQL workflow on top of the shared runtime window model.
   - [x] additive explicit + inferred dependency merge with provenance metadata
   - [x] unmanaged external relation warnings and ambiguous ownership errors
   - [x] follow-up hardening: nested/subquery `WITH` CTE alias exclusion tests for relation inference
+- [x] Documentation refactor for public DSL discoverability and AI-agent routing
 
 ---
 

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -7,6 +7,7 @@ lib/
 ├── favn.ex
 └── favn/
     ├── application.ex
+    ├── agent_guide.ex
     ├── asset.ex
     ├── diagnostic.ex
     ├── assets.ex

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -15,6 +15,7 @@ test/
 ├── pipeline_sqlite_smoke_test.exs
 ├── pipeline_test.exs
 ├── planner_test.exs
+├── public_docs_test.exs
 ├── ref_test.exs
 ├── runner_test.exs
 ├── runtime_projector_test.exs

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -32,13 +32,13 @@ defmodule Favn do
   ## Inspect assets
 
       Favn.list_assets()
-      Favn.list_assets(MyApp.Raw)
+      Favn.list_assets(MyApp.Raw.Sales.Orders)
       Favn.get_asset(MyApp.Raw.Sales.Orders)
       Favn.get_asset({MyApp.Raw.Shopify, :orders})
 
   ## Run and await
 
-      {:ok, run_id} = Favn.run_asset(MyApp.Raw.Sales.Orders)
+      {:ok, run_id} = Favn.run_asset({MyApp.Raw.Sales.Orders, :asset})
       {:ok, run} = Favn.await_run(run_id)
 
       {:ok, run_id} =

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -1,487 +1,80 @@
 defmodule Favn do
   @moduledoc """
-  Favn is a library for defining, inspecting, and orchestrating asset-based workflows in Elixir.
+  Public facade for inspecting assets, planning runs, and executing workflows.
 
-  It is built around the idea that each step in a workflow should be expressed as a normal,
-  business-oriented Elixir function, while Favn adds the metadata and orchestration needed to
-  discover assets, understand their dependencies, and execute them as part of a run.
+  `Favn` is the operator-facing entrypoint for the library. Use it to discover
+  authored assets, inspect dependency relationships, work with pipelines,
+  submit runs, await completion, inspect history, and access SQL helper APIs.
 
-  Favn is intended to be the core library behind orchestrator applications, operator dashboards,
-  scheduling systems, and other tools that need a stable API for working with assets and runs.
+  This moduledoc is intentionally compact. Authoring rules live on the DSL
+  modules such as `Favn.Asset`, `Favn.SQLAsset`, `Favn.MultiAsset`,
+  `Favn.Assets`, `Favn.Pipeline`, and `Favn.Source`.
 
-  ## What Favn provides
-
-  Favn is designed for applications that need to:
-
-    * define assets as plain Elixir functions
-    * attach documentation and metadata directly to those assets through @asset annotations
-    * declare dependencies between assets
-    * inspect assets and their relationships at runtime
-    * execute one asset or a dependency-derived workflow
-    * inspect active and completed runs
-    * subscribe to live events from a run
+  For AI-first routing, start with `Favn.AgentGuide`.
 
   ## Core concepts
 
-  ### Assets
-
-  An asset is a function that represents a meaningful unit of work in a workflow, such as
-  extracting data, transforming a dataset, or producing a modeled output.
-
-  Assets can be authored with:
-
-    * `use Favn.Asset` (preferred single-asset module DSL)
-    * `use Favn.MultiAsset` (advanced generated multi-asset Elixir DSL)
-    * `use Favn.Assets` (compact multi-asset module DSL)
-
-  At compile time,
-  Favn will collect metadata such as:
-
-    * asset name
-    * optional asset title
-    * documentation
-    * metadata (`owner`, `category`, `tags`)
-    * dependency references
-    * optional relation ownership
-    * source file and line
-
-  This keeps the workflow definition close to the business logic while still allowing Favn to
-  introspect and orchestrate the workflow later.
-
-  Asset modules can also inherit relation defaults from `Favn.Namespace` and declare owned
-  relations with `@relation`. Relation ownership is distinct from `@depends`:
-
-      defmodule MyApp.Warehouse.Raw.Sales do
-        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
-      end
-
-      defmodule MyApp.Warehouse.Raw.Sales.Assets do
-        use Favn.Namespace
-        use Favn.Assets
-
-        @asset true
-        @relation true
-        def orders(ctx) do
-          ctx.asset.relation
-          :ok
-        end
-      end
-
-  ### Dependencies
-
-  Assets can depend on other assets. Favn uses those dependency declarations to derive the
-  execution graph automatically.
-
-  Favn models those relationships as a directed acyclic graph (DAG), not as a strict tree.
-  Shared upstream assets are therefore allowed, cycles are rejected, and a later runtime
-  planner can ensure an asset runs at most once in a single run even when multiple downstream
-  assets depend on it.
-
-  In practice, this means users generally do not need to manually define pipelines. When an
-  asset is run, Favn can compute the dependency graph for the requested target and form the
-  execution pipeline from that graph.
-
-  v0.3 introduces a small pipeline composition layer on top of this model for cases where users
-  want to select asset sets and attach orchestration configuration without redefining graph
-  planning rules. Pipeline selection still resolves to asset refs and then delegates dependency
-  planning to the existing planner.
-
-  v0.3 includes stable operator actions for `run`, `cancel`, and run-id-based `rerun`.
-  Rerun defaults to `:resume_from_failure`, with explicit `:exact_replay` also supported.
-  Both modes preserve lineage in `%Favn.Run{}`.
-
-  Runtime windowing foundation work in v0.3 also introduces shared temporal
-  primitives under `Favn.Window.*` (`Spec`, `Anchor`, `Runtime`, and `Key`) so
-  window semantics can be reused consistently across current Elixir assets and
-  future SQL assets. Runtime internals also now carry step identity as
-  `{asset_ref, window_key}`. Planned
-  target identity is now carried as `plan.target_node_keys` to keep runtime
-  completion checks node-key based, and staged runtime recovery now consumes
-  `plan.node_stages` so stage traversal is also node-key native.
-
-  ### Runs
-
-  A run is a single execution of a target asset.
-
-  Depending on the runtime options, a run may include:
-
-    * only the requested asset
-    * the requested asset and its upstream dependencies
-
-  Runs are intended to be observable and inspectable so that orchestrator applications can show
-  progress, history, and live operational state.
-
-  ### Live events
-
-  Favn is intended to expose structured run events so that consumers can subscribe to the
-  progress of an active run.
-
-  This is designed for use cases such as:
-
-    * live operator dashboards
-    * streaming logs and status in a web UI
-    * audit trails
-    * hooks into telemetry or other observability systems
-
-  Runtime PubSub events are a UI/live-subscription contract. Internal runtime
-  machine telemetry is emitted separately via `:telemetry` event names under
-  `[:favn, :runtime, ...]`.
-
-  ### SQL connection foundation
-
-  The first SQL foundation steps are documented in
-  `docs/CONNECTION_FOUNDATION_ARCHITECTURE.md`,
-  `docs/SQL_ADAPTER_ARCHITECTURE.md`, and
-  `docs/sql_adapter_scope.md` (DuckDB/duckdbex v0.4 request scope and
-  implementation gates).
-
-  This includes explicit `Favn.Connection` provider modules, schema-driven
-  runtime config merge validation, boot-time loading with fail-fast validation,
-  and redacted connection lookup/inspection APIs exposed through `Favn`.
-
-  v0.4 also introduces `Favn.SQL.Adapter` and the internal `Favn.SQL` facade as
-  the runtime SQL backend contract starting from `%Favn.Connection.Resolved{}`.
-  DuckDB runtime hardening now keeps table-create semantics aligned across SQL
-  and appender-backed write paths, wraps multi-step write flows in explicit
-  transactions, and normalizes failure semantics into `%Favn.SQL.Error{}`.
-  DuckDB runtime follows single-process optimistic concurrency semantics, with
-  conflict-style failures surfaced as retryable normalized errors.
-
-
-  ## New v0.2 DSL contract
-
-  v0.2 DSL has been refactored to:
-
-      @asset "Asset Name"
-      @meta owner: "data-platform", category: :sales, tags: [:daily]
-      @window Favn.Window.daily(lookback: 1)
-      @doc "What this asset does"
-      @depends {:MyApp.UpstreamAssets, :upstream_asset}
-      @spec asset_name(map()) :: :ok | {:ok, map()} | {:error, term()}
-      def asset_name(ctx) do
-        :ok
-      end
-
-  Important decisions for this refactor:
-
-    * `@depends` is single-entry per attribute (repeat for multiple dependencies)
-    * `@window` is optional and declares runtime window intent for an asset
-    * `@uses` is deferred to a later pipeline-focused iteration
-    * missing `@doc`/`@spec` does not produce warnings or errors
-    * direct inter-asset value passing is removed from the public model
-
-  ## Authoring assets
-
-  Preferred one-module-per-asset style uses `Favn.Asset`:
-
-      defmodule MyApp.Raw.Sales.Orders do
-        use Favn.Namespace, relation: [connection: :warehouse, catalog: :raw, schema: :sales]
-        use Favn.Asset
-
-        @doc "Extract raw orders"
-        @meta owner: "data-platform", category: :sales, tags: [:raw]
-        @relation true
-        def asset(ctx), do: :ok
-      end
-
-  Preferred one-module-per-asset SQL style uses `Favn.SQLAsset`:
-
-      defmodule MyApp.Gold.Sales.FctOrders do
-        use Favn.Namespace, relation: [connection: :warehouse, catalog: :gold, schema: :sales]
-        use Favn.SQLAsset
-
-        @doc "Build the gold fact table for orders"
-        @meta owner: "analytics", category: :sales, tags: [:gold]
-        @window Favn.Window.daily(lookback: 2)
-        @materialized {:incremental, strategy: :delete_insert, window_column: :order_date}
-
-        query do
-          ~SQL\"\"\"
-          select *
-          from silver.sales.stg_orders
-          \"\"\"
-        end
-      end
-
-  SQL assets support both inline `query do ... end` and file-backed
-  `query file: "..."` query definitions.
-
-  The current SQL implementation keeps `~SQL` as the one SQL body language across
-  inline `query` and inline reusable `defsql` definitions, while file-backed SQL
-  forms are loaded at compile time and normalized into the same compiled SQL source
-  and template IR model. SQL authoring now includes one `@name`
-  placeholder model for SQL inputs, expression and relation SQL macros, direct asset
-  references in relation position, and compile-time normalization into a dedicated SQL
-  IR. Runtime helper APIs are available through `render/2`, `preview/2`, `explain/2`,
-  and `materialize/2`. SQL relation references discovered from the typed SQL IR are
-  now also used to infer additive asset dependencies through the registry ownership
-  index, with diagnostics retained on canonical asset metadata. CTE aliases declared
-  with `WITH` are excluded lexically from relation inference, including nested
-  subquery scopes.
-
-  Advanced generated multi-asset extraction style uses `Favn.MultiAsset`:
-
-      defmodule MyApp.Raw.Shopify do
-        use Favn.MultiAsset
-
-        defaults do
-          meta owner: "data-platform", category: :shopify, tags: [:raw]
-
-          rest do
-            primary_key "id"
-            paginator :cursor, cursor_path: "links.next"
-          end
-        end
-
-        @doc "Extract orders"
-        @relation true
-        asset :orders do
-          rest do
-            path "/orders.json"
-            data_path "orders"
-          end
-        end
-
-        def asset(ctx) do
-          MyApp.Shopify.Client.extract(ctx.asset.config, ctx)
-        end
-      end
-
-  Compact multi-asset function style uses `Favn.Assets`:
-
-  A simplified example:
-
-      defmodule MyApp.SalesETL do
-        use Favn.Assets
-
-        @asset true
-        @doc "Extract raw orders from the sales source"
-        def extract_orders(_ctx), do: :ok
-
-        @asset true
-        @doc "Normalize extracted orders"
-        @depends :extract_orders
-        def normalize_orders(_ctx), do: :ok
-      end
-
-  Cross-module dependencies are also expected to be supported:
-
-      defmodule MyApp.GoldETL do
-        use Favn.Assets
-
-        alias MyApp.SalesETL
-
-        @asset true
-        @doc "Build the fact table for sales"
-        @depends {SalesETL, :normalize_orders}
-        def fact_sales(_ctx), do: :ok
-      end
-
-  In this model, workflow structure is derived from the dependencies rather than from a
-  separately maintained pipeline definition.
-
-  ## Using the library
-
-  `Favn` is the main public entrypoint for the library.
-
-  Typical usage from an orchestrator app or operator tool:
+  - Asset: a compiled `%Favn.Asset{}` discovered from a public DSL module
+  - Asset ref: `{Module, :asset_name}` or `{Module, :asset}` for single-asset modules
+  - Pipeline: a named asset selection that still delegates dependency planning to the asset graph
+  - Run: one submitted execution with plan, state, and history
+  - Window: optional runtime time bounds shared by Elixir and SQL assets
+
+  ## Authoring pointers
+
+  - Use `Favn.Asset` for a single Elixir asset module
+  - Use `Favn.SQLAsset` for a single SQL asset module
+  - Use `Favn.MultiAsset` for repetitive extraction assets with shared runtime logic
+  - Use `Favn.Assets` for compact multi-asset function modules when that style is intentional
+  - Use `Favn.Namespace` for inherited relation defaults
+  - Use `Favn.Connection`, `Favn.Window`, and `Favn.Triggers.Schedules` for supporting runtime definitions
+
+  ## Inspect assets
 
       Favn.list_assets()
-
-      Favn.list_assets(MyApp.SalesETL)
-
-      Favn.get_asset({MyApp.SalesETL, :normalize_orders})
-
+      Favn.list_assets(MyApp.Raw)
       Favn.get_asset(MyApp.Raw.Sales.Orders)
+      Favn.get_asset({MyApp.Raw.Shopify, :orders})
 
-      Favn.upstream_assets({MyApp.GoldETL, :fact_sales})
+  ## Run and await
 
-      Favn.dependency_graph({MyApp.GoldETL, :fact_sales}, tags: [:warehouse])
+      {:ok, run_id} = Favn.run_asset(MyApp.Raw.Sales.Orders)
+      {:ok, run} = Favn.await_run(run_id)
 
-      Favn.run_asset({MyApp.GoldETL, :fact_sales})
+      {:ok, run_id} =
+        Favn.run_asset({MyApp.Raw.Shopify, :orders}, dependencies: :none)
 
-      Favn.run_asset({MyApp.GoldETL, :fact_sales}, dependencies: :none)
+  ## Pipelines
 
-      Favn.plan_pipeline(MyApp.Pipelines.DailySales)
+      {:ok, plan} = Favn.plan_pipeline(MyApp.Pipelines.DailySales)
+      {:ok, run_id} = Favn.run_pipeline(MyApp.Pipelines.DailySales)
 
-      Favn.run_pipeline(MyApp.Pipelines.DailySales, params: %{requested_by: "operator"})
-
-      Favn.backfill_asset({MyApp.GoldETL, :fact_sales},
-        range: %{
-          kind: :day,
-          start_at: DateTime.from_naive!(~N[2025-01-01 00:00:00], "Etc/UTC"),
-          end_at: DateTime.from_naive!(~N[2025-01-08 00:00:00], "Etc/UTC"),
-          timezone: "Etc/UTC"
-        }
-      )
-
-      Favn.cancel_run(run_id)
-
-      Favn.check_asset_freshness({MyApp.GoldETL, :fact_sales}, max_age_seconds: 3_600)
-
-      Favn.rerun_run(run_id)
+  ## Runs and history
 
       Favn.get_run(run_id)
-
       Favn.list_runs()
-
       Favn.list_runs(status: :running)
 
-      Favn.subscribe_run(run_id)
+  ## SQL helpers
 
-  ## Setup in a host application
+  SQL assets can be inspected and executed through the same runtime, and also
+  support direct helper APIs:
 
-  Favn is an OTP application, not a standalone server you start with a
-  dedicated `favn` command.
+      Favn.render(MyApp.Gold.Sales.FctOrders, params: %{limit: 100})
+      Favn.preview(MyApp.Gold.Sales.FctOrders, params: %{limit: 100})
+      Favn.explain(MyApp.Gold.Sales.FctOrders)
+      Favn.materialize(MyApp.Gold.Sales.FctOrders)
 
-  A consumer application typically sets Favn up in four steps:
-
-    1. add `:favn` as a dependency in `mix.exs`
-    2. define one or more asset modules with `use Favn.Asset`, `use Favn.MultiAsset`, and/or `use Favn.Assets`
-    3. register those modules under `config :favn, asset_modules: [...]`
-    4. start the host application normally
-
-  Favn is not published on Hex yet, so it should be installed directly
-  from the repository. A minimal dependency declaration looks like this:
-
-      defp deps do
-        [
-          {:favn, git: "https://github.com/eirhop/favn.git", tag: "v0.3.0"}
-        ]
-      end
-
-  Once Hex publishing exists, the dependency can move to a normal versioned
-  package declaration:
-
-      defp deps do
-        [
-          {:favn, "~> 0.3.0"}
-        ]
-      end
-
-  Asset modules usually live in the host application's normal source tree,
-  for example under `lib/my_app/`.
-
-  Once those modules exist, register them in the host application's config.
-  For most projects that means `config/config.exs`, optionally overridden from
-  environment-specific files such as `config/dev.exs`, `config/test.exs`, or
-  `config/runtime.exs` if the application needs environment-dependent module
-  lists.
+  ## Minimal host setup
 
       import Config
 
       config :favn,
-        asset_modules: [
-          MyApp.SalesETL,
-          MyApp.GoldETL
-        ],
-        pipeline_modules: [MyApp.Pipelines.DailySales],
-        scheduler: [enabled: true, default_timezone: "Etc/UTC"]
+        asset_modules: [MyApp.Raw.Sales.Orders],
+        pipeline_modules: [MyApp.Pipelines.DailySales]
 
-  The configured module list is the global discovery scope used by
-  `Favn.list_assets/0` and `Favn.get_asset/1`.
-
-  Run event subscriptions use Phoenix PubSub and default to `Favn.PubSub`.
-  Scheduler runtime discovery is scoped by `config :favn, pipeline_modules: [...]`.
-  Host applications can override the pubsub server name:
-
-      import Config
-
-      config :favn,
-        pubsub_name: MyApp.PubSub
-
-  Run persistence is configured with `:storage_adapter` and
-  `:storage_adapter_opts`.
-
-  For durable single-node SQLite storage:
-
-      import Config
-
-      config :favn,
-        storage_adapter: Favn.Storage.Adapter.SQLite,
-        storage_adapter_opts: [
-          database: "/var/lib/my_app/favn.db",
-          busy_timeout: 5_000,
-          pool_size: 1
-        ]
-
-  In SQLite mode, run ordering uses a dedicated `favn_counters` row
-  (`run_write_order`) to allocate `runs.updated_seq` transactionally.
-  `Favn.list_runs/1` ordering remains newest-first by
-  `updated_seq DESC, updated_at_us DESC, id DESC`.
-
-  ## Starting Favn
-
-  There is no separate Favn server process that operators start manually.
-
-  When the host application boots, Mix starts the `:favn` application as a
-  dependency, and `Favn.Application` loads the configured asset registry during
-  application startup.
-
-  In practice, that means the right startup command is the normal startup
-  command for the host application:
-
-    * `iex -S mix` for interactive local development
-    * `mix run --no-halt` for a long-running non-interactive OTP process
-    * framework-specific commands such as `mix phx.server` when Favn is used
-      inside a Phoenix application
-
-  If the host application is already running under releases, supervision, or a
-  framework entrypoint, Favn starts automatically as part of that boot process.
-
-  ## Configuration lifecycle
-
-  The global asset registry is loaded from application config during startup and
-  then kept in memory for fast lookups. Favn also builds a global dependency
-  graph index during startup from that same canonical asset catalog.
-
-  The graph index is intended to stay read-only for the lifetime of the booted
-  node and supports DAG validation, upstream and downstream inspection,
-  transitive dependency queries, and deterministic topological ordering for
-  later execution planning.
-
-  That means changes to `config :favn, asset_modules: [...]` are not picked up
-  automatically by an already-running node. In normal usage, update the config
-  and restart the host application so Favn reloads the configured registry and
-  dependency graph during boot.
-
-  ## Public API responsibilities
-
-  The intended user-facing responsibilities of this module are:
-
-    * asset discovery
-    * asset inspection
-    * dependency graph inspection
-    * run execution
-    * run inspection
-    * listing historical runs
-    * subscribing to live run events
-
-  This module should stay a thin public facade. Core implementation details should live in
-  dedicated modules underneath.
-
-  ## Design goals
-
-  Favn aims to keep workflow code close to the business domain while still providing the
-  operational features needed by orchestration and observability tooling.
-
-  In practice, that means:
-
-    * business logic remains plain Elixir
-    * documentation lives close to the asset definition
-    * dependencies are simple and explicit
-    * orchestration is derived from asset metadata
-    * the public API stays small and stable
-    * implementation details are pushed into focused modules
-
-  ## Documentation policy
-
-  Documentation ownership is split intentionally:
-
-    * `README.md` is canonical for release status, roadmap planning, and the
-      feature/limitation matrix.
-    * `Favn` moduledoc is canonical for API behavior, contracts, and examples.
-
+  Add `connections`, `scheduler`, `storage_adapter`, and `storage_adapter_opts`
+  as needed by your runtime.
   """
 
   @typedoc """

--- a/lib/favn/agent_guide.ex
+++ b/lib/favn/agent_guide.ex
@@ -1,0 +1,77 @@
+defmodule Favn.AgentGuide do
+  @moduledoc """
+  AI-first routing guide for working with Favn.
+
+  Start here when you need to understand the public surface quickly through
+  `Code.fetch_docs/1`. This module is a router, not the source of truth for all
+  authoring details.
+
+  ## What Favn is
+
+  Favn is an asset-oriented orchestration library for Elixir. Users define
+  business-facing assets in Elixir or SQL, Favn compiles them into canonical
+  `%Favn.Asset{}` values, then uses the dependency graph to inspect, plan, and
+  run workflows.
+
+  ## Public modules to trust first
+
+  - `Favn`: runtime and operator API facade
+  - `Favn.Asset`: preferred single-asset Elixir DSL
+  - `Favn.SQLAsset`: preferred single-asset SQL DSL
+  - `Favn.MultiAsset`: repetitive extraction DSL with generated assets
+  - `Favn.Assets`: compact multi-asset function DSL
+  - `Favn.Namespace`: inherited relation defaults
+  - `Favn.SQL`: reusable SQL DSL and SQL runtime facade
+  - `Favn.Pipeline`: pipeline composition DSL
+  - `Favn.Triggers.Schedules`: reusable named schedules
+  - `Favn.Window`: window constructors used by assets and pipelines
+  - `Favn.Connection`: connection provider contract
+  - `Favn.Source`: external relation declarations
+
+  Internal modules under `Favn.*.*` are implementation details unless a public
+  moduledoc points you there explicitly.
+
+  ## Recommended reading order
+
+  1. Read `Favn.AgentGuide`
+  2. Read `Favn` for the public runtime API
+  3. Read the specific authoring DSL for the task
+  4. Read supporting modules such as `Favn.Namespace`, `Favn.Window`, `Favn.Connection`, or `Favn.Triggers.Schedules`
+
+  ## Which module to read for each task
+
+  - Create one Elixir asset: `Favn.Asset`
+  - Create one SQL asset: `Favn.SQLAsset`, then `Favn.SQL`
+  - Create repetitive extraction assets: `Favn.MultiAsset`
+  - Work in the older compact multi-asset style: `Favn.Assets`
+  - Inspect, run, await, rerun, or list runs: `Favn`
+  - Define pipelines: `Favn.Pipeline`
+  - Work with relation defaults: `Favn.Namespace`
+  - Work with windows: `Favn.Window`
+  - Work with connections: `Favn.Connection`
+  - Work with reusable schedules: `Favn.Triggers.Schedules`
+  - Model external upstream relations: `Favn.Source`
+
+  ## Common scenarios
+
+  ### Create one Elixir asset
+
+  Read `Favn.Asset`.
+
+  ### Create one SQL asset
+
+  Read `Favn.SQLAsset` for asset structure, then `Favn.SQL` for `~SQL` and `defsql`.
+
+  ### Create repetitive extraction assets
+
+  Read `Favn.MultiAsset`, especially `defaults/1`, `asset/2`, and the shared `asset/1` runtime contract.
+
+  ### Inspect and run assets or pipelines
+
+  Read `Favn` and look at `list_assets/0`, `get_asset/1`, `run_asset/2`, `await_run/2`, `plan_pipeline/2`, and `run_pipeline/2`.
+
+  ### Work with connections, windows, or schedules
+
+  Read `Favn.Connection`, `Favn.Window`, `Favn.Pipeline`, and `Favn.Triggers.Schedules`.
+  """
+end

--- a/lib/favn/asset.ex
+++ b/lib/favn/asset.ex
@@ -1,23 +1,78 @@
 defmodule Favn.Asset do
   @moduledoc """
-  Canonical asset metadata captured from an authored Favn asset.
+  Preferred single-asset Elixir DSL and the canonical `%Favn.Asset{}` struct.
 
-  `Favn.Asset` is the normalized shape used by the rest of Favn for
-  introspection, dependency resolution, and execution planning.
+  Use this module when one module should define exactly one executable Elixir
+  asset. That asset is always declared as `def asset(ctx)` and compiles to the
+  canonical ref `{Module, :asset}`.
 
-  It also provides the preferred single-asset Elixir DSL:
+  ## When to use it
+
+  Use `Favn.Asset` when:
+
+  - one module should represent one asset
+  - the runtime logic is normal Elixir code
+  - you want the clearest public authoring surface for humans and AI agents
+
+  Use `Favn.MultiAsset` for repetitive generated assets, and `Favn.SQLAsset`
+  when the primary body is SQL.
+
+  ## Minimal example
 
       defmodule MyApp.Raw.Sales.Orders do
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: "raw", schema: "sales"]
         use Favn.Asset
 
         @doc "Extract raw orders"
         @meta owner: "data-platform", category: :sales, tags: [:raw]
+        @depends MyApp.Raw.Sales.Customers
+        @window Favn.Window.daily()
         @relation true
-        def asset(ctx), do: :ok
+        def asset(ctx) do
+          _asset = ctx.asset
+          _window = ctx.window
+          :ok
+        end
       end
 
-  This module owns validation of the final canonical asset shape after the DSL
-  has normalized authoring-friendly input into runtime-ready values.
+  ## Authoring contract
+
+  - define exactly one public `asset/1`
+  - attach `@doc`, `@meta`, `@depends`, `@window`, and `@relation` directly above `def asset(ctx)`
+  - repeat `@depends` for multiple upstream dependencies
+  - use module shorthand in `@depends` for another single-asset module
+
+  ## What gets compiled
+
+  The DSL compiles into one canonical `%Favn.Asset{}` with:
+
+  - `ref: {Module, :asset}`
+  - `type: :elixir`
+  - normalized metadata and dependency refs
+  - optional window and relation ownership metadata
+
+  ## Runtime context notes
+
+  `ctx` is a `Favn.Run.Context`. In practice, authors most often read:
+
+  - `ctx.asset` for canonical asset metadata
+  - `ctx.asset.config` for compiled config when present
+  - `ctx.asset.relation` for owned relation identity
+  - `ctx.window` for resolved runtime windows on windowed assets
+
+  ## Common mistakes
+
+  - defining more than one `asset/1`
+  - attaching DSL attributes to another function
+  - using an invalid `@depends` shape
+  - declaring multiple `@window` or `@relation` attributes
+
+  ## See also
+
+  - `Favn.AgentGuide`
+  - `Favn.SQLAsset`
+  - `Favn.MultiAsset`
+  - `Favn.Namespace`
   """
 
   alias Favn.Asset.Dependency

--- a/lib/favn/asset.ex
+++ b/lib/favn/asset.ex
@@ -42,6 +42,24 @@ defmodule Favn.Asset do
   - repeat `@depends` for multiple upstream dependencies
   - use module shorthand in `@depends` for another single-asset module
 
+  ## Supported attributes
+
+  - `@doc`: asset documentation shown in compiled docs and metadata
+  - `@meta`: keyword or map metadata such as `owner`, `category`, and `tags`
+  - `@depends`: repeatable dependency declaration
+  - `@window`: one `Favn.Window.*` spec
+  - `@relation`: optional owned relation declaration
+
+  `@depends` supports:
+
+  - `Other.SingleAssetModule`
+  - `{Other.MultiAssetModule, :asset_name}`
+
+  `@relation` supports:
+
+  - `true` to infer from module name plus namespace defaults
+  - keyword or map relation overrides such as `connection`, `catalog`, and `schema`
+
   ## What gets compiled
 
   The DSL compiles into one canonical `%Favn.Asset{}` with:

--- a/lib/favn/assets.ex
+++ b/lib/favn/assets.ex
@@ -32,6 +32,20 @@ defmodule Favn.Assets do
   - attach `@doc`, `@meta`, `@depends`, `@window`, and `@relation` to that same function
   - use `:asset_name` for same-module dependencies and `{Module, :asset_name}` across modules
 
+  ## Supported attributes
+
+  - `@asset`: `true` or a display-name string
+  - `@doc`: per-asset documentation
+  - `@meta`: keyword or map metadata such as `owner`, `category`, and `tags`
+  - `@depends`: repeatable dependency declaration
+  - `@window`: one `Favn.Window.*` spec
+  - `@relation`: `true` or a keyword/map relation override
+
+  `@depends` supports:
+
+  - `:same_module_asset_name`
+  - `{OtherModule, :asset_name}`
+
   ## What gets compiled
 
   Every marked function becomes one canonical `%Favn.Asset{}` with ref

--- a/lib/favn/assets.ex
+++ b/lib/favn/assets.ex
@@ -1,23 +1,47 @@
 defmodule Favn.Assets do
   @moduledoc """
-  Compile-time DSL for authoring Favn assets inside a module.
+  Compact multi-asset function DSL.
 
-  `use Favn.Assets` lets a module mark public functions with `@asset` so Favn
-  can capture canonical `%Favn.Asset{}` metadata for later introspection.
+  `Favn.Assets` lets one module expose multiple public functions as assets using
+  `@asset`. It is still supported, but for new single-asset modules prefer
+  `Favn.Asset`, and for repetitive generated modules prefer `Favn.MultiAsset`.
 
-  This module is intentionally focused on compile-time authoring behavior:
+  ## When to use it
 
-    * collecting metadata from `@asset`
-    * enforcing authoring rules
-    * normalizing DSL-friendly dependency declarations
-    * emitting `__favn_assets__/0` for later runtime inspection
+  Use this module when several closely related assets belong in one module and a
+  function-per-asset style is still the clearest choice.
 
-  Asset authoring contract:
+  ## Minimal example
 
-    * asset functions must have arity 1 and accept one runtime context argument
-    * use repeatable `@depends` attributes for dependencies
-    * use `@meta` for non-execution metadata
-    * use optional `@window Favn.Window.daily()` to define asset windowing
+      defmodule MyApp.SalesETL do
+        use Favn.Assets
+
+        @asset true
+        @doc "Extract raw orders"
+        def extract_orders(_ctx), do: :ok
+
+        @asset true
+        @doc "Build daily sales"
+        @depends :extract_orders
+        def daily_sales(_ctx), do: :ok
+      end
+
+  ## Authoring contract
+
+  - each `@asset` must be followed immediately by one public function with arity 1
+  - attach `@doc`, `@meta`, `@depends`, `@window`, and `@relation` to that same function
+  - use `:asset_name` for same-module dependencies and `{Module, :asset_name}` across modules
+
+  ## What gets compiled
+
+  Every marked function becomes one canonical `%Favn.Asset{}` with ref
+  `{Module, :function_name}`.
+
+  ## See also
+
+  - `Favn.AgentGuide`
+  - `Favn.Asset`
+  - `Favn.MultiAsset`
   """
 
   alias Favn.Asset

--- a/lib/favn/connection.ex
+++ b/lib/favn/connection.ex
@@ -1,10 +1,35 @@
 defmodule Favn.Connection do
   @moduledoc """
-  Behaviour for connection definition providers.
+  Public contract for connection definition providers.
 
-  A provider module returns static connection metadata through `definition/0`.
-  Runtime values are supplied through `config :favn, connections: [...]` and are
-  merged and validated by `Favn.Connection.Loader` during application startup.
+  Use `Favn.Connection` when assets or pipelines need a named backend
+  connection such as DuckDB now and other SQL engines later.
+
+  Provider modules return static connection metadata from `definition/0`. Host
+  applications then supply runtime values through `config :favn, connections: [...]`.
+
+  ## Minimal example
+
+      defmodule MyApp.Connections.Warehouse do
+        @behaviour Favn.Connection
+
+        @impl true
+        def definition do
+          %Favn.Connection.Definition{
+            name: :warehouse,
+            adapter: Favn.SQL.Adapter.DuckDB,
+            config_schema: [
+              %{key: :database, required: true, type: :path}
+            ]
+          }
+        end
+      end
+
+  ## See also
+
+  - `Favn.AgentGuide`
+  - `Favn.SQLAsset`
+  - `Favn.SQL`
   """
 
   alias Favn.Connection.Definition

--- a/lib/favn/connection.ex
+++ b/lib/favn/connection.ex
@@ -17,13 +17,16 @@ defmodule Favn.Connection do
         def definition do
           %Favn.Connection.Definition{
             name: :warehouse,
-            adapter: Favn.SQL.Adapter.DuckDB,
+            adapter: MyApp.WarehouseAdapter,
             config_schema: [
               %{key: :database, required: true, type: :path}
             ]
           }
         end
       end
+
+  The adapter module should implement the SQL adapter contract used by your
+  runtime.
 
   ## See also
 

--- a/lib/favn/connection.ex
+++ b/lib/favn/connection.ex
@@ -28,6 +28,25 @@ defmodule Favn.Connection do
   The adapter module should implement the SQL adapter contract used by your
   runtime.
 
+  ## Definition fields
+
+  `definition/0` returns `%Favn.Connection.Definition{}` with these public
+  fields:
+
+  - `name`: connection name used by assets and runtime lookup
+  - `adapter`: backend adapter module
+  - `config_schema`: runtime config schema entries
+  - `doc`: optional connection documentation
+  - `metadata`: optional descriptive metadata
+
+  Each `config_schema` entry supports:
+
+  - `key`: required config key name
+  - `required`: boolean, defaults to optional when omitted
+  - `default`: optional default value
+  - `secret`: boolean for redaction-sensitive values
+  - `type`: one of `:string`, `:atom`, `:boolean`, `:integer`, `:float`, `:path`, `:module`, `{:in, values}`, or `{:custom, fun}`
+
   ## See also
 
   - `Favn.AgentGuide`

--- a/lib/favn/multi_asset.ex
+++ b/lib/favn/multi_asset.ex
@@ -84,7 +84,7 @@ defmodule Favn.MultiAsset do
 
   `@depends` supports:
 
-  - `Other.SingleAssetModule`
+  - `:same_module_asset_name`
   - `{OtherModule, :asset_name}`
 
   ## What gets compiled
@@ -248,10 +248,10 @@ defmodule Favn.MultiAsset do
 
   The asset block currently supports only `rest do ... end`.
 
-  ## Example
+      ## Example
 
       @doc "Extract orders"
-      @depends MyApp.Raw.Shopify.Customers
+      @depends {MyApp.Raw.Shopify, :customers}
       @relation true
       asset :orders do
         rest do

--- a/lib/favn/multi_asset.ex
+++ b/lib/favn/multi_asset.ex
@@ -1,10 +1,80 @@
 defmodule Favn.MultiAsset do
   @moduledoc """
-  Advanced Elixir DSL for compiling one module into many canonical assets.
+  Advanced Elixir DSL for compiling one module into many generated assets.
 
-  `Favn.MultiAsset` keeps the shared `%Favn.Asset{}` model and runtime contract,
-  while allowing repetitive extraction patterns to share one `asset/1` runtime
-  entrypoint and per-asset compile-time config.
+  Use this module when many assets share the same runtime implementation but
+  differ by declarative config. Each declared `asset :name do ... end` compiles
+  to its own canonical `%Favn.Asset{}` while the module keeps one shared public
+  `asset/1` runtime function.
+
+  ## When to use it
+
+  Use `Favn.MultiAsset` when:
+
+  - you are generating many similar extraction assets
+  - the runtime implementation is shared
+  - per-asset differences are mostly config, metadata, relation ownership, or dependencies
+
+  ## Minimal example
+
+      defmodule MyApp.Raw.Shopify do
+        use Favn.MultiAsset
+
+        defaults do
+          meta owner: "data-platform", category: :shopify, tags: [:raw]
+
+          rest do
+            primary_key "id"
+            paginator :cursor, cursor_path: "links.next"
+          end
+        end
+
+        @doc "Extract orders"
+        @relation true
+        asset :orders do
+          rest do
+            path "/orders.json"
+            data_path "orders"
+          end
+        end
+
+        def asset(ctx) do
+          MyApp.Shopify.Client.extract(ctx.asset.config, ctx)
+        end
+      end
+
+  ## Authoring contract
+
+  - define exactly one public `asset/1` runtime function
+  - define at least one `asset :name do ... end` declaration
+  - use at most one `defaults do ... end` block
+  - attach `@doc`, `@meta`, `@depends`, `@window`, and `@relation` directly above each declared asset
+
+  ## What gets compiled
+
+  Each declaration becomes one canonical `%Favn.Asset{}` with:
+
+  - `ref: {Module, :name}`
+  - `entrypoint: :asset`
+  - merged defaults plus per-asset config in `ctx.asset.config`
+
+  ## Runtime context notes
+
+  The shared runtime usually reads `ctx.asset.config` to decide what to extract.
+  Relation ownership, metadata, and window specs remain per generated asset.
+
+  ## Common mistakes
+
+  - forgetting the shared `asset/1` runtime function
+  - declaring multiple `defaults` blocks
+  - using duplicate asset names
+  - expecting asset blocks to support arbitrary clauses beyond the current DSL
+
+  ## See also
+
+  - `Favn.AgentGuide`
+  - `Favn.Asset`
+  - `Favn.Namespace`
   """
 
   alias Favn.Asset
@@ -86,7 +156,23 @@ defmodule Favn.MultiAsset do
     end
   end
 
-  @doc false
+  @doc """
+  Declares defaults shared by every generated asset in the module.
+
+  Defaults are merged with per-asset declarations. In v0.4 this block supports
+  `meta`, `window`, and `rest`.
+
+  ## Example
+
+      defaults do
+        meta owner: "data-platform", category: :shopify, tags: [:raw]
+
+        rest do
+          primary_key "id"
+          paginator :cursor, cursor_path: "links.next"
+        end
+      end
+  """
   defmacro defaults(do: block) do
     ensure_no_pending_attributes!(__CALLER__)
 
@@ -111,6 +197,24 @@ defmodule Favn.MultiAsset do
     end
   end
 
+  @doc """
+  Declares one generated asset inside a `Favn.MultiAsset` module.
+
+  Attach standard asset attributes such as `@doc`, `@meta`, `@depends`,
+  `@window`, and `@relation` immediately above the declaration.
+
+  ## Example
+
+      @doc "Extract orders"
+      @depends MyApp.Raw.Shopify.Customers
+      @relation true
+      asset :orders do
+        rest do
+          path "/orders.json"
+          data_path "orders"
+        end
+      end
+  """
   defmacro asset(name, do: block) do
     if not is_atom(name) do
       compile_error!(

--- a/lib/favn/multi_asset.ex
+++ b/lib/favn/multi_asset.ex
@@ -50,6 +50,43 @@ defmodule Favn.MultiAsset do
   - use at most one `defaults do ... end` block
   - attach `@doc`, `@meta`, `@depends`, `@window`, and `@relation` directly above each declared asset
 
+  ## Supported attributes and blocks
+
+  Per generated asset you can use:
+
+  - `@doc`
+  - `@meta`
+  - `@depends`
+  - `@window`
+  - `@relation`
+  - `asset :name do ... end`
+
+  `defaults do ... end` currently supports:
+
+  - `meta ...`
+  - `window Favn.Window.*(...)`
+  - `rest do ... end`
+
+  `asset :name do ... end` currently supports:
+
+  - `rest do ... end`
+
+  `rest` currently supports these entries:
+
+  - `path "/path"`: request path or endpoint path
+  - `data_path "items"`: field path containing extracted records
+  - `params %{...}` or keyword list: static request params
+  - `primary_key "id"`: identifier field for downstream extraction logic
+  - `paginator kind, opts`: paginator config map with added `:kind`
+  - `incremental opts`: incremental extraction config, defaults `kind: :cursor`
+  - `method :get` or `"GET"`: request method
+  - `extra %{...}` or keyword list: adapter-specific extra config
+
+  `@depends` supports:
+
+  - `Other.SingleAssetModule`
+  - `{OtherModule, :asset_name}`
+
   ## What gets compiled
 
   Each declaration becomes one canonical `%Favn.Asset{}` with:
@@ -162,6 +199,12 @@ defmodule Favn.MultiAsset do
   Defaults are merged with per-asset declarations. In v0.4 this block supports
   `meta`, `window`, and `rest`.
 
+  Supported entries:
+
+  - `meta owner: ..., category: ..., tags: ...`
+  - `window Favn.Window.daily(...)`
+  - `rest do ... end`
+
   ## Example
 
       defaults do
@@ -202,6 +245,8 @@ defmodule Favn.MultiAsset do
 
   Attach standard asset attributes such as `@doc`, `@meta`, `@depends`,
   `@window`, and `@relation` immediately above the declaration.
+
+  The asset block currently supports only `rest do ... end`.
 
   ## Example
 

--- a/lib/favn/namespace.ex
+++ b/lib/favn/namespace.ex
@@ -26,6 +26,20 @@ defmodule Favn.Namespace do
         use Favn.Namespace, relation: [schema: "sales"]
       end
 
+  ## Supported options
+
+  `use Favn.Namespace` accepts:
+
+  - `relation: [connection: ..., catalog: ..., schema: ...]`
+
+  Supported relation keys:
+
+  - `connection`: atom
+  - `catalog`: string or atom
+  - `schema`: string or atom
+
+  Only `relation:` is supported at the top level.
+
   ## See also
 
   - `Favn.Asset`

--- a/lib/favn/namespace.ex
+++ b/lib/favn/namespace.ex
@@ -1,22 +1,36 @@
 defmodule Favn.Namespace do
   @moduledoc """
-  Namespace config carrier for inherited asset relation defaults.
+  Public helper for inherited relation defaults.
 
-  Supports grouped `relation: [connection: ..., catalog: ..., schema: ...]` for relation defaults.
+  Use `Favn.Namespace` to declare relation defaults once on parent modules, then
+  let `Favn.Asset`, `Favn.SQLAsset`, `Favn.MultiAsset`, `Favn.Assets`, and
+  `Favn.Source` inherit them.
 
-  Example:
+  ## When to use it
 
-      defmodule MyApp do
+  Use this module when many assets share the same `connection`, `catalog`, or
+  `schema` and you want those values derived from module nesting instead of
+  repeated in every asset.
+
+  ## Example
+
+      defmodule MyApp.Warehouse do
         use Favn.Namespace, relation: [connection: :warehouse]
       end
 
-      defmodule MyApp.Raw do
+      defmodule MyApp.Warehouse.Raw do
         use Favn.Namespace, relation: [catalog: "raw"]
       end
 
-      defmodule MyApp.Raw.Stripe do
-        use Favn.Namespace, relation: [schema: "stripe"]
+      defmodule MyApp.Warehouse.Raw.Sales do
+        use Favn.Namespace, relation: [schema: "sales"]
       end
+
+  ## See also
+
+  - `Favn.Asset`
+  - `Favn.SQLAsset`
+  - `Favn.Source`
   """
 
   @supported_keys [:connection, :catalog, :schema]

--- a/lib/favn/pipeline.ex
+++ b/lib/favn/pipeline.ex
@@ -23,6 +23,54 @@ defmodule Favn.Pipeline do
         end
       end
 
+  ## Supported clauses
+
+  A pipeline block supports these clauses:
+
+  - `asset ref_or_module`: add one target asset
+  - `assets refs_or_modules`: add many target assets
+  - `select do ... end`: additive selectors using `asset`, `tag`, `category`, and `module`
+  - `deps :all | :none`: include upstream dependencies or not
+  - `config map_or_keyword`: runtime pipeline config exposed through pipeline context
+  - `meta map_or_keyword`: descriptive metadata for operators and tooling
+  - `schedule {Module, :name}`: reference a named schedule
+  - `schedule cron: ..., ...`: declare an inline schedule
+  - `window atom`: attach a named pipeline window
+  - `source atom`: attach a named pipeline source
+  - `outputs [atom, ...]`: attach named outputs
+
+  ## Schedule options
+
+  Inline `schedule` supports:
+
+  - `cron`: required 5-field cron expression
+  - `timezone`: optional IANA timezone string
+  - `missed`: `:skip | :one | :all`, defaults to `:skip`
+  - `overlap`: `:forbid | :allow | :queue_one`, defaults to `:forbid`
+  - `active`: boolean, defaults to `true`
+
+  ## Full example
+
+      defmodule MyApp.Pipelines.DailySales do
+        use Favn.Pipeline
+
+        pipeline :daily_sales do
+          select do
+            module MyApp.Gold.Sales
+            tag :daily
+            category :sales
+          end
+
+          deps :all
+          config requested_by: "scheduler", priority: :normal
+          meta owner: "analytics", purpose: :daily_refresh
+          schedule cron: "0 2 * * *", timezone: "Europe/Oslo", missed: :one
+          window :daily
+          source :scheduler
+          outputs [:warehouse, :metrics]
+        end
+      end
+
   ## Authoring notes
 
   - declare exactly one `pipeline :name do ... end`
@@ -64,6 +112,8 @@ defmodule Favn.Pipeline do
 
   @doc """
   Declares the pipeline name and body for a pipeline module.
+
+  Each module may declare exactly one pipeline block.
   """
   defmacro pipeline(name, do: block) when is_atom(name) do
     if Module.get_attribute(__CALLER__.module, :favn_pipeline_declared) do
@@ -82,6 +132,15 @@ defmodule Favn.Pipeline do
 
   @doc """
   Chooses whether pipeline runs include upstream dependencies.
+
+  Supported values:
+
+  - `:all`: include upstream dependencies
+  - `:none`: run only the selected targets
+
+  ## Example
+
+      deps :all
   """
   defmacro deps(mode) do
     quote bind_quoted: [mode: mode] do
@@ -94,6 +153,14 @@ defmodule Favn.Pipeline do
 
   @doc """
   Attaches pipeline-level config metadata as a map or keyword list.
+
+  `config` is intended for runtime-facing values that assets or orchestration
+  code may read from pipeline context.
+
+  ## Examples
+
+      config requested_by: "scheduler", priority: :high
+      config %{requested_by: "operator", dry_run: true}
   """
   defmacro config(opts) do
     quote bind_quoted: [opts: opts] do
@@ -106,6 +173,14 @@ defmodule Favn.Pipeline do
 
   @doc """
   Attaches pipeline metadata as a map or keyword list.
+
+  `meta` is intended for descriptive or classification data rather than runtime
+  control fields.
+
+  ## Examples
+
+      meta owner: "analytics", purpose: :daily_refresh
+      meta %{team: "data-platform", tier: :gold}
   """
   defmacro meta(opts) do
     quote bind_quoted: [opts: opts] do
@@ -118,6 +193,29 @@ defmodule Favn.Pipeline do
 
   @doc """
   Attaches a schedule reference or an inline schedule definition.
+
+  Supported forms:
+
+  - `{Module, :name}` for a named schedule from `Favn.Triggers.Schedules`
+  - keyword options for an inline schedule
+
+  Inline options:
+
+  - `cron` required
+  - `timezone` optional
+  - `missed` optional, defaults to `:skip`
+  - `overlap` optional, defaults to `:forbid`
+  - `active` optional, defaults to `true`
+
+  ## Examples
+
+      schedule {MyApp.Schedules, :daily}
+
+      schedule cron: "0 2 * * *",
+               timezone: "Europe/Oslo",
+               missed: :one,
+               overlap: :queue_one,
+               active: true
   """
   defmacro schedule(value) do
     quote bind_quoted: [value: value] do
@@ -129,6 +227,12 @@ defmodule Favn.Pipeline do
 
   @doc """
   Declares the named pipeline window to use at runtime.
+
+  The value must be an atom understood by your runtime or surrounding app.
+
+  ## Example
+
+      window :daily
   """
   defmacro window(name) do
     quote bind_quoted: [name: name] do
@@ -141,6 +245,12 @@ defmodule Favn.Pipeline do
 
   @doc """
   Declares the named pipeline source.
+
+  The value must be an atom understood by your runtime or surrounding app.
+
+  ## Example
+
+      source :scheduler
   """
   defmacro source(name) do
     quote bind_quoted: [name: name] do
@@ -153,6 +263,12 @@ defmodule Favn.Pipeline do
 
   @doc """
   Declares named pipeline outputs.
+
+  The value must be a list of atoms.
+
+  ## Example
+
+      outputs [:warehouse, :metrics]
   """
   defmacro outputs(value) do
     quote bind_quoted: [value: value] do
@@ -165,6 +281,16 @@ defmodule Favn.Pipeline do
 
   @doc """
   Adds one asset ref or single-asset module to the pipeline selection.
+
+  Supported values:
+
+  - `{Module, :asset_name}`
+  - `SingleAssetModule` for modules compiled as `{Module, :asset}`
+
+  ## Examples
+
+      asset {MyApp.Raw.Shopify, :orders}
+      asset MyApp.Gold.Sales.FctOrders
   """
   defmacro asset(ref) do
     quote bind_quoted: [ref: ref] do
@@ -182,6 +308,13 @@ defmodule Favn.Pipeline do
 
   @doc """
   Adds many asset refs or single-asset modules to the pipeline selection.
+
+  ## Example
+
+      assets [
+        {MyApp.Raw.Shopify, :orders},
+        MyApp.Gold.Sales.FctOrders
+      ]
   """
   defmacro assets(refs) do
     quote bind_quoted: [refs: refs] do
@@ -202,6 +335,21 @@ defmodule Favn.Pipeline do
 
   @doc """
   Declares additive selectors such as `asset`, `tag`, `category`, or `module`.
+
+  Supported selector forms inside the block:
+
+  - `asset ref_or_module`
+  - `tag atom_or_string`
+  - `category atom_or_string`
+  - `module Some.Namespace`
+
+  ## Example
+
+      select do
+        module MyApp.Gold.Sales
+        tag :daily
+        category :sales
+      end
   """
   defmacro select(do: block) do
     selectors = __extract_selectors__(block)

--- a/lib/favn/pipeline.ex
+++ b/lib/favn/pipeline.ex
@@ -1,12 +1,39 @@
 defmodule Favn.Pipeline do
   @moduledoc """
-  Tiny code-defined DSL for pipeline composition.
+  Public DSL for pipeline composition.
 
-  This DSL defines orchestration composition only. Dependency planning is still
-  delegated to the existing asset dependency planner.
+  Pipelines select assets and attach orchestration configuration without
+  redefining dependency logic. Favn still derives execution order from the asset
+  graph.
 
-  Selector semantics in `select do ... end` are additive (union-based): each
-  selector contributes refs, then refs are deduplicated and sorted.
+  ## When to use it
+
+  Use `Favn.Pipeline` when you want a named operational unit such as a daily
+  run, a scheduled sync, or a curated asset subset.
+
+  ## Minimal example
+
+      defmodule MyApp.Pipelines.DailySales do
+        use Favn.Pipeline
+
+        pipeline :daily_sales do
+          asset MyApp.Gold.Sales.FctOrders
+          deps :all
+          schedule cron: "0 2 * * *", timezone: "Etc/UTC"
+        end
+      end
+
+  ## Authoring notes
+
+  - declare exactly one `pipeline :name do ... end`
+  - use either shorthand selection (`asset`, `assets`) or `select do ... end`
+  - selector semantics are additive and deduplicated
+
+  ## See also
+
+  - `Favn`
+  - `Favn.Window`
+  - `Favn.Triggers.Schedules`
   """
 
   alias Favn.Pipeline.Definition
@@ -35,6 +62,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Declares the pipeline name and body for a pipeline module.
+  """
   defmacro pipeline(name, do: block) when is_atom(name) do
     if Module.get_attribute(__CALLER__.module, :favn_pipeline_declared) do
       raise ArgumentError, "pipeline can only be declared once per module"
@@ -50,6 +80,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Chooses whether pipeline runs include upstream dependencies.
+  """
   defmacro deps(mode) do
     quote bind_quoted: [mode: mode] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "deps")
@@ -59,6 +92,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Attaches pipeline-level config metadata as a map or keyword list.
+  """
   defmacro config(opts) do
     quote bind_quoted: [opts: opts] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "config")
@@ -68,6 +104,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Attaches pipeline metadata as a map or keyword list.
+  """
   defmacro meta(opts) do
     quote bind_quoted: [opts: opts] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "meta")
@@ -77,6 +116,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Attaches a schedule reference or an inline schedule definition.
+  """
   defmacro schedule(value) do
     quote bind_quoted: [value: value] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "schedule")
@@ -85,6 +127,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Declares the named pipeline window to use at runtime.
+  """
   defmacro window(name) do
     quote bind_quoted: [name: name] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "window")
@@ -94,6 +139,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Declares the named pipeline source.
+  """
   defmacro source(name) do
     quote bind_quoted: [name: name] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "source")
@@ -103,6 +151,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Declares named pipeline outputs.
+  """
   defmacro outputs(value) do
     quote bind_quoted: [value: value] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "outputs")
@@ -112,6 +163,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Adds one asset ref or single-asset module to the pipeline selection.
+  """
   defmacro asset(ref) do
     quote bind_quoted: [ref: ref] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "asset")
@@ -126,6 +180,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Adds many asset refs or single-asset modules to the pipeline selection.
+  """
   defmacro assets(refs) do
     quote bind_quoted: [refs: refs] do
       Favn.Pipeline.ensure_in_pipeline_block!(__MODULE__, "assets")
@@ -143,6 +200,9 @@ defmodule Favn.Pipeline do
     end
   end
 
+  @doc """
+  Declares additive selectors such as `asset`, `tag`, `category`, or `module`.
+  """
   defmacro select(do: block) do
     selectors = __extract_selectors__(block)
 

--- a/lib/favn/source.ex
+++ b/lib/favn/source.ex
@@ -27,6 +27,17 @@ defmodule Favn.Source do
   - declare exactly one `@relation`
   - optionally add `@doc` and `@meta`
 
+  ## Supported attributes
+
+  - `@doc`: source documentation
+  - `@meta`: keyword or map metadata such as `owner`, `category`, and `tags`
+  - `@relation`: required relation declaration
+
+  `@relation` supports:
+
+  - `true` to infer from module name plus namespace defaults
+  - keyword or map relation overrides such as `connection`, `catalog`, and `schema`
+
   ## What gets compiled
 
   A source compiles to one canonical `%Favn.Asset{}` with `type: :source` and no

--- a/lib/favn/source.ex
+++ b/lib/favn/source.ex
@@ -1,22 +1,42 @@
 defmodule Favn.Source do
   @moduledoc """
-  External relational source DSL for declaring upstream data relations.
+  Public DSL for external upstream relations that Favn can reason about but not run.
 
-  Represents a relation in an external data warehouse that Favn can read from
-  and reason about, but does not materialize or execute.
+  Use `Favn.Source` for warehouse objects that participate in lineage and SQL
+  dependency inference but are not executed as materializing assets.
+
+  ## When to use it
+
+  Use this module when a relation is external to Favn-managed execution but you
+  still want it to be explicit and typed in the catalog.
+
+  ## Minimal example
 
       defmodule MyApp.Raw.Stripe.Charges do
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: "raw", schema: "stripe"]
         use Favn.Source
 
+        @doc "External raw Stripe charges table"
+        @meta owner: "data-platform", category: :payments, tags: [:raw]
         @relation true
       end
 
-  The `@relation` attribute is required and follows the same inference rules as `Favn.Asset`.
+  ## Authoring contract
 
-  Supported attributes:
-  - `@doc` - documentation
-  - `@meta` - metadata such as owner, category, tags
-  - `@relation` - the external relation identity (required)
+  - define no user functions
+  - declare exactly one `@relation`
+  - optionally add `@doc` and `@meta`
+
+  ## What gets compiled
+
+  A source compiles to one canonical `%Favn.Asset{}` with `type: :source` and no
+  executable entrypoint.
+
+  ## See also
+
+  - `Favn.AgentGuide`
+  - `Favn.SQLAsset`
+  - `Favn.Namespace`
   """
 
   alias Favn.Asset

--- a/lib/favn/sql.ex
+++ b/lib/favn/sql.ex
@@ -1,16 +1,56 @@
 defmodule Favn.SQL do
   @moduledoc """
-  SQL runtime facade and reusable SQL authoring DSL.
+  Reusable SQL authoring DSL plus the public SQL runtime facade.
 
-  Compiler/discovery and planner flows should remain independent from SQL sessions.
-  Runtime SQL session APIs in this module start from `%Favn.Connection.Resolved{}`.
+  This module serves two related jobs:
 
-  The same module also exposes SQL authoring macros:
+  - define reusable SQL with `defsql`
+  - open SQL sessions and execute backend operations from resolved connections
 
-    * `use Favn.SQL`
-    * `defsql ... do ... end`
-    * `defsql ..., file: "..."`
-    * `~SQL\""" ... \"""`
+  Read this module after `Favn.SQLAsset` when you need reusable SQL, the `~SQL`
+  sigil, or direct SQL helper/runtime APIs.
+
+  ## When to use it
+
+  Use `Favn.SQL` when:
+
+  - a SQL asset needs reusable SQL definitions
+  - you want the canonical `~SQL` body language
+  - you need direct SQL runtime access from `%Favn.Connection.Resolved{}` or a named connection
+
+  ## Minimal example
+
+      defmodule MyApp.SQL.Common do
+        use Favn.SQL
+
+        defsql by_status(status) do
+          ~SQL\"""
+          select *
+          from raw.sales.orders
+          where status = @status
+          \"""
+        end
+      end
+
+  ## Authoring notes
+
+  - `~SQL` only accepts literal strings
+  - interpolation is intentionally rejected
+  - non-reserved `@name` placeholders are explicit SQL inputs
+  - `defsql` can be inline or file-backed
+
+  ## Public vs internal boundary
+
+  `Favn.SQL` is public. Lower-level modules such as `Favn.SQL.Template` and the
+  adapter internals are implementation details unless another public moduledoc
+  explicitly routes you there.
+
+  ## See also
+
+  - `Favn.AgentGuide`
+  - `Favn.SQLAsset`
+  - `Favn.Connection`
+  - `Favn`
   """
 
   alias Favn.Connection.Registry
@@ -41,7 +81,20 @@ defmodule Favn.SQL do
     end
   end
 
-  @doc false
+  @doc """
+  Canonical SQL sigil for Favn SQL authoring.
+
+  The body must be a literal string. Interpolation and sigil modifiers are not
+  supported.
+
+  ## Example
+
+      ~SQL\"""
+      select *
+      from raw.sales.orders
+      where status = @status
+      \"""
+  """
   defmacro sigil_SQL({:<<>>, _meta, parts}, modifiers) when is_list(modifiers) do
     if modifiers != [] do
       compile_error!(__CALLER__.file, __CALLER__.line, "~SQL sigil does not support modifiers")
@@ -66,7 +119,24 @@ defmodule Favn.SQL do
     end
   end
 
-  @doc false
+  @doc """
+  Defines reusable SQL that can be referenced from SQL assets or other reusable
+  SQL definitions.
+
+  Use a function-style head so arguments become named SQL inputs.
+
+  ## Examples
+
+      defsql recent_orders(limit) do
+        ~SQL\"""
+        select *
+        from raw.sales.orders
+        limit @limit
+        \"""
+      end
+
+      defsql recent_orders(limit), file: "sql/recent_orders.sql"
+  """
   defmacro defsql({name, _meta, args_ast}, do: body)
            when is_atom(name) and (is_list(args_ast) or is_nil(args_ast)) do
     args = normalize_defsql_args!(args_ast || [], __CALLER__)

--- a/lib/favn/sql.ex
+++ b/lib/favn/sql.ex
@@ -39,6 +39,13 @@ defmodule Favn.SQL do
   - non-reserved `@name` placeholders are explicit SQL inputs
   - `defsql` can be inline or file-backed
 
+  ## Supported public entrypoints
+
+  - `use Favn.SQL`: enables `defsql` and `~SQL`
+  - `defsql name(args) do ... end`: inline reusable SQL definition
+  - `defsql name(args), file: "..."`: file-backed reusable SQL definition
+  - `~SQL\""" ... \"""`: literal SQL body language
+
   ## Public vs internal boundary
 
   `Favn.SQL` is public. Lower-level modules such as `Favn.SQL.Template` and the
@@ -124,6 +131,11 @@ defmodule Favn.SQL do
   SQL definitions.
 
   Use a function-style head so arguments become named SQL inputs.
+
+  Supported forms:
+
+  - `defsql name(args) do ... end`
+  - `defsql name(args), file: "path/to/query.sql"`
 
   ## Examples
 

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -1,14 +1,77 @@
 defmodule Favn.SQLAsset do
   @moduledoc """
-  Preferred single-module SQL asset DSL.
+  Preferred single-asset SQL DSL.
 
-  `Favn.SQLAsset` compiles one SQL-authored module into one canonical
-  `%Favn.Asset{}` with ref `{Module, :asset}`.
+  Use this module when one module should define one SQL asset. Like
+  `Favn.Asset`, it compiles to one canonical `%Favn.Asset{}` with ref
+  `{Module, :asset}`, but the authored body comes from `query/1` instead of a
+  handwritten `asset/1` function.
 
-  SQL bodies are authored with `query do ... end` or `query file: "..."`.
-  Inline SQL uses a real `~SQL` sigil.
-  SQL compilation keeps the authored SQL source and a normalized SQL template IR
-  so reusable SQL definitions and relation references can be validated at compile time.
+  ## When to use it
+
+  Use `Favn.SQLAsset` when:
+
+  - the asset body is primarily SQL
+  - you want Favn-aware relation references, placeholders, and reusable SQL
+  - you want the SQL asset to participate in the same dependency and runtime model as Elixir assets
+
+  ## Minimal example
+
+      defmodule MyApp.Gold.Sales.FctOrders do
+        use Favn.Namespace, relation: [connection: :warehouse, catalog: "gold", schema: "sales"]
+        use Favn.SQLAsset
+
+        @doc "Build the gold orders fact table"
+        @meta owner: "analytics", category: :sales, tags: [:gold]
+        @depends MyApp.Silver.Sales.StgOrders
+        @window Favn.Window.daily(lookback: 1)
+        @materialized {:incremental, strategy: :delete_insert, window_column: :order_date}
+
+        query do
+          ~SQL\"""
+          select *
+          from MyApp.Silver.Sales.StgOrders
+          where order_date >= @window_start
+            and order_date < @window_end
+          \"""
+        end
+      end
+
+  ## Authoring contract
+
+  - define exactly one `query/1` declaration
+  - declare exactly one `@materialized`
+  - attach `@doc`, `@meta`, `@depends`, `@window`, `@materialized`, and optional `@relation` before `query`
+  - use `~SQL` for inline SQL bodies
+  - use `query file: "..."` for file-backed SQL loaded at compile time
+
+  ## What gets compiled
+
+  The DSL keeps both authored SQL and normalized SQL IR so Favn can validate
+  reusable SQL definitions, placeholders, and typed relation usage at compile
+  time. The final public output is still one canonical `%Favn.Asset{}` plus
+  SQL-specific definition metadata used by rendering and execution.
+
+  ## Runtime context notes
+
+  The generated `asset/1` calls into the SQL runtime automatically. Runtime
+  inputs such as window bounds and explicit `params` are resolved during render
+  and execution, not inside user-authored Elixir code.
+
+  ## Common mistakes
+
+  - defining more than one query
+  - forgetting `@materialized`
+  - using interpolation inside `~SQL`
+  - using invalid `@depends`, `@window`, or `@relation` values
+  - expecting `asset/1` to be user-defined in a `Favn.SQLAsset` module
+
+  ## See also
+
+  - `Favn.AgentGuide`
+  - `Favn.SQL`
+  - `Favn.Window`
+  - `Favn.Connection`
   """
 
   alias Favn.Asset
@@ -79,7 +142,23 @@ defmodule Favn.SQLAsset do
     end
   end
 
-  @doc false
+  @doc """
+  Declares the SQL body for a `Favn.SQLAsset`.
+
+  Use either an inline `~SQL` body or `file: "..."`. Each module may declare
+  exactly one query.
+
+  ## Examples
+
+      query do
+        ~SQL\"""
+        select *
+        from MyApp.Raw.Sales.Orders
+        \"""
+      end
+
+      query file: "sql/fct_orders.sql"
+  """
   defmacro query(do: body) do
     raw_definition = Module.get_attribute(__CALLER__.module, :favn_sql_asset_raw)
 

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -45,6 +45,34 @@ defmodule Favn.SQLAsset do
   - use `~SQL` for inline SQL bodies
   - use `query file: "..."` for file-backed SQL loaded at compile time
 
+  ## Supported attributes
+
+  - `@doc`: asset documentation
+  - `@meta`: keyword or map metadata such as `owner`, `category`, and `tags`
+  - `@depends`: repeatable dependency declaration
+  - `@window`: one `Favn.Window.*` spec
+  - `@relation`: optional owned relation declaration
+  - `@materialized`: required SQL materialization strategy
+
+  `@depends` supports:
+
+  - `Other.SingleAssetModule`
+  - `{Other.MultiAssetModule, :asset_name}`
+
+  `@materialized` currently supports:
+
+  - `:table`
+  - `:view`
+  - `{:incremental, strategy: :append}`
+  - `{:incremental, strategy: :delete_insert, window_column: :column_name}`
+
+  Incremental notes:
+
+  - incremental materialization requires `@window`
+  - `:append` does not accept `:window_column`
+  - `:delete_insert` requires `:window_column`
+  - `:merge`, `:replace`, and `unique_key` are not supported in v0.4
+
   ## What gets compiled
 
   The DSL keeps both authored SQL and normalized SQL IR so Favn can validate
@@ -147,6 +175,11 @@ defmodule Favn.SQLAsset do
 
   Use either an inline `~SQL` body or `file: "..."`. Each module may declare
   exactly one query.
+
+  Supported forms:
+
+  - `query do ... end`
+  - `query file: "path/to/query.sql"`
 
   ## Examples
 

--- a/lib/favn/triggers/schedules.ex
+++ b/lib/favn/triggers/schedules.ex
@@ -1,8 +1,11 @@
 defmodule Favn.Triggers.Schedules do
   @moduledoc """
-  Reusable named schedule trigger definitions.
+  Public DSL for reusable named schedules.
 
-  Modules can declare repeated top-level `schedule/2` clauses:
+  Use this module when multiple pipelines should share stable schedule
+  definitions by reference.
+
+  ## Example
 
       defmodule MyApp.Schedules do
         use Favn.Triggers.Schedules
@@ -13,6 +16,8 @@ defmodule Favn.Triggers.Schedules do
           missed: :skip,
           overlap: :forbid
       end
+
+  Pipelines can then reference `{MyApp.Schedules, :daily}`.
   """
 
   alias Favn.Triggers.Schedule
@@ -30,6 +35,9 @@ defmodule Favn.Triggers.Schedules do
     end
   end
 
+  @doc """
+  Declares one named schedule.
+  """
   defmacro schedule(name, opts) do
     quote bind_quoted: [name: name, opts: opts] do
       unless is_atom(name) do

--- a/lib/favn/triggers/schedules.ex
+++ b/lib/favn/triggers/schedules.ex
@@ -18,6 +18,16 @@ defmodule Favn.Triggers.Schedules do
       end
 
   Pipelines can then reference `{MyApp.Schedules, :daily}`.
+
+  ## Supported options
+
+  `schedule/2` accepts:
+
+  - `cron`: required 5-field cron expression
+  - `timezone`: optional IANA timezone string
+  - `missed`: `:skip | :one | :all`, defaults to `:skip`
+  - `overlap`: `:forbid | :allow | :queue_one`, defaults to `:forbid`
+  - `active`: boolean, defaults to `true`
   """
 
   alias Favn.Triggers.Schedule
@@ -37,6 +47,15 @@ defmodule Favn.Triggers.Schedules do
 
   @doc """
   Declares one named schedule.
+
+  ## Example
+
+      schedule :hourly,
+        cron: "0 * * * *",
+        timezone: "Etc/UTC",
+        missed: :skip,
+        overlap: :forbid,
+        active: true
   """
   defmacro schedule(name, opts) do
     quote bind_quoted: [name: name, opts: opts] do

--- a/lib/favn/window.ex
+++ b/lib/favn/window.ex
@@ -1,28 +1,47 @@
 defmodule Favn.Window do
   @moduledoc """
-  Public runtime windowing primitives.
+  Public window constructors for assets and pipelines.
 
-  This module provides small constructor helpers for canonical window structs.
+  Use this module when authoring `@window` declarations or when constructing
+  anchor/runtime windows directly in tests and runtime code.
+
+  The helpers return canonical window structs used across Elixir assets, SQL
+  assets, pipelines, backfills, and freshness checks.
   """
 
   alias Favn.Window.{Anchor, Runtime, Spec}
 
   @type spec_kind :: Spec.kind()
 
+  @doc """
+  Builds an hourly window spec.
+  """
   @spec hourly(keyword()) :: Spec.t()
   def hourly(opts \\ []), do: Spec.new!(:hour, opts)
 
+  @doc """
+  Builds a daily window spec.
+  """
   @spec daily(keyword()) :: Spec.t()
   def daily(opts \\ []), do: Spec.new!(:day, opts)
 
+  @doc """
+  Builds a monthly window spec.
+  """
   @spec monthly(keyword()) :: Spec.t()
   def monthly(opts \\ []), do: Spec.new!(:month, opts)
 
+  @doc """
+  Builds a named anchor window.
+  """
   @spec anchor(spec_kind(), DateTime.t(), DateTime.t(), keyword()) :: Anchor.t()
   def anchor(kind, %DateTime{} = start_at, %DateTime{} = end_at, opts \\ []) do
     Anchor.new!(kind, start_at, end_at, opts)
   end
 
+  @doc """
+  Builds a runtime window keyed to an anchor window.
+  """
   @spec runtime(spec_kind(), DateTime.t(), DateTime.t(), Favn.Window.Key.t(), keyword()) ::
           Runtime.t()
   def runtime(kind, %DateTime{} = start_at, %DateTime{} = end_at, anchor_key, opts \\ []) do

--- a/lib/favn/window.ex
+++ b/lib/favn/window.ex
@@ -7,6 +7,62 @@ defmodule Favn.Window do
 
   The helpers return canonical window structs used across Elixir assets, SQL
   assets, pipelines, backfills, and freshness checks.
+
+  ## Window types
+
+  - `hourly/1`, `daily/1`, `monthly/1` build asset-level `%Favn.Window.Spec{}` values
+  - `anchor/4` builds a run-level `%Favn.Window.Anchor{}`
+  - `runtime/5` builds a concrete `%Favn.Window.Runtime{}` for one execution node
+
+  ## Spec options
+
+  `hourly/1`, `daily/1`, and `monthly/1` accept these keyword options:
+
+  - `lookback`: non-negative integer, defaults to `0`
+  - `refresh_from`: lower or equal-granularity refresh boundary
+  - `timezone`: IANA timezone string, defaults to `"Etc/UTC"`
+
+  Supported `refresh_from` values:
+
+  - hourly: `nil | :hour`
+  - daily: `nil | :hour | :day`
+  - monthly: `nil | :day | :month`
+
+  ## Anchor/runtime options
+
+  `anchor/4` and `runtime/5` accept:
+
+  - `timezone`: IANA timezone string, defaults to `"Etc/UTC"`
+
+  `start_at` must be strictly before `end_at`.
+
+  ## Examples
+
+      Favn.Window.daily()
+
+      Favn.Window.daily(lookback: 2, refresh_from: :hour, timezone: "Europe/Oslo")
+
+      Favn.Window.monthly(refresh_from: :day)
+
+      anchor =
+        Favn.Window.anchor(
+          :day,
+          DateTime.from_naive!(~N[2026-04-01 00:00:00], "Etc/UTC"),
+          DateTime.from_naive!(~N[2026-04-02 00:00:00], "Etc/UTC")
+        )
+
+      Favn.Window.runtime(
+        :day,
+        DateTime.from_naive!(~N[2026-03-31 00:00:00], "Etc/UTC"),
+        DateTime.from_naive!(~N[2026-04-01 00:00:00], "Etc/UTC"),
+        anchor.key
+      )
+
+  ## When to use what
+
+  - use spec helpers in asset DSLs such as `@window Favn.Window.daily(...)`
+  - use anchor windows when operators or pipelines request a run range
+  - use runtime windows when testing or working with resolved execution nodes
   """
 
   alias Favn.Window.{Anchor, Runtime, Spec}
@@ -15,24 +71,71 @@ defmodule Favn.Window do
 
   @doc """
   Builds an hourly window spec.
+
+  Supported options:
+
+  - `lookback`
+  - `refresh_from: :hour`
+  - `timezone`
+
+  ## Example
+
+      Favn.Window.hourly(lookback: 6, refresh_from: :hour)
   """
   @spec hourly(keyword()) :: Spec.t()
   def hourly(opts \\ []), do: Spec.new!(:hour, opts)
 
   @doc """
   Builds a daily window spec.
+
+  Supported options:
+
+  - `lookback`
+  - `refresh_from: :hour | :day`
+  - `timezone`
+
+  ## Examples
+
+      Favn.Window.daily()
+      Favn.Window.daily(lookback: 1)
+      Favn.Window.daily(lookback: 7, refresh_from: :hour, timezone: "Europe/Oslo")
   """
   @spec daily(keyword()) :: Spec.t()
   def daily(opts \\ []), do: Spec.new!(:day, opts)
 
   @doc """
   Builds a monthly window spec.
+
+  Supported options:
+
+  - `lookback`
+  - `refresh_from: :day | :month`
+  - `timezone`
+
+  ## Example
+
+      Favn.Window.monthly(lookback: 1, refresh_from: :day)
   """
   @spec monthly(keyword()) :: Spec.t()
   def monthly(opts \\ []), do: Spec.new!(:month, opts)
 
   @doc """
   Builds a named anchor window.
+
+  Use this for run-level execution intent such as pipeline runs and backfills.
+
+  Supported options:
+
+  - `timezone`
+
+  ## Example
+
+      Favn.Window.anchor(
+        :day,
+        DateTime.from_naive!(~N[2026-04-01 00:00:00], "Etc/UTC"),
+        DateTime.from_naive!(~N[2026-04-02 00:00:00], "Etc/UTC"),
+        timezone: "Europe/Oslo"
+      )
   """
   @spec anchor(spec_kind(), DateTime.t(), DateTime.t(), keyword()) :: Anchor.t()
   def anchor(kind, %DateTime{} = start_at, %DateTime{} = end_at, opts \\ []) do
@@ -41,6 +144,29 @@ defmodule Favn.Window do
 
   @doc """
   Builds a runtime window keyed to an anchor window.
+
+  Use this when a planner has expanded an anchor window into concrete execution
+  nodes or when tests need a fully resolved runtime window.
+
+  Supported options:
+
+  - `timezone`
+
+  ## Example
+
+      anchor =
+        Favn.Window.anchor(
+          :day,
+          DateTime.from_naive!(~N[2026-04-01 00:00:00], "Etc/UTC"),
+          DateTime.from_naive!(~N[2026-04-02 00:00:00], "Etc/UTC")
+        )
+
+      Favn.Window.runtime(
+        :day,
+        DateTime.from_naive!(~N[2026-03-31 00:00:00], "Etc/UTC"),
+        DateTime.from_naive!(~N[2026-04-01 00:00:00], "Etc/UTC"),
+        anchor.key
+      )
   """
   @spec runtime(spec_kind(), DateTime.t(), DateTime.t(), Favn.Window.Key.t(), keyword()) ::
           Runtime.t()

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Favn.MixProject do
   def project do
     [
       app: :favn,
-      version: "0.3.0",
+      version: "0.4.0",
       description: "Asset-oriented workflow orchestration for Elixir applications",
       elixir: "~> 1.19",
       source_url: "https://github.com/eirhop/favn",

--- a/test/public_docs_test.exs
+++ b/test/public_docs_test.exs
@@ -1,0 +1,62 @@
+defmodule Favn.PublicDocsTest do
+  use ExUnit.Case, async: true
+
+  @modules [
+    Favn,
+    Favn.AgentGuide,
+    Favn.Asset,
+    Favn.SQLAsset,
+    Favn.MultiAsset,
+    Favn.Assets,
+    Favn.Namespace,
+    Favn.SQL,
+    Favn.Pipeline,
+    Favn.Triggers.Schedules,
+    Favn.Window,
+    Favn.Connection,
+    Favn.Source
+  ]
+
+  test "important public modules have moduledocs" do
+    Enum.each(@modules, fn module ->
+      assert moduledoc(module), "expected #{inspect(module)} to have a public moduledoc"
+    end)
+  end
+
+  test "important public DSL entrypoints have docs" do
+    assert doc?(Favn.SQLAsset, :macro, :query, 1)
+    assert doc?(Favn.SQL, :macro, :sigil_SQL, 2)
+    assert doc?(Favn.SQL, :macro, :defsql, 2)
+    assert doc?(Favn.MultiAsset, :macro, :defaults, 1)
+    assert doc?(Favn.MultiAsset, :macro, :asset, 2)
+    assert doc?(Favn.Pipeline, :macro, :pipeline, 2)
+    assert doc?(Favn.Pipeline, :macro, :asset, 1)
+    assert doc?(Favn.Pipeline, :macro, :select, 1)
+    assert doc?(Favn.Triggers.Schedules, :macro, :schedule, 2)
+  end
+
+  defp moduledoc(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, %{"en" => doc}, _, _} when is_binary(doc) -> String.trim(doc) != ""
+      _ -> false
+    end
+  end
+
+  defp doc?(module, kind, name, arity) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _, _, _, _, _, docs} ->
+        Enum.any?(docs, fn
+          {{entry_kind, entry_name, entry_arity}, _, _, %{"en" => doc}, _}
+          when entry_kind == kind and entry_name == name and entry_arity == arity and
+                 is_binary(doc) ->
+            String.trim(doc) != ""
+
+          _ ->
+            false
+        end)
+
+      _ ->
+        false
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- shorten the README and refocus the `Favn` facade docs around the public runtime API
- add `Favn.AgentGuide` and strengthen public DSL moduledocs so agents can route through `Code.fetch_docs/1`
- document key user-facing macros and add a lightweight test that keeps important public docs present

## Testing
- mix format
- mix compile --warnings-as-errors
- mix test
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected