### PR TITLE
Clean up remaining Phase 3 core boundary leaks

### DIFF
--- a/apps/favn/lib/favn.ex
+++ b/apps/favn/lib/favn.ex
@@ -19,6 +19,7 @@ defmodule Favn do
   alias Favn.Pipeline
   alias Favn.Pipeline.Resolver
   alias Favn.Runtime.Manager
+  alias Favn.Triggers.Schedules, as: PipelineSchedules
 
   @type asset_ref :: Favn.Ref.t()
   @type asset :: Asset.t()
@@ -177,16 +178,36 @@ defmodule Favn do
   @spec plan_asset_run(asset_ref() | [asset_ref()], keyword()) ::
           {:ok, Favn.Plan.t()} | {:error, term()}
   def plan_asset_run(target_refs, opts \\ []) do
+    opts = Keyword.put_new(opts, :asset_modules, Application.get_env(:favn, :asset_modules, []))
     Planner.plan(target_refs, opts)
   end
+
+  @doc false
+  @spec resolve_pipeline(module(), keyword()) ::
+          {:ok, Favn.Pipeline.Resolution.t()} | {:error, term()}
+  def resolve_pipeline(pipeline_module, opts \\ [])
+
+  def resolve_pipeline(pipeline_module, opts)
+      when is_atom(pipeline_module) and is_list(opts) do
+    with {:ok, pipeline} <- Pipeline.fetch(pipeline_module),
+         {:ok, assets} <- list_assets() do
+      Resolver.resolve(
+        pipeline,
+        opts
+        |> Keyword.put_new(:assets, assets)
+        |> Keyword.put_new(:schedule_lookup, &PipelineSchedules.fetch/2)
+      )
+    end
+  end
+
+  def resolve_pipeline(_pipeline_module, _opts), do: {:error, :invalid_pipeline}
 
   @doc false
   @spec run_pipeline(module(), keyword()) :: {:ok, term()} | {:error, term()}
   def run_pipeline(pipeline_module, opts \\ [])
 
   def run_pipeline(pipeline_module, opts) when is_atom(pipeline_module) and is_list(opts) do
-    with {:ok, pipeline} <- Pipeline.fetch(pipeline_module),
-         {:ok, resolution} <- Resolver.resolve(pipeline, opts),
+    with {:ok, resolution} <- resolve_pipeline(pipeline_module, opts),
          manager when is_atom(manager) <- Manager,
          true <- function_exported?(manager, :submit_run, 2) do
       submit_opts =

--- a/apps/favn/lib/favn.ex
+++ b/apps/favn/lib/favn.ex
@@ -190,17 +190,26 @@ defmodule Favn do
   def resolve_pipeline(pipeline_module, opts)
       when is_atom(pipeline_module) and is_list(opts) do
     with {:ok, pipeline} <- Pipeline.fetch(pipeline_module),
-         {:ok, assets} <- list_assets() do
-      Resolver.resolve(
-        pipeline,
-        opts
-        |> Keyword.put_new(:assets, assets)
-        |> Keyword.put_new(:schedule_lookup, &PipelineSchedules.fetch/2)
-      )
+         {:ok, resolve_opts} <- resolve_pipeline_opts(opts) do
+      Resolver.resolve(pipeline, resolve_opts)
     end
   end
 
   def resolve_pipeline(_pipeline_module, _opts), do: {:error, :invalid_pipeline}
+
+  defp resolve_pipeline_opts(opts) when is_list(opts) do
+    opts = Keyword.put_new(opts, :schedule_lookup, &PipelineSchedules.fetch/2)
+
+    case Keyword.fetch(opts, :assets) do
+      {:ok, _assets} ->
+        {:ok, opts}
+
+      :error ->
+        with {:ok, assets} <- list_assets() do
+          {:ok, Keyword.put(opts, :assets, assets)}
+        end
+    end
+  end
 
   @doc false
   @spec run_pipeline(module(), keyword()) :: {:ok, term()} | {:error, term()}

--- a/apps/favn/test/boundary_defaults_test.exs
+++ b/apps/favn/test/boundary_defaults_test.exs
@@ -1,0 +1,65 @@
+defmodule Favn.BoundaryDefaultsTest do
+  use ExUnit.Case, async: false
+
+  defmodule TestSchedules do
+    use Favn.Triggers.Schedules
+
+    schedule(:daily, cron: "0 2 * * *", timezone: "Etc/UTC")
+  end
+
+  defmodule RawAsset do
+    use Favn.Asset
+
+    def asset(_ctx), do: :ok
+  end
+
+  defmodule GoldAsset do
+    use Favn.Asset
+
+    @depends RawAsset
+    def asset(_ctx), do: :ok
+  end
+
+  defmodule DailyPipeline do
+    use Favn.Pipeline
+
+    pipeline :daily do
+      select do
+        module(GoldAsset)
+      end
+
+      deps(:all)
+      schedule({TestSchedules, :daily})
+    end
+  end
+
+  setup do
+    previous_assets = Application.get_env(:favn, :asset_modules)
+
+    Application.put_env(:favn, :asset_modules, [RawAsset, GoldAsset])
+
+    on_exit(fn ->
+      if is_nil(previous_assets) do
+        Application.delete_env(:favn, :asset_modules)
+      else
+        Application.put_env(:favn, :asset_modules, previous_assets)
+      end
+    end)
+
+    :ok
+  end
+
+  test "public plan API supplies asset module defaults before delegating" do
+    assert {:ok, plan} = Favn.plan_asset_run({GoldAsset, :asset}, dependencies: :all)
+
+    assert plan.target_refs == [{GoldAsset, :asset}]
+    assert plan.topo_order == [{RawAsset, :asset}, {GoldAsset, :asset}]
+  end
+
+  test "public pipeline resolve API supplies assets and schedule lookup defaults" do
+    assert {:ok, resolution} = Favn.resolve_pipeline(DailyPipeline)
+
+    assert resolution.target_refs == [{GoldAsset, :asset}]
+    assert resolution.pipeline_ctx.schedule.ref == {TestSchedules, :daily}
+  end
+end

--- a/apps/favn/test/boundary_defaults_test.exs
+++ b/apps/favn/test/boundary_defaults_test.exs
@@ -62,4 +62,13 @@ defmodule Favn.BoundaryDefaultsTest do
     assert resolution.target_refs == [{GoldAsset, :asset}]
     assert resolution.pipeline_ctx.schedule.ref == {TestSchedules, :daily}
   end
+
+  test "public pipeline resolve API honors explicit assets override" do
+    assert {:ok, assets} = Favn.list_assets([RawAsset, GoldAsset])
+    Application.put_env(:favn, :asset_modules, [])
+
+    assert {:ok, resolution} = Favn.resolve_pipeline(DailyPipeline, assets: assets)
+    assert resolution.target_refs == [{GoldAsset, :asset}]
+    assert resolution.pipeline_ctx.schedule.ref == {TestSchedules, :daily}
+  end
 end

--- a/apps/favn_core/lib/favn/assets/graph_index.ex
+++ b/apps/favn_core/lib/favn/assets/graph_index.ex
@@ -1,6 +1,6 @@
 defmodule Favn.Assets.GraphIndex do
   @moduledoc """
-  Global dependency graph index for configured Favn assets.
+  Cached dependency graph index for compiled Favn assets.
 
   `Favn.Assets.GraphIndex` builds a read-only directed acyclic graph (DAG) from
   canonical compiled assets. The index can be cached in `:persistent_term` for
@@ -42,6 +42,8 @@ defmodule Favn.Assets.GraphIndex do
   @type error ::
           {:missing_dependency, Ref.t(), Ref.t()}
           | {:cycle, [Ref.t()]}
+          | :asset_modules_required
+          | :index_not_loaded
           | :invalid_opts
           | {:asset_compile_failed, module(), term()}
 
@@ -79,23 +81,20 @@ defmodule Favn.Assets.GraphIndex do
   @spec get() :: {:ok, t()} | {:error, error()}
   def get do
     case :persistent_term.get(@index_key, :undefined) do
-      :undefined -> load_and_fetch_index()
+      :undefined -> {:error, :index_not_loaded}
       %__MODULE__{} = index -> {:ok, index}
     end
   end
 
   @doc """
-  Build and cache the dependency index from configured asset modules.
+  Transitional legacy wrapper.
+
+  Prefer `load/1` with explicit module lists from the public facade.
   """
+  @deprecated "use load/1 with explicit asset modules"
   @spec load() :: :ok | {:error, error()}
   def load do
-    modules = Application.get_env(:favn, :asset_modules, [])
-
-    with {:ok, assets} <- compile_assets(modules),
-         {:ok, %__MODULE__{} = index} <- build_index(assets) do
-      :persistent_term.put(@index_key, index)
-      :ok
-    end
+    {:error, :asset_modules_required}
   end
 
   @doc """
@@ -113,6 +112,10 @@ defmodule Favn.Assets.GraphIndex do
   @doc false
   @spec reload() :: :ok | {:error, error()}
   def reload, do: load()
+
+  @doc false
+  @spec reload([module()]) :: :ok | {:error, error()}
+  def reload(modules), do: load(modules)
 
   @doc """
   Return the immediate upstream dependencies for an asset.
@@ -382,12 +385,6 @@ defmodule Favn.Assets.GraphIndex do
         true -> compare_refs(left.ref, right.ref)
       end
     end)
-  end
-
-  defp load_and_fetch_index do
-    with :ok <- load() do
-      {:ok, :persistent_term.get(@index_key)}
-    end
   end
 
   defp compile_assets(modules) when is_list(modules) do

--- a/apps/favn_core/lib/favn/assets/planner.ex
+++ b/apps/favn_core/lib/favn/assets/planner.ex
@@ -36,7 +36,9 @@ defmodule Favn.Assets.Planner do
           dependencies: dependencies_mode(),
           anchor_window: Anchor.t() | nil,
           anchor_windows: [Anchor.t()],
-          anchor_ranges: [backfill_anchor_range()]
+          anchor_ranges: [backfill_anchor_range()],
+          graph_index: GraphIndex.t() | nil,
+          asset_modules: [module()]
         ]
 
   @spec plan(Ref.t() | [Ref.t()], plan_opts()) :: {:ok, Plan.t()} | {:error, term()}
@@ -45,12 +47,14 @@ defmodule Favn.Assets.Planner do
     anchor_window = Keyword.get(opts, :anchor_window)
     anchor_windows = Keyword.get(opts, :anchor_windows, [])
     anchor_ranges = Keyword.get(opts, :anchor_ranges, [])
+    graph_index = Keyword.get(opts, :graph_index)
+    asset_modules = Keyword.get(opts, :asset_modules)
 
     with {:ok, target_refs} <- normalize_targets(targets),
          :ok <- validate_opts(opts),
          :ok <- validate_dependencies_mode(dependencies),
          {:ok, anchors} <- normalize_anchors(anchor_window, anchor_windows, anchor_ranges),
-         {:ok, index} <- load_graph_index(),
+         {:ok, index} <- resolve_graph_index(graph_index, asset_modules),
          :ok <- validate_target_refs(index, target_refs),
          {:ok, refs} <- selected_refs(index, target_refs, dependencies),
          {:ok, projected_index} <- projected_index(index, refs),
@@ -96,7 +100,9 @@ defmodule Favn.Assets.Planner do
         :dependencies,
         :anchor_window,
         :anchor_windows,
-        :anchor_ranges
+        :anchor_ranges,
+        :graph_index,
+        :asset_modules
       ])
 
   defp validate_dependencies_mode(:all), do: :ok
@@ -154,10 +160,14 @@ defmodule Favn.Assets.Planner do
 
   defp anchor_sort_key(%Anchor{key: key}), do: Key.encode(key)
 
-  defp load_graph_index do
-    modules = Application.get_env(:favn, :asset_modules, [])
-    GraphIndex.index_for_modules(modules)
-  end
+  defp resolve_graph_index(%GraphIndex{} = index, _asset_modules), do: {:ok, index}
+
+  defp resolve_graph_index(nil, modules) when is_list(modules),
+    do: GraphIndex.index_for_modules(modules)
+
+  defp resolve_graph_index(nil, nil), do: {:error, :missing_graph_index_input}
+  defp resolve_graph_index(nil, _other), do: {:error, :invalid_asset_modules}
+  defp resolve_graph_index(_other, _asset_modules), do: {:error, :invalid_graph_index}
 
   defp validate_target_refs(index, refs) do
     case Enum.find(refs, &(not Map.has_key?(index.assets_by_ref, &1))) do

--- a/apps/favn_core/lib/favn/manifest/compatibility.ex
+++ b/apps/favn_core/lib/favn/manifest/compatibility.ex
@@ -7,7 +7,8 @@ defmodule Favn.Manifest.Compatibility do
   @current_runner_contract_version 1
 
   @type error ::
-          {:missing_manifest_field, :schema_version | :runner_contract_version}
+          {:invalid_manifest_input, term()}
+          | {:missing_manifest_field, :schema_version | :runner_contract_version}
           | {:unsupported_schema_version, term(), pos_integer()}
           | {:unsupported_runner_contract_version, term(), pos_integer()}
 
@@ -17,7 +18,7 @@ defmodule Favn.Manifest.Compatibility do
   @spec current_runner_contract_version() :: pos_integer()
   def current_runner_contract_version, do: @current_runner_contract_version
 
-  @spec validate_manifest(map() | struct()) :: :ok | {:error, error()}
+  @spec validate_manifest(term()) :: :ok | {:error, error()}
   def validate_manifest(manifest) when is_map(manifest) or is_struct(manifest) do
     with {:ok, schema_version} <- read_required_field(manifest, :schema_version),
          {:ok, runner_contract_version} <-
@@ -26,6 +27,8 @@ defmodule Favn.Manifest.Compatibility do
       validate_runner_contract_version(runner_contract_version)
     end
   end
+
+  def validate_manifest(other), do: {:error, {:invalid_manifest_input, other}}
 
   @spec validate_schema_version(term()) :: :ok | {:error, error()}
   def validate_schema_version(@current_schema_version), do: :ok

--- a/apps/favn_core/lib/favn/manifest/graph.ex
+++ b/apps/favn_core/lib/favn/manifest/graph.ex
@@ -16,11 +16,14 @@ defmodule Favn.Manifest.Graph do
           topo_order: [ref()]
         }
 
-  @type error :: {:missing_dependency, ref(), ref()} | {:cycle, [ref()]}
+  @type error ::
+          {:missing_dependency, ref(), ref()}
+          | {:cycle, [ref()]}
+          | {:invalid_assets_input, term()}
 
   defstruct nodes: [], edges: [], topo_order: []
 
-  @spec build([map()]) :: {:ok, t()} | {:error, error()}
+  @spec build(term()) :: {:ok, t()} | {:error, error()}
   def build(assets) when is_list(assets) do
     nodes =
       assets
@@ -41,7 +44,7 @@ defmodule Favn.Manifest.Graph do
     end
   end
 
-  def build(_invalid), do: {:error, {:cycle, []}}
+  def build(invalid), do: {:error, {:invalid_assets_input, invalid}}
 
   defp validate_dependencies(assets, node_set) do
     assets

--- a/apps/favn_core/lib/favn/pipeline/resolver.ex
+++ b/apps/favn_core/lib/favn/pipeline/resolver.ex
@@ -9,14 +9,16 @@ defmodule Favn.Pipeline.Resolver do
   alias Favn.Pipeline.Definition
   alias Favn.Pipeline.Resolution
   alias Favn.Triggers.Schedule
-  alias Favn.Triggers.Schedules
   alias Favn.Window.Anchor
+
+  @type schedule_lookup :: (module(), atom() -> {:ok, Schedule.unresolved_t()} | {:error, term()})
 
   @type resolve_opts :: [
           params: map(),
           trigger: map(),
           anchor_window: Anchor.t() | nil,
-          assets: [map()]
+          assets: [map()],
+          schedule_lookup: schedule_lookup() | nil
         ]
 
   @spec resolve(Definition.t(), resolve_opts()) :: {:ok, Resolution.t()} | {:error, term()}
@@ -25,14 +27,17 @@ defmodule Favn.Pipeline.Resolver do
     params = Keyword.get(opts, :params, %{})
     anchor_window = Keyword.get(opts, :anchor_window)
     assets_opt = Keyword.get(opts, :assets)
+    schedule_lookup = Keyword.get(opts, :schedule_lookup)
     default_timezone = Schedule.default_timezone()
 
     with :ok <- validate_definition(definition),
          :ok <- validate_params(params),
          :ok <- validate_trigger(trigger),
          :ok <- validate_anchor_window(anchor_window),
+         :ok <- validate_schedule_lookup(schedule_lookup),
          :ok <- validate_assets_opt(assets_opt),
-         {:ok, schedule} <- resolve_schedule(definition.schedule, default_timezone),
+         {:ok, schedule} <-
+           resolve_schedule(definition.schedule, default_timezone, schedule_lookup),
          {:ok, assets} <- resolve_assets(assets_opt),
          {:ok, target_refs} <- resolve_selectors(definition, assets) do
       pipeline_ctx = %{
@@ -120,27 +125,37 @@ defmodule Favn.Pipeline.Resolver do
 
   defp validate_anchor_window(other), do: {:error, {:invalid_anchor_window, other}}
 
-  defp validate_assets_opt(nil), do: :ok
+  defp validate_schedule_lookup(nil), do: :ok
+  defp validate_schedule_lookup(fun) when is_function(fun, 2), do: :ok
+  defp validate_schedule_lookup(other), do: {:error, {:invalid_schedule_lookup, other}}
+
+  defp validate_assets_opt(nil), do: {:error, :missing_assets}
   defp validate_assets_opt(values) when is_list(values), do: :ok
   defp validate_assets_opt(other), do: {:error, {:invalid_assets_opt, other}}
 
-  defp resolve_assets(nil), do: list_assets()
+  defp resolve_assets(nil), do: {:error, :missing_assets}
   defp resolve_assets(values), do: {:ok, values}
 
-  defp resolve_schedule(nil, _default_timezone), do: {:ok, nil}
+  defp resolve_schedule(nil, _default_timezone, _lookup), do: {:ok, nil}
 
-  defp resolve_schedule({:inline, %Schedule{} = schedule}, default_timezone) do
+  defp resolve_schedule({:inline, %Schedule{} = schedule}, default_timezone, _lookup) do
     Schedule.apply_default_timezone(schedule, default_timezone)
   end
 
-  defp resolve_schedule({:ref, {module, name}}, default_timezone)
+  defp resolve_schedule({:ref, {module, name}}, _default_timezone, nil)
        when is_atom(module) and is_atom(name) do
-    with {:ok, schedule} <- fetch_schedule(module, name) do
+    {:error, :missing_schedule_lookup}
+  end
+
+  defp resolve_schedule({:ref, {module, name}}, default_timezone, schedule_lookup)
+       when is_atom(module) and is_atom(name) do
+    with {:ok, schedule} <- schedule_lookup.(module, name) do
       Schedule.apply_default_timezone(schedule, default_timezone)
     end
   end
 
-  defp resolve_schedule(value, _default_timezone), do: {:error, {:invalid_schedule, value}}
+  defp resolve_schedule(value, _default_timezone, _lookup),
+    do: {:error, {:invalid_schedule, value}}
 
   defp resolve_selectors(%Definition{selectors: selectors}, assets) do
     assets_by_ref = Map.new(assets, &{&1.ref, &1})
@@ -165,13 +180,15 @@ defmodule Favn.Pipeline.Resolver do
   end
 
   defp selector_refs({:module, mod}, assets, _assets_by_ref) do
-    if asset_module?(mod) do
-      {:ok,
-       assets
-       |> Enum.filter(&(&1.module == mod))
-       |> Enum.map(& &1.ref)}
-    else
+    refs =
+      assets
+      |> Enum.filter(&(&1.module == mod))
+      |> Enum.map(& &1.ref)
+
+    if refs == [] do
       {:error, :not_asset_module}
+    else
+      {:ok, refs}
     end
   end
 
@@ -187,49 +204,21 @@ defmodule Favn.Pipeline.Resolver do
   defp selector_refs({:category, value}, assets, _assets_by_ref) do
     refs =
       assets
-      |> Enum.filter(fn asset -> Map.get(asset.meta, :category) == value end)
+      |> Enum.filter(fn asset ->
+        asset
+        |> Map.get(:meta, %{})
+        |> Map.get(:category)
+        |> Kernel.==(value)
+      end)
       |> Enum.map(& &1.ref)
 
     {:ok, refs}
   end
 
   defp tags_from_meta(asset) do
-    case Map.get(asset.meta, :tags, []) do
+    case Map.get(Map.get(asset, :meta, %{}), :tags, []) do
       values when is_list(values) -> values
       _ -> []
-    end
-  end
-
-  defp list_assets do
-    facade_module = Module.concat([Favn])
-
-    with {:module, ^facade_module} <- Code.ensure_loaded(facade_module),
-         true <- function_exported?(facade_module, :list_assets, 0) do
-      facade_module.list_assets()
-    else
-      _ -> {:error, :runtime_not_available}
-    end
-  end
-
-  defp asset_module?(module) when is_atom(module) do
-    facade_module = Module.concat([Favn])
-
-    with {:module, ^facade_module} <- Code.ensure_loaded(facade_module),
-         true <- function_exported?(facade_module, :asset_module?, 1) do
-      facade_module.asset_module?(module)
-    else
-      _ -> false
-    end
-  end
-
-  defp fetch_schedule(module, name) when is_atom(module) and is_atom(name) do
-    schedules_module = Module.concat([Favn, Triggers, Schedules])
-
-    with {:module, ^schedules_module} <- Code.ensure_loaded(schedules_module),
-         true <- function_exported?(schedules_module, :fetch, 2) do
-      schedules_module.fetch(module, name)
-    else
-      _ -> {:error, :schedule_not_found}
     end
   end
 end

--- a/apps/favn_core/test/boundary_explicit_inputs_test.exs
+++ b/apps/favn_core/test/boundary_explicit_inputs_test.exs
@@ -1,0 +1,88 @@
+defmodule Favn.BoundaryExplicitInputsTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Assets.GraphIndex
+  alias Favn.Assets.Planner
+  alias Favn.Pipeline.Definition
+  alias Favn.Pipeline.Resolver
+  alias Favn.Triggers.Schedule
+
+  test "planner builds from explicit graph index input" do
+    assets = [
+      %{ref: {MyApp.Raw, :asset}, module: MyApp.Raw, name: :asset, depends_on: []},
+      %{
+        ref: {MyApp.Gold, :asset},
+        module: MyApp.Gold,
+        name: :asset,
+        depends_on: [{MyApp.Raw, :asset}]
+      }
+    ]
+
+    assert {:ok, index} = GraphIndex.build_index(assets)
+
+    assert {:ok, plan} =
+             Planner.plan({MyApp.Gold, :asset},
+               graph_index: index,
+               dependencies: :all
+             )
+
+    assert plan.target_refs == [{MyApp.Gold, :asset}]
+    assert plan.topo_order == [{MyApp.Raw, :asset}, {MyApp.Gold, :asset}]
+  end
+
+  test "planner rejects missing explicit graph input" do
+    assert {:error, :missing_graph_index_input} = Planner.plan({MyApp.Gold, :asset})
+  end
+
+  test "resolver resolves from explicit assets and schedule lookup" do
+    definition = %Definition{
+      module: MyApp.Pipelines.Daily,
+      name: :daily,
+      selectors: [{:module, MyApp.Gold}],
+      deps: :all,
+      schedule: {:ref, {MyApp.Schedules, :daily}}
+    }
+
+    assets = [
+      %{ref: {MyApp.Gold, :asset}, module: MyApp.Gold, name: :asset, meta: %{tags: [:daily]}}
+    ]
+
+    assert {:ok, named_schedule} =
+             Schedule.named(:daily, cron: "0 2 * * *", timezone: "Etc/UTC")
+
+    schedule_lookup = fn MyApp.Schedules, :daily -> {:ok, named_schedule} end
+
+    assert {:ok, resolution} =
+             Resolver.resolve(definition,
+               assets: assets,
+               schedule_lookup: schedule_lookup
+             )
+
+    assert resolution.target_refs == [{MyApp.Gold, :asset}]
+    assert resolution.pipeline_ctx.schedule.id == :daily
+    assert resolution.pipeline_ctx.schedule.cron == "0 2 * * *"
+  end
+
+  test "resolver rejects missing explicit assets" do
+    definition = %Definition{
+      module: MyApp.Pipelines.Daily,
+      name: :daily,
+      selectors: [{:asset, {MyApp.Gold, :asset}}]
+    }
+
+    assert {:error, :missing_assets} = Resolver.resolve(definition)
+  end
+
+  test "resolver rejects schedule refs without explicit lookup" do
+    definition = %Definition{
+      module: MyApp.Pipelines.Daily,
+      name: :daily,
+      selectors: [{:asset, {MyApp.Gold, :asset}}],
+      schedule: {:ref, {MyApp.Schedules, :daily}}
+    }
+
+    assets = [%{ref: {MyApp.Gold, :asset}, module: MyApp.Gold, name: :asset, meta: %{}}]
+
+    assert {:error, :missing_schedule_lookup} = Resolver.resolve(definition, assets: assets)
+  end
+end

--- a/apps/favn_core/test/boundary_explicit_inputs_test.exs
+++ b/apps/favn_core/test/boundary_explicit_inputs_test.exs
@@ -7,6 +7,19 @@ defmodule Favn.BoundaryExplicitInputsTest do
   alias Favn.Pipeline.Resolver
   alias Favn.Triggers.Schedule
 
+  defmodule RawAsset do
+    use Favn.Asset
+
+    def asset(_ctx), do: :ok
+  end
+
+  defmodule GoldAsset do
+    use Favn.Asset
+
+    @depends RawAsset
+    def asset(_ctx), do: :ok
+  end
+
   test "planner builds from explicit graph index input" do
     assets = [
       %{ref: {MyApp.Raw, :asset}, module: MyApp.Raw, name: :asset, depends_on: []},
@@ -32,6 +45,17 @@ defmodule Favn.BoundaryExplicitInputsTest do
 
   test "planner rejects missing explicit graph input" do
     assert {:error, :missing_graph_index_input} = Planner.plan({MyApp.Gold, :asset})
+  end
+
+  test "planner builds from explicit asset modules input" do
+    assert {:ok, plan} =
+             Planner.plan({GoldAsset, :asset},
+               asset_modules: [RawAsset, GoldAsset],
+               dependencies: :all
+             )
+
+    assert plan.target_refs == [{GoldAsset, :asset}]
+    assert plan.topo_order == [{RawAsset, :asset}, {GoldAsset, :asset}]
   end
 
   test "resolver resolves from explicit assets and schedule lookup" do

--- a/apps/favn_core/test/manifest/compatibility_test.exs
+++ b/apps/favn_core/test/manifest/compatibility_test.exs
@@ -35,4 +35,9 @@ defmodule Favn.Manifest.CompatibilityTest do
     assert {:error, {:missing_manifest_field, :runner_contract_version}} =
              Compatibility.validate_manifest(manifest)
   end
+
+  test "rejects non-map compatibility input with tagged error" do
+    assert {:error, {:invalid_manifest_input, :invalid}} =
+             Compatibility.validate_manifest(:invalid)
+  end
 end

--- a/apps/favn_core/test/manifest/graph_test.exs
+++ b/apps/favn_core/test/manifest/graph_test.exs
@@ -36,4 +36,8 @@ defmodule Favn.Manifest.GraphTest do
 
     assert {:error, {:cycle, [{MyApp.A, :asset}, {MyApp.B, :asset}]}} = Graph.build(assets)
   end
+
+  test "returns tagged invalid input errors" do
+    assert {:error, {:invalid_assets_input, :invalid}} = Graph.build(:invalid)
+  end
 end

--- a/apps/favn_legacy/lib/favn/application.ex
+++ b/apps/favn_legacy/lib/favn/application.ex
@@ -29,10 +29,11 @@ defmodule Favn.Application do
   def start(_type, _args) do
     adapter = Favn.Storage.adapter_module()
     pubsub_name = Application.get_env(:favn, :pubsub_name, Favn.PubSub)
+    asset_modules = Application.get_env(:favn, :asset_modules, [])
     pubsub_child = {Phoenix.PubSub, name: pubsub_name}
 
     with :ok <- Registry.load(),
-         :ok <- GraphIndex.load(),
+         :ok <- GraphIndex.load(asset_modules),
          {:ok, connections} <- load_connections_or_raise(),
          :ok <- Favn.Storage.validate_adapter(adapter),
          {:ok, child_specs} <- Favn.Storage.child_specs() do

--- a/apps/favn_legacy/lib/favn/scheduler/registry.ex
+++ b/apps/favn_legacy/lib/favn/scheduler/registry.ex
@@ -6,6 +6,7 @@ defmodule Favn.Scheduler.Registry do
   alias Favn.Pipeline
   alias Favn.Pipeline.Resolver
   alias Favn.Triggers.Schedule
+  alias Favn.Triggers.Schedules
 
   @type scheduled_pipeline :: %{
           module: module(),
@@ -39,7 +40,11 @@ defmodule Favn.Scheduler.Registry do
   defp discover_module(pipeline_module, assets)
        when is_atom(pipeline_module) and is_list(assets) do
     with {:ok, definition} <- Pipeline.fetch(pipeline_module),
-         {:ok, resolution} <- Resolver.resolve(definition, assets: assets),
+         {:ok, resolution} <-
+           Resolver.resolve(definition,
+             assets: assets,
+             schedule_lookup: &Schedules.fetch/2
+           ),
          {:ok, schedule} <- resolve_schedule(resolution.pipeline_ctx.schedule),
          :ok <- validate_window_for_schedule(definition.window, schedule) do
       case schedule do

--- a/apps/favn_legacy/test/support/favn_test_setup.ex
+++ b/apps/favn_legacy/test/support/favn_test_setup.ex
@@ -37,7 +37,7 @@ defmodule Favn.TestSetup do
     :ok = Registry.reload()
 
     if Keyword.get(opts, :reload_graph?, false) do
-      :ok = GraphIndex.reload()
+      :ok = GraphIndex.reload(modules)
     end
 
     :ok
@@ -98,13 +98,17 @@ defmodule Favn.TestSetup do
     :ok = Registry.reload()
 
     if Keyword.get(opts, :reload_graph?, false) do
-      :ok = GraphIndex.reload()
+      :ok = GraphIndex.reload(current_asset_modules())
     end
 
     :ok
   end
 
   defp restore_registry({:error, _reason}, _opts), do: :ok
+
+  defp current_asset_modules do
+    Application.get_env(:favn, :asset_modules, [])
+  end
 
   defp restore_env(key, nil), do: Application.delete_env(:favn, key)
   defp restore_env(key, value), do: Application.put_env(:favn, key, value)

--- a/docs/refactor/PHASE_3_TODO.md
+++ b/docs/refactor/PHASE_3_TODO.md
@@ -58,6 +58,7 @@ Phase 3 implementation scope is complete. Remaining unchecked items are intentio
 - [x] Thin `apps/favn/lib/favn.ex` so it delegates build/version/serialization work to `favn_core`.
 - [x] Keep public DSL entrypoints in `apps/favn/lib/favn/*.ex` and point them at core-owned structs/helpers.
 - [x] Remove duplicate ownership so `Favn.*` internal modules do not compile from both apps at once.
+- [x] Remove remaining core boundary leaks so planner/graph/resolver run on explicit inputs rather than `:favn` app-config/facade callbacks.
 - [x] Leave runtime execution, scheduling, and storage files untouched for later phases.
 
 ## Shared Contracts For Later Runtime Split
@@ -82,6 +83,8 @@ Phase 3 implementation scope is complete. Remaining unchecked items are intentio
 - [x] Keep `apps/favn/test` focused on public facade/DSL tests only.
 - [x] Keep runtime, scheduler, storage, and SQL execution tests in `apps/favn_legacy/test` for now.
 - [x] Lock contract tests before starting Phase 4 runner implementation.
+- [x] Add explicit-input boundary tests for planner/resolver in `apps/favn_core/test`.
+- [x] Add public-facade default assembly tests in `apps/favn/test`.
 
 ## Docs Updates
 

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -71,3 +71,4 @@ Notes:
 - Initial Phase 3 tests now exist under `apps/favn_core/test/manifest/` and `apps/favn_core/test/contracts/`.
 - `apps/favn_core/test/manifest/` now includes `build_test.exs` and `graph_test.exs` in addition to serializer/version/identity/compatibility coverage.
 - `apps/favn_core/test/contracts/contract_lock_test.exs` now locks runner contract key shapes before Phase 4 runner work.
+- Boundary-leak cleanup coverage now includes `apps/favn_core/test/boundary_explicit_inputs_test.exs` and `apps/favn/test/boundary_defaults_test.exs`.


### PR DESCRIPTION
## Summary
- remove the remaining `favn_core -> favn` boundary leaks in planner/graph and pipeline resolution paths by keeping core on explicit inputs only
- keep public ergonomics in `favn` by assembling defaults there before delegating into `favn_core`
- fix the follow-up regression from the earlier cleanup branch by updating legacy zero-arg graph reload callers to pass explicit asset modules and add the missing planner `asset_modules:` coverage

## Boundary cleanup details
- removed core config discovery from graph/planning path
  - `Favn.Assets.GraphIndex.load/0` remains a deprecated transitional wrapper and no longer performs app-config discovery
  - `Favn.Assets.Planner` now requires explicit `graph_index:` or explicit `asset_modules:` input
- removed core facade callbacks from `Favn.Pipeline.Resolver`
  - resolver no longer calls `Favn.list_assets/0`, `Favn.asset_module?/1`, or `Favn.Triggers.Schedules.fetch/2`
  - resolver now works from explicit `assets:` and optional `schedule_lookup:`
- kept public defaults in `apps/favn/lib/favn.ex`
  - `plan_asset_run/2` assembles default `asset_modules`
  - `resolve_pipeline/2` assembles default `assets` and `schedule_lookup`
  - `run_pipeline/2` delegates through `resolve_pipeline/2`

## Follow-up fix for the closed PR 75 branch
- updated legacy support helpers in `apps/favn_legacy/test/support/favn_test_setup.ex` to call `GraphIndex.reload(modules)` explicitly instead of broken zero-arg `reload/0`
- added planner test coverage for the explicit `asset_modules:` path in `apps/favn_core/test/boundary_explicit_inputs_test.exs`

## Transitional wrapper left intentionally
- `Favn.Assets.GraphIndex.load/0` is still present only as a deprecated transitional wrapper; `load/1` and `reload/1` are the intended explicit-input paths

## Validation
- mix format
- mix compile --warnings-as-errors
- mix test
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected
- `mix test test/graph_index_test.exs` in `apps/favn_legacy`