### PR TITLE
Add durable run queue admission and queue observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Favn.list_assets()
 {:ok, run_id} = Favn.run_asset({MyApp.Raw.Sales.Orders, :asset})
 {:ok, run} = Favn.await_run(run_id)
 
+# queued run inspection
+{:ok, queued_runs} = Favn.list_runs(status: :queued)
+{:ok, queue_entries} = Favn.list_queued_runs()
+
 # Operator-facing connection inspection is redacted:
 [%Favn.Connection.Info{} = conn] = Favn.list_connections()
 {:ok, %Favn.Connection.Info{} = warehouse} = Favn.get_connection(:warehouse)

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -218,6 +218,11 @@ Goal: make single-node production usage reliable and inspectable.
 - [x] PostgreSQL storage foundation architecture plan (`docs/POSTGRES_STORAGE_FOUNDATION_PLAN.md`)
 - [x] PostgreSQL storage adapter implementation
 - [ ] Queueing and admission control
+  - [x] Introduce queued run lifecycle (`:queued`, `queued_at`, `admitted_at`, `queue_seq`)
+  - [x] Add single-node FIFO admission gate with global `runtime_max_active_runs`
+  - [x] Add queued-run cancellation path and queued-run restore on runtime boot
+  - [x] Add `run_admitted` lifecycle event and queue inspection API (`list_queued_runs/1`)
+  - [ ] Finish runtime/docs/test hardening pass for queue/admission behavior
 - [ ] Concurrency controls
 - [ ] Run deduplication / run keys
 - [ ] Improved failure recovery

--- a/lib/favn.ex
+++ b/lib/favn.ex
@@ -54,6 +54,7 @@ defmodule Favn do
       Favn.get_run(run_id)
       Favn.list_runs()
       Favn.list_runs(status: :running)
+      Favn.list_queued_runs()
 
   ## SQL helpers
 
@@ -115,9 +116,23 @@ defmodule Favn do
   Filter options for `list_runs/1`.
   """
   @type list_runs_opts :: [
-          status: :running | :ok | :error | :cancelled | :timed_out,
+          status: :queued | :running | :ok | :error | :cancelled | :timed_out,
           limit: pos_integer()
         ]
+
+  @typedoc """
+  Filter options for `list_queued_runs/1`.
+  """
+  @type list_queued_runs_opts :: [limit: pos_integer()]
+
+  @typedoc """
+  Queue inspection entry with computed operator-facing metadata.
+  """
+  @type queued_run_entry :: %{
+          required(:run) => Favn.Run.t(),
+          required(:queue_position) => pos_integer(),
+          required(:queued_for_ms) => non_neg_integer()
+        }
 
   @typedoc """
   Run retrieval/listing errors returned by storage-backed APIs.
@@ -733,7 +748,7 @@ defmodule Favn do
         (passed through as provided; unlike `run_pipeline/2`, no schedule normalization
         is applied to manually injected `pipeline_context`)
       * `max_concurrency: pos_integer()` (default from runtime config, fallback `1`)
-      * `timeout_ms: pos_integer()` timeout counted from run start
+      * `timeout_ms: pos_integer()` timeout counted from admitted run start
       * `retry: false | true | keyword() | map()` (default from app config, fallback disabled)
         * `max_attempts: pos_integer()` (includes first attempt)
         * `delay_ms: non_neg_integer()` (fixed delay between attempts)
@@ -747,6 +762,7 @@ defmodule Favn do
   Runtime semantics:
 
     * returns immediately with a generated `run_id`
+    * accepted submissions may be admitted immediately or placed in durable queue
     * orchestration is owned by supervised runtime processes
     * independent ready steps may execute in parallel up to `max_concurrency`
     * retries are evaluated per-step and re-admitted under the same bounded concurrency
@@ -914,6 +930,7 @@ defmodule Favn do
 
   Returns:
 
+    * `{:ok, :cancelled}` when a queued run is cancelled before admission
     * `{:ok, :cancelling}` when cancellation request is accepted
     * `{:ok, :cancelled}` when run is already cancelled
     * `{:ok, :already_terminal}` when run already reached a non-cancel terminal status
@@ -977,6 +994,7 @@ defmodule Favn do
   Returns:
 
     * `{:ok, %Favn.Run{status: :ok}}` on successful completion
+    * queued runs continue polling until they are admitted and terminalized
     * `{:error, %Favn.Run{status: :cancelled}}` when cancellation completes
     * `{:error, %Favn.Run{status: :error}}` when the run fails
     * `{:error, %Favn.Run{status: :timed_out}}` when the run times out
@@ -1019,7 +1037,7 @@ defmodule Favn do
 
   Accepted options:
 
-    * `status: :running | :ok | :error | :cancelled | :timed_out`
+    * `status: :queued | :running | :ok | :error | :cancelled | :timed_out`
     * `limit: positive_integer()`
 
   Deterministic behavior:
@@ -1045,6 +1063,44 @@ defmodule Favn do
   @spec list_runs(list_runs_opts()) :: {:ok, [Favn.Run.t()]} | {:error, run_error()}
   def list_runs(opts \\ []) when is_list(opts) do
     Favn.Storage.list_runs(opts)
+  end
+
+  @doc """
+  List queued runs with queue position and queue age metadata.
+
+  Accepted options:
+
+    * `limit: positive_integer()`
+
+  Deterministic behavior:
+
+    * rows are returned in admission order (`queue_position` ascending)
+
+  Returns:
+
+    * `{:ok, [%{run: %Favn.Run{}, queue_position: pos_integer(), queued_for_ms: non_neg_integer()}]}`
+    * `{:error, :invalid_opts}` for unsupported filters
+    * `{:error, {:store_error, reason}}` for storage adapter/internal failures
+  """
+  @spec list_queued_runs(list_queued_runs_opts()) ::
+          {:ok, [queued_run_entry()]} | {:error, run_error()}
+  def list_queued_runs(opts \\ []) when is_list(opts) do
+    with {:ok, runs} <- Favn.Storage.list_queued_runs(opts) do
+      now = DateTime.utc_now()
+
+      entries =
+        runs
+        |> Enum.with_index(1)
+        |> Enum.map(fn {run, index} ->
+          %{
+            run: run,
+            queue_position: index,
+            queued_for_ms: queued_for_ms(run.queued_at, now)
+          }
+        end)
+
+      {:ok, entries}
+    end
   end
 
   @doc """
@@ -1097,4 +1153,9 @@ defmodule Favn do
   def unsubscribe_run(run_id) do
     Events.unsubscribe_run(run_id)
   end
+
+  defp queued_for_ms(%DateTime{} = queued_at, %DateTime{} = now),
+    do: max(DateTime.diff(now, queued_at, :millisecond), 0)
+
+  defp queued_for_ms(_, _), do: 0
 end

--- a/lib/favn/run.ex
+++ b/lib/favn/run.ex
@@ -9,7 +9,7 @@ defmodule Favn.Run do
   alias Favn.Ref
   alias Favn.Run.AssetResult
 
-  @type status :: :running | :ok | :error | :cancelled | :timed_out
+  @type status :: :queued | :running | :ok | :error | :cancelled | :timed_out
 
   @type t :: %__MODULE__{
           id: String.t(),
@@ -23,7 +23,10 @@ defmodule Favn.Run do
           timeout_ms: pos_integer() | nil,
           status: status(),
           event_seq: non_neg_integer(),
-          started_at: DateTime.t(),
+          queued_at: DateTime.t() | nil,
+          admitted_at: DateTime.t() | nil,
+          queue_seq: pos_integer() | nil,
+          started_at: DateTime.t() | nil,
           finished_at: DateTime.t() | nil,
           params: map(),
           retry_policy: map(),
@@ -44,6 +47,9 @@ defmodule Favn.Run do
     :id,
     :target_refs,
     :plan,
+    :queued_at,
+    :admitted_at,
+    :queue_seq,
     :started_at,
     status: :running,
     event_seq: 0,

--- a/lib/favn/runtime/coordinator.ex
+++ b/lib/favn/runtime/coordinator.ex
@@ -38,7 +38,7 @@ defmodule Favn.Runtime.Coordinator do
          {:ok, state} <- emit_initial_ready_steps(state),
          {:ok, state} <- dispatch_ready_work(state),
          {:ok, state} <- maybe_finalize_terminal(state) do
-      {:noreply, %{data | state: state}}
+      reply_after_progress(data, state)
     else
       {:error, reason} ->
         {:stop, reason, data}
@@ -49,7 +49,7 @@ defmodule Favn.Runtime.Coordinator do
   def handle_cast({:cancel_run, reason}, %{state: state} = data) when is_map(reason) do
     with {:ok, state} <- request_cancellation(state, reason),
          {:ok, state} <- maybe_finalize_terminal(state) do
-      {:noreply, %{data | state: state}}
+      reply_after_progress(data, state)
     else
       {:error, reason} -> {:stop, reason, data}
     end
@@ -60,7 +60,7 @@ defmodule Favn.Runtime.Coordinator do
     with {:ok, state} <- handle_step_result(state, exec_ref, ref, result),
          {:ok, state} <- dispatch_ready_work(state),
          {:ok, state} <- maybe_finalize_terminal(state) do
-      {:noreply, %{data | state: state}}
+      reply_after_progress(data, state)
     else
       {:error, {:invalid_step_transition, status, event}} ->
         Logger.warning(
@@ -80,7 +80,7 @@ defmodule Favn.Runtime.Coordinator do
          {:ok, state} <- maybe_make_retry_ready(state, ref, attempt),
          {:ok, state} <- dispatch_ready_work(state),
          {:ok, state} <- maybe_finalize_terminal(state) do
-      {:noreply, %{data | state: state}}
+      reply_after_progress(data, state)
     else
       {:error, reason} -> {:stop, reason, data}
     end
@@ -90,7 +90,7 @@ defmodule Favn.Runtime.Coordinator do
   def handle_info(:run_deadline_reached, %{state: state} = data) do
     with {:ok, state} <- request_timeout(state),
          {:ok, state} <- maybe_finalize_terminal(state) do
-      {:noreply, %{data | state: state}}
+      reply_after_progress(data, state)
     else
       {:error, reason} -> {:stop, reason, data}
     end
@@ -113,7 +113,7 @@ defmodule Favn.Runtime.Coordinator do
                    ),
                  {:ok, state} <- dispatch_ready_work(state),
                  {:ok, state} <- maybe_finalize_terminal(state) do
-              {:noreply, %{data | state: state}}
+              reply_after_progress(data, state)
             else
               {:error, reason} -> {:stop, reason, data}
             end
@@ -765,6 +765,12 @@ defmodule Favn.Runtime.Coordinator do
 
     data =
       case event_name do
+        :run_started ->
+          %{}
+          |> maybe_put_data(:queued_at, state.queued_at)
+          |> maybe_put_data(:admitted_at, state.admitted_at)
+          |> maybe_put_data(:queue_wait_ms, queue_wait_ms(state))
+
         :run_finished ->
           %{duration_ms: run_duration_ms}
 
@@ -795,6 +801,32 @@ defmodule Favn.Runtime.Coordinator do
 
     {event_name, %{entity: :run, status: state.run_status, data: data}}
   end
+
+  defp maybe_put_data(data, _key, nil), do: data
+  defp maybe_put_data(data, key, value), do: Map.put(data, key, value)
+
+  defp reply_after_progress(data, %State{} = state) do
+    if terminal_state?(state) do
+      {:stop, :normal, %{data | state: state}}
+    else
+      {:noreply, %{data | state: state}}
+    end
+  end
+
+  defp terminal_state?(%State{} = state) do
+    state.run_status in [:success, :failed, :cancelled, :timed_out] and
+      map_size(state.inflight_execs) == 0 and
+      not retries_pending?(state)
+  end
+
+  defp queue_wait_ms(%State{
+         queued_at: %DateTime{} = queued_at,
+         admitted_at: %DateTime{} = admitted_at
+       }) do
+    max(DateTime.diff(admitted_at, queued_at, :millisecond), 0)
+  end
+
+  defp queue_wait_ms(_state), do: nil
 
   defp payload_with_error_metadata(payload, error) do
     payload

--- a/lib/favn/runtime/engine.ex
+++ b/lib/favn/runtime/engine.ex
@@ -45,7 +45,7 @@ defmodule Favn.Runtime.Engine do
 
   defp do_await_run(run_id, start_ms, timeout, poll_interval_ms) do
     case Favn.Storage.get_run(run_id) do
-      {:ok, %Favn.Run{status: :running}} ->
+      {:ok, %Favn.Run{status: status}} when status in [:queued, :running] ->
         if timed_out?(start_ms, timeout) do
           {:error, :timeout}
         else

--- a/lib/favn/runtime/events.ex
+++ b/lib/favn/runtime/events.ex
@@ -13,6 +13,7 @@ defmodule Favn.Runtime.Events do
   @typedoc "Run lifecycle event type."
   @type event_type ::
           :run_created
+          | :run_admitted
           | :run_started
           | :run_cancel_requested
           | :run_cancelled

--- a/lib/favn/runtime/manager.ex
+++ b/lib/favn/runtime/manager.ex
@@ -48,7 +48,26 @@ defmodule Favn.Runtime.Manager do
   def rerun_run(_run_id, _opts), do: {:error, :invalid_run_id}
 
   @impl true
-  def init(_opts), do: {:ok, %{run_monitors: %{}, run_pids: %{}}}
+  def init(_opts) do
+    max_active_runs =
+      Application.get_env(:favn, :runtime_max_active_runs, 1)
+      |> normalize_max_active_runs()
+
+    {:ok,
+     %{
+       run_monitors: %{},
+       run_pids: %{},
+       queue_ids: [],
+       queued_runs: %{},
+       max_active_runs: max_active_runs
+     }, {:continue, :restore_queue}}
+  end
+
+  @impl true
+  def handle_continue(:restore_queue, state) do
+    next_state = restore_queued_runs(state)
+    {:noreply, maybe_admit_runs(next_state)}
+  end
 
   @impl true
   def handle_call({:submit_run, target_refs, opts}, _from, state) do
@@ -73,35 +92,38 @@ defmodule Favn.Runtime.Manager do
 
   @impl true
   def handle_call({:cancel_run, run_id}, _from, state) do
-    reply =
+    {reply, next_state} =
       case Favn.Storage.get_run(run_id) do
+        {:ok, %{status: :queued} = run} ->
+          cancel_queued_run(run, state)
+
         {:ok, %{status: :cancelled}} ->
-          {:ok, :cancelled}
+          {{:ok, :cancelled}, state}
 
         {:ok, %{status: :running, terminal_reason: %{kind: :timed_out}}} ->
-          {:error, :timeout_in_progress}
+          {{:error, :timeout_in_progress}, state}
 
         {:ok, %{status: :running}} ->
           case Map.fetch(state.run_pids, run_id) do
             {:ok, pid} ->
               GenServer.cast(pid, {:cancel_run, %{requested_by: :api}})
-              {:ok, :cancelling}
+              {{:ok, :cancelling}, state}
 
             :error ->
-              {:error, :coordinator_unavailable}
+              {{:error, :coordinator_unavailable}, state}
           end
 
         {:ok, _run} ->
-          {:ok, :already_terminal}
+          {{:ok, :already_terminal}, state}
 
         {:error, :not_found} ->
-          {:error, :not_found}
+          {{:error, :not_found}, state}
 
         {:error, reason} ->
-          {:error, reason}
+          {{:error, reason}, state}
       end
 
-    {:reply, reply, state}
+    {:reply, reply, maybe_admit_runs(next_state)}
   end
 
   defp do_submit_run(target_refs, opts, state) do
@@ -118,35 +140,29 @@ defmodule Favn.Runtime.Manager do
          :ok <- validate_timeout_ms(timeout_ms),
          {:ok, retry_policy} <- validate_retry_policy(retry_policy),
          {:ok, plan} <- resolve_plan(target_refs, dependencies, opts),
-         runtime_state <-
-           build_runtime_state(
-             plan,
-             params,
-             pipeline_context,
-             max_concurrency,
-             timeout_ms,
-             retry_policy,
-             opts
-           ),
-         {:ok, pid} <- start_run_coordinator(runtime_state) do
-      with :ok <- persist_initial_snapshot(runtime_state),
-           :ok <- emit_run_created(runtime_state),
-           :ok <- kickoff_run(pid) do
-        ref = Process.monitor(pid)
+         {:ok, queue_seq} <- Favn.Storage.allocate_queue_seq() do
+      queued_run =
+        build_queued_run(
+          plan,
+          params,
+          pipeline_context,
+          max_concurrency,
+          timeout_ms,
+          retry_policy,
+          queue_seq,
+          opts
+        )
 
+      with :ok <- persist_queued_run(queued_run),
+           :ok <- emit_run_created(queued_run) do
         next_state =
           state
-          |> put_in([:run_monitors, ref], runtime_state.run_id)
-          |> put_in([:run_pids, runtime_state.run_id], pid)
+          |> enqueue_run(queued_run)
+          |> maybe_admit_runs()
 
-        {{:ok, runtime_state.run_id}, next_state}
+        {{:ok, queued_run.id}, next_state}
       else
         {:error, reason} ->
-          _ = DynamicSupervisor.terminate_child(Favn.Runtime.RunSupervisor, pid)
-          {{:error, reason}, state}
-
-        {:start_failed_after_spawn, ^pid, reason} ->
-          _ = DynamicSupervisor.terminate_child(Favn.Runtime.RunSupervisor, pid)
           {{:error, reason}, state}
       end
     else
@@ -164,16 +180,18 @@ defmodule Favn.Runtime.Manager do
       maybe_finalize_crashed_run(run_id, reason)
     end
 
-    {:noreply, %{state | run_monitors: remaining, run_pids: run_pids}}
+    next_state = %{state | run_monitors: remaining, run_pids: run_pids}
+    {:noreply, maybe_admit_runs(next_state)}
   end
 
-  defp build_runtime_state(
+  defp build_queued_run(
          plan,
          params,
          pipeline_context,
          max_concurrency,
          timeout_ms,
          retry_policy,
+         queue_seq,
          opts
        ) do
     submit_kind = Keyword.get(opts, :_submit_kind, :asset)
@@ -186,27 +204,48 @@ defmodule Favn.Runtime.Manager do
     lineage_depth = Keyword.get(opts, :_lineage_depth, 0)
     operator_reason = Keyword.get(opts, :_operator_reason)
 
-    %State{
-      run_id: new_run_id(),
+    now = DateTime.utc_now()
+    run_id = new_run_id()
+    resume_successful_steps = Keyword.get(opts, :_resume_successful_steps, %{})
+
+    root_run_id =
+      case root_run_id do
+        nil -> run_id
+        value -> value
+      end
+
+    asset_results = build_asset_results_from_node_results(resume_successful_steps)
+
+    %Favn.Run{
+      id: run_id,
       target_refs: plan.target_refs,
-      target_node_keys: plan.target_node_keys,
       plan: plan,
-      params: params,
+      pipeline: public_pipeline(pipeline_context),
       pipeline_context: pipeline_context,
-      max_concurrency: max_concurrency,
-      timeout_ms: timeout_ms,
-      retry_policy: retry_policy,
       submit_kind: submit_kind,
       submit_ref: submit_ref,
-      replay_mode: replay_mode,
       backfill: backfill,
+      max_concurrency: max_concurrency,
+      timeout_ms: timeout_ms,
+      status: :queued,
+      event_seq: 0,
+      queued_at: now,
+      admitted_at: nil,
+      queue_seq: queue_seq,
+      started_at: nil,
+      finished_at: nil,
+      params: params,
+      retry_policy: retry_policy,
+      replay_mode: replay_mode,
       rerun_of_run_id: rerun_of_run_id,
       parent_run_id: parent_run_id,
       root_run_id: root_run_id,
       lineage_depth: lineage_depth,
       operator_reason: operator_reason,
-      event_seq: 1,
-      steps: build_steps(plan, retry_policy, Keyword.get(opts, :_resume_successful_steps, %{}))
+      asset_results: asset_results,
+      node_results: resume_successful_steps,
+      error: nil,
+      terminal_reason: nil
     }
   end
 
@@ -289,30 +328,295 @@ defmodule Favn.Runtime.Manager do
     end
   end
 
-  defp emit_run_created(%State{} = runtime_state) do
+  defp persist_queued_run(%Favn.Run{} = queued_run) do
+    case Favn.Storage.put_run(queued_run) do
+      :ok -> :ok
+      {:error, reason} -> {:error, {:storage_persist_failed, reason}}
+    end
+  end
+
+  defp emit_run_created(%Favn.Run{} = run) do
     _ =
       Telemetry.emit_runtime_event(:run_created, %{
-        run_id: runtime_state.run_id,
+        run_id: run.id,
         seq: 1,
         entity: :run,
-        status: runtime_state.run_status,
-        data: %{}
+        status: :queued,
+        data: %{
+          submit_kind: run.submit_kind,
+          replay_mode: run.replay_mode,
+          rerun_of_run_id: run.rerun_of_run_id,
+          parent_run_id: run.parent_run_id,
+          root_run_id: run.root_run_id,
+          queued_at: run.queued_at,
+          queue_seq: run.queue_seq,
+          initial_status: :queued
+        }
       })
 
-    Events.publish_run_event(runtime_state.run_id, :run_created, %{
+    Events.publish_run_event(run.id, :run_created, %{
       seq: 1,
       entity: :run,
-      status: runtime_state.run_status,
+      status: :queued,
       data: %{
-        submit_kind: runtime_state.submit_kind,
-        replay_mode: runtime_state.replay_mode,
-        rerun_of_run_id: runtime_state.rerun_of_run_id,
-        parent_run_id: runtime_state.parent_run_id,
-        root_run_id: runtime_state.root_run_id
+        submit_kind: run.submit_kind,
+        replay_mode: run.replay_mode,
+        rerun_of_run_id: run.rerun_of_run_id,
+        parent_run_id: run.parent_run_id,
+        root_run_id: run.root_run_id,
+        queued_at: run.queued_at,
+        queue_seq: run.queue_seq,
+        initial_status: :queued
       }
     })
 
     :ok
+  end
+
+  defp build_runtime_state_from_run(%Favn.Run{} = run) do
+    %State{
+      run_id: run.id,
+      target_refs: run.target_refs,
+      target_node_keys: run.plan.target_node_keys,
+      plan: run.plan,
+      params: run.params,
+      pipeline_context: run.pipeline_context,
+      max_concurrency: run.max_concurrency,
+      timeout_ms: run.timeout_ms,
+      retry_policy: run.retry_policy,
+      submit_kind: run.submit_kind,
+      submit_ref: run.submit_ref,
+      replay_mode: run.replay_mode,
+      backfill: run.backfill,
+      rerun_of_run_id: run.rerun_of_run_id,
+      parent_run_id: run.parent_run_id,
+      root_run_id: run.root_run_id,
+      lineage_depth: run.lineage_depth,
+      operator_reason: run.operator_reason,
+      event_seq: max(run.event_seq, 1),
+      queued_at: run.queued_at,
+      admitted_at: run.admitted_at,
+      queue_seq: run.queue_seq,
+      steps: build_steps(run.plan, run.retry_policy, resume_successful_steps_from_run(run))
+    }
+  end
+
+  defp build_asset_results_from_node_results(node_results) do
+    node_results
+    |> Enum.group_by(fn {{{module, name}, _window_key}, _result} -> {module, name} end)
+    |> Enum.reduce(%{}, fn {ref, grouped}, acc ->
+      {_node_key, result} =
+        Enum.max_by(grouped, fn {node_key, result} ->
+          {result.attempt_count || 0, inspect(node_key)}
+        end)
+
+      Map.put(acc, ref, result)
+    end)
+  end
+
+  defp resume_successful_steps_from_run(%Favn.Run{} = run) do
+    Enum.reduce(run.node_results, %{}, fn {node_key, result}, acc ->
+      if result.status == :ok do
+        Map.put(acc, node_key, result)
+      else
+        acc
+      end
+    end)
+  end
+
+  defp public_pipeline(nil), do: nil
+
+  defp public_pipeline(pipeline_context) when is_map(pipeline_context) do
+    %{
+      id: Map.get(pipeline_context, :id),
+      name: Map.get(pipeline_context, :name),
+      run_kind: Map.get(pipeline_context, :run_kind),
+      resolved_refs: Map.get(pipeline_context, :resolved_refs, []),
+      deps: Map.get(pipeline_context, :deps),
+      trigger: Map.get(pipeline_context, :trigger),
+      schedule: Map.get(pipeline_context, :schedule),
+      window: Map.get(pipeline_context, :window),
+      anchor_window: Map.get(pipeline_context, :anchor_window),
+      backfill_range: Map.get(pipeline_context, :backfill_range),
+      anchor_ranges: Map.get(pipeline_context, :anchor_ranges, []),
+      source: Map.get(pipeline_context, :source),
+      outputs: Map.get(pipeline_context, :outputs, [])
+    }
+  end
+
+  defp restore_queued_runs(state) do
+    case Favn.Storage.list_queued_runs() do
+      {:ok, runs} ->
+        Enum.reduce(runs, state, fn run, acc -> enqueue_run(acc, run) end)
+
+      {:error, _reason} ->
+        state
+    end
+  end
+
+  defp enqueue_run(state, %Favn.Run{} = run) do
+    %{
+      state
+      | queue_ids: state.queue_ids ++ [run.id],
+        queued_runs: Map.put(state.queued_runs, run.id, run)
+    }
+  end
+
+  defp maybe_admit_runs(state) do
+    admit_runs(state, length(state.queue_ids))
+  end
+
+  defp admit_runs(state, 0), do: state
+
+  defp admit_runs(state, attempts_left) when attempts_left > 0 do
+    cond do
+      map_size(state.run_pids) >= state.max_active_runs ->
+        state
+
+      state.queue_ids == [] ->
+        state
+
+      true ->
+        case admit_next_run_once(state) do
+          {:ok, next_state} -> admit_runs(next_state, attempts_left - 1)
+          {:error, next_state} -> admit_runs(next_state, attempts_left - 1)
+        end
+    end
+  end
+
+  defp admit_next_run_once(%{queue_ids: [run_id | rest]} = state) do
+    case Map.pop(state.queued_runs, run_id) do
+      {nil, queued_runs} ->
+        {:ok, %{state | queue_ids: rest, queued_runs: queued_runs}}
+
+      {%Favn.Run{} = run, queued_runs} ->
+        base_state = %{state | queue_ids: rest, queued_runs: queued_runs}
+
+        case admit_run(run, base_state) do
+          {:ok, next_state} ->
+            {:ok, next_state}
+
+          {:error, _reason} ->
+            requeued_state = enqueue_run(base_state, run)
+            {:error, requeued_state}
+        end
+    end
+  end
+
+  defp admit_next_run_once(state), do: {:ok, state}
+
+  defp admit_run(%Favn.Run{} = run, state) do
+    admitted_at = DateTime.utc_now()
+    runtime_state = build_runtime_state_from_run(%{run | admitted_at: admitted_at})
+    runtime_state = %{runtime_state | event_seq: runtime_state.event_seq + 1}
+
+    with {:ok, pid} <- start_run_coordinator(runtime_state) do
+      with :ok <- emit_run_admitted(runtime_state),
+           :ok <- persist_initial_snapshot(runtime_state),
+           :ok <- kickoff_run(pid) do
+        ref = Process.monitor(pid)
+
+        next_state =
+          state
+          |> put_in([:run_monitors, ref], runtime_state.run_id)
+          |> put_in([:run_pids, runtime_state.run_id], pid)
+
+        {:ok, next_state}
+      else
+        {:error, reason} ->
+          _ = DynamicSupervisor.terminate_child(Favn.Runtime.RunSupervisor, pid)
+          {:error, reason}
+
+        {:start_failed_after_spawn, ^pid, reason} ->
+          _ = DynamicSupervisor.terminate_child(Favn.Runtime.RunSupervisor, pid)
+          {:error, reason}
+      end
+    end
+  end
+
+  defp cancel_queued_run(%Favn.Run{} = run, state) do
+    requested_at = DateTime.utc_now()
+    next_seq = max(run.event_seq, 1) + 1
+
+    cancelled =
+      %{run | status: :cancelled, event_seq: next_seq, finished_at: requested_at}
+      |> Map.put(:terminal_reason, %{
+        kind: :cancelled,
+        source_status: :queued,
+        requested_at: requested_at,
+        finished_at: requested_at
+      })
+
+    case Favn.Storage.put_run(cancelled) do
+      :ok ->
+        _ =
+          Telemetry.emit_runtime_event(:run_cancelled, %{
+            run_id: run.id,
+            seq: next_seq,
+            entity: :run,
+            status: :cancelled,
+            data: %{terminal_reason: cancelled.terminal_reason}
+          })
+
+        _ =
+          Events.publish_run_event(run.id, :run_cancelled, %{
+            seq: next_seq,
+            entity: :run,
+            status: :cancelled,
+            data: %{terminal_reason: cancelled.terminal_reason}
+          })
+
+        {{:ok, :cancelled}, remove_from_queue(state, run.id)}
+
+      {:error, reason} ->
+        {{:error, reason}, state}
+    end
+  end
+
+  defp emit_run_admitted(%State{} = runtime_state) do
+    queue_wait_ms = queue_wait_ms(runtime_state.queued_at, runtime_state.admitted_at)
+
+    _ =
+      Telemetry.emit_runtime_event(:run_admitted, %{
+        run_id: runtime_state.run_id,
+        seq: runtime_state.event_seq,
+        entity: :run,
+        status: runtime_state.run_status,
+        data: %{
+          queued_at: runtime_state.queued_at,
+          admitted_at: runtime_state.admitted_at,
+          queue_seq: runtime_state.queue_seq,
+          queue_wait_ms: queue_wait_ms
+        }
+      })
+
+    _ =
+      Events.publish_run_event(runtime_state.run_id, :run_admitted, %{
+        seq: runtime_state.event_seq,
+        entity: :run,
+        status: runtime_state.run_status,
+        data: %{
+          queued_at: runtime_state.queued_at,
+          admitted_at: runtime_state.admitted_at,
+          queue_seq: runtime_state.queue_seq,
+          queue_wait_ms: queue_wait_ms
+        }
+      })
+
+    :ok
+  end
+
+  defp queue_wait_ms(%DateTime{} = queued_at, %DateTime{} = admitted_at),
+    do: max(DateTime.diff(admitted_at, queued_at, :millisecond), 0)
+
+  defp queue_wait_ms(_, _), do: nil
+
+  defp remove_from_queue(state, run_id) do
+    %{
+      state
+      | queue_ids: Enum.reject(state.queue_ids, &(&1 == run_id)),
+        queued_runs: Map.delete(state.queued_runs, run_id)
+    }
   end
 
   defp kickoff_run(pid) when is_pid(pid) do
@@ -390,6 +694,7 @@ defmodule Favn.Runtime.Manager do
        when status in [:ok, :error, :cancelled, :timed_out],
        do: :ok
 
+  defp ensure_terminal(%Favn.Run{status: :queued}), do: {:error, :run_not_terminal}
   defp ensure_terminal(%Favn.Run{status: :running}), do: {:error, :run_not_terminal}
 
   defp normalize_rerun_mode(opts) do
@@ -500,6 +805,8 @@ defmodule Favn.Runtime.Manager do
     max(DateTime.diff(finished_at, started_at, :millisecond), 0)
   end
 
+  defp run_duration_ms(_run), do: nil
+
   defp validate_max_concurrency(value) when is_integer(value) and value > 0, do: :ok
   defp validate_max_concurrency(_), do: {:error, :invalid_max_concurrency}
 
@@ -510,6 +817,9 @@ defmodule Favn.Runtime.Manager do
   defp resolve_max_concurrency(opts) do
     Keyword.get(opts, :max_concurrency, Application.get_env(:favn, :runtime_max_concurrency, 1))
   end
+
+  defp normalize_max_active_runs(value) when is_integer(value) and value > 0, do: value
+  defp normalize_max_active_runs(_), do: 1
 
   defp resolve_retry_policy(opts) do
     configured = Application.get_env(:favn, :runtime_retry, false)

--- a/lib/favn/runtime/manager.ex
+++ b/lib/favn/runtime/manager.ex
@@ -65,8 +65,13 @@ defmodule Favn.Runtime.Manager do
 
   @impl true
   def handle_continue(:restore_queue, state) do
-    next_state = restore_queued_runs(state)
-    {:noreply, maybe_admit_runs(next_state)}
+    case restore_queued_runs(state) do
+      {:ok, restored_state} ->
+        {:noreply, maybe_admit_runs(restored_state)}
+
+      {:error, reason} ->
+        {:stop, {:queue_restore_failed, reason}, state}
+    end
   end
 
   @impl true
@@ -447,10 +452,11 @@ defmodule Favn.Runtime.Manager do
   defp restore_queued_runs(state) do
     case Favn.Storage.list_queued_runs() do
       {:ok, runs} ->
-        Enum.reduce(runs, state, fn run, acc -> enqueue_run(acc, run) end)
+        restored = Enum.reduce(runs, state, fn run, acc -> enqueue_run(acc, run) end)
+        {:ok, restored}
 
-      {:error, _reason} ->
-        state
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
@@ -479,26 +485,28 @@ defmodule Favn.Runtime.Manager do
       true ->
         case admit_next_run_once(state) do
           {:ok, next_state} -> admit_runs(next_state, attempts_left - 1)
-          {:error, next_state} -> admit_runs(next_state, attempts_left - 1)
+          {:halt, next_state} -> next_state
         end
     end
   end
 
   defp admit_next_run_once(%{queue_ids: [run_id | rest]} = state) do
-    case Map.pop(state.queued_runs, run_id) do
-      {nil, queued_runs} ->
-        {:ok, %{state | queue_ids: rest, queued_runs: queued_runs}}
+    case Map.fetch(state.queued_runs, run_id) do
+      :error ->
+        {:ok, %{state | queue_ids: rest}}
 
-      {%Favn.Run{} = run, queued_runs} ->
-        base_state = %{state | queue_ids: rest, queued_runs: queued_runs}
-
-        case admit_run(run, base_state) do
+      {:ok, %Favn.Run{} = run} ->
+        case admit_run(run, state) do
           {:ok, next_state} ->
-            {:ok, next_state}
+            {:ok,
+             %{
+               next_state
+               | queue_ids: rest,
+                 queued_runs: Map.delete(next_state.queued_runs, run_id)
+             }}
 
           {:error, _reason} ->
-            requeued_state = enqueue_run(base_state, run)
-            {:error, requeued_state}
+            {:halt, state}
         end
     end
   end
@@ -511,8 +519,8 @@ defmodule Favn.Runtime.Manager do
     runtime_state = %{runtime_state | event_seq: runtime_state.event_seq + 1}
 
     with {:ok, pid} <- start_run_coordinator(runtime_state) do
-      with :ok <- emit_run_admitted(runtime_state),
-           :ok <- persist_initial_snapshot(runtime_state),
+      with :ok <- persist_initial_snapshot(runtime_state),
+           :ok <- emit_run_admitted(runtime_state),
            :ok <- kickoff_run(pid) do
         ref = Process.monitor(pid)
 

--- a/lib/favn/runtime/projector.ex
+++ b/lib/favn/runtime/projector.ex
@@ -22,6 +22,9 @@ defmodule Favn.Runtime.Projector do
       timeout_ms: state.timeout_ms,
       status: public_status(state.run_status),
       event_seq: state.event_seq,
+      queued_at: state.queued_at,
+      admitted_at: state.admitted_at,
+      queue_seq: state.queue_seq,
       started_at: state.started_at,
       finished_at: state.finished_at,
       params: state.params,
@@ -59,6 +62,7 @@ defmodule Favn.Runtime.Projector do
     }
   end
 
+  defp public_status(:queued), do: :queued
   defp public_status(:pending), do: :running
   defp public_status(status) when status in [:running, :cancelling, :timing_out], do: :running
   defp public_status(:success), do: :ok

--- a/lib/favn/runtime/state.ex
+++ b/lib/favn/runtime/state.ex
@@ -1,3 +1,4 @@
+# credo:disable-for-this-file Credo.Check.Warning.StructFieldAmount
 defmodule Favn.Runtime.State do
   @moduledoc """
   Internal run-scoped runtime state owned by the coordinator.
@@ -8,7 +9,8 @@ defmodule Favn.Runtime.State do
   alias Favn.Runtime.StepState
 
   @type run_status ::
-          :pending
+          :queued
+          | :pending
           | :running
           | :cancelling
           | :cancelled
@@ -39,6 +41,9 @@ defmodule Favn.Runtime.State do
           max_concurrency: pos_integer(),
           admission_open?: boolean(),
           event_seq: non_neg_integer(),
+          queued_at: DateTime.t() | nil,
+          admitted_at: DateTime.t() | nil,
+          queue_seq: pos_integer() | nil,
           started_at: DateTime.t() | nil,
           finished_at: DateTime.t() | nil,
           cancel_requested_at: DateTime.t() | nil,
@@ -76,6 +81,9 @@ defmodule Favn.Runtime.State do
     max_concurrency: 1,
     admission_open?: true,
     event_seq: 0,
+    queued_at: nil,
+    admitted_at: nil,
+    queue_seq: nil,
     started_at: nil,
     finished_at: nil,
     cancel_requested_at: nil,

--- a/lib/favn/runtime/telemetry.ex
+++ b/lib/favn/runtime/telemetry.ex
@@ -44,6 +44,7 @@ defmodule Favn.Runtime.Telemetry do
   end
 
   defp event_name_for(:run_started, _attrs), do: [:favn, :runtime, :run, :start]
+  defp event_name_for(:run_admitted, _attrs), do: [:favn, :runtime, :run, :admitted]
   defp event_name_for(:run_finished, _attrs), do: [:favn, :runtime, :run, :stop]
   defp event_name_for(:run_failed, _attrs), do: [:favn, :runtime, :run, :exception]
   defp event_name_for(:step_started, _attrs), do: [:favn, :runtime, :step, :start]

--- a/lib/favn/storage.ex
+++ b/lib/favn/storage.ex
@@ -66,7 +66,7 @@ defmodule Favn.Storage do
 
   Supported filters:
 
-    * `:status` - one of `:running | :ok | :error | :cancelled | :timed_out`
+    * `:status` - one of `:queued | :running | :ok | :error | :cancelled | :timed_out`
     * `:limit` - positive integer max result count
   """
   @spec list_runs(Favn.list_runs_opts()) :: {:ok, [Run.t()]} | {:error, error()}
@@ -76,6 +76,28 @@ defmodule Favn.Storage do
         adapter.list_runs(opts, adapter_opts)
       end)
     end
+  end
+
+  @doc false
+  @spec list_queued_runs(keyword()) :: {:ok, [Run.t()]} | {:error, error()}
+  def list_queued_runs(opts \\ []) when is_list(opts) do
+    limit = Keyword.get(opts, :limit)
+
+    if is_nil(limit) or (is_integer(limit) and limit > 0) do
+      adapter_call(:list_queued_runs, %{run_id: :all}, fn adapter, adapter_opts ->
+        adapter.list_queued_runs(opts, adapter_opts)
+      end)
+    else
+      {:error, :invalid_opts}
+    end
+  end
+
+  @doc false
+  @spec allocate_queue_seq() :: {:ok, pos_integer()} | {:error, error()}
+  def allocate_queue_seq do
+    adapter_call(:allocate_queue_seq, %{run_id: :queue_seq}, fn adapter, adapter_opts ->
+      adapter.allocate_queue_seq(adapter_opts)
+    end)
   end
 
   @doc """
@@ -110,6 +132,8 @@ defmodule Favn.Storage do
       {:put_run, 2},
       {:get_run, 2},
       {:list_runs, 2},
+      {:list_queued_runs, 2},
+      {:allocate_queue_seq, 1},
       {:put_scheduler_state, 2},
       {:get_scheduler_state, 3}
     ]
@@ -130,7 +154,8 @@ defmodule Favn.Storage do
     limit = Keyword.get(opts, :limit)
 
     cond do
-      not is_nil(status) and status not in [:running, :ok, :error, :cancelled, :timed_out] ->
+      not is_nil(status) and
+          status not in [:queued, :running, :ok, :error, :cancelled, :timed_out] ->
         {:error, :invalid_opts}
 
       not is_nil(limit) and (not is_integer(limit) or limit <= 0) ->

--- a/lib/favn/storage/adapter.ex
+++ b/lib/favn/storage/adapter.ex
@@ -53,6 +53,10 @@ defmodule Favn.Storage.Adapter do
 
   @callback list_runs(list_opts(), adapter_opts()) :: {:ok, [Run.t()]} | {:error, error()}
 
+  @callback list_queued_runs(keyword(), adapter_opts()) :: {:ok, [Run.t()]} | {:error, error()}
+
+  @callback allocate_queue_seq(adapter_opts()) :: {:ok, pos_integer()} | {:error, error()}
+
   @callback put_scheduler_state(SchedulerState.t(), adapter_opts()) :: :ok | {:error, error()}
 
   @callback get_scheduler_state(module(), atom() | nil, adapter_opts()) ::

--- a/lib/favn/storage/adapter/memory.ex
+++ b/lib/favn/storage/adapter/memory.ex
@@ -161,6 +161,35 @@ defmodule Favn.Storage.Adapter.Memory do
     error -> {:error, error}
   end
 
+  @impl true
+  @spec list_queued_runs(keyword(), keyword()) :: {:ok, [Run.t()]} | {:error, term()}
+  def list_queued_runs(opts, _adapter_opts) when is_list(opts) do
+    limit = Keyword.get(opts, :limit)
+
+    runs =
+      @table_name
+      |> :ets.tab2list()
+      |> Enum.map(fn
+        {_id, run, _inserted_seq, _updated_seq, _event_seq, _snapshot_hash} -> run
+        {_id, run, _inserted_seq, _updated_seq} -> run
+      end)
+      |> Enum.filter(&(&1.status == :queued))
+      |> Enum.sort_by(fn run -> {run.queue_seq || 0, run.id} end, :asc)
+      |> maybe_limit(limit)
+
+    {:ok, runs}
+  rescue
+    error -> {:error, error}
+  end
+
+  @impl true
+  @spec allocate_queue_seq(keyword()) :: {:ok, pos_integer()} | {:error, term()}
+  def allocate_queue_seq(_opts) do
+    {:ok, System.unique_integer([:monotonic, :positive])}
+  rescue
+    error -> {:error, error}
+  end
+
   defp maybe_filter_status(runs, nil), do: runs
 
   defp maybe_filter_status(runs, status) do

--- a/lib/favn/storage/adapter/postgres.ex
+++ b/lib/favn/storage/adapter/postgres.ex
@@ -105,6 +105,48 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   @impl true
+  def list_queued_runs(opts, adapter_opts) when is_list(opts) and is_list(adapter_opts) do
+    with {:ok, repo} <- resolve_repo(adapter_opts),
+         :ok <- ensure_schema_ready(repo) do
+      limit = Keyword.get(opts, :limit)
+      {sql, params} = build_list_queued_query(limit)
+
+      case SQL.query(repo, sql, params) do
+        {:ok, %{rows: rows}} -> decode_list_rows(rows)
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp build_list_queued_query(nil) do
+    {
+      "SELECT snapshot_json FROM favn_runs WHERE status = 'queued' ORDER BY queue_seq ASC, id ASC",
+      []
+    }
+  end
+
+  defp build_list_queued_query(limit) do
+    {
+      "SELECT snapshot_json FROM favn_runs WHERE status = 'queued' ORDER BY queue_seq ASC, id ASC LIMIT $1",
+      [limit]
+    }
+  end
+
+  @impl true
+  def allocate_queue_seq(opts) when is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         :ok <- ensure_schema_ready(repo) do
+      sql = "SELECT nextval('favn_run_queue_seq')"
+
+      case SQL.query(repo, sql, []) do
+        {:ok, %{rows: [[value]]}} when is_integer(value) and value > 0 -> {:ok, value}
+        {:ok, _} -> {:error, :invalid_queue_seq}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
   def get_scheduler_state(pipeline_module, schedule_id, opts)
       when is_atom(pipeline_module) and (is_atom(schedule_id) or is_nil(schedule_id)) and
              is_list(opts) do
@@ -258,6 +300,9 @@ defmodule Favn.Storage.Adapter.Postgres do
       event_seq,
       write_seq,
       started_at,
+      queued_at,
+      admitted_at,
+      queue_seq,
       finished_at,
       max_concurrency,
       timeout_ms,
@@ -285,7 +330,8 @@ defmodule Favn.Storage.Adapter.Postgres do
     VALUES (
       $1, $2, $3, $4, $5, $6, $7, $8, $9, $10,
       $11, $12, $13, $14, $15, $16, $17, $18, $19, $20,
-      $21, $22, $23, $24, $25, $26, $27, $28, $29, $29
+      $21, $22, $23, $24, $25, $26, $27, $28, $29, $30,
+      $31, $32, $32
     )
     ON CONFLICT(id) DO UPDATE SET
       status = EXCLUDED.status,
@@ -294,6 +340,9 @@ defmodule Favn.Storage.Adapter.Postgres do
       event_seq = EXCLUDED.event_seq,
       write_seq = EXCLUDED.write_seq,
       started_at = EXCLUDED.started_at,
+      queued_at = EXCLUDED.queued_at,
+      admitted_at = EXCLUDED.admitted_at,
+      queue_seq = EXCLUDED.queue_seq,
       finished_at = EXCLUDED.finished_at,
       max_concurrency = EXCLUDED.max_concurrency,
       timeout_ms = EXCLUDED.timeout_ms,
@@ -330,6 +379,9 @@ defmodule Favn.Storage.Adapter.Postgres do
       run.event_seq,
       write_seq,
       run.started_at,
+      run.queued_at,
+      run.admitted_at,
+      run.queue_seq,
       run.finished_at,
       run.max_concurrency,
       run.timeout_ms,

--- a/lib/favn/storage/adapter/sqlite.ex
+++ b/lib/favn/storage/adapter/sqlite.ex
@@ -59,6 +59,9 @@ defmodule Favn.Storage.Adapter.SQLite do
         status,
         event_seq,
         snapshot_hash,
+        queued_at,
+        admitted_at,
+        queue_seq,
         started_at,
         finished_at,
         inserted_at_us,
@@ -66,11 +69,14 @@ defmodule Favn.Storage.Adapter.SQLite do
         updated_seq,
         run_blob
       )
-      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?7, ?8, ?9)
+      VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?10, ?11, ?12)
       ON CONFLICT(id) DO UPDATE SET
         status = excluded.status,
         event_seq = excluded.event_seq,
         snapshot_hash = excluded.snapshot_hash,
+        queued_at = excluded.queued_at,
+        admitted_at = excluded.admitted_at,
+        queue_seq = excluded.queue_seq,
         started_at = excluded.started_at,
         finished_at = excluded.finished_at,
         updated_at_us = excluded.updated_at_us,
@@ -159,6 +165,9 @@ defmodule Favn.Storage.Adapter.SQLite do
            Atom.to_string(run.status),
            run.event_seq,
            snapshot_hash,
+           datetime_to_iso(run.queued_at),
+           datetime_to_iso(run.admitted_at),
+           run.queue_seq,
            datetime_to_iso(run.started_at),
            datetime_to_iso(run.finished_at),
            context.now_us,
@@ -223,6 +232,67 @@ defmodule Favn.Storage.Adapter.SQLite do
 
         {:error, reason} ->
           {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_queued_runs(opts, adapter_opts) when is_list(opts) and is_list(adapter_opts) do
+    with {:ok, _repo_config} <- repo_config(adapter_opts),
+         :ok <- ensure_repo_started() do
+      limit = Keyword.get(opts, :limit)
+
+      {sql, params} = build_list_queued_query(limit)
+
+      case SQL.query(Repo, sql, params) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> Enum.reduce_while({:ok, []}, fn [blob], {:ok, acc} ->
+            case deserialize_run(blob) do
+              {:ok, run} -> {:cont, {:ok, [run | acc]}}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+          |> case do
+            {:ok, runs} -> {:ok, Enum.reverse(runs)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp build_list_queued_query(nil) do
+    {
+      "SELECT run_blob FROM runs WHERE status = ?1 ORDER BY queue_seq ASC, id ASC",
+      ["queued"]
+    }
+  end
+
+  defp build_list_queued_query(limit) do
+    {
+      "SELECT run_blob FROM runs WHERE status = ?1 ORDER BY queue_seq ASC, id ASC LIMIT ?2",
+      ["queued", limit]
+    }
+  end
+
+  @impl true
+  def allocate_queue_seq(adapter_opts) when is_list(adapter_opts) do
+    with {:ok, _repo_config} <- repo_config(adapter_opts),
+         :ok <- ensure_repo_started() do
+      sql = """
+      INSERT INTO favn_counters (name, value)
+      VALUES (?1, 1)
+      ON CONFLICT(name) DO UPDATE SET value = value + 1
+      RETURNING value
+      """
+
+      case SQL.query(Repo, sql, ["run_queue_seq"]) do
+        {:ok, %{rows: [[value]]}} when is_integer(value) and value > 0 -> {:ok, value}
+        {:ok, _} -> {:error, :invalid_queue_seq}
+        {:error, reason} -> {:error, reason}
       end
     end
   end

--- a/lib/favn/storage/postgres/migrations/create_foundation.ex
+++ b/lib/favn/storage/postgres/migrations/create_foundation.ex
@@ -4,6 +4,7 @@ defmodule Favn.Storage.Postgres.Migrations.CreateFoundation do
 
   def up do
     execute("CREATE SEQUENCE IF NOT EXISTS favn_run_write_seq")
+    execute("CREATE SEQUENCE IF NOT EXISTS favn_run_queue_seq")
 
     create table(:favn_runs, primary_key: false) do
       add(:id, :text, primary_key: true)
@@ -12,7 +13,10 @@ defmodule Favn.Storage.Postgres.Migrations.CreateFoundation do
       add(:replay_mode, :text, null: false)
       add(:event_seq, :bigint, null: false)
       add(:write_seq, :bigint, null: false)
-      add(:started_at, :utc_datetime_usec, null: false)
+      add(:queued_at, :utc_datetime_usec)
+      add(:admitted_at, :utc_datetime_usec)
+      add(:queue_seq, :bigint)
+      add(:started_at, :utc_datetime_usec)
       add(:finished_at, :utc_datetime_usec)
       add(:max_concurrency, :integer, null: false)
       add(:timeout_ms, :integer)
@@ -38,7 +42,7 @@ defmodule Favn.Storage.Postgres.Migrations.CreateFoundation do
     end
 
     execute(
-      "ALTER TABLE favn_runs ADD CONSTRAINT favn_runs_status_check CHECK (status IN ('running', 'ok', 'error', 'cancelled', 'timed_out'))"
+      "ALTER TABLE favn_runs ADD CONSTRAINT favn_runs_status_check CHECK (status IN ('queued', 'running', 'ok', 'error', 'cancelled', 'timed_out'))"
     )
 
     execute(
@@ -50,7 +54,9 @@ defmodule Favn.Storage.Postgres.Migrations.CreateFoundation do
     )
 
     create(unique_index(:favn_runs, [:write_seq]))
+    create(unique_index(:favn_runs, [:queue_seq]))
     create(index(:favn_runs, [:status, :write_seq]))
+    create(index(:favn_runs, [:status, :queue_seq]))
     create(index(:favn_runs, [:root_run_id, :write_seq]))
     create(index(:favn_runs, [:parent_run_id, :write_seq]))
     create(index(:favn_runs, [:rerun_of_run_id, :write_seq]))
@@ -129,6 +135,7 @@ defmodule Favn.Storage.Postgres.Migrations.CreateFoundation do
     drop(table(:favn_asset_window_latest))
     drop(table(:favn_run_nodes))
     drop(table(:favn_runs))
+    execute("DROP SEQUENCE IF EXISTS favn_run_queue_seq")
     execute("DROP SEQUENCE IF EXISTS favn_run_write_seq")
   end
 end

--- a/lib/favn/storage/sqlite/migrations/create_runs.ex
+++ b/lib/favn/storage/sqlite/migrations/create_runs.ex
@@ -8,6 +8,9 @@ defmodule Favn.Storage.SQLite.Migrations.CreateRuns do
       add(:status, :text, null: false)
       add(:event_seq, :bigint, null: false)
       add(:snapshot_hash, :text, null: false)
+      add(:queued_at, :utc_datetime)
+      add(:admitted_at, :utc_datetime)
+      add(:queue_seq, :bigint)
       add(:started_at, :utc_datetime)
       add(:finished_at, :utc_datetime)
       add(:inserted_at_us, :bigint, null: false)
@@ -17,6 +20,7 @@ defmodule Favn.Storage.SQLite.Migrations.CreateRuns do
     end
 
     create(index(:runs, [:status]))
+    create(index(:runs, [:status, :queue_seq, :id]))
     create(index(:runs, [:updated_seq, :updated_at_us, :id]))
 
     create table(:favn_counters, primary_key: false) do
@@ -70,6 +74,12 @@ defmodule Favn.Storage.SQLite.Migrations.CreateRuns do
     execute("""
     INSERT INTO favn_counters (name, value)
     VALUES ('run_write_order', 0)
+    ON CONFLICT(name) DO NOTHING
+    """)
+
+    execute("""
+    INSERT INTO favn_counters (name, value)
+    VALUES ('run_queue_seq', 0)
     ON CONFLICT(name) DO NOTHING
     """)
   end

--- a/test/favn_test.exs
+++ b/test/favn_test.exs
@@ -58,6 +58,12 @@ defmodule FavnTest do
     def list_runs(_opts, _adapter_opts), do: {:error, :list_failed}
 
     @impl true
+    def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def allocate_queue_seq(_opts), do: {:ok, 1}
+
+    @impl true
     def scheduler_child_spec(_opts), do: :none
 
     @impl true
@@ -311,5 +317,7 @@ defmodule FavnTest do
     assert {:error, {:store_error, :read_failed}} = Favn.get_run("run-1")
     assert {:error, {:store_error, :list_failed}} = Favn.list_runs()
     assert {:error, :invalid_opts} = Favn.list_runs(status: :pending)
+    assert {:ok, []} = Favn.list_queued_runs()
+    assert {:error, :invalid_opts} = Favn.list_queued_runs(limit: 0)
   end
 end

--- a/test/runner_test.exs
+++ b/test/runner_test.exs
@@ -66,6 +66,12 @@ defmodule Favn.RunnerTest do
     def list_runs(_opts, _adapter_opts), do: {:ok, []}
 
     @impl true
+    def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def allocate_queue_seq(_opts), do: {:ok, 1}
+
+    @impl true
     def scheduler_child_spec(_opts), do: :none
 
     @impl true
@@ -218,7 +224,7 @@ defmodule Favn.RunnerTest do
              {RunnerAssets, :transform}
            ]
 
-    assert run.event_seq == 12
+    assert run.event_seq == 13
   end
 
   test "supports dependencies: :none target-only runs" do
@@ -239,7 +245,7 @@ defmodule Favn.RunnerTest do
              {:invalid_return_shape, {:ok, :bad_shape},
               expected: ":ok | {:ok, map()} | {:error, reason}"}
 
-    assert run.event_seq == 9
+    assert run.event_seq == 10
   end
 
   test "captures raised exceptions with stacktrace details" do
@@ -310,6 +316,37 @@ defmodule Favn.RunnerTest do
 
     assert {:ok, limited_runs} = Favn.list_runs(limit: 1)
     assert Enum.map(limited_runs, & &1.id) == Enum.take(all_run_ids, 1)
+  end
+
+  test "queues excess submissions and supports queued cancellation" do
+    Application.put_env(:favn, :runtime_max_active_runs, 1)
+
+    assert {:ok, running_run_id} = Favn.run_asset({RunnerAssets, :slow_asset})
+    assert {:ok, queued_run_id} = Favn.run_asset({RunnerAssets, :final})
+
+    assert_eventually(fn ->
+      case Favn.get_run(queued_run_id) do
+        {:ok, %Favn.Run{status: :queued, queued_at: %DateTime{}, queue_seq: queue_seq}} ->
+          is_integer(queue_seq) and queue_seq > 0
+
+        _ ->
+          false
+      end
+    end)
+
+    assert {:ok, queued_runs} = Favn.list_runs(status: :queued)
+    assert queued_run_id in Enum.map(queued_runs, & &1.id)
+
+    assert {:ok, queue_entries} = Favn.list_queued_runs()
+
+    assert Enum.any?(queue_entries, fn entry ->
+             entry.run.id == queued_run_id and entry.queue_position >= 1 and
+               is_integer(entry.queued_for_ms)
+           end)
+
+    assert {:ok, :cancelled} = Favn.cancel_run(queued_run_id)
+    assert {:error, %Favn.Run{status: :cancelled}} = Favn.await_run(queued_run_id)
+    assert {:ok, %Favn.Run{status: :ok}} = Favn.await_run(running_run_id)
   end
 
   test "returns :not_found for missing runs" do

--- a/test/runtime_telemetry_test.exs
+++ b/test/runtime_telemetry_test.exs
@@ -20,6 +20,12 @@ defmodule Favn.RuntimeTelemetryTest do
     def list_runs(_opts, _adapter_opts), do: {:ok, []}
 
     @impl true
+    def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def allocate_queue_seq(_opts), do: {:ok, 1}
+
+    @impl true
     def scheduler_child_spec(_opts), do: :none
 
     @impl true
@@ -45,6 +51,7 @@ defmodule Favn.RuntimeTelemetryTest do
 
     events = [
       [:favn, :runtime, :run, :created],
+      [:favn, :runtime, :run, :admitted],
       [:favn, :runtime, :run, :start],
       [:favn, :runtime, :run, :stop],
       [:favn, :runtime, :run, :exception],
@@ -93,6 +100,7 @@ defmodule Favn.RuntimeTelemetryTest do
     events = telemetry_events_for(run_id)
 
     assert_count(events, [:favn, :runtime, :run, :created], 1)
+    assert_count(events, [:favn, :runtime, :run, :admitted], 1)
     assert_count(events, [:favn, :runtime, :run, :start], 1)
     assert_count(events, [:favn, :runtime, :run, :stop], 1)
     assert has_event?(events, [:favn, :runtime, :step, :ready], fn _m, md -> is_tuple(md.ref) end)

--- a/test/storage_test.exs
+++ b/test/storage_test.exs
@@ -22,6 +22,12 @@ defmodule Favn.StorageTest do
     def list_runs(_opts, _adapter_opts), do: {:error, :list_failed}
 
     @impl true
+    def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def allocate_queue_seq(_opts), do: {:ok, 1}
+
+    @impl true
     def scheduler_child_spec(_opts), do: :none
 
     @impl true
@@ -45,6 +51,12 @@ defmodule Favn.StorageTest do
 
     @impl true
     def list_runs(_opts, _adapter_opts), do: {:error, {:store_error, :already_normalized}}
+
+    @impl true
+    def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def allocate_queue_seq(_opts), do: {:ok, 1}
 
     @impl true
     def scheduler_child_spec(_opts), do: :none
@@ -71,6 +83,12 @@ defmodule Favn.StorageTest do
 
     @impl true
     def list_runs(_opts, _adapter_opts), do: {:error, :invalid_opts}
+
+    @impl true
+    def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def allocate_queue_seq(_opts), do: {:ok, 1}
 
     @impl true
     def scheduler_child_spec(_opts), do: :none
@@ -101,6 +119,12 @@ defmodule Favn.StorageTest do
     def list_runs(_opts, _adapter_opts), do: {:ok, []}
 
     @impl true
+    def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def allocate_queue_seq(_opts), do: {:ok, 1}
+
+    @impl true
     def put_scheduler_state(_state, _opts), do: :ok
 
     @impl true
@@ -126,6 +150,12 @@ defmodule Favn.StorageTest do
     def list_runs(_opts, _adapter_opts), do: {:ok, []}
 
     @impl true
+    def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def allocate_queue_seq(_opts), do: {:ok, 1}
+
+    @impl true
     def put_scheduler_state(_state, _opts), do: raise("scheduler boom")
 
     @impl true
@@ -149,6 +179,12 @@ defmodule Favn.StorageTest do
 
     @impl true
     def list_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def allocate_queue_seq(_opts), do: {:ok, 1}
 
     @impl true
     def put_scheduler_state(_state, _opts), do: :ok
@@ -197,6 +233,12 @@ defmodule Favn.StorageTest do
 
     assert {:error, :invalid_opts} = Storage.list_runs(status: :pending)
     assert {:error, :invalid_opts} = Storage.list_runs(limit: 0)
+  end
+
+  test "list_runs/1 accepts :queued status filter" do
+    Application.put_env(:favn, :storage_adapter, RawErrorStore)
+
+    assert {:error, {:store_error, :list_failed}} = Storage.list_runs(status: :queued)
   end
 
   test "scheduler child_specs normalize malformed adapter responses" do

--- a/test/support/fixtures/assets/runner_assets.ex
+++ b/test/support/fixtures/assets/runner_assets.ex
@@ -264,6 +264,12 @@ defmodule Favn.Test.Fixtures.Assets.Runner.TerminalFailingStore do
   def list_runs(_opts, _adapter_opts), do: {:ok, []}
 
   @impl true
+  def list_queued_runs(_opts, _adapter_opts), do: {:ok, []}
+
+  @impl true
+  def allocate_queue_seq(_opts), do: {:ok, 1}
+
+  @impl true
   def scheduler_child_spec(_opts), do: :none
 
   @impl true


### PR DESCRIPTION
## Summary
- separates submission from admission by persisting accepted runs as `:queued` first, then admitting them via a single-node FIFO gate with configurable `runtime_max_active_runs`
- adds durable queue lifecycle state and metadata (`queued_at`, `admitted_at`, `queue_seq`), queued cancellation semantics, queued restore-on-boot, and a new `run_admitted` lifecycle event
- introduces queue inspection API `Favn.list_queued_runs/1` with operator-facing queue position and queued age metadata, and extends memory/sqlite/postgres adapters + migrations for queued persistence/querying

## Validation
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`