### PR TITLE
Refactor public connection info to one canonical type

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ config :favn,
 Favn.list_assets()
 {:ok, run_id} = Favn.run_asset({MyApp.Raw.Sales.Orders, :asset})
 {:ok, run} = Favn.await_run(run_id)
+
+# Operator-facing connection inspection is redacted:
+[%Favn.Connection.Info{} = conn] = Favn.list_connections()
+{:ok, %Favn.Connection.Info{} = warehouse} = Favn.get_connection(:warehouse)
 ```
 
 ## Install And Configure

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -11,6 +11,7 @@ Favn is an asset-first orchestrator for ETL/ELT workloads.
 - [x] Credo strict cleanup across runtime, storage, docs, fixtures, and tests
 - [x] Shared relation resolver extracted for `Favn.Assets.Compiler`, `Favn.MultiAsset`, and `Favn.SQLAsset`
 - [x] Shared compile-time DSL helper foundation extracted to `Favn.DSL.Compiler` (`Favn.Asset`, `Favn.MultiAsset`, `Favn.SQLAsset`, `Favn.SQL`)
+- [x] Canonical public connection inspection payload extracted to `Favn.Connection.Info`
 
 Near-term priority is a practical path to real usage:
 

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -31,6 +31,7 @@ lib/
     ├── connection/
     │   ├── definition.ex
     │   ├── error.ex
+    │   ├── info.ex
     │   ├── loader.ex
     │   ├── registry.ex
     │   ├── resolved.ex

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -257,6 +257,7 @@ defmodule Favn do
   alias Favn.Assets.Planner
   alias Favn.Assets.Registry
   alias Favn.Backfill
+  alias Favn.Connection.Info
   alias Favn.Connection.NotFoundError
   alias Favn.Connection.Registry, as: ConnectionRegistry
   alias Favn.Connection.Sanitizer
@@ -450,23 +451,14 @@ defmodule Favn do
   @typedoc """
   Public redacted connection inspection payload.
   """
-  @type connection_info :: %{
-          name: atom(),
-          adapter: module(),
-          module: module(),
-          config: map(),
-          required_keys: [atom()],
-          secret_fields: [atom()],
-          schema_keys: [atom()],
-          metadata: map()
-        }
+  @type connection_info :: Info.t()
 
   @doc """
   List all registered connections with secrets redacted.
 
   Returns:
 
-    * list of maps with stable connection metadata and redacted config
+    * list of `%Favn.Connection.Info{}` with stable connection metadata and redacted config
   """
   @spec list_connections() :: [connection_info()]
   def list_connections do

--- a/lib/favn/connection/info.ex
+++ b/lib/favn/connection/info.ex
@@ -1,0 +1,31 @@
+defmodule Favn.Connection.Info do
+  @moduledoc """
+  Public redacted connection inspection payload returned by `Favn` APIs.
+
+  This shape is intentionally stable and safe for operator-facing inspection.
+  Runtime-only details remain on `%Favn.Connection.Resolved{}`.
+  """
+
+  @enforce_keys [:name, :adapter, :module, :config]
+  defstruct [
+    :name,
+    :adapter,
+    :module,
+    :config,
+    required_keys: [],
+    secret_fields: [],
+    schema_keys: [],
+    metadata: %{}
+  ]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          adapter: module(),
+          module: module(),
+          config: map(),
+          required_keys: [atom()],
+          secret_fields: [atom()],
+          schema_keys: [atom()],
+          metadata: map()
+        }
+end

--- a/lib/favn/connection/sanitizer.ex
+++ b/lib/favn/connection/sanitizer.ex
@@ -1,27 +1,17 @@
 defmodule Favn.Connection.Sanitizer do
   @moduledoc false
 
+  alias Favn.Connection.Info
   alias Favn.Connection.Resolved
 
-  @type connection_info :: %{
-          name: atom(),
-          adapter: module(),
-          module: module(),
-          config: map(),
-          required_keys: [atom()],
-          secret_fields: [atom()],
-          schema_keys: [atom()],
-          metadata: map()
-        }
-
-  @spec redact(Resolved.t()) :: connection_info()
+  @spec redact(Resolved.t()) :: Info.t()
   def redact(%Resolved{} = resolved) do
     redacted_config =
       Enum.reduce(resolved.secret_fields, resolved.config, fn key, acc ->
         if Map.has_key?(acc, key), do: Map.put(acc, key, :redacted), else: acc
       end)
 
-    %{
+    %Info{
       name: resolved.name,
       adapter: resolved.adapter,
       module: resolved.module,

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -4,6 +4,7 @@ defmodule Favn.ConnectionTest do
   alias Favn.Connection.ConfigError
   alias Favn.Connection.Definition
   alias Favn.Connection.Error
+  alias Favn.Connection.Info
   alias Favn.Connection.Loader
   alias Favn.Connection.NotFoundError
   alias Favn.Connection.Resolved
@@ -204,11 +205,12 @@ defmodule Favn.ConnectionTest do
     assert Favn.connection_registered?(:warehouse)
 
     assert {:ok, connection} = Favn.get_connection(:warehouse)
+    assert %Info{} = connection
     assert connection.config.password == :redacted
     assert connection.config.database == "/tmp/db"
 
-    assert [%{name: :warehouse}] = Favn.list_connections()
-    assert %{name: :warehouse} = Favn.get_connection!(:warehouse)
+    assert [%Info{name: :warehouse}] = Favn.list_connections()
+    assert %Info{name: :warehouse} = Favn.get_connection!(:warehouse)
     assert {:error, :not_found} = Favn.get_connection(:missing)
     assert_raise NotFoundError, fn -> Favn.get_connection!(:missing) end
   end


### PR DESCRIPTION
## Summary
- introduce `%Favn.Connection.Info{}` as the canonical public redacted connection inspection shape
- update `Favn` and `Favn.Connection.Sanitizer` to use the shared type/struct and explicit conversion from `%Favn.Connection.Resolved{}`
- keep external fields and redaction behavior unchanged while updating tests and docs to reflect the canonical output type

## Validation
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`