### PR TITLE
Extract shared compile-time DSL compiler helpers

### DIFF
--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -10,6 +10,7 @@ Favn is an asset-first orchestrator for ETL/ELT workloads.
 
 - [x] Credo strict cleanup across runtime, storage, docs, fixtures, and tests
 - [x] Shared relation resolver extracted for `Favn.Assets.Compiler`, `Favn.MultiAsset`, and `Favn.SQLAsset`
+- [x] Shared compile-time DSL helper foundation extracted to `Favn.DSL.Compiler` (`Favn.Asset`, `Favn.MultiAsset`, `Favn.SQLAsset`, `Favn.SQL`)
 
 Near-term priority is a practical path to real usage:
 

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -10,6 +10,8 @@ lib/
     ├── agent_guide.ex
     ├── asset.ex
     ├── diagnostic.ex
+    ├── dsl/
+    │   └── compiler.ex
     ├── assets.ex
     ├── namespace.ex
     ├── multi_asset.ex

--- a/lib/favn/asset.ex
+++ b/lib/favn/asset.ex
@@ -96,6 +96,7 @@ defmodule Favn.Asset do
   alias Favn.Asset.Dependency
   alias Favn.Asset.RelationInput
   alias Favn.Diagnostic
+  alias Favn.DSL.Compiler, as: DSLCompiler
   alias Favn.Ref
   alias Favn.RelationRef
   alias Favn.SQLAsset.Materialization
@@ -124,14 +125,18 @@ defmodule Favn.Asset do
         capture_single_asset_definition!(env)
 
       {:def, :asset, _other_arity} ->
-        compile_error!(
+        DSLCompiler.compile_error!(
           env.file,
           env.line,
           "Favn.Asset requires exactly one public asset/1 function"
         )
 
       {:defp, :asset, _arity} ->
-        compile_error!(env.file, env.line, "Favn.Asset requires a public def asset(ctx)")
+        DSLCompiler.compile_error!(
+          env.file,
+          env.line,
+          "Favn.Asset requires a public def asset(ctx)"
+        )
 
       {kind, _name, _arity} when kind in [:def, :defp] ->
         validate_no_stray_asset_attributes!(env, kind, name, arity)
@@ -146,7 +151,7 @@ defmodule Favn.Asset do
     raw_asset = Module.get_attribute(env.module, :favn_single_asset_raw)
 
     if is_nil(raw_asset) do
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "Favn.Asset modules must define exactly one public asset/1 function"
@@ -163,7 +168,7 @@ defmodule Favn.Asset do
         :ok
 
       _ ->
-        compile_error!(
+        DSLCompiler.compile_error!(
           env.file,
           env.line,
           "@depends/@meta/@window/@relation must be attached to def asset(ctx)"
@@ -388,7 +393,7 @@ defmodule Favn.Asset do
 
   defp capture_single_asset_definition!(env) do
     if Module.get_attribute(env.module, :favn_single_asset_raw) do
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "Favn.Asset modules can define only one asset/1 function"
@@ -410,8 +415,8 @@ defmodule Favn.Asset do
       module: env.module,
       name: :asset,
       arity: 1,
-      doc: normalize_doc(Module.get_attribute(env.module, :doc)),
-      file: normalize_file(env.file),
+      doc: DSLCompiler.normalize_doc(Module.get_attribute(env.module, :doc)),
+      file: DSLCompiler.normalize_file(env.file),
       line: env.line,
       depends: depends,
       meta: meta,
@@ -446,17 +451,17 @@ defmodule Favn.Asset do
       validate!(asset)
     rescue
       error in ArgumentError ->
-        compile_error!(raw_asset.file, raw_asset.line, error.message)
+        DSLCompiler.compile_error!(raw_asset.file, raw_asset.line, error.message)
     end
   end
 
   defp normalize_single_asset_depends!(depends, raw_asset) do
     Enum.map(depends, fn
       module when is_atom(module) ->
-        if module_atom?(module) do
+        if DSLCompiler.module_atom?(module) do
           Ref.new(module, :asset)
         else
-          compile_error!(
+          DSLCompiler.compile_error!(
             raw_asset.file,
             raw_asset.line,
             "invalid @depends entry #{inspect(module)}; expected Module or {Module, :asset_name}"
@@ -464,10 +469,10 @@ defmodule Favn.Asset do
         end
 
       {module, name} when is_atom(module) and is_atom(name) ->
-        if module_atom?(module) do
+        if DSLCompiler.module_atom?(module) do
           Ref.new(module, name)
         else
-          compile_error!(
+          DSLCompiler.compile_error!(
             raw_asset.file,
             raw_asset.line,
             "invalid @depends entry #{inspect({module, name})}; expected Module or {Module, :asset_name}"
@@ -475,7 +480,7 @@ defmodule Favn.Asset do
         end
 
       dependency ->
-        compile_error!(
+        DSLCompiler.compile_error!(
           raw_asset.file,
           raw_asset.line,
           "invalid @depends entry #{inspect(dependency)}; expected Module or {Module, :asset_name}"
@@ -486,14 +491,15 @@ defmodule Favn.Asset do
   defp normalize_single_asset_meta!(meta, raw_asset) do
     normalize_meta!(meta)
   rescue
-    error in ArgumentError -> compile_error!(raw_asset.file, raw_asset.line, error.message)
+    error in ArgumentError ->
+      DSLCompiler.compile_error!(raw_asset.file, raw_asset.line, error.message)
   end
 
   defp normalize_single_asset_window!([], _raw_asset), do: nil
   defp normalize_single_asset_window!([%Spec{} = spec], _raw_asset), do: spec
 
   defp normalize_single_asset_window!([_a, _b | _rest], raw_asset) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       raw_asset.file,
       raw_asset.line,
       "multiple @window attributes are not allowed; use at most one @window for def asset(ctx)"
@@ -501,7 +507,7 @@ defmodule Favn.Asset do
   end
 
   defp normalize_single_asset_window!(value, raw_asset) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       raw_asset.file,
       raw_asset.line,
       "invalid @window value #{inspect(value)}; expected Favn.Window spec like Favn.Window.daily()"
@@ -511,13 +517,12 @@ defmodule Favn.Asset do
   defp validate_relation_attr!([], _env), do: :ok
 
   defp validate_relation_attr!([relation], env) do
-    valid? =
-      relation == true or (is_list(relation) and Keyword.keyword?(relation)) or is_map(relation)
+    valid? = DSLCompiler.valid_relation_attr_value?(relation)
 
     if valid? do
       :ok
     else
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "invalid @relation value #{inspect(relation)}; expected true, a keyword list, or a map"
@@ -526,7 +531,7 @@ defmodule Favn.Asset do
   end
 
   defp validate_relation_attr!([_a, _b | _rest], env) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       env.file,
       env.line,
       "multiple @relation attributes are not allowed; use at most one @relation for def asset(ctx)"
@@ -545,7 +550,7 @@ defmodule Favn.Asset do
       Module.delete_attribute(env.module, :window)
       Module.delete_attribute(env.module, :relation)
 
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "@depends/@meta/@window/@relation on #{kind} #{name}/#{arity} requires def asset(ctx) immediately below those attributes"
@@ -553,27 +558,5 @@ defmodule Favn.Asset do
     else
       :ok
     end
-  end
-
-  defp normalize_doc({_line, false}), do: nil
-  defp normalize_doc({_line, doc}) when is_binary(doc), do: doc
-  defp normalize_doc(false), do: nil
-  defp normalize_doc(doc) when is_binary(doc), do: doc
-  defp normalize_doc(_), do: nil
-
-  defp normalize_file(file) do
-    file
-    |> to_string()
-    |> Path.relative_to_cwd()
-  end
-
-  defp compile_error!(file, line, description) do
-    raise CompileError, file: file, line: line, description: description
-  end
-
-  defp module_atom?(module) when is_atom(module) do
-    module
-    |> Atom.to_string()
-    |> String.starts_with?("Elixir.")
   end
 end

--- a/lib/favn/dsl/compiler.ex
+++ b/lib/favn/dsl/compiler.ex
@@ -1,0 +1,41 @@
+defmodule Favn.DSL.Compiler do
+  @moduledoc false
+
+  @spec compile_error!(String.t() | charlist(), pos_integer() | nil, String.t()) :: no_return()
+  def compile_error!(file, line, description) do
+    raise CompileError, file: file, line: line, description: description
+  end
+
+  @spec normalize_file(Path.t()) :: String.t()
+  def normalize_file(file) do
+    file
+    |> to_string()
+    |> Path.relative_to_cwd()
+  end
+
+  @spec normalize_doc(term()) :: String.t() | nil
+  def normalize_doc({_line, false}), do: nil
+  def normalize_doc({_line, doc}) when is_binary(doc), do: doc
+  def normalize_doc(false), do: nil
+  def normalize_doc(doc) when is_binary(doc), do: doc
+  def normalize_doc(_), do: nil
+
+  @spec module_atom?(atom()) :: boolean()
+  def module_atom?(module) when is_atom(module) do
+    module
+    |> Atom.to_string()
+    |> String.starts_with?("Elixir.")
+  end
+
+  @spec fetch_accum_attribute(module(), atom()) :: list()
+  def fetch_accum_attribute(module, attribute) when is_atom(module) and is_atom(attribute) do
+    module
+    |> Module.get_attribute(attribute)
+    |> List.wrap()
+  end
+
+  @spec valid_relation_attr_value?(term()) :: boolean()
+  def valid_relation_attr_value?(relation) do
+    relation == true or (is_list(relation) and Keyword.keyword?(relation)) or is_map(relation)
+  end
+end

--- a/lib/favn/multi_asset.ex
+++ b/lib/favn/multi_asset.ex
@@ -116,6 +116,7 @@ defmodule Favn.MultiAsset do
 
   alias Favn.Asset
   alias Favn.Asset.RelationResolver
+  alias Favn.DSL.Compiler, as: DSLCompiler
   alias Favn.Namespace
   alias Favn.Ref
   alias Favn.Window.Spec
@@ -171,14 +172,14 @@ defmodule Favn.MultiAsset do
           end
 
         {:def, :asset, _other_arity} ->
-          compile_error!(
+          DSLCompiler.compile_error!(
             env.file,
             env.line,
             "Favn.MultiAsset requires exactly one public asset/1 function"
           )
 
         {:defp, :asset, _arity} ->
-          compile_error!(
+          DSLCompiler.compile_error!(
             env.file,
             env.line,
             "Favn.MultiAsset requires a public def asset(ctx)"
@@ -222,7 +223,7 @@ defmodule Favn.MultiAsset do
     current = Module.get_attribute(__CALLER__.module, :favn_multi_asset_defaults_raw)
 
     if current do
-      compile_error!(
+      DSLCompiler.compile_error!(
         __CALLER__.file,
         __CALLER__.line,
         "multiple defaults blocks are not allowed; use at most one defaults do ... end"
@@ -262,7 +263,7 @@ defmodule Favn.MultiAsset do
   """
   defmacro asset(name, do: block) do
     if not is_atom(name) do
-      compile_error!(
+      DSLCompiler.compile_error!(
         __CALLER__.file,
         __CALLER__.line,
         "asset name must be an atom, got: #{Macro.to_string(name)}"
@@ -273,7 +274,7 @@ defmodule Favn.MultiAsset do
 
     raw_decl = %{
       name: name,
-      file: normalize_file(__CALLER__.file),
+      file: DSLCompiler.normalize_file(__CALLER__.file),
       line: __CALLER__.line,
       rest: asset_rest
     }
@@ -295,7 +296,7 @@ defmodule Favn.MultiAsset do
     runtime_count = Module.get_attribute(env.module, :favn_multi_asset_runtime_count) || 0
 
     if runtime_count != 1 do
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "Favn.MultiAsset modules must define exactly one public asset/1 function"
@@ -310,7 +311,7 @@ defmodule Favn.MultiAsset do
       |> Enum.reverse()
 
     if raw_assets == [] do
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "Favn.MultiAsset modules must declare at least one asset :name do ... end"
@@ -353,11 +354,11 @@ defmodule Favn.MultiAsset do
   defp capture_generated_asset_definition!(env, decl_fun) do
     decl = fetch_decl!(env.module, decl_fun, env)
 
-    depends = env.module |> fetch_accum_attribute(:depends) |> Enum.reverse()
+    depends = env.module |> DSLCompiler.fetch_accum_attribute(:depends) |> Enum.reverse()
     meta = Module.get_attribute(env.module, :meta)
-    window = env.module |> fetch_accum_attribute(:window) |> Enum.reverse()
-    relation = env.module |> fetch_accum_attribute(:relation) |> Enum.reverse()
-    doc = normalize_doc(Module.get_attribute(env.module, :doc))
+    window = env.module |> DSLCompiler.fetch_accum_attribute(:window) |> Enum.reverse()
+    relation = env.module |> DSLCompiler.fetch_accum_attribute(:relation) |> Enum.reverse()
+    doc = DSLCompiler.normalize_doc(Module.get_attribute(env.module, :doc))
 
     validate_relation_attr!(relation, env)
 
@@ -406,7 +407,11 @@ defmodule Favn.MultiAsset do
         decl
 
       nil ->
-        compile_error!(env.file, env.line, "internal error: missing declaration for #{decl_fun}")
+        DSLCompiler.compile_error!(
+          env.file,
+          env.line,
+          "internal error: missing declaration for #{decl_fun}"
+        )
     end
   end
 
@@ -419,7 +424,7 @@ defmodule Favn.MultiAsset do
           :ok
 
         [first | _rest] ->
-          compile_error!(
+          DSLCompiler.compile_error!(
             first.file,
             first.line,
             "duplicate asset name #{inspect(name)}; asset names must be unique within a module"
@@ -454,7 +459,7 @@ defmodule Favn.MultiAsset do
       Asset.validate!(asset)
     rescue
       error in ArgumentError ->
-        compile_error!(raw_asset.file, raw_asset.line, error.message)
+        DSLCompiler.compile_error!(raw_asset.file, raw_asset.line, error.message)
     end
   end
 
@@ -471,7 +476,7 @@ defmodule Favn.MultiAsset do
 
           {:rest, _meta, [[do: rest_block]]} ->
             if rest_count > 0 do
-              compile_error!(
+              DSLCompiler.compile_error!(
                 env.file,
                 env.line,
                 "multiple rest blocks are not allowed inside defaults"
@@ -481,7 +486,7 @@ defmodule Favn.MultiAsset do
             {meta, window_spec, normalize_rest_block!(rest_block, env), rest_count + 1}
 
           other ->
-            compile_error!(
+            DSLCompiler.compile_error!(
               env.file,
               env.line,
               "defaults only supports meta, window, and rest blocks; got: #{Macro.to_string(other)}"
@@ -500,7 +505,7 @@ defmodule Favn.MultiAsset do
         case expression do
           {:rest, _meta, [[do: rest_block]]} ->
             if rest_count > 0 do
-              compile_error!(
+              DSLCompiler.compile_error!(
                 env.file,
                 env.line,
                 "multiple rest blocks are not allowed inside asset #{inspect(name)}"
@@ -510,7 +515,7 @@ defmodule Favn.MultiAsset do
             {normalize_rest_block!(rest_block, env), rest_count + 1}
 
           other ->
-            compile_error!(
+            DSLCompiler.compile_error!(
               env.file,
               env.line,
               "asset blocks only support rest do ... end in v0.4; got: #{Macro.to_string(other)}"
@@ -562,7 +567,7 @@ defmodule Favn.MultiAsset do
           kind = eval_quoted!(kind_ast, env)
 
           if not is_atom(kind) do
-            compile_error!(
+            DSLCompiler.compile_error!(
               env.file,
               env.line,
               "rest.paginator kind must be an atom, got: #{inspect(kind)}"
@@ -581,7 +586,7 @@ defmodule Favn.MultiAsset do
           value = eval_quoted!(value_ast, env)
 
           if not (is_atom(value) or is_binary(value)) do
-            compile_error!(
+            DSLCompiler.compile_error!(
               env.file,
               env.line,
               "rest.method must be an atom or string, got: #{inspect(value)}"
@@ -599,7 +604,7 @@ defmodule Favn.MultiAsset do
           )
 
         other ->
-          compile_error!(
+          DSLCompiler.compile_error!(
             env.file,
             env.line,
             "rest only supports path, data_path, params, primary_key, paginator, incremental, method, and extra; got: #{Macro.to_string(other)}"
@@ -610,7 +615,11 @@ defmodule Favn.MultiAsset do
 
   defp put_unique_rest_slot!(acc, key, value, env) do
     if Map.has_key?(acc, key) do
-      compile_error!(env.file, env.line, "multiple rest.#{key} entries are not allowed")
+      DSLCompiler.compile_error!(
+        env.file,
+        env.line,
+        "multiple rest.#{key} entries are not allowed"
+      )
     end
 
     Map.put(acc, key, value)
@@ -619,8 +628,8 @@ defmodule Favn.MultiAsset do
   defp normalize_depends!(depends, raw_asset) do
     Enum.map(depends, fn
       name when is_atom(name) ->
-        if module_atom?(name) do
-          compile_error!(
+        if DSLCompiler.module_atom?(name) do
+          DSLCompiler.compile_error!(
             raw_asset.file,
             raw_asset.line,
             "invalid @depends entry #{inspect(name)}; expected :asset_name or {Module, :asset_name}; module shorthand is not supported in Favn.MultiAsset"
@@ -633,7 +642,7 @@ defmodule Favn.MultiAsset do
         Ref.new(module, name)
 
       dependency ->
-        compile_error!(
+        DSLCompiler.compile_error!(
           raw_asset.file,
           raw_asset.line,
           "invalid @depends entry #{inspect(dependency)}; expected :asset_name or {Module, :asset_name}"
@@ -660,7 +669,7 @@ defmodule Favn.MultiAsset do
     end)
   rescue
     error in ArgumentError ->
-      compile_error!(env.file, env.line, error.message)
+      DSLCompiler.compile_error!(env.file, env.line, error.message)
   end
 
   defp fetch_raw_relation(module, name) do
@@ -681,7 +690,7 @@ defmodule Favn.MultiAsset do
     assets
   rescue
     error in ArgumentError ->
-      compile_error!(env.file, env.line, error.message)
+      DSLCompiler.compile_error!(env.file, env.line, error.message)
   end
 
   defp normalize_meta!(meta, _env) when is_nil(meta), do: %{}
@@ -690,14 +699,14 @@ defmodule Favn.MultiAsset do
     Asset.normalize_meta!(meta)
   rescue
     error in ArgumentError ->
-      compile_error!(env.file, env.line, error.message)
+      DSLCompiler.compile_error!(env.file, env.line, error.message)
   end
 
   defp normalize_window!([], _env), do: nil
   defp normalize_window!([%Spec{} = spec], _env), do: spec
 
   defp normalize_window!([_a, _b | _rest], env) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       env.file,
       env.line,
       "multiple @window attributes are not allowed; use at most one @window per asset declaration"
@@ -705,7 +714,7 @@ defmodule Favn.MultiAsset do
   end
 
   defp normalize_window!(value, env) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       env.file,
       env.line,
       "invalid @window value #{inspect(value)}; expected Favn.Window spec like Favn.Window.daily()"
@@ -715,7 +724,7 @@ defmodule Favn.MultiAsset do
   defp normalize_window_value!(%Spec{} = spec, _env), do: spec
 
   defp normalize_window_value!(value, env) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       env.file,
       env.line,
       "invalid defaults window value #{inspect(value)}; expected Favn.Window spec like Favn.Window.daily()"
@@ -725,13 +734,12 @@ defmodule Favn.MultiAsset do
   defp validate_relation_attr!([], _env), do: :ok
 
   defp validate_relation_attr!([relation], env) do
-    valid? =
-      relation == true or (is_list(relation) and Keyword.keyword?(relation)) or is_map(relation)
+    valid? = DSLCompiler.valid_relation_attr_value?(relation)
 
     if valid? do
       :ok
     else
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "invalid @relation value #{inspect(relation)}; expected true, a keyword list, or a map"
@@ -740,7 +748,7 @@ defmodule Favn.MultiAsset do
   end
 
   defp validate_relation_attr!([_a, _b | _rest], env) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       env.file,
       env.line,
       "multiple @relation attributes are not allowed; use at most one @relation per asset declaration"
@@ -748,11 +756,11 @@ defmodule Favn.MultiAsset do
   end
 
   defp validate_no_stray_asset_attributes!(env, kind, name, arity) do
-    depends = fetch_accum_attribute(env.module, :depends)
+    depends = DSLCompiler.fetch_accum_attribute(env.module, :depends)
     meta = Module.get_attribute(env.module, :meta)
-    window = fetch_accum_attribute(env.module, :window)
-    relation = fetch_accum_attribute(env.module, :relation)
-    doc = normalize_doc(Module.get_attribute(env.module, :doc))
+    window = DSLCompiler.fetch_accum_attribute(env.module, :window)
+    relation = DSLCompiler.fetch_accum_attribute(env.module, :relation)
+    doc = DSLCompiler.normalize_doc(Module.get_attribute(env.module, :doc))
 
     if depends != [] or not is_nil(meta) or window != [] or relation != [] or not is_nil(doc) do
       Module.delete_attribute(env.module, :depends)
@@ -761,7 +769,7 @@ defmodule Favn.MultiAsset do
       Module.delete_attribute(env.module, :relation)
       clear_doc!(env.module, env.line)
 
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "@doc/@depends/@meta/@window/@relation on #{kind} #{name}/#{arity} requires asset :name do immediately below those attributes"
@@ -772,10 +780,10 @@ defmodule Favn.MultiAsset do
   end
 
   defp ensure_no_pending_attributes!(env) do
-    depends = fetch_accum_attribute(env.module, :depends)
+    depends = DSLCompiler.fetch_accum_attribute(env.module, :depends)
     meta = Module.get_attribute(env.module, :meta)
-    window = fetch_accum_attribute(env.module, :window)
-    relation = fetch_accum_attribute(env.module, :relation)
+    window = DSLCompiler.fetch_accum_attribute(env.module, :window)
+    relation = DSLCompiler.fetch_accum_attribute(env.module, :relation)
     pending_doc? = pending_doc?(env.module)
 
     if depends != [] or not is_nil(meta) or window != [] or relation != [] or pending_doc? do
@@ -785,7 +793,7 @@ defmodule Favn.MultiAsset do
       Module.delete_attribute(env.module, :relation)
       clear_doc!(env.module, env.line)
 
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "@doc/@meta/@depends/@window/@relation must be attached to an immediately following asset :name do"
@@ -843,7 +851,7 @@ defmodule Favn.MultiAsset do
     if Keyword.keyword?(value) do
       Map.new(value)
     else
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "#{label} must be a keyword list or map, got: #{inspect(value)}"
@@ -854,7 +862,7 @@ defmodule Favn.MultiAsset do
   defp normalize_map_like!(value, _label, _env) when is_map(value), do: value
 
   defp normalize_map_like!(value, label, env) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       env.file,
       env.line,
       "#{label} must be a keyword list or map, got: #{inspect(value)}"
@@ -864,7 +872,7 @@ defmodule Favn.MultiAsset do
   defp normalize_binary!(value, _field, _env) when is_binary(value), do: value
 
   defp normalize_binary!(value, field, env) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       env.file,
       env.line,
       "rest.#{field} must be a string, got: #{inspect(value)}"
@@ -876,43 +884,14 @@ defmodule Favn.MultiAsset do
     value
   rescue
     error in [CompileError, SyntaxError, ArgumentError] ->
-      compile_error!(env.file, env.line, Exception.message(error))
+      DSLCompiler.compile_error!(env.file, env.line, Exception.message(error))
   end
 
   defp block_expressions({:__block__, _meta, expressions}), do: expressions
   defp block_expressions(nil), do: []
   defp block_expressions(expression), do: [expression]
 
-  defp fetch_accum_attribute(module, attribute) do
-    case Module.get_attribute(module, attribute) do
-      nil -> []
-      value when is_list(value) -> value
-    end
-  end
-
-  defp normalize_doc({_line, false}), do: nil
-  defp normalize_doc({_line, doc}) when is_binary(doc), do: doc
-  defp normalize_doc(false), do: nil
-  defp normalize_doc(doc) when is_binary(doc), do: doc
-  defp normalize_doc(_), do: nil
-
-  defp normalize_file(file) do
-    file
-    |> to_string()
-    |> Path.relative_to_cwd()
-  end
-
-  defp compile_error!(file, line, description) do
-    raise CompileError, file: file, line: line, description: description
-  end
-
   defp clear_doc!(module, line) do
     Module.put_attribute(module, :doc, {line, false})
-  end
-
-  defp module_atom?(module) when is_atom(module) do
-    module
-    |> Atom.to_string()
-    |> String.starts_with?("Elixir.")
   end
 end

--- a/lib/favn/sql.ex
+++ b/lib/favn/sql.ex
@@ -62,6 +62,7 @@ defmodule Favn.SQL do
 
   alias Favn.Connection.Registry
   alias Favn.Connection.Resolved
+  alias Favn.DSL.Compiler, as: DSLCompiler
   alias Favn.RelationRef
   alias Favn.SQL.Definition
   alias Favn.SQL.Definition.Param
@@ -104,13 +105,17 @@ defmodule Favn.SQL do
   """
   defmacro sigil_SQL({:<<>>, _meta, parts}, modifiers) when is_list(modifiers) do
     if modifiers != [] do
-      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL sigil does not support modifiers")
+      DSLCompiler.compile_error!(
+        __CALLER__.file,
+        __CALLER__.line,
+        "~SQL sigil does not support modifiers"
+      )
     end
 
     if Enum.all?(parts, &is_binary/1) do
       Enum.join(parts)
     else
-      compile_error!(
+      DSLCompiler.compile_error!(
         __CALLER__.file,
         __CALLER__.line,
         "~SQL sigil does not support interpolation"
@@ -120,9 +125,17 @@ defmodule Favn.SQL do
 
   defmacro sigil_SQL(_body, modifiers) do
     if modifiers != [] do
-      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL sigil does not support modifiers")
+      DSLCompiler.compile_error!(
+        __CALLER__.file,
+        __CALLER__.line,
+        "~SQL sigil does not support modifiers"
+      )
     else
-      compile_error!(__CALLER__.file, __CALLER__.line, "~SQL body must be a literal string")
+      DSLCompiler.compile_error!(
+        __CALLER__.file,
+        __CALLER__.line,
+        "~SQL body must be a literal string"
+      )
     end
   end
 
@@ -162,9 +175,9 @@ defmodule Favn.SQL do
       args: args,
       arity: arity,
       sql: sql,
-      file: normalize_file(__CALLER__.file),
+      file: DSLCompiler.normalize_file(__CALLER__.file),
       line: __CALLER__.line,
-      sql_file: normalize_file(__CALLER__.file),
+      sql_file: DSLCompiler.normalize_file(__CALLER__.file),
       sql_line: __CALLER__.line
     }
 
@@ -188,7 +201,7 @@ defmodule Favn.SQL do
       args: args,
       arity: arity,
       sql: source.sql,
-      file: normalize_file(__CALLER__.file),
+      file: DSLCompiler.normalize_file(__CALLER__.file),
       line: __CALLER__.line,
       sql_file: source.sql_file,
       sql_line: source.sql_line
@@ -201,7 +214,7 @@ defmodule Favn.SQL do
   end
 
   defmacro defsql(_head, do: _body) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       __CALLER__.file,
       __CALLER__.line,
       "defsql expects a function-style head, for example defsql my_macro(arg) do ... end"
@@ -209,7 +222,7 @@ defmodule Favn.SQL do
   end
 
   defmacro defsql(_head, file: _path) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       __CALLER__.file,
       __CALLER__.line,
       "defsql expects a function-style head, for example defsql my_macro(arg), file: \"sql/my_macro.sql\""
@@ -217,7 +230,7 @@ defmodule Favn.SQL do
   end
 
   defmacro defsql(_head, opts) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       __CALLER__.file,
       __CALLER__.line,
       "defsql expects either a do block or file: \"path/to/query.sql\", got: #{Macro.to_string(opts)}"
@@ -610,7 +623,7 @@ defmodule Favn.SQL do
           if function_exported?(module, :__favn_sql_definitions__, 0) do
             module.__favn_sql_definitions__()
           else
-            compile_error!(
+            DSLCompiler.compile_error!(
               "nofile",
               1,
               "imported SQL provider #{inspect(module)} does not define reusable SQL"
@@ -618,7 +631,7 @@ defmodule Favn.SQL do
           end
 
         {:error, _reason} ->
-          compile_error!(
+          DSLCompiler.compile_error!(
             "nofile",
             1,
             "imported SQL provider #{inspect(module)} could not be resolved"
@@ -636,7 +649,7 @@ defmodule Favn.SQL do
         name
 
       other ->
-        compile_error!(
+        DSLCompiler.compile_error!(
           env.file,
           env.line,
           "defsql arguments must be plain variable names, got: #{Macro.to_string(other)}"
@@ -649,7 +662,7 @@ defmodule Favn.SQL do
 
     Enum.each(args, fn arg ->
       if MapSet.member?(reserved, arg) do
-        compile_error!(
+        DSLCompiler.compile_error!(
           env.file,
           env.line,
           "defsql argument @#{arg} is reserved for runtime SQL inputs"
@@ -669,7 +682,7 @@ defmodule Favn.SQL do
         file = definition.declared_file || definition.file
         line = definition.declared_line || definition.line
 
-        compile_error!(
+        DSLCompiler.compile_error!(
           file,
           line,
           "duplicate defsql #{name}/#{arity}; each defsql name/arity must be unique per module"
@@ -690,7 +703,7 @@ defmodule Favn.SQL do
         file = first.declared_file || first.file
         line = first.declared_line || first.line
 
-        compile_error!(
+        DSLCompiler.compile_error!(
           file,
           line,
           "duplicate visible defsql #{name}/#{arity} for #{inspect(owner_module)}; conflicting providers: #{providers}"
@@ -713,7 +726,7 @@ defmodule Favn.SQL do
         Enum.reverse([key | stack])
         |> Enum.map_join(" -> ", fn {name, arity} -> "#{name}/#{arity}" end)
 
-      compile_error!(
+      DSLCompiler.compile_error!(
         definition.file,
         definition.line,
         "cyclic defsql definitions detected: #{path}"
@@ -739,34 +752,24 @@ defmodule Favn.SQL do
         extract_sigil_sql!(parts_ast, modifiers, env, error_message)
 
       _ ->
-        compile_error!(env.file, env.line, error_message)
+        DSLCompiler.compile_error!(env.file, env.line, error_message)
     end
   end
 
   defp extract_sigil_sql!(_parts_ast, modifiers, env, _error_message) when modifiers != [] do
-    compile_error!(env.file, env.line, "~SQL sigil does not support modifiers")
+    DSLCompiler.compile_error!(env.file, env.line, "~SQL sigil does not support modifiers")
   end
 
   defp extract_sigil_sql!({:<<>>, _meta, parts}, [], env, _error_message) do
     if Enum.all?(parts, &is_binary/1) do
       Enum.join(parts)
     else
-      compile_error!(env.file, env.line, "~SQL sigil does not support interpolation")
+      DSLCompiler.compile_error!(env.file, env.line, "~SQL sigil does not support interpolation")
     end
   end
 
   defp extract_sigil_sql!(_parts_ast, [], env, error_message) do
-    compile_error!(env.file, env.line, error_message)
-  end
-
-  defp normalize_file(file) do
-    file
-    |> to_string()
-    |> Path.relative_to_cwd()
-  end
-
-  defp compile_error!(file, line, description) do
-    raise CompileError, file: file, line: line, description: description
+    DSLCompiler.compile_error!(env.file, env.line, error_message)
   end
 
   defp run_statements(session, statements, opts) do

--- a/lib/favn/sql_asset.ex
+++ b/lib/favn/sql_asset.ex
@@ -104,6 +104,7 @@ defmodule Favn.SQLAsset do
 
   alias Favn.Asset
   alias Favn.Asset.RelationResolver
+  alias Favn.DSL.Compiler, as: DSLCompiler
   alias Favn.Namespace
   alias Favn.Ref
   alias Favn.RelationRef
@@ -156,7 +157,7 @@ defmodule Favn.SQLAsset do
     else
       case {kind, name, arity} do
         {kind, :asset, _arity} when kind in [:def, :defp] ->
-          compile_error!(
+          DSLCompiler.compile_error!(
             env.file,
             env.line,
             "Favn.SQLAsset reserves asset/1 and generates it automatically"
@@ -197,7 +198,7 @@ defmodule Favn.SQLAsset do
     raw_definition = Module.get_attribute(__CALLER__.module, :favn_sql_asset_raw)
 
     if raw_definition do
-      compile_error!(
+      DSLCompiler.compile_error!(
         __CALLER__.file,
         __CALLER__.line,
         "Favn.SQLAsset modules can define only one query body"
@@ -208,9 +209,9 @@ defmodule Favn.SQLAsset do
 
     Module.put_attribute(__CALLER__.module, :favn_sql_asset_raw, %{
       module: __CALLER__.module,
-      file: normalize_file(__CALLER__.file),
+      file: DSLCompiler.normalize_file(__CALLER__.file),
       line: __CALLER__.line,
-      sql_file: normalize_file(__CALLER__.file),
+      sql_file: DSLCompiler.normalize_file(__CALLER__.file),
       sql_line: __CALLER__.line,
       sql: sql
     })
@@ -224,7 +225,7 @@ defmodule Favn.SQLAsset do
     raw_definition = Module.get_attribute(__CALLER__.module, :favn_sql_asset_raw)
 
     if raw_definition do
-      compile_error!(
+      DSLCompiler.compile_error!(
         __CALLER__.file,
         __CALLER__.line,
         "Favn.SQLAsset modules can define only one query body"
@@ -235,7 +236,7 @@ defmodule Favn.SQLAsset do
 
     Module.put_attribute(__CALLER__.module, :favn_sql_asset_raw, %{
       module: __CALLER__.module,
-      file: normalize_file(__CALLER__.file),
+      file: DSLCompiler.normalize_file(__CALLER__.file),
       line: __CALLER__.line,
       sql_file: source.sql_file,
       sql_line: source.sql_line,
@@ -248,7 +249,7 @@ defmodule Favn.SQLAsset do
   end
 
   defmacro query(opts) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       __CALLER__.file,
       __CALLER__.line,
       "query expects either a do block or file: \"path/to/query.sql\", got: #{Macro.to_string(opts)}"
@@ -260,7 +261,7 @@ defmodule Favn.SQLAsset do
     base_definition = Module.get_attribute(env.module, :favn_sql_asset_raw)
 
     if is_nil(base_definition) do
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "Favn.SQLAsset modules must define exactly one query body"
@@ -269,18 +270,27 @@ defmodule Favn.SQLAsset do
 
     raw_definition =
       base_definition
-      |> Map.put(:doc, normalize_doc(Module.get_attribute(env.module, :doc)))
-      |> Map.put(:depends, env.module |> fetch_accum_attribute(:depends) |> Enum.reverse())
+      |> Map.put(:doc, DSLCompiler.normalize_doc(Module.get_attribute(env.module, :doc)))
+      |> Map.put(
+        :depends,
+        env.module |> DSLCompiler.fetch_accum_attribute(:depends) |> Enum.reverse()
+      )
       |> Map.put(:meta, Module.get_attribute(env.module, :meta))
-      |> Map.put(:window, env.module |> fetch_accum_attribute(:window) |> Enum.reverse())
-      |> Map.put(:relation, env.module |> fetch_accum_attribute(:relation) |> Enum.reverse())
+      |> Map.put(
+        :window,
+        env.module |> DSLCompiler.fetch_accum_attribute(:window) |> Enum.reverse()
+      )
+      |> Map.put(
+        :relation,
+        env.module |> DSLCompiler.fetch_accum_attribute(:relation) |> Enum.reverse()
+      )
       |> Map.put(
         :materialized,
-        env.module |> fetch_accum_attribute(:materialized) |> Enum.reverse()
+        env.module |> DSLCompiler.fetch_accum_attribute(:materialized) |> Enum.reverse()
       )
       |> Map.put(
         :sql_imports,
-        env.module |> fetch_accum_attribute(:favn_sql_imports) |> Enum.reverse()
+        env.module |> DSLCompiler.fetch_accum_attribute(:favn_sql_imports) |> Enum.reverse()
       )
 
     definition = build_definition!(raw_definition)
@@ -374,7 +384,7 @@ defmodule Favn.SQLAsset do
       definition
     rescue
       error in ArgumentError ->
-        compile_error!(raw_definition.file, raw_definition.line, error.message)
+        DSLCompiler.compile_error!(raw_definition.file, raw_definition.line, error.message)
     end
   end
 
@@ -384,10 +394,10 @@ defmodule Favn.SQLAsset do
         Ref.new(module, :asset)
 
       {module, name} when is_atom(module) and is_atom(name) ->
-        if module_atom?(module) do
+        if DSLCompiler.module_atom?(module) do
           Ref.new(module, name)
         else
-          compile_error!(
+          DSLCompiler.compile_error!(
             raw_definition.file,
             raw_definition.line,
             "invalid @depends entry #{inspect({module, name})}; expected Module or {Module, :asset_name}"
@@ -395,7 +405,7 @@ defmodule Favn.SQLAsset do
         end
 
       dependency ->
-        compile_error!(
+        DSLCompiler.compile_error!(
           raw_definition.file,
           raw_definition.line,
           "invalid @depends entry #{inspect(dependency)}; expected Module or {Module, :asset_name}"
@@ -407,14 +417,14 @@ defmodule Favn.SQLAsset do
     Asset.normalize_meta!(meta)
   rescue
     error in ArgumentError ->
-      compile_error!(raw_definition.file, raw_definition.line, error.message)
+      DSLCompiler.compile_error!(raw_definition.file, raw_definition.line, error.message)
   end
 
   defp normalize_window!([], _raw_definition), do: nil
   defp normalize_window!([%Spec{} = spec], _raw_definition), do: spec
 
   defp normalize_window!([_a, _b | _rest], raw_definition) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       raw_definition.file,
       raw_definition.line,
       "multiple @window attributes are not allowed; use at most one @window before query"
@@ -422,7 +432,7 @@ defmodule Favn.SQLAsset do
   end
 
   defp normalize_window!(value, raw_definition) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       raw_definition.file,
       raw_definition.line,
       "invalid @window value #{inspect(value)}; expected Favn.Window spec like Favn.Window.daily()"
@@ -435,11 +445,11 @@ defmodule Favn.SQLAsset do
     |> validate_incremental_materialized!(window_spec, raw_definition)
   rescue
     error in ArgumentError ->
-      compile_error!(raw_definition.file, raw_definition.line, error.message)
+      DSLCompiler.compile_error!(raw_definition.file, raw_definition.line, error.message)
   end
 
   defp normalize_materialized!([], _window_spec, raw_definition) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       raw_definition.file,
       raw_definition.line,
       "Favn.SQLAsset requires one @materialized attribute"
@@ -447,7 +457,7 @@ defmodule Favn.SQLAsset do
   end
 
   defp normalize_materialized!([_a, _b | _rest], _window_spec, raw_definition) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       raw_definition.file,
       raw_definition.line,
       "multiple @materialized attributes are not allowed; use exactly one @materialized before query"
@@ -462,7 +472,7 @@ defmodule Favn.SQLAsset do
     strategy = Keyword.fetch!(opts, :strategy)
 
     if is_nil(window_spec) do
-      compile_error!(
+      DSLCompiler.compile_error!(
         raw_definition.file,
         raw_definition.line,
         "incremental SQL materialization requires @window"
@@ -470,7 +480,7 @@ defmodule Favn.SQLAsset do
     end
 
     if Keyword.has_key?(opts, :unique_key) do
-      compile_error!(
+      DSLCompiler.compile_error!(
         raw_definition.file,
         raw_definition.line,
         "incremental materialization unique_key is reserved for future :merge semantics and is not supported in Phase 4b"
@@ -480,7 +490,7 @@ defmodule Favn.SQLAsset do
     case strategy do
       :append ->
         if Keyword.has_key?(opts, :window_column) do
-          compile_error!(
+          DSLCompiler.compile_error!(
             raw_definition.file,
             raw_definition.line,
             "incremental :append does not accept :window_column"
@@ -493,7 +503,7 @@ defmodule Favn.SQLAsset do
             :ok
 
           :error ->
-            compile_error!(
+            DSLCompiler.compile_error!(
               raw_definition.file,
               raw_definition.line,
               "incremental :delete_insert requires :window_column"
@@ -501,14 +511,14 @@ defmodule Favn.SQLAsset do
         end
 
       :merge ->
-        compile_error!(
+        DSLCompiler.compile_error!(
           raw_definition.file,
           raw_definition.line,
           "incremental strategy :merge is not supported in Phase 4b"
         )
 
       :replace ->
-        compile_error!(
+        DSLCompiler.compile_error!(
           raw_definition.file,
           raw_definition.line,
           "incremental strategy :replace is not supported in Phase 4b"
@@ -536,7 +546,7 @@ defmodule Favn.SQLAsset do
           if Keyword.keyword?(attrs) do
             Map.new(attrs)
           else
-            compile_error!(
+            DSLCompiler.compile_error!(
               raw_definition.file,
               raw_definition.line,
               "invalid @relation value #{inspect(attrs)}; expected true, a keyword list, or a map"
@@ -547,14 +557,14 @@ defmodule Favn.SQLAsset do
           attrs
 
         [_a, _b | _rest] ->
-          compile_error!(
+          DSLCompiler.compile_error!(
             raw_definition.file,
             raw_definition.line,
             "multiple @relation attributes are not allowed; use at most one @relation before query do ... end"
           )
 
         [other] ->
-          compile_error!(
+          DSLCompiler.compile_error!(
             raw_definition.file,
             raw_definition.line,
             "invalid @relation value #{inspect(other)}; expected true, a keyword list, or a map"
@@ -566,11 +576,11 @@ defmodule Favn.SQLAsset do
     |> ensure_sql_relation!(raw_definition)
   rescue
     error in ArgumentError ->
-      compile_error!(raw_definition.file, raw_definition.line, error.message)
+      DSLCompiler.compile_error!(raw_definition.file, raw_definition.line, error.message)
   end
 
   defp ensure_sql_relation!(%RelationRef{connection: nil}, raw_definition) do
-    compile_error!(
+    DSLCompiler.compile_error!(
       raw_definition.file,
       raw_definition.line,
       "SQL assets require a connection through Favn.Namespace or @relation"
@@ -581,11 +591,11 @@ defmodule Favn.SQLAsset do
     do: relation_ref
 
   defp validate_no_stray_asset_attributes!(env, kind, name, arity) do
-    depends = fetch_accum_attribute(env.module, :depends)
+    depends = DSLCompiler.fetch_accum_attribute(env.module, :depends)
     meta = Module.get_attribute(env.module, :meta)
-    window = fetch_accum_attribute(env.module, :window)
-    relation = fetch_accum_attribute(env.module, :relation)
-    materialized = fetch_accum_attribute(env.module, :materialized)
+    window = DSLCompiler.fetch_accum_attribute(env.module, :window)
+    relation = DSLCompiler.fetch_accum_attribute(env.module, :relation)
+    materialized = DSLCompiler.fetch_accum_attribute(env.module, :materialized)
 
     if depends != [] or not is_nil(meta) or window != [] or relation != [] or materialized != [] do
       Module.delete_attribute(env.module, :depends)
@@ -594,7 +604,7 @@ defmodule Favn.SQLAsset do
       Module.delete_attribute(env.module, :relation)
       Module.delete_attribute(env.module, :materialized)
 
-      compile_error!(
+      DSLCompiler.compile_error!(
         env.file,
         env.line,
         "@depends/@meta/@window/@relation/@materialized on #{kind} #{name}/#{arity} requires query immediately below those attributes"
@@ -618,7 +628,7 @@ defmodule Favn.SQLAsset do
           if function_exported?(module, :__favn_sql_definitions__, 0) do
             module.__favn_sql_definitions__()
           else
-            compile_error!(
+            DSLCompiler.compile_error!(
               raw_definition.file,
               raw_definition.line,
               "imported SQL provider #{inspect(module)} does not define reusable SQL"
@@ -626,7 +636,7 @@ defmodule Favn.SQLAsset do
           end
 
         {:error, _reason} ->
-          compile_error!(
+          DSLCompiler.compile_error!(
             raw_definition.file,
             raw_definition.line,
             "imported SQL provider #{inspect(module)} could not be resolved"
@@ -644,47 +654,19 @@ defmodule Favn.SQLAsset do
       {{name, arity}, definitions} ->
         providers = definitions |> Enum.map(&inspect(&1.module)) |> Enum.sort() |> Enum.join(", ")
 
-        compile_error!(
+        DSLCompiler.compile_error!(
           raw_definition.file,
           raw_definition.line,
           "duplicate visible defsql #{name}/#{arity}; conflicting providers: #{providers}"
         )
 
       {other, _definitions} ->
-        compile_error!(
+        DSLCompiler.compile_error!(
           raw_definition.file,
           raw_definition.line,
           "invalid SQL definition import #{inspect(other)}"
         )
     end)
     |> Map.new()
-  end
-
-  defp normalize_doc({_line, false}), do: nil
-  defp normalize_doc({_line, doc}) when is_binary(doc), do: doc
-  defp normalize_doc(false), do: nil
-  defp normalize_doc(doc) when is_binary(doc), do: doc
-  defp normalize_doc(_), do: nil
-
-  defp fetch_accum_attribute(module, attribute) do
-    module
-    |> Module.get_attribute(attribute)
-    |> List.wrap()
-  end
-
-  defp normalize_file(file) do
-    file
-    |> to_string()
-    |> Path.relative_to_cwd()
-  end
-
-  defp compile_error!(file, line, description) do
-    raise CompileError, file: file, line: line, description: description
-  end
-
-  defp module_atom?(module) when is_atom(module) do
-    module
-    |> Atom.to_string()
-    |> String.starts_with?("Elixir.")
   end
 end


### PR DESCRIPTION
## Summary
- add internal `Favn.DSL.Compiler` for shared compile-time helper functions used by `Favn.Asset`, `Favn.MultiAsset`, `Favn.SQLAsset`, and `Favn.SQL`
- move low-level repeated helpers into the shared module (`compile_error!`, `normalize_file`, `normalize_doc`, module atom checks, accumulated attribute fetches, and relation-attribute shape check)
- keep DSL-specific normalization and validation logic local to each module to avoid over-abstracting macro behavior

## Validation
- mix format
- mix compile --warnings-as-errors
- mix test
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected