### PR TITLE
Implement phase 6 storage adapter foundations

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,11 @@ Current extracted adapter module names during migration:
 - SQLite: `FavnStorageSqlite.Adapter`
 - Postgres: `FavnStoragePostgres.Adapter`
 
+Current storage-format note:
+
+- SQLite/Postgres foundation adapters still persist run/event/scheduler payload bodies as BEAM term blobs for the first extracted cut
+- this is intentional temporary scaffolding, not the long-term JSON/JSONB end state described in the architecture notes
+
 SQLite local-dev persistence example:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ Favn `v0.5.0` refactor is in progress.
 
 ## Current Focus
 
-- finish remaining Phase 4 cleanup and begin Phase 6 storage-adapter extraction
+- execute Phase 6 storage-adapter extraction for SQLite and Postgres
+- finish the small Phase 5 storage-boundary cleanup needed for real extracted adapters
+- bundle the remaining SQL manifest-execution and temporary seam cleanup work into Phase 7 alongside `favn_duckdb`
 - keep `favn` as the public DSL/facade package
 - re-center internal compiler / manifest / planning / shared-contract machinery into `favn_core`
 - use the now-locked manifest/version/runner contracts to migrate remaining control-plane behavior into `favn_orchestrator`
@@ -41,3 +43,59 @@ Favn `v0.5.0` refactor is in progress.
 - `docs/refactor/PHASE_4_TODO.md` - Phase 4 implementation checklist
 - `docs/refactor/PHASE_5_ORCHESTRATOR_BOUNDARY_PLAN.md` - Phase 5 orchestrator architecture plan
 - `docs/refactor/PHASE_5_TODO.md` - Phase 5 implementation checklist
+- `docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md` - Phase 6 storage adapter architecture plan
+- `docs/refactor/PHASE_6_TODO.md` - Phase 6 implementation checklist
+
+## Storage Adapter Verification Notes
+
+- SQLite adapter coverage runs in normal `mix test` execution.
+- Postgres live integration coverage is opt-in via `FAVN_POSTGRES_TEST_URL`:
+  - `mix test apps/favn_storage_postgres/test/integration/adapter_live_test.exs`
+
+## Storage Adapter Configuration
+
+Current extracted adapter module names during migration:
+
+- SQLite: `FavnStorageSqlite.Adapter`
+- Postgres: `FavnStoragePostgres.Adapter`
+
+SQLite local-dev persistence example:
+
+```elixir
+config :favn_orchestrator,
+  storage_adapter: FavnStorageSqlite.Adapter,
+  storage_adapter_opts: [
+    database: ".favn/dev.sqlite3",
+    migration_mode: :auto,
+    pool_size: 1
+  ]
+```
+
+Postgres managed mode example:
+
+```elixir
+config :favn_orchestrator,
+  storage_adapter: FavnStoragePostgres.Adapter,
+  storage_adapter_opts: [
+    repo_mode: :managed,
+    repo_config: [
+      hostname: "localhost",
+      database: "favn",
+      username: "postgres",
+      password: "postgres"
+    ],
+    migration_mode: :manual
+  ]
+```
+
+Postgres external mode example:
+
+```elixir
+config :favn_orchestrator,
+  storage_adapter: FavnStoragePostgres.Adapter,
+  storage_adapter_opts: [
+    repo_mode: :external,
+    repo: MyApp.Repo,
+    migration_mode: :manual
+  ]
+```

--- a/apps/favn_orchestrator/lib/favn/storage.ex
+++ b/apps/favn_orchestrator/lib/favn/storage.ex
@@ -18,12 +18,8 @@ defmodule Favn.Storage do
     adapter = adapter_module()
 
     with :ok <- validate_adapter(adapter) do
-      if adapter_started?(adapter) do
-        {:ok, []}
-      else
-        OrchestratorStorage.child_specs()
-        |> normalize_result()
-      end
+      OrchestratorStorage.child_specs()
+      |> normalize_result()
     end
   end
 
@@ -146,10 +142,6 @@ defmodule Favn.Storage do
 
   defp normalize_result({:ok, _value} = ok), do: ok
   defp normalize_result({:error, reason}), do: normalize_error(reason)
-
-  defp adapter_started?(adapter) when is_atom(adapter) do
-    Process.whereis(adapter) != nil
-  end
 
   defp normalize_error(:not_found), do: {:error, :not_found}
   defp normalize_error(:invalid_opts), do: {:error, :invalid_opts}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -8,6 +8,10 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   alias Favn.Manifest.Version
   alias Favn.Scheduler.State, as: SchedulerState
   alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage.RunEventCodec
+  alias FavnOrchestrator.Storage.RunStateCodec
+  alias FavnOrchestrator.Storage.SchedulerStateCodec
+  alias FavnOrchestrator.Storage.WriteSemantics
 
   @type state :: %{
           manifests: %{required(String.t()) => Version.t()},
@@ -31,19 +35,30 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
 
   @impl true
   def child_spec(opts) when is_list(opts) do
-    {:ok,
-     %{
-       id: __MODULE__,
-       start: {__MODULE__, :start_link, [opts]},
-       type: :worker,
-       restart: :permanent,
-       shutdown: 5000
-     }}
+    runtime_name = runtime_name(opts)
+
+    if runtime_started?(runtime_name) do
+      :none
+    else
+      start_opts =
+        opts
+        |> Keyword.delete(:server)
+        |> Keyword.put(:name, runtime_name)
+
+      {:ok,
+       %{
+         id: {__MODULE__, runtime_name},
+         start: {__MODULE__, :start_link, [start_opts]},
+         type: :worker,
+         restart: :permanent,
+         shutdown: 5000
+       }}
+    end
   end
 
   @spec scheduler_child_spec(keyword()) :: {:ok, Supervisor.child_spec()} | :none
   def scheduler_child_spec(opts \\ []) when is_list(opts) do
-    if Process.whereis(__MODULE__) do
+    if runtime_started?(runtime_name(opts)) do
       :none
     else
       child_spec(opts)
@@ -83,8 +98,10 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
 
   @impl true
   def put_run(%RunState{} = run, opts \\ []) when is_list(opts) do
-    server = Keyword.get(opts, :server, __MODULE__)
-    GenServer.call(server, {:put_run, run})
+    with {:ok, normalized} <- RunStateCodec.normalize(run) do
+      server = Keyword.get(opts, :server, __MODULE__)
+      GenServer.call(server, {:put_run, normalized})
+    end
   end
 
   @impl true
@@ -103,8 +120,10 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   @impl true
   def append_run_event(run_id, event, opts \\ [])
       when is_binary(run_id) and is_map(event) and is_list(opts) do
-    server = Keyword.get(opts, :server, __MODULE__)
-    GenServer.call(server, {:append_run_event, run_id, event})
+    with {:ok, normalized} <- RunEventCodec.normalize(run_id, event) do
+      server = Keyword.get(opts, :server, __MODULE__)
+      GenServer.call(server, {:append_run_event, run_id, normalized})
+    end
   end
 
   @impl true
@@ -114,11 +133,13 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   @impl true
-  def put_scheduler_state({pipeline_module, schedule_id} = key, scheduler_state, opts)
-      when is_atom(pipeline_module) and is_map(scheduler_state) and is_list(opts) do
-    _ = schedule_id
-    server = Keyword.get(opts, :server, __MODULE__)
-    GenServer.call(server, {:put_scheduler_state, key, scheduler_state})
+  def put_scheduler_state(key, scheduler_state, opts)
+      when is_map(scheduler_state) and is_list(opts) do
+    with {:ok, normalized_key} <- SchedulerStateCodec.normalize_key(key),
+         {:ok, normalized_state} <- SchedulerStateCodec.normalize_state(scheduler_state) do
+      server = Keyword.get(opts, :server, __MODULE__)
+      GenServer.call(server, {:put_scheduler_state, normalized_key, normalized_state})
+    end
   end
 
   @spec put_scheduler_state(SchedulerState.t(), keyword()) :: :ok | {:error, term()}
@@ -134,11 +155,11 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   @impl true
-  def get_scheduler_state({pipeline_module, schedule_id} = key, opts \\ [])
-      when is_atom(pipeline_module) and is_list(opts) do
-    _ = schedule_id
-    server = Keyword.get(opts, :server, __MODULE__)
-    GenServer.call(server, {:get_scheduler_state, key})
+  def get_scheduler_state(key, opts \\ []) when is_list(opts) do
+    with {:ok, normalized_key} <- SchedulerStateCodec.normalize_key(key) do
+      server = Keyword.get(opts, :server, __MODULE__)
+      GenServer.call(server, {:get_scheduler_state, normalized_key})
+    end
   end
 
   @spec get_scheduler_state(module(), atom() | nil, keyword()) ::
@@ -350,7 +371,21 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   def handle_call({:get_scheduler_state, key}, _from, state) do
-    {:reply, {:ok, Map.get(state.scheduler_states, key)}, state}
+    value =
+      case Map.get(state.scheduler_states, key) do
+        nil ->
+          nil
+
+        stored when is_map(stored) ->
+          {pipeline_module, schedule_id} = key
+
+          struct(
+            SchedulerState,
+            Map.merge(stored, %{pipeline_module: pipeline_module, schedule_id: schedule_id})
+          )
+      end
+
+    {:reply, {:ok, value}, state}
   end
 
   defp put_run_with_semantics(runs, %RunState{} = incoming) do
@@ -358,17 +393,17 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       :error ->
         {:ok, Map.put(runs, incoming.id, incoming)}
 
-      {:ok, %RunState{} = existing} when incoming.event_seq > existing.event_seq ->
-        {:ok, Map.put(runs, incoming.id, incoming)}
-
-      {:ok, %RunState{} = existing} when incoming.event_seq < existing.event_seq ->
-        {{:error, :stale_write}, runs}
-
-      {:ok, %RunState{} = existing} when incoming.snapshot_hash == existing.snapshot_hash ->
-        {:ok, runs}
-
-      {:ok, %RunState{}} ->
-        {{:error, :conflicting_snapshot}, runs}
+      {:ok, %RunState{} = existing} ->
+        case WriteSemantics.decide(
+               existing.event_seq,
+               existing.snapshot_hash,
+               incoming.event_seq,
+               incoming.snapshot_hash
+             ) do
+          :replace -> {:ok, Map.put(runs, incoming.id, incoming)}
+          :idempotent -> {:ok, runs}
+          {:error, reason} -> {{:error, reason}, runs}
+        end
     end
     |> normalize_put_run_reply()
   end
@@ -389,4 +424,11 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       _ -> runs
     end
   end
+
+  defp runtime_name(opts) do
+    Keyword.get(opts, :server, Keyword.get(opts, :name, __MODULE__))
+  end
+
+  defp runtime_started?(name) when is_atom(name), do: Process.whereis(name) != nil
+  defp runtime_started?(_name), do: false
 end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/manifest_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/manifest_codec.ex
@@ -1,0 +1,78 @@
+defmodule FavnOrchestrator.Storage.ManifestCodec do
+  @moduledoc false
+
+  alias Favn.Manifest.Serializer
+  alias Favn.Manifest.Version
+
+  @type record :: %{
+          required(:manifest_version_id) => String.t(),
+          required(:content_hash) => String.t(),
+          required(:schema_version) => pos_integer(),
+          required(:runner_contract_version) => pos_integer(),
+          required(:serialization_format) => String.t(),
+          required(:manifest_json) => String.t(),
+          optional(:inserted_at) => DateTime.t() | nil
+        }
+
+  @spec to_record(Version.t()) :: {:ok, record()} | {:error, term()}
+  def to_record(%Version{} = version) do
+    with {:ok, manifest_json} <- Serializer.encode_manifest(version.manifest) do
+      {:ok,
+       %{
+         manifest_version_id: version.manifest_version_id,
+         content_hash: version.content_hash,
+         schema_version: version.schema_version,
+         runner_contract_version: version.runner_contract_version,
+         serialization_format: version.serialization_format,
+         manifest_json: manifest_json,
+         inserted_at: version.inserted_at
+       }}
+    end
+  end
+
+  @spec from_record(record()) :: {:ok, Version.t()} | {:error, term()}
+  def from_record(record) when is_map(record) do
+    with {:ok, manifest_version_id} <- fetch_non_empty_binary(record, :manifest_version_id),
+         {:ok, content_hash} <- fetch_non_empty_binary(record, :content_hash),
+         {:ok, serialization_format} <- fetch_non_empty_binary(record, :serialization_format),
+         {:ok, manifest_json} <- fetch_non_empty_binary(record, :manifest_json),
+         {:ok, manifest} <- Serializer.decode_manifest(manifest_json),
+         {:ok, version} <-
+           Version.new(manifest,
+             manifest_version_id: manifest_version_id,
+             serialization_format: serialization_format,
+             inserted_at: Map.get(record, :inserted_at)
+           ),
+         :ok <- verify_content_hash(version.content_hash, content_hash),
+         :ok <- verify_schema(version.schema_version, Map.get(record, :schema_version)),
+         :ok <-
+           verify_runner_contract(
+             version.runner_contract_version,
+             Map.get(record, :runner_contract_version)
+           ) do
+      {:ok, version}
+    end
+  end
+
+  defp fetch_non_empty_binary(record, key) do
+    case Map.get(record, key) do
+      value when is_binary(value) and value != "" -> {:ok, value}
+      value -> {:error, {:invalid_manifest_record_field, key, value}}
+    end
+  end
+
+  defp verify_content_hash(actual, actual), do: :ok
+
+  defp verify_content_hash(actual, expected),
+    do: {:error, {:manifest_content_hash_mismatch, expected, actual}}
+
+  defp verify_schema(actual, actual), do: :ok
+
+  defp verify_schema(actual, expected),
+    do: {:error, {:manifest_schema_mismatch, expected, actual}}
+
+  defp verify_runner_contract(actual, actual), do: :ok
+
+  defp verify_runner_contract(actual, expected),
+    do: {:error, {:manifest_runner_contract_mismatch, expected, actual}}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_event_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_event_codec.ex
@@ -1,0 +1,63 @@
+defmodule FavnOrchestrator.Storage.RunEventCodec do
+  @moduledoc false
+
+  @spec normalize(String.t(), map()) :: {:ok, map()} | {:error, term()}
+  def normalize(run_id, event) when is_binary(run_id) and is_map(event) do
+    with {:ok, sequence} <- validate_sequence(Map.get(event, :sequence)),
+         :ok <- validate_run_id(run_id, Map.get(event, :run_id)),
+         {:ok, event_type} <- validate_event_type(Map.get(event, :event_type)),
+         {:ok, occurred_at} <- normalize_occurred_at(Map.get(event, :occurred_at)),
+         {:ok, status} <- normalize_status(Map.get(event, :status)) do
+      {:ok,
+       %{
+         run_id: run_id,
+         sequence: sequence,
+         event_type: event_type,
+         occurred_at: occurred_at,
+         status: status,
+         manifest_version_id: normalize_optional_binary(Map.get(event, :manifest_version_id)),
+         manifest_content_hash: normalize_optional_binary(Map.get(event, :manifest_content_hash)),
+         asset_ref: normalize_asset_ref(Map.get(event, :asset_ref)),
+         data: normalize_data(Map.get(event, :data))
+       }}
+    end
+  end
+
+  defp validate_sequence(sequence) when is_integer(sequence) and sequence > 0, do: {:ok, sequence}
+  defp validate_sequence(value), do: {:error, {:invalid_run_event_field, :sequence, value}}
+
+  defp validate_run_id(_run_id, nil), do: :ok
+  defp validate_run_id(run_id, run_id), do: :ok
+  defp validate_run_id(_run_id, value), do: {:error, {:invalid_run_event_field, :run_id, value}}
+
+  defp validate_event_type(value) when is_atom(value) and not is_nil(value), do: {:ok, value}
+  defp validate_event_type(value) when is_binary(value) and value != "", do: {:ok, value}
+  defp validate_event_type(value), do: {:error, {:invalid_run_event_field, :event_type, value}}
+
+  defp normalize_occurred_at(nil), do: {:ok, DateTime.utc_now()}
+  defp normalize_occurred_at(%DateTime{} = occurred_at), do: {:ok, occurred_at}
+
+  defp normalize_occurred_at(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, occurred_at, _offset} -> {:ok, occurred_at}
+      _ -> {:error, {:invalid_run_event_field, :occurred_at, value}}
+    end
+  end
+
+  defp normalize_occurred_at(value), do: {:error, {:invalid_run_event_field, :occurred_at, value}}
+
+  defp normalize_status(nil), do: {:ok, nil}
+  defp normalize_status(status) when is_atom(status), do: {:ok, status}
+  defp normalize_status(status) when is_binary(status), do: {:ok, status}
+  defp normalize_status(value), do: {:error, {:invalid_run_event_field, :status, value}}
+
+  defp normalize_optional_binary(nil), do: nil
+  defp normalize_optional_binary(value) when is_binary(value) and value != "", do: value
+  defp normalize_optional_binary(_value), do: nil
+
+  defp normalize_asset_ref({module, name} = ref) when is_atom(module) and is_atom(name), do: ref
+  defp normalize_asset_ref(_value), do: nil
+
+  defp normalize_data(data) when is_map(data), do: data
+  defp normalize_data(_value), do: %{}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_state_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_state_codec.ex
@@ -1,0 +1,49 @@
+defmodule FavnOrchestrator.Storage.RunStateCodec do
+  @moduledoc false
+
+  alias FavnOrchestrator.RunState
+
+  @spec normalize(RunState.t()) :: {:ok, RunState.t()} | {:error, term()}
+  def normalize(%RunState{} = run_state) do
+    with :ok <- validate_identity(run_state),
+         :ok <- validate_asset_ref(run_state.asset_ref),
+         :ok <- validate_event_seq(run_state.event_seq) do
+      {:ok, RunState.with_snapshot_hash(run_state)}
+    end
+  end
+
+  @spec to_record(RunState.t()) :: {:ok, map()} | {:error, term()}
+  def to_record(%RunState{} = run_state) do
+    with {:ok, normalized} <- normalize(run_state) do
+      {:ok, Map.from_struct(normalized)}
+    end
+  end
+
+  @spec from_record(map()) :: {:ok, RunState.t()} | {:error, term()}
+  def from_record(record) when is_map(record) do
+    run_state = struct(RunState, record)
+    normalize(run_state)
+  end
+
+  defp validate_identity(%RunState{} = run_state) do
+    cond do
+      not (is_binary(run_state.id) and run_state.id != "") ->
+        {:error, :invalid_run_id}
+
+      not (is_binary(run_state.manifest_version_id) and run_state.manifest_version_id != "") ->
+        {:error, :invalid_manifest_version_id}
+
+      not (is_binary(run_state.manifest_content_hash) and run_state.manifest_content_hash != "") ->
+        {:error, :invalid_manifest_content_hash}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp validate_asset_ref({module, name}) when is_atom(module) and is_atom(name), do: :ok
+  defp validate_asset_ref(_value), do: {:error, :invalid_asset_ref}
+
+  defp validate_event_seq(event_seq) when is_integer(event_seq) and event_seq >= 0, do: :ok
+  defp validate_event_seq(_value), do: {:error, :invalid_event_seq}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/scheduler_state_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/scheduler_state_codec.ex
@@ -1,0 +1,72 @@
+defmodule FavnOrchestrator.Storage.SchedulerStateCodec do
+  @moduledoc false
+
+  alias Favn.Scheduler.State, as: SchedulerState
+
+  @type key :: {module(), atom() | nil}
+
+  @spec normalize_key(term()) :: {:ok, key()} | {:error, term()}
+  def normalize_key({pipeline_module, schedule_id}) when is_atom(pipeline_module) do
+    if is_atom(schedule_id) or is_nil(schedule_id) do
+      {:ok, {pipeline_module, schedule_id}}
+    else
+      {:error, {:invalid_scheduler_key, {pipeline_module, schedule_id}}}
+    end
+  end
+
+  def normalize_key(value), do: {:error, {:invalid_scheduler_key, value}}
+
+  @spec normalize_state(map() | SchedulerState.t()) :: {:ok, map()} | {:error, term()}
+  def normalize_state(%SchedulerState{} = scheduler_state) do
+    scheduler_state
+    |> Map.from_struct()
+    |> Map.drop([:pipeline_module, :schedule_id])
+    |> normalize_state()
+  end
+
+  def normalize_state(state) when is_map(state) do
+    with :ok <-
+           validate_optional_binary(:schedule_fingerprint, Map.get(state, :schedule_fingerprint)),
+         :ok <- validate_optional_datetime(:last_evaluated_at, Map.get(state, :last_evaluated_at)),
+         :ok <- validate_optional_datetime(:last_due_at, Map.get(state, :last_due_at)),
+         :ok <-
+           validate_optional_datetime(
+             :last_submitted_due_at,
+             Map.get(state, :last_submitted_due_at)
+           ),
+         :ok <- validate_optional_binary(:in_flight_run_id, Map.get(state, :in_flight_run_id)),
+         :ok <- validate_optional_datetime(:queued_due_at, Map.get(state, :queued_due_at)),
+         :ok <- validate_optional_datetime(:updated_at, Map.get(state, :updated_at)),
+         :ok <- validate_optional_version(Map.get(state, :version)) do
+      {:ok,
+       %{
+         schedule_fingerprint: Map.get(state, :schedule_fingerprint),
+         last_evaluated_at: Map.get(state, :last_evaluated_at),
+         last_due_at: Map.get(state, :last_due_at),
+         last_submitted_due_at: Map.get(state, :last_submitted_due_at),
+         in_flight_run_id: Map.get(state, :in_flight_run_id),
+         queued_due_at: Map.get(state, :queued_due_at),
+         updated_at: Map.get(state, :updated_at),
+         version: Map.get(state, :version)
+       }}
+    end
+  end
+
+  def normalize_state(value), do: {:error, {:invalid_scheduler_state, value}}
+
+  defp validate_optional_binary(_field, nil), do: :ok
+  defp validate_optional_binary(_field, value) when is_binary(value), do: :ok
+
+  defp validate_optional_binary(field, value),
+    do: {:error, {:invalid_scheduler_field, field, value}}
+
+  defp validate_optional_datetime(_field, nil), do: :ok
+  defp validate_optional_datetime(_field, %DateTime{}), do: :ok
+
+  defp validate_optional_datetime(field, value),
+    do: {:error, {:invalid_scheduler_field, field, value}}
+
+  defp validate_optional_version(nil), do: :ok
+  defp validate_optional_version(value) when is_integer(value) and value > 0, do: :ok
+  defp validate_optional_version(value), do: {:error, {:invalid_scheduler_field, :version, value}}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/write_semantics.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/write_semantics.ex
@@ -1,0 +1,20 @@
+defmodule FavnOrchestrator.Storage.WriteSemantics do
+  @moduledoc false
+
+  @type decision ::
+          :insert | :replace | :idempotent | {:error, :conflicting_snapshot | :stale_write}
+
+  @spec decide(non_neg_integer() | nil, String.t() | nil, non_neg_integer(), String.t()) ::
+          decision()
+  def decide(nil, _existing_hash, _incoming_event_seq, _incoming_hash), do: :insert
+
+  def decide(existing_event_seq, existing_hash, incoming_event_seq, incoming_hash)
+      when is_integer(existing_event_seq) and is_integer(incoming_event_seq) do
+    cond do
+      incoming_event_seq > existing_event_seq -> :replace
+      incoming_event_seq < existing_event_seq -> {:error, :stale_write}
+      existing_hash == incoming_hash -> :idempotent
+      true -> {:error, :conflicting_snapshot}
+    end
+  end
+end

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -1,0 +1,205 @@
+defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Manifest
+  alias Favn.Manifest.Version
+  alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage
+  alias FavnOrchestrator.Storage.Adapter.Memory
+
+  @memory_server Module.concat(__MODULE__, MemoryServer)
+  @sqlite_supervisor Module.concat(__MODULE__, SQLiteSupervisor)
+  @postgres_supervisor Module.concat(__MODULE__, PostgresSupervisor)
+
+  setup do
+    previous_adapter = Application.get_env(:favn_orchestrator, :storage_adapter)
+    previous_opts = Application.get_env(:favn_orchestrator, :storage_adapter_opts)
+
+    on_exit(fn ->
+      restore_env(:favn_orchestrator, :storage_adapter, previous_adapter)
+      restore_env(:favn_orchestrator, :storage_adapter_opts, previous_opts)
+    end)
+
+    :ok
+  end
+
+  test "shared contract holds for memory adapter" do
+    opts = [server: @memory_server]
+
+    with_storage_adapter(Memory, opts, fn ->
+      assert_shared_contract("memory")
+    end)
+  end
+
+  test "shared contract holds for sqlite adapter" do
+    db_path =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_contract_sqlite_#{System.unique_integer([:positive])}.db"
+      )
+
+    opts = [
+      database: db_path,
+      supervisor_name: @sqlite_supervisor,
+      migration_mode: :auto
+    ]
+
+    with_storage_adapter(FavnStorageSqlite.Adapter, opts, fn ->
+      assert_shared_contract("sqlite")
+    end)
+
+    File.rm(db_path)
+  end
+
+  test "shared contract holds for postgres adapter (opt-in)" do
+    case postgres_opts() do
+      nil ->
+        :ok
+
+      opts ->
+        with_storage_adapter(FavnStoragePostgres.Adapter, opts, fn ->
+          assert_shared_contract("postgres")
+        end)
+    end
+  end
+
+  defp with_storage_adapter(adapter, opts, fun) when is_function(fun, 0) do
+    Application.put_env(:favn_orchestrator, :storage_adapter, adapter)
+    Application.put_env(:favn_orchestrator, :storage_adapter_opts, opts)
+
+    assert {:ok, child_specs} = Storage.child_specs()
+    Enum.each(child_specs, &start_supervised!/1)
+
+    fun.()
+  end
+
+  defp assert_shared_contract(label) do
+    manifest_version_id = "mv_contract_#{label}_#{System.unique_integer([:positive])}"
+    version = manifest_version(manifest_version_id)
+
+    assert :ok = Storage.put_manifest_version(version)
+    assert :ok = Storage.put_manifest_version(version)
+    assert :ok = Storage.set_active_manifest_version(manifest_version_id)
+    assert {:ok, ^manifest_version_id} = Storage.get_active_manifest_version()
+
+    run =
+      RunState.new(
+        id: "run_contract_#{label}_#{System.unique_integer([:positive])}",
+        manifest_version_id: version.manifest_version_id,
+        manifest_content_hash: version.content_hash,
+        asset_ref: {MyApp.Asset, :asset}
+      )
+
+    assert :ok = Storage.put_run(run)
+    assert :ok = Storage.put_run(run)
+
+    stale = %{run | event_seq: run.event_seq - 1} |> RunState.with_snapshot_hash()
+    assert {:error, :stale_write} = Storage.put_run(stale)
+
+    conflict = %{run | status: :error} |> RunState.with_snapshot_hash()
+    assert {:error, :conflicting_snapshot} = Storage.put_run(conflict)
+
+    assert {:ok, listed} = Storage.list_runs(status: :pending, limit: 10)
+    assert Enum.any?(listed, &(&1.id == run.id))
+
+    event = %{
+      sequence: 1,
+      event_type: :run_started,
+      occurred_at: DateTime.utc_now(),
+      data: %{kind: label}
+    }
+
+    assert :ok = Storage.append_run_event(run.id, event)
+
+    assert {:error, :conflicting_event_sequence} =
+             Storage.append_run_event(run.id, %{sequence: 1, event_type: :run_updated})
+
+    assert {:ok, [stored_event]} = Storage.list_run_events(run.id)
+    assert stored_event.sequence == 1
+
+    key = {MyApp.Pipeline, :daily}
+    assert :ok = Storage.put_scheduler_state(key, %{version: 1, last_due_at: DateTime.utc_now()})
+    assert {:error, :stale_scheduler_state} = Storage.put_scheduler_state(key, %{version: 1})
+    assert :ok = Storage.put_scheduler_state(key, %{last_due_at: DateTime.utc_now()})
+    assert {:ok, %Favn.Scheduler.State{schedule_id: :daily}} = Storage.get_scheduler_state(key)
+  end
+
+  defp manifest_version(manifest_version_id) do
+    manifest = %Manifest{
+      assets: [
+        %Favn.Manifest.Asset{ref: {MyApp.Asset, :asset}, module: MyApp.Asset, name: :asset}
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
+    version
+  end
+
+  defp postgres_opts do
+    case System.get_env("FAVN_POSTGRES_TEST_URL") do
+      url when is_binary(url) and url != "" ->
+        repo_config = repo_config_from_url(url)
+
+        if valid_repo_config?(repo_config) do
+          [
+            repo_mode: :managed,
+            repo_config: Keyword.merge(repo_config, pool_size: 1),
+            migration_mode: :auto,
+            supervisor_name: @postgres_supervisor
+          ]
+        else
+          nil
+        end
+
+      _ ->
+        nil
+    end
+  end
+
+  defp repo_config_from_url(url) do
+    uri = URI.parse(url)
+
+    [database | _rest] =
+      uri.path
+      |> to_string()
+      |> String.trim_leading("/")
+      |> String.split("/", trim: true)
+
+    [
+      hostname: uri.host,
+      port: uri.port || 5432,
+      database: database,
+      username: user_from_userinfo(uri.userinfo),
+      password: password_from_userinfo(uri.userinfo),
+      ssl: false,
+      show_sensitive_data_on_connection_error: true
+    ]
+  end
+
+  defp valid_repo_config?(repo_config) do
+    Enum.all?([:hostname, :database, :username, :password], fn key ->
+      value = Keyword.get(repo_config, key)
+      is_binary(value) and value != ""
+    end)
+  end
+
+  defp user_from_userinfo(nil), do: nil
+
+  defp user_from_userinfo(userinfo) do
+    userinfo
+    |> String.split(":", parts: 2)
+    |> List.first()
+  end
+
+  defp password_from_userinfo(nil), do: nil
+
+  defp password_from_userinfo(userinfo) do
+    case String.split(userinfo, ":", parts: 2) do
+      [_user] -> nil
+      [_user, password] -> password
+    end
+  end
+
+  defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_env(app, key, value), do: Application.put_env(app, key, value)
+end

--- a/apps/favn_orchestrator/test/storage/manifest_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/manifest_codec_test.exs
@@ -1,0 +1,39 @@
+defmodule FavnOrchestrator.Storage.ManifestCodecTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Manifest
+  alias Favn.Manifest.Version
+  alias FavnOrchestrator.Storage.ManifestCodec
+
+  test "round-trips manifest version records" do
+    version = manifest_version("mv_codec")
+
+    assert {:ok, record} = ManifestCodec.to_record(version)
+    assert record.manifest_version_id == "mv_codec"
+
+    assert {:ok, decoded} = ManifestCodec.from_record(record)
+    assert decoded.manifest_version_id == version.manifest_version_id
+    assert decoded.content_hash == version.content_hash
+  end
+
+  test "rejects content hash mismatch" do
+    version = manifest_version("mv_codec_mismatch")
+    assert {:ok, record} = ManifestCodec.to_record(version)
+
+    mismatch = %{record | content_hash: "wrong_hash"}
+
+    assert {:error, {:manifest_content_hash_mismatch, "wrong_hash", _actual}} =
+             ManifestCodec.from_record(mismatch)
+  end
+
+  defp manifest_version(manifest_version_id) do
+    manifest = %Manifest{
+      assets: [
+        %Favn.Manifest.Asset{ref: {MyApp.Asset, :asset}, module: MyApp.Asset, name: :asset}
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
+    version
+  end
+end

--- a/apps/favn_orchestrator/test/storage/memory_adapter_test.exs
+++ b/apps/favn_orchestrator/test/storage/memory_adapter_test.exs
@@ -44,6 +44,33 @@ defmodule FavnOrchestrator.Storage.MemoryAdapterTest do
     assert {:error, :conflicting_snapshot} = Storage.put_run(conflict)
   end
 
+  test "normalizes and validates run events" do
+    event = %{sequence: 1, event_type: :run_started, occurred_at: DateTime.utc_now()}
+
+    assert :ok = Storage.append_run_event("run_1", event)
+    assert {:ok, [stored]} = Storage.list_run_events("run_1")
+    assert stored.run_id == "run_1"
+    assert stored.sequence == 1
+
+    assert {:error, {:invalid_run_event_field, :sequence, 0}} =
+             Storage.append_run_event("run_1", %{sequence: 0, event_type: :run_started})
+
+    assert {:error, :conflicting_event_sequence} =
+             Storage.append_run_event("run_1", %{sequence: 1, event_type: :run_updated})
+  end
+
+  test "validates scheduler state payload" do
+    key = {MyApp.Pipeline, :daily}
+    now = DateTime.utc_now()
+
+    assert :ok = Storage.put_scheduler_state(key, %{last_due_at: now, version: 1})
+    assert {:ok, stored} = Storage.get_scheduler_state(key)
+    assert stored.last_due_at == now
+
+    assert {:error, {:invalid_scheduler_field, :last_due_at, "bad"}} =
+             Storage.put_scheduler_state(key, %{last_due_at: "bad", version: 2})
+  end
+
   defp manifest_version(manifest_version_id) do
     manifest = %Manifest{
       assets: [

--- a/apps/favn_orchestrator/test/storage/run_event_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/run_event_codec_test.exs
@@ -1,0 +1,62 @@
+defmodule FavnOrchestrator.Storage.RunEventCodecTest do
+  use ExUnit.Case, async: true
+
+  alias FavnOrchestrator.Storage.RunEventCodec
+
+  test "normalizes valid run events" do
+    occurred_at = DateTime.utc_now()
+
+    event = %{
+      run_id: "run_event",
+      sequence: 2,
+      event_type: :run_updated,
+      occurred_at: occurred_at,
+      status: :running,
+      manifest_version_id: "mv_1",
+      manifest_content_hash: "hash_1",
+      asset_ref: {MyApp.Asset, :asset},
+      data: %{attempt: 1}
+    }
+
+    assert {:ok, normalized} = RunEventCodec.normalize("run_event", event)
+    assert normalized.sequence == 2
+    assert normalized.event_type == :run_updated
+    assert normalized.occurred_at == occurred_at
+    assert normalized.data == %{attempt: 1}
+  end
+
+  test "accepts ISO8601 timestamps" do
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    assert {:ok, normalized} =
+             RunEventCodec.normalize("run_iso", %{
+               sequence: 1,
+               event_type: :run_started,
+               occurred_at: now
+             })
+
+    assert %DateTime{} = normalized.occurred_at
+  end
+
+  test "rejects invalid run events" do
+    assert {:error, {:invalid_run_event_field, :sequence, 0}} =
+             RunEventCodec.normalize("run_1", %{sequence: 0, event_type: :run_started})
+
+    assert {:error, {:invalid_run_event_field, :run_id, "other"}} =
+             RunEventCodec.normalize("run_1", %{
+               sequence: 1,
+               event_type: :run_started,
+               run_id: "other"
+             })
+
+    assert {:error, {:invalid_run_event_field, :event_type, nil}} =
+             RunEventCodec.normalize("run_1", %{sequence: 1, event_type: nil})
+
+    assert {:error, {:invalid_run_event_field, :occurred_at, 1}} =
+             RunEventCodec.normalize("run_1", %{
+               sequence: 1,
+               event_type: :run_started,
+               occurred_at: 1
+             })
+  end
+end

--- a/apps/favn_orchestrator/test/storage/run_state_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/run_state_codec_test.exs
@@ -1,0 +1,44 @@
+defmodule FavnOrchestrator.Storage.RunStateCodecTest do
+  use ExUnit.Case, async: true
+
+  alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage.RunStateCodec
+
+  test "normalizes run state and refreshes snapshot hash" do
+    run_state =
+      RunState.new(
+        id: "run_codec",
+        manifest_version_id: "mv_codec",
+        manifest_content_hash: "hash_codec",
+        asset_ref: {MyApp.Asset, :asset}
+      )
+
+    tampered = %{run_state | snapshot_hash: "bad"}
+
+    assert {:ok, normalized} = RunStateCodec.normalize(tampered)
+    assert normalized.snapshot_hash == RunState.with_snapshot_hash(run_state).snapshot_hash
+  end
+
+  test "rejects invalid run identity" do
+    run_state =
+      RunState.new(
+        id: "run_codec_invalid",
+        manifest_version_id: "mv_codec",
+        manifest_content_hash: "hash_codec",
+        asset_ref: {MyApp.Asset, :asset}
+      )
+
+    assert {:error, :invalid_run_id} = RunStateCodec.normalize(%{run_state | id: nil})
+
+    assert {:error, :invalid_manifest_version_id} =
+             RunStateCodec.normalize(%{run_state | manifest_version_id: ""})
+
+    assert {:error, :invalid_manifest_content_hash} =
+             RunStateCodec.normalize(%{run_state | manifest_content_hash: nil})
+
+    assert {:error, :invalid_asset_ref} =
+             RunStateCodec.normalize(%{run_state | asset_ref: :invalid})
+
+    assert {:error, :invalid_event_seq} = RunStateCodec.normalize(%{run_state | event_seq: -1})
+  end
+end

--- a/apps/favn_orchestrator/test/storage/scheduler_state_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/scheduler_state_codec_test.exs
@@ -1,0 +1,50 @@
+defmodule FavnOrchestrator.Storage.SchedulerStateCodecTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Scheduler.State, as: SchedulerState
+  alias FavnOrchestrator.Storage.SchedulerStateCodec
+
+  test "normalizes scheduler key and map payload" do
+    now = DateTime.utc_now()
+
+    state = %{
+      schedule_fingerprint: "fp",
+      last_evaluated_at: now,
+      last_due_at: now,
+      last_submitted_due_at: now,
+      in_flight_run_id: "run_1",
+      queued_due_at: now,
+      updated_at: now,
+      version: 2
+    }
+
+    assert {:ok, {MyApp.Pipeline, :daily}} =
+             SchedulerStateCodec.normalize_key({MyApp.Pipeline, :daily})
+
+    assert {:ok, normalized} = SchedulerStateCodec.normalize_state(state)
+    assert normalized.version == 2
+    assert normalized.in_flight_run_id == "run_1"
+  end
+
+  test "normalizes scheduler struct payload" do
+    scheduler_state = %SchedulerState{
+      pipeline_module: MyApp.Pipeline,
+      schedule_id: :daily,
+      schedule_fingerprint: "fp"
+    }
+
+    assert {:ok, normalized} = SchedulerStateCodec.normalize_state(scheduler_state)
+    assert normalized.schedule_fingerprint == "fp"
+    refute Map.has_key?(normalized, :pipeline_module)
+  end
+
+  test "rejects invalid scheduler key and payload fields" do
+    assert {:error, {:invalid_scheduler_key, :bad}} = SchedulerStateCodec.normalize_key(:bad)
+
+    assert {:error, {:invalid_scheduler_field, :version, 0}} =
+             SchedulerStateCodec.normalize_state(%{version: 0})
+
+    assert {:error, {:invalid_scheduler_field, :last_due_at, "bad"}} =
+             SchedulerStateCodec.normalize_state(%{last_due_at: "bad"})
+  end
+end

--- a/apps/favn_orchestrator/test/storage/write_semantics_test.exs
+++ b/apps/favn_orchestrator/test/storage/write_semantics_test.exs
@@ -1,0 +1,25 @@
+defmodule FavnOrchestrator.Storage.WriteSemanticsTest do
+  use ExUnit.Case, async: true
+
+  alias FavnOrchestrator.Storage.WriteSemantics
+
+  test "returns :insert when no existing snapshot exists" do
+    assert :insert = WriteSemantics.decide(nil, nil, 1, "hash")
+  end
+
+  test "returns :replace for monotonic event sequence increases" do
+    assert :replace = WriteSemantics.decide(1, "hash_a", 2, "hash_b")
+  end
+
+  test "returns stale_write when incoming event sequence regresses" do
+    assert {:error, :stale_write} = WriteSemantics.decide(2, "hash_a", 1, "hash_b")
+  end
+
+  test "returns :idempotent for same event sequence and snapshot hash" do
+    assert :idempotent = WriteSemantics.decide(2, "hash_a", 2, "hash_a")
+  end
+
+  test "returns conflicting_snapshot for same event sequence with different hash" do
+    assert {:error, :conflicting_snapshot} = WriteSemantics.decide(2, "hash_a", 2, "hash_b")
+  end
+end

--- a/apps/favn_orchestrator/test/storage_facade_test.exs
+++ b/apps/favn_orchestrator/test/storage_facade_test.exs
@@ -59,6 +59,53 @@ defmodule Favn.StorageFacadeTest do
     def get_scheduler_state(_module, _schedule_id, _opts), do: {:ok, nil}
   end
 
+  defmodule ChildSpecProbeAdapterStub do
+    @behaviour Favn.Storage.Adapter
+
+    @impl true
+    def child_spec(opts) do
+      test_pid = Keyword.fetch!(opts, :test_pid)
+      send(test_pid, :child_spec_called)
+      :none
+    end
+
+    @impl true
+    def put_manifest_version(_version, _opts), do: :ok
+
+    @impl true
+    def get_manifest_version(_manifest_version_id, _opts), do: {:error, :not_found}
+
+    @impl true
+    def list_manifest_versions(_opts), do: {:ok, []}
+
+    @impl true
+    def set_active_manifest_version(_manifest_version_id, _opts), do: :ok
+
+    @impl true
+    def get_active_manifest_version(_opts), do: {:error, :not_found}
+
+    @impl true
+    def put_run(_run_state, _opts), do: :ok
+
+    @impl true
+    def get_run(_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
+    def list_runs(_opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
+    def append_run_event(_run_id, _event, _opts), do: :ok
+
+    @impl true
+    def list_run_events(_run_id, _opts), do: {:ok, []}
+
+    @impl true
+    def put_scheduler_state(_key, _state, _opts), do: :ok
+
+    @impl true
+    def get_scheduler_state(_key, _opts), do: {:ok, nil}
+  end
+
   setup do
     previous_adapter = Application.get_env(:favn_orchestrator, :storage_adapter)
     previous_opts = Application.get_env(:favn_orchestrator, :storage_adapter_opts)
@@ -113,6 +160,14 @@ defmodule Favn.StorageFacadeTest do
     assert {:ok, run_state} = OrchestratorStorage.get_run("run_storage_facade")
     assert run_state.id == "run_storage_facade"
     assert run_state.manifest_version_id == "mv_storage_facade"
+  end
+
+  test "always delegates child spec setup to orchestrator storage" do
+    Application.put_env(:favn_orchestrator, :storage_adapter, ChildSpecProbeAdapterStub)
+    Application.put_env(:favn_orchestrator, :storage_adapter_opts, test_pid: self())
+
+    assert {:ok, []} = Storage.child_specs()
+    assert_receive :child_spec_called
   end
 
   defp restore_env(app, key, nil), do: Application.delete_env(app, key)

--- a/apps/favn_storage_postgres/README.md
+++ b/apps/favn_storage_postgres/README.md
@@ -26,6 +26,7 @@ Current status:
 - supports managed and external repo modes
 - managed mode supports migration bootstrap (`:auto`) and schema-ready enforcement (`:manual`)
 - persists manifest versions, active manifest pointer, run snapshots, run events, and scheduler cursors
+- current persisted run/event/scheduler payloads use BEAM term blobs as a temporary foundation choice; this should be replaced with more inspectable canonical payload storage before final cutover
 
 ## Runtime modes
 
@@ -46,3 +47,8 @@ Postgres live integration coverage is opt-in to avoid requiring a local DB for n
   - `mix test apps/favn_storage_postgres/test/integration/adapter_live_test.exs`
 
 If `FAVN_POSTGRES_TEST_URL` is not set, the live integration test module is skipped.
+
+## Instance model
+
+- current managed mode supports one Postgres adapter instance per BEAM node
+- the adapter repo is globally named inside the adapter app, so `supervisor_name` should be treated as supervisor identity only, not as a multi-instance isolation mechanism

--- a/apps/favn_storage_postgres/README.md
+++ b/apps/favn_storage_postgres/README.md
@@ -11,6 +11,8 @@ Visibility:
 Allowed dependencies in Phase 1:
 
 - `favn_orchestrator`
+- `ecto_sql`
+- `postgrex`
 
 Must not depend on in Phase 1:
 
@@ -19,4 +21,28 @@ Must not depend on in Phase 1:
 
 Current status:
 
-- scaffold-only, not implemented yet
+- implemented initial Phase 6 Postgres adapter foundation
+- module entrypoint: `FavnStoragePostgres.Adapter`
+- supports managed and external repo modes
+- managed mode supports migration bootstrap (`:auto`) and schema-ready enforcement (`:manual`)
+- persists manifest versions, active manifest pointer, run snapshots, run events, and scheduler cursors
+
+## Runtime modes
+
+- managed mode:
+  - configure `repo_mode: :managed` with `repo_config: [...]`
+  - use `migration_mode: :auto` for local/dev bootstrap or `:manual` for production migration discipline
+- external mode:
+  - configure `repo_mode: :external` with `repo: MyApp.Repo`
+  - `migration_mode` must remain `:manual`
+
+## Live integration tests
+
+Postgres live integration coverage is opt-in to avoid requiring a local DB for normal CI/dev loops.
+
+- set `FAVN_POSTGRES_TEST_URL`, for example:
+  - `export FAVN_POSTGRES_TEST_URL=postgres://postgres:postgres@localhost:5432/favn_test`
+- run:
+  - `mix test apps/favn_storage_postgres/test/integration/adapter_live_test.exs`
+
+If `FAVN_POSTGRES_TEST_URL` is not set, the live integration test module is skipped.

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres.ex
@@ -1,18 +1,5 @@
 defmodule FavnStoragePostgres do
   @moduledoc """
-  Documentation for `FavnStoragePostgres`.
+  Postgres storage adapter app for orchestrator control-plane persistence.
   """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> FavnStoragePostgres.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/adapter.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/adapter.ex
@@ -13,6 +13,7 @@ defmodule FavnStoragePostgres.Adapter do
   alias FavnOrchestrator.Storage.RunStateCodec
   alias FavnOrchestrator.Storage.SchedulerStateCodec
   alias FavnOrchestrator.Storage.WriteSemantics
+  alias FavnStoragePostgres.Migrations
   alias FavnStoragePostgres.Repo
   alias FavnStoragePostgres.Supervisor, as: PostgresSupervisor
 
@@ -243,35 +244,8 @@ defmodule FavnStoragePostgres.Adapter do
   def put_scheduler_state(key, state, opts) when is_map(state) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts),
          {:ok, normalized_key} <- SchedulerStateCodec.normalize_key(key),
-         {:ok, normalized_state} <- SchedulerStateCodec.normalize_state(state),
-         {:ok, existing_version} <- fetch_scheduler_version(repo, normalized_key),
-         {:ok, write_version} <-
-           resolve_scheduler_version(existing_version, normalized_state[:version]) do
-      persisted = Map.put(normalized_state, :version, write_version)
-      {pipeline_module, schedule_id} = normalized_key
-
-      sql =
-        """
-        INSERT INTO favn_scheduler_cursors (pipeline_module, schedule_id, version, updated_at, state_blob)
-        VALUES ($1, $2, $3, $4, $5)
-        ON CONFLICT(pipeline_module, schedule_id) DO UPDATE SET
-          version = EXCLUDED.version,
-          updated_at = EXCLUDED.updated_at,
-          state_blob = EXCLUDED.state_blob
-        """
-
-      params = [
-        Atom.to_string(pipeline_module),
-        encode_schedule_id(schedule_id),
-        write_version,
-        DateTime.utc_now(),
-        encode_term(persisted)
-      ]
-
-      case SQL.query(repo, sql, params) do
-        {:ok, _} -> :ok
-        {:error, reason} -> {:error, reason}
-      end
+         {:ok, normalized_state} <- SchedulerStateCodec.normalize_state(state) do
+      persist_scheduler_state(repo, normalized_key, normalized_state)
     end
   end
 
@@ -281,7 +255,7 @@ defmodule FavnStoragePostgres.Adapter do
          {:ok, {pipeline_module, schedule_id}} <- SchedulerStateCodec.normalize_key(key) do
       sql =
         """
-        SELECT state_blob
+        SELECT version, state_blob
         FROM favn_scheduler_cursors
         WHERE pipeline_module = $1 AND schedule_id = $2
         LIMIT 1
@@ -293,13 +267,17 @@ defmodule FavnStoragePostgres.Adapter do
         {:ok, %{rows: []}} ->
           {:ok, nil}
 
-        {:ok, %{rows: [[blob]]}} ->
+        {:ok, %{rows: [[version, blob]]}} ->
           with {:ok, decoded} <- decode_term(blob),
                true <- is_map(decoded) do
             {:ok,
              struct(
                Favn.Scheduler.State,
-               Map.merge(decoded, %{pipeline_module: pipeline_module, schedule_id: schedule_id})
+               Map.merge(decoded, %{
+                 pipeline_module: pipeline_module,
+                 schedule_id: schedule_id,
+                 version: version
+               })
              )}
           else
             false -> {:error, :invalid_scheduler_blob}
@@ -314,13 +292,9 @@ defmodule FavnStoragePostgres.Adapter do
 
   defp persist_run(repo, run) do
     repo.transact(fn ->
-      with {:ok, existing} <- fetch_run_head(repo, run.id),
-           decision <- decide_run_write(existing, run),
-           :ok <- persist_run_decision(repo, decision, run) do
-        :ok
-      else
-        {:error, reason} ->
-          repo.rollback(reason)
+      case guarded_put_run(repo, run) do
+        :ok -> {:ok, :ok}
+        {:error, reason} -> repo.rollback(reason)
       end
     end)
     |> case do
@@ -329,10 +303,7 @@ defmodule FavnStoragePostgres.Adapter do
     end
   end
 
-  defp persist_run_decision(_repo, :idempotent, _run), do: :ok
-  defp persist_run_decision(_repo, {:error, reason}, _run), do: {:error, reason}
-
-  defp persist_run_decision(repo, decision, run) when decision in [:insert, :replace] do
+  defp guarded_put_run(repo, run) do
     with {:ok, updated_seq} <- next_updated_seq(repo) do
       sql =
         """
@@ -358,6 +329,7 @@ defmodule FavnStoragePostgres.Adapter do
           inserted_at = EXCLUDED.inserted_at,
           updated_at = EXCLUDED.updated_at,
           run_blob = EXCLUDED.run_blob
+        WHERE EXCLUDED.event_seq > favn_runs.event_seq
         """
 
       params = [
@@ -374,17 +346,126 @@ defmodule FavnStoragePostgres.Adapter do
       ]
 
       case SQL.query(repo, sql, params) do
-        {:ok, _} -> :ok
+        {:ok, %{num_rows: num_rows}} when num_rows > 0 -> :ok
+        {:ok, _} -> classify_run_write_result(repo, run)
         {:error, reason} -> {:error, reason}
       end
     end
   end
 
-  defp decide_run_write(nil, run),
-    do: WriteSemantics.decide(nil, nil, run.event_seq, run.snapshot_hash)
+  defp classify_run_write_result(repo, run) do
+    with {:ok, existing} <- fetch_run_head(repo, run.id) do
+      case existing do
+        {existing_event_seq, existing_hash} ->
+          case WriteSemantics.decide(
+                 existing_event_seq,
+                 existing_hash,
+                 run.event_seq,
+                 run.snapshot_hash
+               ) do
+            :idempotent -> :ok
+            {:error, reason} -> {:error, reason}
+            other -> {:error, {:unexpected_run_write_decision, other}}
+          end
 
-  defp decide_run_write({existing_event_seq, existing_hash}, run) do
-    WriteSemantics.decide(existing_event_seq, existing_hash, run.event_seq, run.snapshot_hash)
+        nil ->
+          {:error, :run_write_not_applied}
+      end
+    end
+  end
+
+  defp persist_scheduler_state(repo, key, normalized_state) do
+    repo.transact(fn ->
+      case guarded_put_scheduler_state(repo, key, normalized_state) do
+        :ok -> {:ok, :ok}
+        {:error, reason} -> repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp guarded_put_scheduler_state(repo, {pipeline_module, schedule_id} = key, normalized_state) do
+    encoded_state = normalized_state |> Map.delete(:version) |> encode_term()
+    encoded_schedule_id = encode_schedule_id(schedule_id)
+    updated_at = DateTime.utc_now()
+
+    {sql, params} =
+      scheduler_upsert_query(
+        Atom.to_string(pipeline_module),
+        encoded_schedule_id,
+        normalized_state,
+        updated_at,
+        encoded_state
+      )
+
+    case SQL.query(repo, sql, params) do
+      {:ok, %{num_rows: num_rows}} when num_rows > 0 -> :ok
+      {:ok, _} -> classify_scheduler_write_result(repo, key, normalized_state[:version])
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp scheduler_upsert_query(
+         pipeline_module,
+         encoded_schedule_id,
+         normalized_state,
+         updated_at,
+         encoded_state
+       ) do
+    case normalized_state[:version] do
+      nil ->
+        {
+          """
+          INSERT INTO favn_scheduler_cursors (pipeline_module, schedule_id, version, updated_at, state_blob)
+          VALUES ($1, $2, 1, $3, $4)
+          ON CONFLICT(pipeline_module, schedule_id) DO UPDATE SET
+            version = favn_scheduler_cursors.version + 1,
+            updated_at = EXCLUDED.updated_at,
+            state_blob = EXCLUDED.state_blob
+          """,
+          [pipeline_module, encoded_schedule_id, updated_at, encoded_state]
+        }
+
+      incoming_version ->
+        expected_previous = incoming_version - 1
+
+        {
+          """
+          INSERT INTO favn_scheduler_cursors (pipeline_module, schedule_id, version, updated_at, state_blob)
+          SELECT $1, $2, $3, $4, $5
+          WHERE $3 = 1 OR EXISTS (
+            SELECT 1
+            FROM favn_scheduler_cursors
+            WHERE pipeline_module = $1 AND schedule_id = $2
+          )
+          ON CONFLICT(pipeline_module, schedule_id) DO UPDATE SET
+            version = EXCLUDED.version,
+            updated_at = EXCLUDED.updated_at,
+            state_blob = EXCLUDED.state_blob
+          WHERE favn_scheduler_cursors.version = $6
+          """,
+          [
+            pipeline_module,
+            encoded_schedule_id,
+            incoming_version,
+            updated_at,
+            encoded_state,
+            expected_previous
+          ]
+        }
+    end
+  end
+
+  defp classify_scheduler_write_result(repo, key, incoming_version) do
+    with {:ok, existing_version} <- fetch_scheduler_version(repo, key) do
+      case resolve_scheduler_version(existing_version, incoming_version) do
+        {:ok, _version} -> {:error, :scheduler_write_not_applied}
+        {:error, reason} -> {:error, reason}
+      end
+    end
   end
 
   defp next_updated_seq(repo) do
@@ -597,7 +678,13 @@ defmodule FavnStoragePostgres.Adapter do
           {:ok, Repo}
 
         :external ->
-          {:ok, Keyword.fetch!(normalized, :repo)}
+          repo = Keyword.fetch!(normalized, :repo)
+
+          if Migrations.schema_ready?(repo) do
+            {:ok, repo}
+          else
+            {:error, :schema_not_ready}
+          end
       end
     end
   end

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/adapter.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/adapter.ex
@@ -1,0 +1,670 @@
+defmodule FavnStoragePostgres.Adapter do
+  @moduledoc """
+  Postgres-backed storage adapter implementing `Favn.Storage.Adapter`.
+  """
+
+  @behaviour Favn.Storage.Adapter
+
+  alias Ecto.Adapters.SQL
+  alias Favn.Manifest.Version
+  alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage.ManifestCodec
+  alias FavnOrchestrator.Storage.RunEventCodec
+  alias FavnOrchestrator.Storage.RunStateCodec
+  alias FavnOrchestrator.Storage.SchedulerStateCodec
+  alias FavnOrchestrator.Storage.WriteSemantics
+  alias FavnStoragePostgres.Repo
+  alias FavnStoragePostgres.Supervisor, as: PostgresSupervisor
+
+  @active_manifest_key "active_manifest_version_id"
+  @nil_schedule_id "__nil__"
+
+  @impl true
+  def child_spec(opts) when is_list(opts) do
+    with {:ok, normalized} <- normalize_opts(opts) do
+      case Keyword.fetch!(normalized, :repo_mode) do
+        :managed ->
+          supervisor_name = Keyword.fetch!(normalized, :supervisor_name)
+
+          if Process.whereis(supervisor_name) do
+            :none
+          else
+            {:ok,
+             Supervisor.child_spec(
+               {PostgresSupervisor,
+                [
+                  name: supervisor_name,
+                  repo_config: Keyword.fetch!(normalized, :repo_config),
+                  migration_mode: Keyword.fetch!(normalized, :migration_mode)
+                ]},
+               id: supervisor_name,
+               restart: :permanent,
+               shutdown: 5_000,
+               type: :supervisor
+             )}
+          end
+
+        :external ->
+          :none
+      end
+    end
+  end
+
+  @impl true
+  def put_manifest_version(%Version{} = version, opts) when is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, record} <- ManifestCodec.to_record(version),
+         {:ok, existing} <- fetch_manifest_hash(repo, record.manifest_version_id) do
+      case existing do
+        nil -> insert_manifest_record(repo, record)
+        hash when hash == record.content_hash -> :ok
+        _other -> {:error, :manifest_version_conflict}
+      end
+    end
+  end
+
+  @impl true
+  def get_manifest_version(manifest_version_id, opts)
+      when is_binary(manifest_version_id) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, row} <- fetch_manifest_record(repo, manifest_version_id) do
+      case row do
+        nil -> {:error, :manifest_version_not_found}
+        record -> ManifestCodec.from_record(record)
+      end
+    end
+  end
+
+  @impl true
+  def list_manifest_versions(opts) when is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, rows} <- fetch_manifest_records(repo) do
+      rows
+      |> Enum.reduce_while({:ok, []}, fn record, {:ok, acc} ->
+        case ManifestCodec.from_record(record) do
+          {:ok, version} -> {:cont, {:ok, [version | acc]}}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+      end)
+      |> case do
+        {:ok, versions} -> {:ok, Enum.reverse(versions)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def set_active_manifest_version(manifest_version_id, opts)
+      when is_binary(manifest_version_id) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, existing} <- fetch_manifest_hash(repo, manifest_version_id),
+         false <- is_nil(existing) do
+      sql =
+        """
+        INSERT INTO favn_runtime_settings (key, value_text, updated_at)
+        VALUES ($1, $2, $3)
+        ON CONFLICT(key) DO UPDATE SET value_text = EXCLUDED.value_text, updated_at = EXCLUDED.updated_at
+        """
+
+      case SQL.query(repo, sql, [@active_manifest_key, manifest_version_id, DateTime.utc_now()]) do
+        {:ok, _} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      true -> {:error, :manifest_version_not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
+  def get_active_manifest_version(opts) when is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      sql = "SELECT value_text FROM favn_runtime_settings WHERE key = $1 LIMIT 1"
+
+      case SQL.query(repo, sql, [@active_manifest_key]) do
+        {:ok, %{rows: [[manifest_version_id]]}}
+        when is_binary(manifest_version_id) and manifest_version_id != "" ->
+          {:ok, manifest_version_id}
+
+        {:ok, %{rows: []}} ->
+          {:error, :active_manifest_not_set}
+
+        {:ok, _} ->
+          {:error, :active_manifest_not_set}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def put_run(%RunState{} = run, opts) when is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, normalized} <- RunStateCodec.normalize(run) do
+      persist_run(repo, normalized)
+    end
+  end
+
+  @impl true
+  def get_run(run_id, opts) when is_binary(run_id) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      sql = "SELECT run_blob FROM favn_runs WHERE run_id = $1 LIMIT 1"
+
+      case SQL.query(repo, sql, [run_id]) do
+        {:ok, %{rows: [[blob]]}} -> decode_run(blob)
+        {:ok, %{rows: []}} -> {:error, :not_found}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_runs(run_opts, opts) when is_list(run_opts) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      {sql, params} = list_runs_query(run_opts)
+
+      case SQL.query(repo, sql, params) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> Enum.reduce_while({:ok, []}, fn [blob], {:ok, acc} ->
+            case decode_run(blob) do
+              {:ok, run} -> {:cont, {:ok, [run | acc]}}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+          |> case do
+            {:ok, runs} -> {:ok, Enum.reverse(runs)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def append_run_event(run_id, event, opts)
+      when is_binary(run_id) and is_map(event) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, normalized} <- RunEventCodec.normalize(run_id, event) do
+      sql =
+        """
+        INSERT INTO favn_run_events (run_id, sequence, occurred_at, event_blob)
+        VALUES ($1, $2, $3, $4)
+        """
+
+      case SQL.query(repo, sql, [
+             run_id,
+             normalized.sequence,
+             normalized.occurred_at,
+             encode_term(normalized)
+           ]) do
+        {:ok, _} ->
+          :ok
+
+        {:error, %Postgrex.Error{postgres: %{code: :unique_violation}}} ->
+          {:error, :conflicting_event_sequence}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_run_events(run_id, opts) when is_binary(run_id) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      sql = "SELECT event_blob FROM favn_run_events WHERE run_id = $1 ORDER BY sequence ASC"
+
+      case SQL.query(repo, sql, [run_id]) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> Enum.reduce_while({:ok, []}, fn [blob], {:ok, acc} ->
+            case decode_term(blob) do
+              {:ok, event} when is_map(event) -> {:cont, {:ok, [event | acc]}}
+              {:ok, other} -> {:halt, {:error, {:invalid_event_blob, other}}}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+          |> case do
+            {:ok, events} -> {:ok, Enum.reverse(events)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def put_scheduler_state(key, state, opts) when is_map(state) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, normalized_key} <- SchedulerStateCodec.normalize_key(key),
+         {:ok, normalized_state} <- SchedulerStateCodec.normalize_state(state),
+         {:ok, existing_version} <- fetch_scheduler_version(repo, normalized_key),
+         {:ok, write_version} <-
+           resolve_scheduler_version(existing_version, normalized_state[:version]) do
+      persisted = Map.put(normalized_state, :version, write_version)
+      {pipeline_module, schedule_id} = normalized_key
+
+      sql =
+        """
+        INSERT INTO favn_scheduler_cursors (pipeline_module, schedule_id, version, updated_at, state_blob)
+        VALUES ($1, $2, $3, $4, $5)
+        ON CONFLICT(pipeline_module, schedule_id) DO UPDATE SET
+          version = EXCLUDED.version,
+          updated_at = EXCLUDED.updated_at,
+          state_blob = EXCLUDED.state_blob
+        """
+
+      params = [
+        Atom.to_string(pipeline_module),
+        encode_schedule_id(schedule_id),
+        write_version,
+        DateTime.utc_now(),
+        encode_term(persisted)
+      ]
+
+      case SQL.query(repo, sql, params) do
+        {:ok, _} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def get_scheduler_state(key, opts) when is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, {pipeline_module, schedule_id}} <- SchedulerStateCodec.normalize_key(key) do
+      sql =
+        """
+        SELECT state_blob
+        FROM favn_scheduler_cursors
+        WHERE pipeline_module = $1 AND schedule_id = $2
+        LIMIT 1
+        """
+
+      params = [Atom.to_string(pipeline_module), encode_schedule_id(schedule_id)]
+
+      case SQL.query(repo, sql, params) do
+        {:ok, %{rows: []}} ->
+          {:ok, nil}
+
+        {:ok, %{rows: [[blob]]}} ->
+          with {:ok, decoded} <- decode_term(blob),
+               true <- is_map(decoded) do
+            {:ok,
+             struct(
+               Favn.Scheduler.State,
+               Map.merge(decoded, %{pipeline_module: pipeline_module, schedule_id: schedule_id})
+             )}
+          else
+            false -> {:error, :invalid_scheduler_blob}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp persist_run(repo, run) do
+    repo.transact(fn ->
+      with {:ok, existing} <- fetch_run_head(repo, run.id),
+           decision <- decide_run_write(existing, run),
+           :ok <- persist_run_decision(repo, decision, run) do
+        :ok
+      else
+        {:error, reason} ->
+          repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp persist_run_decision(_repo, :idempotent, _run), do: :ok
+  defp persist_run_decision(_repo, {:error, reason}, _run), do: {:error, reason}
+
+  defp persist_run_decision(repo, decision, run) when decision in [:insert, :replace] do
+    with {:ok, updated_seq} <- next_updated_seq(repo) do
+      sql =
+        """
+        INSERT INTO favn_runs (
+          run_id,
+          manifest_version_id,
+          manifest_content_hash,
+          status,
+          event_seq,
+          snapshot_hash,
+          updated_seq,
+          inserted_at,
+          updated_at,
+          run_blob
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+        ON CONFLICT(run_id) DO UPDATE SET
+          manifest_version_id = EXCLUDED.manifest_version_id,
+          manifest_content_hash = EXCLUDED.manifest_content_hash,
+          status = EXCLUDED.status,
+          event_seq = EXCLUDED.event_seq,
+          snapshot_hash = EXCLUDED.snapshot_hash,
+          updated_seq = EXCLUDED.updated_seq,
+          inserted_at = EXCLUDED.inserted_at,
+          updated_at = EXCLUDED.updated_at,
+          run_blob = EXCLUDED.run_blob
+        """
+
+      params = [
+        run.id,
+        run.manifest_version_id,
+        run.manifest_content_hash,
+        to_string(run.status),
+        run.event_seq,
+        run.snapshot_hash,
+        updated_seq,
+        run.inserted_at,
+        run.updated_at,
+        encode_term(run)
+      ]
+
+      case SQL.query(repo, sql, params) do
+        {:ok, _} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp decide_run_write(nil, run),
+    do: WriteSemantics.decide(nil, nil, run.event_seq, run.snapshot_hash)
+
+  defp decide_run_write({existing_event_seq, existing_hash}, run) do
+    WriteSemantics.decide(existing_event_seq, existing_hash, run.event_seq, run.snapshot_hash)
+  end
+
+  defp next_updated_seq(repo) do
+    sql = "SELECT nextval('favn_run_write_seq')"
+
+    case SQL.query(repo, sql, []) do
+      {:ok, %{rows: [[value]]}} when is_integer(value) -> {:ok, value}
+      {:ok, _} -> {:error, :invalid_counter_value}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_manifest_hash(repo, manifest_version_id) do
+    sql = "SELECT content_hash FROM favn_manifest_versions WHERE manifest_version_id = $1 LIMIT 1"
+
+    case SQL.query(repo, sql, [manifest_version_id]) do
+      {:ok, %{rows: [[hash]]}} -> {:ok, hash}
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_manifest_record(repo, manifest_version_id) do
+    sql =
+      """
+      SELECT manifest_version_id, content_hash, schema_version, runner_contract_version, serialization_format, manifest_json, inserted_at
+      FROM favn_manifest_versions
+      WHERE manifest_version_id = $1
+      LIMIT 1
+      """
+
+    case SQL.query(repo, sql, [manifest_version_id]) do
+      {:ok, %{rows: [[id, hash, schema, runner_contract, format, manifest_json, inserted_at]]}} ->
+        {:ok,
+         %{
+           manifest_version_id: id,
+           content_hash: hash,
+           schema_version: schema,
+           runner_contract_version: runner_contract,
+           serialization_format: format,
+           manifest_json: manifest_json,
+           inserted_at: inserted_at
+         }}
+
+      {:ok, %{rows: []}} ->
+        {:ok, nil}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp fetch_manifest_records(repo) do
+    sql =
+      """
+      SELECT manifest_version_id, content_hash, schema_version, runner_contract_version, serialization_format, manifest_json, inserted_at
+      FROM favn_manifest_versions
+      ORDER BY manifest_version_id ASC
+      """
+
+    case SQL.query(repo, sql, []) do
+      {:ok, %{rows: rows}} ->
+        mapped =
+          Enum.map(rows, fn [
+                              id,
+                              hash,
+                              schema,
+                              runner_contract,
+                              format,
+                              manifest_json,
+                              inserted_at
+                            ] ->
+            %{
+              manifest_version_id: id,
+              content_hash: hash,
+              schema_version: schema,
+              runner_contract_version: runner_contract,
+              serialization_format: format,
+              manifest_json: manifest_json,
+              inserted_at: inserted_at
+            }
+          end)
+
+        {:ok, mapped}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp fetch_run_head(repo, run_id) do
+    sql = "SELECT event_seq, snapshot_hash FROM favn_runs WHERE run_id = $1 LIMIT 1"
+
+    case SQL.query(repo, sql, [run_id]) do
+      {:ok, %{rows: [[event_seq, snapshot_hash]]}} -> {:ok, {event_seq, snapshot_hash}}
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_scheduler_version(repo, {pipeline_module, schedule_id}) do
+    sql =
+      """
+      SELECT version
+      FROM favn_scheduler_cursors
+      WHERE pipeline_module = $1 AND schedule_id = $2
+      LIMIT 1
+      """
+
+    params = [Atom.to_string(pipeline_module), encode_schedule_id(schedule_id)]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: [[version]]}} when is_integer(version) -> {:ok, version}
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:ok, _} -> {:error, :invalid_scheduler_version}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_scheduler_version(nil, nil), do: {:ok, 1}
+  defp resolve_scheduler_version(nil, 1), do: {:ok, 1}
+  defp resolve_scheduler_version(nil, _incoming), do: {:error, :invalid_scheduler_version}
+  defp resolve_scheduler_version(existing, nil) when is_integer(existing), do: {:ok, existing + 1}
+
+  defp resolve_scheduler_version(existing, incoming)
+       when is_integer(existing) and is_integer(incoming) and incoming == existing + 1,
+       do: {:ok, incoming}
+
+  defp resolve_scheduler_version(_existing, _incoming), do: {:error, :stale_scheduler_state}
+
+  defp insert_manifest_record(repo, record) do
+    sql =
+      """
+      INSERT INTO favn_manifest_versions (
+        manifest_version_id,
+        content_hash,
+        schema_version,
+        runner_contract_version,
+        serialization_format,
+        manifest_json,
+        inserted_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7)
+      """
+
+    params = [
+      record.manifest_version_id,
+      record.content_hash,
+      record.schema_version,
+      record.runner_contract_version,
+      record.serialization_format,
+      record.manifest_json,
+      record.inserted_at
+    ]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp list_runs_query(run_opts) do
+    status = Keyword.get(run_opts, :status)
+    limit = Keyword.get(run_opts, :limit)
+
+    cond do
+      is_nil(status) and is_nil(limit) ->
+        {"SELECT run_blob FROM favn_runs ORDER BY updated_seq DESC, run_id DESC", []}
+
+      is_nil(status) ->
+        {"SELECT run_blob FROM favn_runs ORDER BY updated_seq DESC, run_id DESC LIMIT $1",
+         [limit]}
+
+      is_nil(limit) ->
+        {
+          "SELECT run_blob FROM favn_runs WHERE status = $1 ORDER BY updated_seq DESC, run_id DESC",
+          [Atom.to_string(status)]
+        }
+
+      true ->
+        {
+          "SELECT run_blob FROM favn_runs WHERE status = $1 ORDER BY updated_seq DESC, run_id DESC LIMIT $2",
+          [Atom.to_string(status), limit]
+        }
+    end
+  end
+
+  defp decode_run(blob) do
+    with {:ok, decoded} <- decode_term(blob),
+         %RunState{} = run_state <- decoded,
+         {:ok, normalized} <- RunStateCodec.normalize(run_state) do
+      {:ok, normalized}
+    else
+      {:error, reason} -> {:error, reason}
+      other -> {:error, {:invalid_run_blob, other}}
+    end
+  end
+
+  defp encode_term(value), do: :erlang.term_to_binary(value)
+
+  defp decode_term(blob) when is_binary(blob) do
+    {:ok, :erlang.binary_to_term(blob, [:safe])}
+  rescue
+    error -> {:error, {:invalid_blob, error}}
+  end
+
+  defp resolve_repo(opts) do
+    with {:ok, normalized} <- normalize_opts(opts) do
+      case Keyword.fetch!(normalized, :repo_mode) do
+        :managed ->
+          {:ok, Repo}
+
+        :external ->
+          {:ok, Keyword.fetch!(normalized, :repo)}
+      end
+    end
+  end
+
+  defp normalize_opts(opts) do
+    repo_mode = Keyword.get(opts, :repo_mode, :managed)
+
+    case repo_mode do
+      :managed ->
+        with {:ok, repo_config} <- validate_repo_config(Keyword.get(opts, :repo_config, [])),
+             {:ok, migration_mode} <-
+               validate_migration_mode(Keyword.get(opts, :migration_mode, :manual)) do
+          {:ok,
+           [
+             repo_mode: :managed,
+             repo_config: repo_config,
+             migration_mode: migration_mode,
+             supervisor_name: Keyword.get(opts, :supervisor_name, FavnStoragePostgres.Supervisor)
+           ]}
+        end
+
+      :external ->
+        with {:ok, repo} <- validate_external_repo(Keyword.get(opts, :repo)),
+             :ok <- validate_external_migration_mode(Keyword.get(opts, :migration_mode, :manual)) do
+          {:ok, [repo_mode: :external, repo: repo, migration_mode: :manual]}
+        end
+
+      other ->
+        {:error, {:invalid_repo_mode, other}}
+    end
+  end
+
+  defp validate_repo_config(repo_config) when is_list(repo_config) do
+    required = [:hostname, :database, :username, :password]
+
+    case Enum.find(required, fn key ->
+           value = Keyword.get(repo_config, key)
+           not (is_binary(value) and value != "")
+         end) do
+      nil -> {:ok, repo_config}
+      missing -> {:error, {:invalid_repo_config, missing}}
+    end
+  end
+
+  defp validate_repo_config(_other), do: {:error, {:invalid_repo_config, :not_keyword}}
+
+  defp validate_migration_mode(:manual), do: {:ok, :manual}
+  defp validate_migration_mode(:auto), do: {:ok, :auto}
+  defp validate_migration_mode(other), do: {:error, {:invalid_migration_mode, other}}
+
+  defp validate_external_migration_mode(:manual), do: :ok
+
+  defp validate_external_migration_mode(other),
+    do: {:error, {:invalid_external_migration_mode, other}}
+
+  defp validate_external_repo(repo) when is_atom(repo) do
+    with {:module, ^repo} <- Code.ensure_loaded(repo),
+         true <- function_exported?(repo, :__adapter__, 0),
+         Ecto.Adapters.Postgres <- repo.__adapter__() do
+      {:ok, repo}
+    else
+      _ -> {:error, {:invalid_external_repo, repo}}
+    end
+  end
+
+  defp validate_external_repo(other), do: {:error, {:invalid_external_repo, other}}
+
+  defp encode_schedule_id(nil), do: @nil_schedule_id
+  defp encode_schedule_id(schedule_id) when is_atom(schedule_id), do: Atom.to_string(schedule_id)
+end

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
@@ -1,0 +1,59 @@
+defmodule FavnStoragePostgres.Migrations do
+  @moduledoc false
+
+  alias Ecto.Adapters.SQL
+  alias FavnStoragePostgres.Migrations.CreateFoundation
+
+  @migrations [{20_260_415_100_000, CreateFoundation}]
+  @expected_versions Enum.map(@migrations, fn {version, _module} -> to_string(version) end)
+
+  @spec migrate!(module()) :: :ok
+  def migrate!(repo) when is_atom(repo) do
+    {:ok, _migrated, _apps} =
+      Ecto.Migrator.with_repo(repo, fn migrator_repo ->
+        Ecto.Migrator.run(migrator_repo, @migrations, :up, all: true)
+      end)
+
+    :ok
+  end
+
+  @spec schema_ready?(module()) :: boolean()
+  def schema_ready?(repo) when is_atom(repo) do
+    schema_objects_ready?(repo) and migration_versions_ready?(repo)
+  end
+
+  defp schema_objects_ready?(repo) do
+    required = [
+      "public.favn_manifest_versions",
+      "public.favn_runtime_settings",
+      "public.favn_runs",
+      "public.favn_run_events",
+      "public.favn_scheduler_cursors",
+      "public.favn_run_write_seq"
+    ]
+
+    placeholders = Enum.map_join(1..length(required), ",", &"$#{&1}")
+
+    sql =
+      "SELECT bool_and(to_regclass(name) IS NOT NULL) FROM unnest(ARRAY[#{placeholders}]::text[]) AS name"
+
+    case SQL.query(repo, sql, required) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+
+  defp migration_versions_ready?(repo) do
+    placeholders = Enum.map_join(1..length(@expected_versions), ",", &"$#{&1}")
+
+    sql =
+      "SELECT COUNT(*) = $#{length(@expected_versions) + 1} FROM schema_migrations WHERE version IN (#{placeholders})"
+
+    params = @expected_versions ++ [length(@expected_versions)]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+end

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/create_foundation.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/create_foundation.ex
@@ -1,0 +1,70 @@
+defmodule FavnStoragePostgres.Migrations.CreateFoundation do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE SEQUENCE IF NOT EXISTS favn_run_write_seq START 1")
+
+    create table(:favn_manifest_versions, primary_key: false) do
+      add(:manifest_version_id, :string, primary_key: true)
+      add(:content_hash, :string, null: false)
+      add(:schema_version, :integer, null: false)
+      add(:runner_contract_version, :integer, null: false)
+      add(:serialization_format, :string, null: false)
+      add(:manifest_json, :text, null: false)
+      add(:inserted_at, :utc_datetime_usec)
+    end
+
+    create(unique_index(:favn_manifest_versions, [:content_hash]))
+
+    create table(:favn_runtime_settings, primary_key: false) do
+      add(:key, :string, primary_key: true)
+      add(:value_text, :text)
+      add(:updated_at, :utc_datetime_usec)
+    end
+
+    create table(:favn_runs, primary_key: false) do
+      add(:run_id, :string, primary_key: true)
+      add(:manifest_version_id, :string, null: false)
+      add(:manifest_content_hash, :string, null: false)
+      add(:status, :string, null: false)
+      add(:event_seq, :integer, null: false)
+      add(:snapshot_hash, :string, null: false)
+      add(:updated_seq, :bigint, null: false)
+      add(:inserted_at, :utc_datetime_usec)
+      add(:updated_at, :utc_datetime_usec)
+      add(:run_blob, :binary, null: false)
+    end
+
+    create(index(:favn_runs, [:status, :updated_seq]))
+
+    create table(:favn_run_events, primary_key: false) do
+      add(:run_id, :string, null: false)
+      add(:sequence, :integer, null: false)
+      add(:occurred_at, :utc_datetime_usec)
+      add(:event_blob, :binary, null: false)
+    end
+
+    create(unique_index(:favn_run_events, [:run_id, :sequence]))
+
+    create table(:favn_scheduler_cursors, primary_key: false) do
+      add(:pipeline_module, :string, null: false)
+      add(:schedule_id, :string, null: false)
+      add(:version, :integer, null: false)
+      add(:updated_at, :utc_datetime_usec)
+      add(:state_blob, :binary, null: false)
+    end
+
+    create(unique_index(:favn_scheduler_cursors, [:pipeline_module, :schedule_id]))
+  end
+
+  def down do
+    drop(table(:favn_scheduler_cursors))
+    drop(table(:favn_run_events))
+    drop(table(:favn_runs))
+    drop(table(:favn_runtime_settings))
+    drop(table(:favn_manifest_versions))
+    execute("DROP SEQUENCE IF EXISTS favn_run_write_seq")
+  end
+end

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/repo.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/repo.ex
@@ -1,0 +1,7 @@
+defmodule FavnStoragePostgres.Repo do
+  @moduledoc false
+
+  use Ecto.Repo,
+    otp_app: :favn_storage_postgres,
+    adapter: Ecto.Adapters.Postgres
+end

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/supervisor.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/supervisor.ex
@@ -1,0 +1,57 @@
+defmodule FavnStoragePostgres.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  alias FavnStoragePostgres.Migrations
+  alias FavnStoragePostgres.Repo
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) when is_list(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  def init(opts) do
+    repo_config = Keyword.fetch!(opts, :repo_config)
+    migration_mode = Keyword.get(opts, :migration_mode, :manual)
+
+    :ok = bootstrap_storage(repo_config, migration_mode)
+
+    children = [{Repo, Keyword.put(repo_config, :name, Repo)}]
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp bootstrap_storage(repo_config, :auto) do
+    {:ok, pid} = Repo.start_link(Keyword.put(repo_config, :name, Repo))
+
+    try do
+      Migrations.migrate!(Repo)
+    after
+      GenServer.stop(pid)
+    end
+
+    :ok
+  end
+
+  defp bootstrap_storage(repo_config, :manual) do
+    {:ok, pid} = Repo.start_link(Keyword.put(repo_config, :name, Repo))
+
+    try do
+      if Migrations.schema_ready?(Repo) do
+        :ok
+      else
+        raise "favn postgres schema is not ready; run migrations or set migration_mode: :auto"
+      end
+    after
+      GenServer.stop(pid)
+    end
+
+    :ok
+  end
+
+  defp bootstrap_storage(_repo_config, mode) do
+    raise "invalid postgres migration mode: #{inspect(mode)}"
+  end
+end

--- a/apps/favn_storage_postgres/mix.exs
+++ b/apps/favn_storage_postgres/mix.exs
@@ -5,7 +5,7 @@ defmodule FavnStoragePostgres.MixProject do
     [
       app: :favn_storage_postgres,
       version: "0.5.0-dev",
-      description: "Internal Postgres storage adapter scaffold for orchestrator",
+      description: "Postgres storage adapter for orchestrator runtime state",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -18,13 +18,15 @@ defmodule FavnStoragePostgres.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :ecto_sql]
     ]
   end
 
   defp deps do
     [
-      {:favn_orchestrator, in_umbrella: true}
+      {:favn_orchestrator, in_umbrella: true},
+      {:ecto_sql, "~> 3.13.4"},
+      {:postgrex, "~> 0.22"}
     ]
   end
 end

--- a/apps/favn_storage_postgres/test/adapter_test.exs
+++ b/apps/favn_storage_postgres/test/adapter_test.exs
@@ -1,0 +1,66 @@
+defmodule FavnStoragePostgres.AdapterTest do
+  use ExUnit.Case, async: true
+
+  alias FavnStoragePostgres.Adapter
+
+  defmodule ExternalRepoStub do
+    def __adapter__, do: Ecto.Adapters.Postgres
+  end
+
+  test "managed mode validates repo config" do
+    assert {:error, {:invalid_repo_config, :hostname}} =
+             Adapter.child_spec(repo_mode: :managed, repo_config: [])
+
+    assert {:error, {:invalid_migration_mode, :bad}} =
+             Adapter.child_spec(
+               repo_mode: :managed,
+               repo_config: [
+                 hostname: "localhost",
+                 database: "favn",
+                 username: "postgres",
+                 password: "postgres"
+               ],
+               migration_mode: :bad
+             )
+  end
+
+  test "managed mode returns supervisor child spec" do
+    assert {:ok, child_spec} =
+             Adapter.child_spec(
+               repo_mode: :managed,
+               repo_config: [
+                 hostname: "localhost",
+                 database: "favn",
+                 username: "postgres",
+                 password: "postgres"
+               ],
+               migration_mode: :manual,
+               supervisor_name: Module.concat([__MODULE__, "Supervisor"])
+             )
+
+    assert match?(%{id: _id, start: {_, _, _}}, child_spec)
+  end
+
+  test "external mode requires a postgres repo module and manual migration mode" do
+    assert :none =
+             Adapter.child_spec(
+               repo_mode: :external,
+               repo: ExternalRepoStub,
+               migration_mode: :manual
+             )
+
+    assert {:error, {:invalid_external_repo, :bad}} =
+             Adapter.child_spec(repo_mode: :external, repo: :bad, migration_mode: :manual)
+
+    assert {:error, {:invalid_external_migration_mode, :auto}} =
+             Adapter.child_spec(
+               repo_mode: :external,
+               repo: ExternalRepoStub,
+               migration_mode: :auto
+             )
+  end
+
+  test "invalid repo mode is rejected" do
+    assert {:error, {:invalid_repo_mode, :bogus}} = Adapter.child_spec(repo_mode: :bogus)
+  end
+end

--- a/apps/favn_storage_postgres/test/favn_storage_postgres_test.exs
+++ b/apps/favn_storage_postgres/test/favn_storage_postgres_test.exs
@@ -1,8 +1,0 @@
-defmodule FavnStoragePostgresTest do
-  use ExUnit.Case
-  doctest FavnStoragePostgres
-
-  test "greets the world" do
-    assert FavnStoragePostgres.hello() == :world
-  end
-end

--- a/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
+++ b/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
@@ -1,0 +1,131 @@
+defmodule FavnStoragePostgres.Integration.AdapterLiveTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Manifest
+  alias Favn.Manifest.Version
+  alias FavnOrchestrator.RunState
+  alias FavnStoragePostgres.Adapter
+
+  setup_all do
+    case System.get_env("FAVN_POSTGRES_TEST_URL") do
+      url when is_binary(url) and url != "" ->
+        repo_config = repo_config_from_url(url)
+
+        if valid_repo_config?(repo_config) do
+          unique = System.unique_integer([:positive])
+          supervisor_name = Module.concat([__MODULE__, "Supervisor#{unique}"])
+
+          opts = [
+            repo_mode: :managed,
+            repo_config: Keyword.merge(repo_config, pool_size: 1),
+            migration_mode: :auto,
+            supervisor_name: supervisor_name
+          ]
+
+          assert {:ok, child_spec} = Adapter.child_spec(opts)
+          start_supervised!(child_spec)
+
+          {:ok, opts: opts}
+        else
+          {:ok, opts: nil}
+        end
+
+      _missing ->
+        {:ok, opts: nil}
+    end
+  end
+
+  test "round-trips manifests, runs, events, and scheduler state", context do
+    case context[:opts] do
+      nil ->
+        :ok
+
+      opts ->
+        version = manifest_version("mv_pg_live_#{System.unique_integer([:positive])}")
+
+        assert :ok = Adapter.put_manifest_version(version, opts)
+        assert :ok = Adapter.set_active_manifest_version(version.manifest_version_id, opts)
+        assert {:ok, active_manifest_version_id} = Adapter.get_active_manifest_version(opts)
+        assert active_manifest_version_id == version.manifest_version_id
+
+        run =
+          RunState.new(
+            id: "run_pg_live_#{System.unique_integer([:positive])}",
+            manifest_version_id: version.manifest_version_id,
+            manifest_content_hash: version.content_hash,
+            asset_ref: {MyApp.Asset, :asset}
+          )
+
+        assert :ok = Adapter.put_run(run, opts)
+        assert {:ok, stored_run} = Adapter.get_run(run.id, opts)
+        assert stored_run.id == run.id
+
+        assert :ok =
+                 Adapter.append_run_event(run.id, %{sequence: 1, event_type: :run_started}, opts)
+
+        assert {:ok, [event]} = Adapter.list_run_events(run.id, opts)
+        assert event.sequence == 1
+
+        key = {MyApp.Pipeline, :daily}
+        assert :ok = Adapter.put_scheduler_state(key, %{version: 1}, opts)
+
+        assert {:ok, %Favn.Scheduler.State{schedule_id: :daily}} =
+                 Adapter.get_scheduler_state(key, opts)
+    end
+  end
+
+  defp repo_config_from_url(url) do
+    uri = URI.parse(url)
+
+    [database | _rest] =
+      uri.path
+      |> to_string()
+      |> String.trim_leading("/")
+      |> String.split("/", trim: true)
+
+    [
+      hostname: uri.host,
+      port: uri.port || 5432,
+      database: database,
+      username: uri.userinfo |> user_from_userinfo(),
+      password: uri.userinfo |> password_from_userinfo(),
+      ssl: false,
+      show_sensitive_data_on_connection_error: true
+    ]
+  end
+
+  defp user_from_userinfo(nil), do: nil
+
+  defp user_from_userinfo(userinfo) do
+    userinfo
+    |> String.split(":", parts: 2)
+    |> List.first()
+  end
+
+  defp password_from_userinfo(nil), do: nil
+
+  defp password_from_userinfo(userinfo) do
+    case String.split(userinfo, ":", parts: 2) do
+      [_user] -> nil
+      [_user, password] -> password
+    end
+  end
+
+  defp valid_repo_config?(repo_config) do
+    Enum.all?([:hostname, :database, :username, :password], fn key ->
+      value = Keyword.get(repo_config, key)
+      is_binary(value) and value != ""
+    end)
+  end
+
+  defp manifest_version(manifest_version_id) do
+    manifest = %Manifest{
+      assets: [
+        %Favn.Manifest.Asset{ref: {MyApp.Asset, :asset}, module: MyApp.Asset, name: :asset}
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
+    version
+  end
+end

--- a/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
+++ b/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
@@ -17,7 +17,7 @@ defmodule FavnStoragePostgres.Integration.AdapterLiveTest do
 
           opts = [
             repo_mode: :managed,
-            repo_config: Keyword.merge(repo_config, pool_size: 1),
+            repo_config: Keyword.merge(repo_config, pool_size: 4),
             migration_mode: :auto,
             supervisor_name: supervisor_name
           ]
@@ -74,6 +74,68 @@ defmodule FavnStoragePostgres.Integration.AdapterLiveTest do
     end
   end
 
+  test "enforces run write conflicts under concurrent updates", context do
+    case context[:opts] do
+      nil ->
+        :ok
+
+      opts ->
+        version = manifest_version("mv_pg_concurrency_#{System.unique_integer([:positive])}")
+        assert :ok = Adapter.put_manifest_version(version, opts)
+
+        base =
+          RunState.new(
+            id: "run_pg_concurrent_#{System.unique_integer([:positive])}",
+            manifest_version_id: version.manifest_version_id,
+            manifest_content_hash: version.content_hash,
+            asset_ref: {MyApp.Asset, :asset}
+          )
+
+        assert :ok = Adapter.put_run(base, opts)
+
+        running = %{base | event_seq: 2, status: :running} |> RunState.with_snapshot_hash()
+        failed = %{base | event_seq: 2, status: :error} |> RunState.with_snapshot_hash()
+
+        results =
+          concurrent_results(fn -> Adapter.put_run(running, opts) end, fn ->
+            Adapter.put_run(failed, opts)
+          end)
+
+        assert Enum.sort(results) == [:ok, {:error, :conflicting_snapshot}]
+    end
+  end
+
+  test "enforces scheduler version checks under concurrent updates", context do
+    case context[:opts] do
+      nil ->
+        :ok
+
+      opts ->
+        key = {MyApp.Pipeline, :daily}
+        assert :ok = Adapter.put_scheduler_state(key, %{version: 1}, opts)
+
+        results =
+          concurrent_results(
+            fn ->
+              Adapter.put_scheduler_state(
+                key,
+                %{version: 2, last_due_at: DateTime.utc_now()},
+                opts
+              )
+            end,
+            fn ->
+              Adapter.put_scheduler_state(
+                key,
+                %{version: 2, last_due_at: DateTime.utc_now()},
+                opts
+              )
+            end
+          )
+
+        assert Enum.sort(results) == [:ok, {:error, :stale_scheduler_state}]
+    end
+  end
+
   defp repo_config_from_url(url) do
     uri = URI.parse(url)
 
@@ -127,5 +189,28 @@ defmodule FavnStoragePostgres.Integration.AdapterLiveTest do
 
     {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
     version
+  end
+
+  defp concurrent_results(fun_a, fun_b) do
+    parent = self()
+
+    task_a = Task.async(fn -> await_release(parent, :task_a, fun_a) end)
+    task_b = Task.async(fn -> await_release(parent, :task_b, fun_b) end)
+
+    assert_receive {:ready, :task_a}
+    assert_receive {:ready, :task_b}
+
+    send(task_a.pid, :go)
+    send(task_b.pid, :go)
+
+    [Task.await(task_a, 5_000), Task.await(task_b, 5_000)]
+  end
+
+  defp await_release(parent, label, fun) do
+    send(parent, {:ready, label})
+
+    receive do
+      :go -> fun.()
+    end
   end
 end

--- a/apps/favn_storage_sqlite/README.md
+++ b/apps/favn_storage_sqlite/README.md
@@ -11,6 +11,8 @@ Visibility:
 Allowed dependencies in Phase 1:
 
 - `favn_orchestrator`
+- `ecto_sql`
+- `ecto_sqlite3`
 
 Must not depend on in Phase 1:
 
@@ -19,4 +21,24 @@ Must not depend on in Phase 1:
 
 Current status:
 
-- scaffold-only, not implemented yet
+- implemented initial Phase 6 SQLite adapter foundation
+- module entrypoint: `FavnStorageSqlite.Adapter`
+- managed repo bootstrap with startup migrations
+- persists manifest versions, active manifest pointer, run snapshots, run events, and scheduler cursors
+
+## Runtime configuration
+
+SQLite is the persistent local-dev adapter path.
+
+```elixir
+config :favn_orchestrator,
+  storage_adapter: FavnStorageSqlite.Adapter,
+  storage_adapter_opts: [
+    database: ".favn/dev.sqlite3",
+    migration_mode: :auto,
+    pool_size: 1,
+    busy_timeout: 5_000
+  ]
+```
+
+Use `migration_mode: :manual` only when schema lifecycle is controlled externally.

--- a/apps/favn_storage_sqlite/README.md
+++ b/apps/favn_storage_sqlite/README.md
@@ -25,6 +25,7 @@ Current status:
 - module entrypoint: `FavnStorageSqlite.Adapter`
 - managed repo bootstrap with startup migrations
 - persists manifest versions, active manifest pointer, run snapshots, run events, and scheduler cursors
+- current persisted run/event/scheduler payloads use BEAM term blobs as a temporary foundation choice; this should be replaced with more inspectable canonical payload storage before final cutover
 
 ## Runtime configuration
 
@@ -42,3 +43,8 @@ config :favn_orchestrator,
 ```
 
 Use `migration_mode: :manual` only when schema lifecycle is controlled externally.
+
+## Instance model
+
+- current managed mode supports one SQLite adapter instance per BEAM node
+- the adapter repo is globally named inside the adapter app, so `supervisor_name` should be treated as supervisor identity only, not as a multi-instance isolation mechanism

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite.ex
@@ -1,18 +1,5 @@
 defmodule FavnStorageSqlite do
   @moduledoc """
-  Documentation for `FavnStorageSqlite`.
+  SQLite storage adapter app for orchestrator control-plane persistence.
   """
-
-  @doc """
-  Hello world.
-
-  ## Examples
-
-      iex> FavnStorageSqlite.hello()
-      :world
-
-  """
-  def hello do
-    :world
-  end
 end

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/adapter.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/adapter.ex
@@ -1,0 +1,605 @@
+defmodule FavnStorageSqlite.Adapter do
+  @moduledoc """
+  SQLite-backed storage adapter implementing `Favn.Storage.Adapter`.
+  """
+
+  @behaviour Favn.Storage.Adapter
+
+  alias Ecto.Adapters.SQL
+  alias Favn.Manifest.Version
+  alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage.ManifestCodec
+  alias FavnOrchestrator.Storage.RunEventCodec
+  alias FavnOrchestrator.Storage.RunStateCodec
+  alias FavnOrchestrator.Storage.SchedulerStateCodec
+  alias FavnOrchestrator.Storage.WriteSemantics
+  alias FavnStorageSqlite.Repo
+  alias FavnStorageSqlite.Supervisor, as: SQLiteSupervisor
+
+  @active_manifest_key "active_manifest_version_id"
+  @write_counter_key "run_write_order"
+  @nil_schedule_id "__nil__"
+
+  @impl true
+  def child_spec(opts) when is_list(opts) do
+    with {:ok, normalized} <- normalize_opts(opts) do
+      supervisor_name = Keyword.fetch!(normalized, :supervisor_name)
+
+      if Process.whereis(supervisor_name) do
+        :none
+      else
+        {:ok,
+         Supervisor.child_spec(
+           {SQLiteSupervisor, normalized},
+           id: supervisor_name,
+           restart: :permanent,
+           shutdown: 5_000,
+           type: :supervisor
+         )}
+      end
+    end
+  end
+
+  @impl true
+  def put_manifest_version(%Version{} = version, opts) when is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, record} <- ManifestCodec.to_record(version),
+         {:ok, existing} <- fetch_manifest_hash(repo, record.manifest_version_id) do
+      case existing do
+        nil -> insert_manifest_record(repo, record)
+        hash when hash == record.content_hash -> :ok
+        _other -> {:error, :manifest_version_conflict}
+      end
+    end
+  end
+
+  @impl true
+  def get_manifest_version(manifest_version_id, opts)
+      when is_binary(manifest_version_id) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, row} <- fetch_manifest_record(repo, manifest_version_id) do
+      case row do
+        nil -> {:error, :manifest_version_not_found}
+        record -> ManifestCodec.from_record(record)
+      end
+    end
+  end
+
+  @impl true
+  def list_manifest_versions(opts) when is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, rows} <- fetch_manifest_records(repo) do
+      rows
+      |> Enum.reduce_while({:ok, []}, fn record, {:ok, acc} ->
+        case ManifestCodec.from_record(record) do
+          {:ok, version} -> {:cont, {:ok, [version | acc]}}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+      end)
+      |> case do
+        {:ok, versions} -> {:ok, Enum.reverse(versions)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def set_active_manifest_version(manifest_version_id, opts)
+      when is_binary(manifest_version_id) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, existing} <- fetch_manifest_hash(repo, manifest_version_id),
+         false <- is_nil(existing) do
+      sql =
+        """
+        INSERT INTO favn_runtime_settings (key, value_text, updated_at)
+        VALUES (?1, ?2, ?3)
+        ON CONFLICT(key) DO UPDATE SET value_text = excluded.value_text, updated_at = excluded.updated_at
+        """
+
+      case SQL.query(repo, sql, [@active_manifest_key, manifest_version_id, DateTime.utc_now()]) do
+        {:ok, _} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    else
+      true -> {:error, :manifest_version_not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @impl true
+  def get_active_manifest_version(opts) when is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      sql = "SELECT value_text FROM favn_runtime_settings WHERE key = ?1 LIMIT 1"
+
+      case SQL.query(repo, sql, [@active_manifest_key]) do
+        {:ok, %{rows: [[manifest_version_id]]}}
+        when is_binary(manifest_version_id) and manifest_version_id != "" ->
+          {:ok, manifest_version_id}
+
+        {:ok, %{rows: []}} ->
+          {:error, :active_manifest_not_set}
+
+        {:ok, _} ->
+          {:error, :active_manifest_not_set}
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def put_run(%RunState{} = run, opts) when is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, normalized} <- RunStateCodec.normalize(run),
+         {:ok, existing} <- fetch_run_head(repo, normalized.id),
+         decision <- decide_run_write(existing, normalized) do
+      persist_run_decision(repo, decision, normalized)
+    end
+  end
+
+  @impl true
+  def get_run(run_id, opts) when is_binary(run_id) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      sql = "SELECT run_blob FROM favn_runs WHERE run_id = ?1 LIMIT 1"
+
+      case SQL.query(repo, sql, [run_id]) do
+        {:ok, %{rows: [[blob]]}} -> decode_run(blob)
+        {:ok, %{rows: []}} -> {:error, :not_found}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_runs(run_opts, opts) when is_list(run_opts) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      {sql, params} = list_runs_query(run_opts)
+
+      case SQL.query(repo, sql, params) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> Enum.reduce_while({:ok, []}, fn [blob], {:ok, acc} ->
+            case decode_run(blob) do
+              {:ok, run} -> {:cont, {:ok, [run | acc]}}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+          |> case do
+            {:ok, runs} -> {:ok, Enum.reverse(runs)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def append_run_event(run_id, event, opts)
+      when is_binary(run_id) and is_map(event) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, normalized} <- RunEventCodec.normalize(run_id, event) do
+      sql =
+        """
+        INSERT INTO favn_run_events (run_id, sequence, occurred_at, event_blob)
+        VALUES (?1, ?2, ?3, ?4)
+        """
+
+      case SQL.query(repo, sql, [
+             run_id,
+             normalized.sequence,
+             normalized.occurred_at,
+             encode_term(normalized)
+           ]) do
+        {:ok, _} ->
+          :ok
+
+        {:error, %{sqlite: %{code: :constraint_failed}}} ->
+          {:error, :conflicting_event_sequence}
+
+        {:error, %Exqlite.Error{message: message} = reason} when is_binary(message) ->
+          if String.contains?(message, "UNIQUE constraint failed") do
+            {:error, :conflicting_event_sequence}
+          else
+            {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_run_events(run_id, opts) when is_binary(run_id) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      sql = "SELECT event_blob FROM favn_run_events WHERE run_id = ?1 ORDER BY sequence ASC"
+
+      case SQL.query(repo, sql, [run_id]) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> Enum.reduce_while({:ok, []}, fn [blob], {:ok, acc} ->
+            case decode_term(blob) do
+              {:ok, event} when is_map(event) -> {:cont, {:ok, [event | acc]}}
+              {:ok, other} -> {:halt, {:error, {:invalid_event_blob, other}}}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+          |> case do
+            {:ok, events} -> {:ok, Enum.reverse(events)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def put_scheduler_state(key, state, opts) when is_map(state) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, normalized_key} <- SchedulerStateCodec.normalize_key(key),
+         {:ok, normalized_state} <- SchedulerStateCodec.normalize_state(state),
+         {:ok, existing_version} <- fetch_scheduler_version(repo, normalized_key),
+         {:ok, write_version} <-
+           resolve_scheduler_version(existing_version, normalized_state[:version]) do
+      persisted = Map.put(normalized_state, :version, write_version)
+
+      sql =
+        """
+        INSERT INTO favn_scheduler_cursors (pipeline_module, schedule_id, version, updated_at, state_blob)
+        VALUES (?1, ?2, ?3, ?4, ?5)
+        ON CONFLICT(pipeline_module, schedule_id) DO UPDATE SET
+          version = excluded.version,
+          updated_at = excluded.updated_at,
+          state_blob = excluded.state_blob
+        """
+
+      {pipeline_module, schedule_id} = normalized_key
+
+      params = [
+        Atom.to_string(pipeline_module),
+        encode_schedule_id(schedule_id),
+        write_version,
+        DateTime.utc_now(),
+        encode_term(persisted)
+      ]
+
+      case SQL.query(repo, sql, params) do
+        {:ok, _} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def get_scheduler_state(key, opts) when is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, {pipeline_module, schedule_id}} <- SchedulerStateCodec.normalize_key(key) do
+      sql =
+        """
+        SELECT state_blob
+        FROM favn_scheduler_cursors
+        WHERE pipeline_module = ?1 AND schedule_id = ?2
+        LIMIT 1
+        """
+
+      params = [Atom.to_string(pipeline_module), encode_schedule_id(schedule_id)]
+
+      case SQL.query(repo, sql, params) do
+        {:ok, %{rows: []}} ->
+          {:ok, nil}
+
+        {:ok, %{rows: [[blob]]}} ->
+          with {:ok, decoded} <- decode_term(blob),
+               true <- is_map(decoded) do
+            {:ok,
+             struct(
+               Favn.Scheduler.State,
+               Map.merge(decoded, %{pipeline_module: pipeline_module, schedule_id: schedule_id})
+             )}
+          else
+            false -> {:error, :invalid_scheduler_blob}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  defp persist_run_decision(_repo, :idempotent, _run), do: :ok
+  defp persist_run_decision(_repo, {:error, reason}, _run), do: {:error, reason}
+
+  defp persist_run_decision(repo, decision, run) when decision in [:insert, :replace] do
+    with {:ok, updated_seq} <- next_updated_seq(repo) do
+      sql =
+        """
+        INSERT INTO favn_runs (
+          run_id,
+          manifest_version_id,
+          manifest_content_hash,
+          status,
+          event_seq,
+          snapshot_hash,
+          updated_seq,
+          inserted_at,
+          updated_at,
+          run_blob
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+        ON CONFLICT(run_id) DO UPDATE SET
+          manifest_version_id = excluded.manifest_version_id,
+          manifest_content_hash = excluded.manifest_content_hash,
+          status = excluded.status,
+          event_seq = excluded.event_seq,
+          snapshot_hash = excluded.snapshot_hash,
+          updated_seq = excluded.updated_seq,
+          inserted_at = excluded.inserted_at,
+          updated_at = excluded.updated_at,
+          run_blob = excluded.run_blob
+        """
+
+      params = [
+        run.id,
+        run.manifest_version_id,
+        run.manifest_content_hash,
+        to_string(run.status),
+        run.event_seq,
+        run.snapshot_hash,
+        updated_seq,
+        run.inserted_at,
+        run.updated_at,
+        encode_term(run)
+      ]
+
+      case SQL.query(repo, sql, params) do
+        {:ok, _} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp decide_run_write(nil, run),
+    do: WriteSemantics.decide(nil, nil, run.event_seq, run.snapshot_hash)
+
+  defp decide_run_write({existing_event_seq, existing_hash}, run) do
+    WriteSemantics.decide(existing_event_seq, existing_hash, run.event_seq, run.snapshot_hash)
+  end
+
+  defp next_updated_seq(repo) do
+    sql =
+      """
+      INSERT INTO favn_counters (name, value)
+      VALUES (?1, 1)
+      ON CONFLICT(name) DO UPDATE SET value = value + 1
+      RETURNING value
+      """
+
+    case SQL.query(repo, sql, [@write_counter_key]) do
+      {:ok, %{rows: [[value]]}} when is_integer(value) -> {:ok, value}
+      {:ok, _} -> {:error, :invalid_counter_value}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_manifest_hash(repo, manifest_version_id) do
+    sql = "SELECT content_hash FROM favn_manifest_versions WHERE manifest_version_id = ?1 LIMIT 1"
+
+    case SQL.query(repo, sql, [manifest_version_id]) do
+      {:ok, %{rows: [[hash]]}} -> {:ok, hash}
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_manifest_record(repo, manifest_version_id) do
+    sql =
+      """
+      SELECT manifest_version_id, content_hash, schema_version, runner_contract_version, serialization_format, manifest_json, inserted_at
+      FROM favn_manifest_versions
+      WHERE manifest_version_id = ?1
+      LIMIT 1
+      """
+
+    case SQL.query(repo, sql, [manifest_version_id]) do
+      {:ok, %{rows: [[id, hash, schema, runner_contract, format, manifest_json, inserted_at]]}} ->
+        {:ok,
+         %{
+           manifest_version_id: id,
+           content_hash: hash,
+           schema_version: schema,
+           runner_contract_version: runner_contract,
+           serialization_format: format,
+           manifest_json: manifest_json,
+           inserted_at: inserted_at
+         }}
+
+      {:ok, %{rows: []}} ->
+        {:ok, nil}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp fetch_manifest_records(repo) do
+    sql =
+      """
+      SELECT manifest_version_id, content_hash, schema_version, runner_contract_version, serialization_format, manifest_json, inserted_at
+      FROM favn_manifest_versions
+      ORDER BY manifest_version_id ASC
+      """
+
+    case SQL.query(repo, sql, []) do
+      {:ok, %{rows: rows}} ->
+        mapped =
+          Enum.map(rows, fn [
+                              id,
+                              hash,
+                              schema,
+                              runner_contract,
+                              format,
+                              manifest_json,
+                              inserted_at
+                            ] ->
+            %{
+              manifest_version_id: id,
+              content_hash: hash,
+              schema_version: schema,
+              runner_contract_version: runner_contract,
+              serialization_format: format,
+              manifest_json: manifest_json,
+              inserted_at: inserted_at
+            }
+          end)
+
+        {:ok, mapped}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp fetch_run_head(repo, run_id) do
+    sql = "SELECT event_seq, snapshot_hash FROM favn_runs WHERE run_id = ?1 LIMIT 1"
+
+    case SQL.query(repo, sql, [run_id]) do
+      {:ok, %{rows: [[event_seq, snapshot_hash]]}} -> {:ok, {event_seq, snapshot_hash}}
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_scheduler_version(repo, {pipeline_module, schedule_id}) do
+    sql =
+      """
+      SELECT version
+      FROM favn_scheduler_cursors
+      WHERE pipeline_module = ?1 AND schedule_id = ?2
+      LIMIT 1
+      """
+
+    params = [Atom.to_string(pipeline_module), encode_schedule_id(schedule_id)]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: [[version]]}} when is_integer(version) -> {:ok, version}
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:ok, _} -> {:error, :invalid_scheduler_version}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_scheduler_version(nil, nil), do: {:ok, 1}
+  defp resolve_scheduler_version(nil, 1), do: {:ok, 1}
+  defp resolve_scheduler_version(nil, _incoming), do: {:error, :invalid_scheduler_version}
+  defp resolve_scheduler_version(existing, nil) when is_integer(existing), do: {:ok, existing + 1}
+
+  defp resolve_scheduler_version(existing, incoming)
+       when is_integer(existing) and is_integer(incoming) and incoming == existing + 1,
+       do: {:ok, incoming}
+
+  defp resolve_scheduler_version(_existing, _incoming), do: {:error, :stale_scheduler_state}
+
+  defp insert_manifest_record(repo, record) do
+    sql =
+      """
+      INSERT INTO favn_manifest_versions (
+        manifest_version_id,
+        content_hash,
+        schema_version,
+        runner_contract_version,
+        serialization_format,
+        manifest_json,
+        inserted_at
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7)
+      """
+
+    params = [
+      record.manifest_version_id,
+      record.content_hash,
+      record.schema_version,
+      record.runner_contract_version,
+      record.serialization_format,
+      record.manifest_json,
+      record.inserted_at
+    ]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp list_runs_query(run_opts) do
+    status = Keyword.get(run_opts, :status)
+    limit = Keyword.get(run_opts, :limit)
+
+    cond do
+      is_nil(status) and is_nil(limit) ->
+        {"SELECT run_blob FROM favn_runs ORDER BY updated_seq DESC, run_id DESC", []}
+
+      is_nil(status) ->
+        {"SELECT run_blob FROM favn_runs ORDER BY updated_seq DESC, run_id DESC LIMIT ?1",
+         [limit]}
+
+      is_nil(limit) ->
+        {
+          "SELECT run_blob FROM favn_runs WHERE status = ?1 ORDER BY updated_seq DESC, run_id DESC",
+          [Atom.to_string(status)]
+        }
+
+      true ->
+        {
+          "SELECT run_blob FROM favn_runs WHERE status = ?1 ORDER BY updated_seq DESC, run_id DESC LIMIT ?2",
+          [Atom.to_string(status), limit]
+        }
+    end
+  end
+
+  defp decode_run(blob) do
+    with {:ok, decoded} <- decode_term(blob),
+         %RunState{} = run_state <- decoded,
+         {:ok, normalized} <- RunStateCodec.normalize(run_state) do
+      {:ok, normalized}
+    else
+      {:error, reason} -> {:error, reason}
+      other -> {:error, {:invalid_run_blob, other}}
+    end
+  end
+
+  defp encode_term(value), do: :erlang.term_to_binary(value)
+
+  defp decode_term(blob) when is_binary(blob) do
+    {:ok, :erlang.binary_to_term(blob, [:safe])}
+  rescue
+    error -> {:error, {:invalid_blob, error}}
+  end
+
+  defp repo_name(opts) do
+    with {:ok, _normalized} <- normalize_opts(opts), do: {:ok, Repo}
+  end
+
+  defp normalize_opts(opts) do
+    database = Keyword.get(opts, :database)
+
+    if is_binary(database) and database != "" do
+      {:ok,
+       [
+         database: database,
+         pool_size: Keyword.get(opts, :pool_size, 1),
+         busy_timeout: Keyword.get(opts, :busy_timeout, 5_000),
+         migration_mode: Keyword.get(opts, :migration_mode, :auto),
+         supervisor_name: Keyword.get(opts, :supervisor_name, FavnStorageSqlite.Supervisor)
+       ]}
+    else
+      {:error, :sqlite_database_required}
+    end
+  end
+
+  defp encode_schedule_id(nil), do: @nil_schedule_id
+  defp encode_schedule_id(schedule_id) when is_atom(schedule_id), do: Atom.to_string(schedule_id)
+end

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/adapter.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/adapter.ex
@@ -13,6 +13,7 @@ defmodule FavnStorageSqlite.Adapter do
   alias FavnOrchestrator.Storage.RunStateCodec
   alias FavnOrchestrator.Storage.SchedulerStateCodec
   alias FavnOrchestrator.Storage.WriteSemantics
+  alias FavnStorageSqlite.Migrations
   alias FavnStorageSqlite.Repo
   alias FavnStorageSqlite.Supervisor, as: SQLiteSupervisor
 
@@ -131,10 +132,8 @@ defmodule FavnStorageSqlite.Adapter do
   @impl true
   def put_run(%RunState{} = run, opts) when is_list(opts) do
     with {:ok, repo} <- repo_name(opts),
-         {:ok, normalized} <- RunStateCodec.normalize(run),
-         {:ok, existing} <- fetch_run_head(repo, normalized.id),
-         decision <- decide_run_write(existing, normalized) do
-      persist_run_decision(repo, decision, normalized)
+         {:ok, normalized} <- RunStateCodec.normalize(run) do
+      persist_run(repo, normalized)
     end
   end
 
@@ -242,36 +241,8 @@ defmodule FavnStorageSqlite.Adapter do
   def put_scheduler_state(key, state, opts) when is_map(state) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts),
          {:ok, normalized_key} <- SchedulerStateCodec.normalize_key(key),
-         {:ok, normalized_state} <- SchedulerStateCodec.normalize_state(state),
-         {:ok, existing_version} <- fetch_scheduler_version(repo, normalized_key),
-         {:ok, write_version} <-
-           resolve_scheduler_version(existing_version, normalized_state[:version]) do
-      persisted = Map.put(normalized_state, :version, write_version)
-
-      sql =
-        """
-        INSERT INTO favn_scheduler_cursors (pipeline_module, schedule_id, version, updated_at, state_blob)
-        VALUES (?1, ?2, ?3, ?4, ?5)
-        ON CONFLICT(pipeline_module, schedule_id) DO UPDATE SET
-          version = excluded.version,
-          updated_at = excluded.updated_at,
-          state_blob = excluded.state_blob
-        """
-
-      {pipeline_module, schedule_id} = normalized_key
-
-      params = [
-        Atom.to_string(pipeline_module),
-        encode_schedule_id(schedule_id),
-        write_version,
-        DateTime.utc_now(),
-        encode_term(persisted)
-      ]
-
-      case SQL.query(repo, sql, params) do
-        {:ok, _} -> :ok
-        {:error, reason} -> {:error, reason}
-      end
+         {:ok, normalized_state} <- SchedulerStateCodec.normalize_state(state) do
+      persist_scheduler_state(repo, normalized_key, normalized_state)
     end
   end
 
@@ -281,7 +252,7 @@ defmodule FavnStorageSqlite.Adapter do
          {:ok, {pipeline_module, schedule_id}} <- SchedulerStateCodec.normalize_key(key) do
       sql =
         """
-        SELECT state_blob
+        SELECT version, state_blob
         FROM favn_scheduler_cursors
         WHERE pipeline_module = ?1 AND schedule_id = ?2
         LIMIT 1
@@ -293,13 +264,17 @@ defmodule FavnStorageSqlite.Adapter do
         {:ok, %{rows: []}} ->
           {:ok, nil}
 
-        {:ok, %{rows: [[blob]]}} ->
+        {:ok, %{rows: [[version, blob]]}} ->
           with {:ok, decoded} <- decode_term(blob),
                true <- is_map(decoded) do
             {:ok,
              struct(
                Favn.Scheduler.State,
-               Map.merge(decoded, %{pipeline_module: pipeline_module, schedule_id: schedule_id})
+               Map.merge(decoded, %{
+                 pipeline_module: pipeline_module,
+                 schedule_id: schedule_id,
+                 version: version
+               })
              )}
           else
             false -> {:error, :invalid_scheduler_blob}
@@ -312,10 +287,20 @@ defmodule FavnStorageSqlite.Adapter do
     end
   end
 
-  defp persist_run_decision(_repo, :idempotent, _run), do: :ok
-  defp persist_run_decision(_repo, {:error, reason}, _run), do: {:error, reason}
+  defp persist_run(repo, run) do
+    repo.transact(fn ->
+      case guarded_put_run(repo, run) do
+        :ok -> {:ok, :ok}
+        {:error, reason} -> repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
-  defp persist_run_decision(repo, decision, run) when decision in [:insert, :replace] do
+  defp guarded_put_run(repo, run) do
     with {:ok, updated_seq} <- next_updated_seq(repo) do
       sql =
         """
@@ -341,6 +326,7 @@ defmodule FavnStorageSqlite.Adapter do
           inserted_at = excluded.inserted_at,
           updated_at = excluded.updated_at,
           run_blob = excluded.run_blob
+        WHERE excluded.event_seq > favn_runs.event_seq
         """
 
       params = [
@@ -357,17 +343,133 @@ defmodule FavnStorageSqlite.Adapter do
       ]
 
       case SQL.query(repo, sql, params) do
-        {:ok, _} -> :ok
+        {:ok, %{num_rows: num_rows}} when num_rows > 0 -> :ok
+        {:ok, _} -> classify_run_write_result(repo, run)
         {:error, reason} -> {:error, reason}
       end
     end
   end
 
-  defp decide_run_write(nil, run),
-    do: WriteSemantics.decide(nil, nil, run.event_seq, run.snapshot_hash)
+  defp classify_run_write_result(repo, run) do
+    with {:ok, existing} <- fetch_run_head(repo, run.id) do
+      case existing do
+        {existing_event_seq, existing_hash} ->
+          case WriteSemantics.decide(
+                 existing_event_seq,
+                 existing_hash,
+                 run.event_seq,
+                 run.snapshot_hash
+               ) do
+            :idempotent -> :ok
+            {:error, reason} -> {:error, reason}
+            other -> {:error, {:unexpected_run_write_decision, other}}
+          end
 
-  defp decide_run_write({existing_event_seq, existing_hash}, run) do
-    WriteSemantics.decide(existing_event_seq, existing_hash, run.event_seq, run.snapshot_hash)
+        nil ->
+          {:error, :run_write_not_applied}
+      end
+    end
+  end
+
+  defp persist_scheduler_state(repo, key, normalized_state) do
+    repo.transact(fn ->
+      case guarded_put_scheduler_state(repo, key, normalized_state) do
+        :ok -> {:ok, :ok}
+        {:error, reason} -> repo.rollback(reason)
+      end
+    end)
+    |> case do
+      {:ok, :ok} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp guarded_put_scheduler_state(repo, {pipeline_module, schedule_id} = key, normalized_state) do
+    encoded_state = normalized_state |> Map.delete(:version) |> encode_term()
+    encoded_schedule_id = encode_schedule_id(schedule_id)
+    updated_at = DateTime.utc_now()
+
+    {sql, params} =
+      scheduler_upsert_query(
+        pipeline_module,
+        encoded_schedule_id,
+        normalized_state,
+        updated_at,
+        encoded_state
+      )
+
+    case SQL.query(repo, sql, params) do
+      {:ok, %{num_rows: num_rows}} when num_rows > 0 ->
+        :ok
+
+      {:ok, _} ->
+        classify_scheduler_write_result(repo, key, normalized_state[:version])
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp scheduler_upsert_query(
+         pipeline_module,
+         encoded_schedule_id,
+         normalized_state,
+         updated_at,
+         encoded_state
+       ) do
+    pipeline_module_name = Atom.to_string(pipeline_module)
+
+    case normalized_state[:version] do
+      nil ->
+        {
+          """
+          INSERT INTO favn_scheduler_cursors (pipeline_module, schedule_id, version, updated_at, state_blob)
+          VALUES (?1, ?2, 1, ?3, ?4)
+          ON CONFLICT(pipeline_module, schedule_id) DO UPDATE SET
+            version = favn_scheduler_cursors.version + 1,
+            updated_at = excluded.updated_at,
+            state_blob = excluded.state_blob
+          """,
+          [pipeline_module_name, encoded_schedule_id, updated_at, encoded_state]
+        }
+
+      incoming_version ->
+        expected_previous = incoming_version - 1
+
+        {
+          """
+          INSERT INTO favn_scheduler_cursors (pipeline_module, schedule_id, version, updated_at, state_blob)
+          SELECT ?1, ?2, ?3, ?4, ?5
+          WHERE ?3 = 1 OR EXISTS (
+            SELECT 1
+            FROM favn_scheduler_cursors
+            WHERE pipeline_module = ?1 AND schedule_id = ?2
+          )
+          ON CONFLICT(pipeline_module, schedule_id) DO UPDATE SET
+            version = excluded.version,
+            updated_at = excluded.updated_at,
+            state_blob = excluded.state_blob
+          WHERE favn_scheduler_cursors.version = ?6
+          """,
+          [
+            pipeline_module_name,
+            encoded_schedule_id,
+            incoming_version,
+            updated_at,
+            encoded_state,
+            expected_previous
+          ]
+        }
+    end
+  end
+
+  defp classify_scheduler_write_result(repo, key, incoming_version) do
+    with {:ok, existing_version} <- fetch_scheduler_version(repo, key) do
+      case resolve_scheduler_version(existing_version, incoming_version) do
+        {:ok, _version} -> {:error, :scheduler_write_not_applied}
+        {:error, reason} -> {:error, reason}
+      end
+    end
   end
 
   defp next_updated_seq(repo) do
@@ -580,7 +682,10 @@ defmodule FavnStorageSqlite.Adapter do
   end
 
   defp repo_name(opts) do
-    with {:ok, _normalized} <- normalize_opts(opts), do: {:ok, Repo}
+    with {:ok, normalized} <- normalize_opts(opts),
+         :ok <- ensure_schema_ready(normalized) do
+      {:ok, Repo}
+    end
   end
 
   defp normalize_opts(opts) do
@@ -597,6 +702,13 @@ defmodule FavnStorageSqlite.Adapter do
        ]}
     else
       {:error, :sqlite_database_required}
+    end
+  end
+
+  defp ensure_schema_ready(normalized_opts) do
+    case Keyword.fetch!(normalized_opts, :migration_mode) do
+      :auto -> :ok
+      :manual -> if(Migrations.schema_ready?(Repo), do: :ok, else: {:error, :schema_not_ready})
     end
   end
 

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
@@ -1,0 +1,17 @@
+defmodule FavnStorageSqlite.Migrations do
+  @moduledoc false
+
+  alias FavnStorageSqlite.Migrations.CreateFoundation
+
+  @migrations [{20_260_415_000_000, CreateFoundation}]
+
+  @spec migrate!(module()) :: :ok
+  def migrate!(repo) when is_atom(repo) do
+    {:ok, _migrated, _apps} =
+      Ecto.Migrator.with_repo(repo, fn migrator_repo ->
+        Ecto.Migrator.run(migrator_repo, @migrations, :up, all: true)
+      end)
+
+    :ok
+  end
+end

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
@@ -1,9 +1,11 @@
 defmodule FavnStorageSqlite.Migrations do
   @moduledoc false
 
+  alias Ecto.Adapters.SQL
   alias FavnStorageSqlite.Migrations.CreateFoundation
 
   @migrations [{20_260_415_000_000, CreateFoundation}]
+  @expected_versions Enum.map(@migrations, fn {version, _module} -> to_string(version) end)
 
   @spec migrate!(module()) :: :ok
   def migrate!(repo) when is_atom(repo) do
@@ -13,5 +15,49 @@ defmodule FavnStorageSqlite.Migrations do
       end)
 
     :ok
+  end
+
+  @spec schema_ready?(module()) :: boolean()
+  def schema_ready?(repo) when is_atom(repo) do
+    schema_objects_ready?(repo) and migration_versions_ready?(repo)
+  end
+
+  defp schema_objects_ready?(repo) do
+    required = [
+      "favn_manifest_versions",
+      "favn_runtime_settings",
+      "favn_runs",
+      "favn_run_events",
+      "favn_scheduler_cursors",
+      "favn_counters"
+    ]
+
+    placeholders = Enum.map_join(1..length(required), ",", &"?#{&1}")
+
+    sql =
+      "SELECT COUNT(*) = ?#{length(required) + 1} FROM sqlite_master WHERE type = 'table' AND name IN (#{placeholders})"
+
+    params = required ++ [length(required)]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: [[1]]}} -> true
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
+  end
+
+  defp migration_versions_ready?(repo) do
+    placeholders = Enum.map_join(1..length(@expected_versions), ",", &"?#{&1}")
+
+    sql =
+      "SELECT COUNT(*) = ?#{length(@expected_versions) + 1} FROM schema_migrations WHERE version IN (#{placeholders})"
+
+    params = @expected_versions ++ [length(@expected_versions)]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: [[1]]}} -> true
+      {:ok, %{rows: [[true]]}} -> true
+      _ -> false
+    end
   end
 end

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/create_foundation.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/create_foundation.ex
@@ -1,0 +1,64 @@
+defmodule FavnStorageSqlite.Migrations.CreateFoundation do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    create table(:favn_manifest_versions, primary_key: false) do
+      add(:manifest_version_id, :string, primary_key: true)
+      add(:content_hash, :string, null: false)
+      add(:schema_version, :integer, null: false)
+      add(:runner_contract_version, :integer, null: false)
+      add(:serialization_format, :string, null: false)
+      add(:manifest_json, :text, null: false)
+      add(:inserted_at, :utc_datetime_usec)
+    end
+
+    create(unique_index(:favn_manifest_versions, [:content_hash]))
+
+    create table(:favn_runtime_settings, primary_key: false) do
+      add(:key, :string, primary_key: true)
+      add(:value_text, :text)
+      add(:updated_at, :utc_datetime_usec)
+    end
+
+    create table(:favn_runs, primary_key: false) do
+      add(:run_id, :string, primary_key: true)
+      add(:manifest_version_id, :string, null: false)
+      add(:manifest_content_hash, :string, null: false)
+      add(:status, :string, null: false)
+      add(:event_seq, :integer, null: false)
+      add(:snapshot_hash, :string, null: false)
+      add(:updated_seq, :integer, null: false)
+      add(:inserted_at, :utc_datetime_usec)
+      add(:updated_at, :utc_datetime_usec)
+      add(:run_blob, :binary, null: false)
+    end
+
+    create(index(:favn_runs, [:status, :updated_seq]))
+
+    create table(:favn_run_events, primary_key: false) do
+      add(:run_id, :string, null: false)
+      add(:sequence, :integer, null: false)
+      add(:occurred_at, :utc_datetime_usec)
+      add(:event_blob, :binary, null: false)
+    end
+
+    create(unique_index(:favn_run_events, [:run_id, :sequence]))
+
+    create table(:favn_scheduler_cursors, primary_key: false) do
+      add(:pipeline_module, :string, null: false)
+      add(:schedule_id, :string, null: false)
+      add(:version, :integer, null: false)
+      add(:updated_at, :utc_datetime_usec)
+      add(:state_blob, :binary, null: false)
+    end
+
+    create(unique_index(:favn_scheduler_cursors, [:pipeline_module, :schedule_id]))
+
+    create table(:favn_counters, primary_key: false) do
+      add(:name, :string, primary_key: true)
+      add(:value, :integer, null: false)
+    end
+  end
+end

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/repo.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/repo.ex
@@ -1,0 +1,7 @@
+defmodule FavnStorageSqlite.Repo do
+  @moduledoc false
+
+  use Ecto.Repo,
+    otp_app: :favn_storage_sqlite,
+    adapter: Ecto.Adapters.SQLite3
+end

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/supervisor.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/supervisor.ex
@@ -17,12 +17,32 @@ defmodule FavnStorageSqlite.Supervisor do
     repo_name = Repo
     repo_opts = repo_opts(opts)
 
-    if Keyword.get(opts, :migration_mode, :auto) == :auto do
-      :ok = run_migrations(repo_name, repo_opts)
-    end
+    :ok = bootstrap_storage(repo_name, repo_opts, Keyword.get(opts, :migration_mode, :auto))
 
     children = [{Repo, Keyword.put(repo_opts, :name, repo_name)}]
     Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp bootstrap_storage(repo_name, repo_opts, :auto), do: run_migrations(repo_name, repo_opts)
+
+  defp bootstrap_storage(repo_name, repo_opts, :manual) do
+    {:ok, pid} = Repo.start_link(Keyword.put(repo_opts, :name, repo_name))
+
+    try do
+      if Migrations.schema_ready?(repo_name) do
+        :ok
+      else
+        raise "favn sqlite schema is not ready; run migrations or set migration_mode: :auto"
+      end
+    after
+      GenServer.stop(pid)
+    end
+
+    :ok
+  end
+
+  defp bootstrap_storage(_repo_name, _repo_opts, mode) do
+    raise "invalid sqlite migration mode: #{inspect(mode)}"
   end
 
   defp run_migrations(repo_name, repo_opts) do

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/supervisor.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/supervisor.ex
@@ -1,0 +1,47 @@
+defmodule FavnStorageSqlite.Supervisor do
+  @moduledoc false
+
+  use Supervisor
+
+  alias FavnStorageSqlite.Migrations
+  alias FavnStorageSqlite.Repo
+
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) when is_list(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    Supervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  def init(opts) do
+    repo_name = Repo
+    repo_opts = repo_opts(opts)
+
+    if Keyword.get(opts, :migration_mode, :auto) == :auto do
+      :ok = run_migrations(repo_name, repo_opts)
+    end
+
+    children = [{Repo, Keyword.put(repo_opts, :name, repo_name)}]
+    Supervisor.init(children, strategy: :one_for_one)
+  end
+
+  defp run_migrations(repo_name, repo_opts) do
+    {:ok, pid} = Repo.start_link(Keyword.put(repo_opts, :name, repo_name))
+
+    try do
+      Migrations.migrate!(repo_name)
+    after
+      GenServer.stop(pid)
+    end
+
+    :ok
+  end
+
+  defp repo_opts(opts) do
+    [
+      database: Keyword.fetch!(opts, :database),
+      pool_size: Keyword.get(opts, :pool_size, 1),
+      busy_timeout: Keyword.get(opts, :busy_timeout, 5_000)
+    ]
+  end
+end

--- a/apps/favn_storage_sqlite/mix.exs
+++ b/apps/favn_storage_sqlite/mix.exs
@@ -5,7 +5,7 @@ defmodule FavnStorageSqlite.MixProject do
     [
       app: :favn_storage_sqlite,
       version: "0.5.0-dev",
-      description: "Internal SQLite storage adapter scaffold for orchestrator",
+      description: "SQLite storage adapter for orchestrator runtime state",
       build_path: "../../_build",
       config_path: "../../config/config.exs",
       deps_path: "../../deps",
@@ -18,13 +18,15 @@ defmodule FavnStorageSqlite.MixProject do
 
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :ecto_sql]
     ]
   end
 
   defp deps do
     [
-      {:favn_orchestrator, in_umbrella: true}
+      {:favn_orchestrator, in_umbrella: true},
+      {:ecto_sql, "~> 3.13.4"},
+      {:ecto_sqlite3, "~> 0.22.0"}
     ]
   end
 end

--- a/apps/favn_storage_sqlite/test/adapter_test.exs
+++ b/apps/favn_storage_sqlite/test/adapter_test.exs
@@ -1,0 +1,110 @@
+defmodule FavnStorageSqlite.AdapterTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Manifest
+  alias Favn.Manifest.Version
+  alias FavnOrchestrator.RunState
+  alias FavnStorageSqlite.Adapter
+
+  setup do
+    unique = System.unique_integer([:positive])
+    db_path = Path.join(System.tmp_dir!(), "favn_storage_sqlite_#{unique}.db")
+    supervisor_name = Module.concat([__MODULE__, "Supervisor#{unique}"])
+
+    opts = [database: db_path, supervisor_name: supervisor_name, migration_mode: :auto]
+
+    assert {:ok, child_spec} = Adapter.child_spec(opts)
+    start_supervised!(child_spec)
+
+    on_exit(fn ->
+      File.rm(db_path)
+    end)
+
+    {:ok, opts: opts}
+  end
+
+  test "stores manifest versions and supports activation", %{opts: opts} do
+    version = manifest_version("mv_sqlite")
+
+    assert :ok = Adapter.put_manifest_version(version, opts)
+    assert :ok = Adapter.put_manifest_version(version, opts)
+
+    assert {:ok, stored} = Adapter.get_manifest_version("mv_sqlite", opts)
+    assert stored.content_hash == version.content_hash
+
+    assert :ok = Adapter.set_active_manifest_version("mv_sqlite", opts)
+    assert {:ok, "mv_sqlite"} = Adapter.get_active_manifest_version(opts)
+  end
+
+  test "enforces run snapshot write semantics", %{opts: opts} do
+    base =
+      RunState.new(
+        id: "run_sqlite_1",
+        manifest_version_id: "mv_sqlite",
+        manifest_content_hash: "hash_sqlite",
+        asset_ref: {MyApp.Asset, :asset}
+      )
+
+    assert :ok = Adapter.put_run(base, opts)
+    assert :ok = Adapter.put_run(base, opts)
+
+    stale = %{base | event_seq: 0} |> RunState.with_snapshot_hash()
+    assert {:error, :stale_write} = Adapter.put_run(stale, opts)
+
+    conflict = %{base | status: :error} |> RunState.with_snapshot_hash()
+    assert {:error, :conflicting_snapshot} = Adapter.put_run(conflict, opts)
+
+    assert {:ok, stored} = Adapter.get_run(base.id, opts)
+    assert stored.status == :pending
+  end
+
+  test "stores run events and scheduler cursor state", %{opts: opts} do
+    event = %{
+      sequence: 1,
+      event_type: :run_started,
+      occurred_at: DateTime.utc_now(),
+      data: %{a: 1}
+    }
+
+    assert :ok = Adapter.append_run_event("run_sqlite_events", event, opts)
+
+    assert {:error, :conflicting_event_sequence} =
+             Adapter.append_run_event(
+               "run_sqlite_events",
+               %{sequence: 1, event_type: :run_updated},
+               opts
+             )
+
+    assert {:ok, [stored_event]} = Adapter.list_run_events("run_sqlite_events", opts)
+    assert stored_event.sequence == 1
+    assert stored_event.run_id == "run_sqlite_events"
+
+    key = {MyApp.Pipeline, :daily}
+
+    assert :ok =
+             Adapter.put_scheduler_state(
+               key,
+               %{last_due_at: DateTime.utc_now(), version: 1},
+               opts
+             )
+
+    assert {:error, :stale_scheduler_state} =
+             Adapter.put_scheduler_state(key, %{version: 1}, opts)
+
+    assert :ok = Adapter.put_scheduler_state(key, %{last_due_at: DateTime.utc_now()}, opts)
+
+    assert {:ok, %Favn.Scheduler.State{schedule_id: :daily}} =
+             Adapter.get_scheduler_state(key, opts)
+  end
+
+  defp manifest_version(manifest_version_id) do
+    manifest = %Manifest{
+      assets: [
+        %Favn.Manifest.Asset{ref: {MyApp.Asset, :asset}, module: MyApp.Asset, name: :asset}
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
+    version
+  end
+end

--- a/apps/favn_storage_sqlite/test/adapter_test.exs
+++ b/apps/favn_storage_sqlite/test/adapter_test.exs
@@ -6,15 +6,24 @@ defmodule FavnStorageSqlite.AdapterTest do
   alias FavnOrchestrator.RunState
   alias FavnStorageSqlite.Adapter
 
-  setup do
+  setup context do
     unique = System.unique_integer([:positive])
     db_path = Path.join(System.tmp_dir!(), "favn_storage_sqlite_#{unique}.db")
     supervisor_name = Module.concat([__MODULE__, "Supervisor#{unique}"])
 
-    opts = [database: db_path, supervisor_name: supervisor_name, migration_mode: :auto]
+    opts = [
+      database: db_path,
+      supervisor_name: supervisor_name,
+      migration_mode: :auto,
+      pool_size: 4
+    ]
 
-    assert {:ok, child_spec} = Adapter.child_spec(opts)
-    start_supervised!(child_spec)
+    if context[:without_started_adapter] != true do
+      maybe_stop_process(FavnStorageSqlite.Repo)
+
+      {:ok, supervisor_pid} = FavnStorageSqlite.Supervisor.start_link(opts)
+      on_exit(fn -> maybe_stop_pid(supervisor_pid) end)
+    end
 
     on_exit(fn ->
       File.rm(db_path)
@@ -97,6 +106,71 @@ defmodule FavnStorageSqlite.AdapterTest do
              Adapter.get_scheduler_state(key, opts)
   end
 
+  @tag without_started_adapter: true
+  test "rejects manual mode startup when schema is missing" do
+    unique = System.unique_integer([:positive])
+    db_path = Path.join(System.tmp_dir!(), "favn_storage_sqlite_manual_#{unique}.db")
+
+    opts = [
+      database: db_path,
+      supervisor_name: Module.concat([__MODULE__, "ManualSupervisor#{unique}"]),
+      migration_mode: :manual
+    ]
+
+    parent = self()
+
+    spawn(fn ->
+      Process.flag(:trap_exit, true)
+
+      result =
+        try do
+          FavnStorageSqlite.Supervisor.start_link(opts)
+        catch
+          :exit, reason -> {:exit, reason}
+        end
+
+      send(parent, {:manual_start_result, result})
+    end)
+
+    assert_receive {:manual_start_result, {:error, {%RuntimeError{message: message}, _}}}
+
+    assert message =~ "favn sqlite schema is not ready"
+
+    File.rm(db_path)
+  end
+
+  test "enforces run write conflicts under concurrent updates", %{opts: opts} do
+    base = run_state("run_sqlite_concurrent", "mv_sqlite", "hash_sqlite")
+    assert :ok = Adapter.put_run(base, opts)
+
+    running = %{base | event_seq: 2, status: :running} |> RunState.with_snapshot_hash()
+    failed = %{base | event_seq: 2, status: :error} |> RunState.with_snapshot_hash()
+
+    results =
+      concurrent_results(fn -> Adapter.put_run(running, opts) end, fn ->
+        Adapter.put_run(failed, opts)
+      end)
+
+    assert Enum.sort(results) == [:ok, {:error, :conflicting_snapshot}]
+  end
+
+  test "enforces scheduler version checks under concurrent updates", %{opts: opts} do
+    key = {MyApp.Pipeline, :daily}
+    assert :ok = Adapter.put_scheduler_state(key, %{version: 1}, opts)
+
+    results =
+      concurrent_results(
+        fn ->
+          Adapter.put_scheduler_state(key, %{version: 2, last_due_at: DateTime.utc_now()}, opts)
+        end,
+        fn ->
+          Adapter.put_scheduler_state(key, %{version: 2, last_due_at: DateTime.utc_now()}, opts)
+        end
+      )
+
+    assert Enum.sort(results) == [:ok, {:error, :stale_scheduler_state}]
+  end
+
   defp manifest_version(manifest_version_id) do
     manifest = %Manifest{
       assets: [
@@ -106,5 +180,53 @@ defmodule FavnStorageSqlite.AdapterTest do
 
     {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
     version
+  end
+
+  defp run_state(id, manifest_version_id, manifest_content_hash) do
+    RunState.new(
+      id: id,
+      manifest_version_id: manifest_version_id,
+      manifest_content_hash: manifest_content_hash,
+      asset_ref: {MyApp.Asset, :asset}
+    )
+  end
+
+  defp concurrent_results(fun_a, fun_b) do
+    parent = self()
+
+    task_a = Task.async(fn -> await_release(parent, :task_a, fun_a) end)
+    task_b = Task.async(fn -> await_release(parent, :task_b, fun_b) end)
+
+    assert_receive {:ready, :task_a}
+    assert_receive {:ready, :task_b}
+
+    send(task_a.pid, :go)
+    send(task_b.pid, :go)
+
+    [Task.await(task_a, 5_000), Task.await(task_b, 5_000)]
+  end
+
+  defp await_release(parent, label, fun) do
+    send(parent, {:ready, label})
+
+    receive do
+      :go -> fun.()
+    end
+  end
+
+  defp maybe_stop_process(name) when is_atom(name) do
+    case Process.whereis(name) do
+      nil -> :ok
+      pid -> GenServer.stop(pid)
+    end
+  end
+
+  defp maybe_stop_pid(pid) when is_pid(pid) do
+    if Process.alive?(pid) do
+      Process.unlink(pid)
+      Process.exit(pid, :shutdown)
+    else
+      :ok
+    end
   end
 end

--- a/apps/favn_storage_sqlite/test/favn_storage_sqlite_test.exs
+++ b/apps/favn_storage_sqlite/test/favn_storage_sqlite_test.exs
@@ -1,8 +1,0 @@
-defmodule FavnStorageSqliteTest do
-  use ExUnit.Case
-  doctest FavnStorageSqlite
-
-  test "greets the world" do
-    assert FavnStorageSqlite.hello() == :world
-  end
-end

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -287,7 +287,20 @@ Pre-refactor groundwork already completed in the legacy runtime and to be carrie
   - [x] `Favn.Storage` adapter validation/defaults and `Favn.Storage.Adapter` behaviour now align with the orchestrator storage contract shape (no legacy adapter callback assumptions), and the duplicate `FavnOrchestrator.Storage.Adapter` contract has been collapsed away before Phase 6 plugin extraction
   - [x] manual pipeline submission now resolves from persisted manifest pipeline descriptors in orchestrator, with projector coverage and same-node orchestrator-to-runner integration coverage added
 - [ ] Phase 6: add `favn_storage_sqlite` and `favn_storage_postgres`
+  - [x] planning docs created: `docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md`
+  - [x] implementation checklist created: `docs/refactor/PHASE_6_TODO.md`
+  - [x] Phase 5 carry-over cleanup: remove the memory-specific adapter lifecycle shortcut and re-center shared storage codecs/write semantics into orchestrator ownership
+  - [x] initial `favn_storage_sqlite` foundation implemented with managed repo bootstrap + migrations, adapter contract coverage, and persisted manifests/runs/events/scheduler cursors
+  - [x] shared adapter contract coverage added across memory/sqlite/postgres with opt-in live postgres path
+  - [ ] finish local-dev integration and polish for `favn_storage_sqlite` as the persistent default (`mix favn.dev --sqlite` path)
+  - [x] initial `favn_storage_postgres` foundation implemented with managed/external repo modes, migration runner/schema checks, and persisted manifests/runs/events/scheduler cursors
+  - [x] add opt-in live Postgres integration coverage (`FAVN_POSTGRES_TEST_URL`) and document managed/external wiring
+  - [ ] broaden Postgres integration coverage for transaction/concurrency behavior against a live database
+  - [ ] end cleanup: rename temporary adapter modules (`FavnStorageSqlite.Adapter`, `FavnStoragePostgres.Adapter`) to preserved `Favn.Storage.Adapter.*` names after legacy module collisions are removed
 - [ ] Phase 7: move DuckDB into `favn_duckdb`
+  - [ ] carry SQL asset execution payload in the manifest/core contract
+  - [ ] enable manifest-pinned SQL asset execution in `favn_runner`
+  - [ ] remove temporary migration/runtime seams in `favn` after the manifest-backed runner SQL path lands
 - [ ] Phase 8: add `favn_view`
 - [ ] Phase 9: ship developer tooling and packaging flows
 - [ ] Phase 10: cut over and delete legacy runtime paths
@@ -301,6 +314,8 @@ Detailed migration planning for the current refactor slices lives in:
 - `docs/refactor/PHASE_4_TODO.md`
 - `docs/refactor/PHASE_5_ORCHESTRATOR_BOUNDARY_PLAN.md`
 - `docs/refactor/PHASE_5_TODO.md`
+- `docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md`
+- `docs/refactor/PHASE_6_TODO.md`
 
 Deferred until after the refactor unless needed to establish the new boundaries:
 

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -292,11 +292,13 @@ Pre-refactor groundwork already completed in the legacy runtime and to be carrie
   - [x] Phase 5 carry-over cleanup: remove the memory-specific adapter lifecycle shortcut and re-center shared storage codecs/write semantics into orchestrator ownership
   - [x] initial `favn_storage_sqlite` foundation implemented with managed repo bootstrap + migrations, adapter contract coverage, and persisted manifests/runs/events/scheduler cursors
   - [x] shared adapter contract coverage added across memory/sqlite/postgres with opt-in live postgres path
+  - [x] guarded SQL write semantics now enforce atomic run snapshot and scheduler version invariants in SQLite and Postgres, with concurrency-focused SQLite tests and opt-in live Postgres concurrency tests
   - [ ] finish local-dev integration and polish for `favn_storage_sqlite` as the persistent default (`mix favn.dev --sqlite` path)
   - [x] initial `favn_storage_postgres` foundation implemented with managed/external repo modes, migration runner/schema checks, and persisted manifests/runs/events/scheduler cursors
   - [x] add opt-in live Postgres integration coverage (`FAVN_POSTGRES_TEST_URL`) and document managed/external wiring
   - [ ] broaden Postgres integration coverage for transaction/concurrency behavior against a live database
   - [ ] end cleanup: rename temporary adapter modules (`FavnStorageSqlite.Adapter`, `FavnStoragePostgres.Adapter`) to preserved `Favn.Storage.Adapter.*` names after legacy module collisions are removed
+  - [ ] end cleanup: replace temporary BEAM term-blob payload storage with the intended canonical inspectable payload format
 - [ ] Phase 7: move DuckDB into `favn_duckdb`
   - [ ] carry SQL asset execution payload in the manifest/core contract
   - [ ] enable manifest-pinned SQL asset execution in `favn_runner`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -286,26 +286,29 @@ Pre-refactor groundwork already completed in the legacy runtime and to be carrie
   - [x] preserved public `Favn.Storage` contract is now owned by orchestrator-side files, and the scheduler matrix now covers overlap policies, missed-occurrence behavior, and window anchor propagation
   - [x] `Favn.Storage` adapter validation/defaults and `Favn.Storage.Adapter` behaviour now align with the orchestrator storage contract shape (no legacy adapter callback assumptions), and the duplicate `FavnOrchestrator.Storage.Adapter` contract has been collapsed away before Phase 6 plugin extraction
   - [x] manual pipeline submission now resolves from persisted manifest pipeline descriptors in orchestrator, with projector coverage and same-node orchestrator-to-runner integration coverage added
-- [ ] Phase 6: add `favn_storage_sqlite` and `favn_storage_postgres`
+- [x] Phase 6: add `favn_storage_sqlite` and `favn_storage_postgres`
   - [x] planning docs created: `docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md`
   - [x] implementation checklist created: `docs/refactor/PHASE_6_TODO.md`
   - [x] Phase 5 carry-over cleanup: remove the memory-specific adapter lifecycle shortcut and re-center shared storage codecs/write semantics into orchestrator ownership
   - [x] initial `favn_storage_sqlite` foundation implemented with managed repo bootstrap + migrations, adapter contract coverage, and persisted manifests/runs/events/scheduler cursors
   - [x] shared adapter contract coverage added across memory/sqlite/postgres with opt-in live postgres path
   - [x] guarded SQL write semantics now enforce atomic run snapshot and scheduler version invariants in SQLite and Postgres, with concurrency-focused SQLite tests and opt-in live Postgres concurrency tests
-  - [ ] finish local-dev integration and polish for `favn_storage_sqlite` as the persistent default (`mix favn.dev --sqlite` path)
   - [x] initial `favn_storage_postgres` foundation implemented with managed/external repo modes, migration runner/schema checks, and persisted manifests/runs/events/scheduler cursors
   - [x] add opt-in live Postgres integration coverage (`FAVN_POSTGRES_TEST_URL`) and document managed/external wiring
-  - [ ] broaden Postgres integration coverage for transaction/concurrency behavior against a live database
-  - [ ] end cleanup: rename temporary adapter modules (`FavnStorageSqlite.Adapter`, `FavnStoragePostgres.Adapter`) to preserved `Favn.Storage.Adapter.*` names after legacy module collisions are removed
-  - [ ] end cleanup: replace temporary BEAM term-blob payload storage with the intended canonical inspectable payload format
+  - [x] later-phase storage follow-ups moved to future roadmap phases so Phase 6 can close cleanly
 - [ ] Phase 7: move DuckDB into `favn_duckdb`
   - [ ] carry SQL asset execution payload in the manifest/core contract
   - [ ] enable manifest-pinned SQL asset execution in `favn_runner`
   - [ ] remove temporary migration/runtime seams in `favn` after the manifest-backed runner SQL path lands
 - [ ] Phase 8: add `favn_view`
 - [ ] Phase 9: ship developer tooling and packaging flows
+  - [ ] finish local-dev integration and polish for `favn_storage_sqlite` as the persistent `mix favn.dev --sqlite` path
+  - [ ] broaden live Postgres migration/transaction/concurrency coverage in a production-like verification path
 - [ ] Phase 10: cut over and delete legacy runtime paths
+  - [ ] rename temporary adapter modules (`FavnStorageSqlite.Adapter`, `FavnStoragePostgres.Adapter`) to preserved `Favn.Storage.Adapter.*` names after legacy module collisions are removed
+  - [ ] replace temporary BEAM term-blob payload storage with the intended canonical inspectable payload format
+  - [ ] decide whether scheduler writes without explicit versions should stay permissive or become stricter optimistic writes
+  - [ ] replace repeated external Postgres schema-readiness checks with a clearer startup/cached readiness strategy
 
 Detailed migration planning for the current refactor slices lives in:
 

--- a/docs/REFACTOR.md
+++ b/docs/REFACTOR.md
@@ -501,6 +501,16 @@ The remaining SQL payload / manifest-pinned SQL execution work and the final tem
 - `mix favn.dev --sqlite` works with persistent local state
 - orchestrator can run with Postgres adapter for production-oriented setups
 
+### Status
+Implemented.
+
+Phase 6 closed with the extracted storage foundations complete, shared adapter contract coverage in place, and atomic SQL-side storage invariants enforced for the current contract.
+
+The remaining storage-related follow-ups were intentionally moved out of Phase 6 because they belong to later phases:
+
+- Phase 9: local-dev `mix favn.dev --sqlite` polish and broader live Postgres verification flows
+- Phase 10: adapter module rename cleanup, temporary term-blob replacement, scheduler blind-write policy decision, and external Postgres readiness optimization during final cutover
+
 ---
 
 ## Phase 7 — Move DuckDB into a runner plugin
@@ -569,6 +579,11 @@ Tooling behavior:
 - Docker/dev-container mode may be added optionally later
 - single-image assembly combines runtime artifacts with user runner payload and manifest
 
+Additional storage follow-ups in this phase:
+
+- finish local-dev integration and polish for the extracted SQLite adapter path behind `mix favn.dev --sqlite`
+- broaden live Postgres migration/transaction/concurrency verification in a production-like test path
+
 ### Exit criteria
 - user can go from `{:favn, ...}` dependency to local UI and orchestration quickly
 - user can package single-node and split deployments without understanding internal app structure
@@ -586,6 +601,13 @@ Retire the old monolith safely.
 - migrate CI to umbrella layout
 - delete root legacy `/lib` and `/test` structure
 - eventually remove `favn_legacy`
+
+Final storage cleanup in this phase:
+
+- rename temporary extracted adapter modules back to preserved `Favn.Storage.Adapter.*` names once legacy collisions are gone
+- replace temporary BEAM term-blob payload storage with the intended canonical inspectable payload format
+- decide whether scheduler writes without explicit versions should remain permissive or move to stricter optimistic semantics
+- replace repeated external Postgres schema-readiness checks with a clearer startup/cached readiness strategy
 
 ### Exit criteria
 - all supported flows run on the new architecture

--- a/docs/REFACTOR.md
+++ b/docs/REFACTOR.md
@@ -481,11 +481,20 @@ Phase 5 cleanup completed after initial implementation:
 ### Goal
 Support realistic persistence modes without polluting core apps.
 
+Detailed implementation planning for this phase lives in:
+
+- `docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md`
+- `docs/refactor/PHASE_6_TODO.md`
+
 ### Deliverables
 - `favn_storage_sqlite`
 - `favn_storage_postgres`
 
 Postgres should carry forward the production-oriented transactional/persistence model already being designed, but applied to the new orchestrator architecture rather than the old monolith. :contentReference[oaicite:7]{index=7}
+
+Phase 6 should begin with a small storage-boundary cleanup inherited from Phase 5 so the extracted adapter apps can own lifecycle and shared serialization semantics cleanly.
+
+The remaining SQL payload / manifest-pinned SQL execution work and the final temporary seam removal in `favn` should move with Phase 7, where DuckDB/plugin extraction and runner-side SQL ownership are already the main concern.
 
 ### Exit criteria
 - `mix favn.dev` works with memory by default
@@ -504,6 +513,12 @@ Prove the optional execution plugin model.
 - DuckDB runtime execution through runner plugin integration
 - plugin loading/configuration path through `favn`
 - initial public plugin packaging strategy
+
+Phase 7 should also absorb the remaining older carried-forward SQL follow-ups:
+
+- carry SQL asset execution payload in the manifest/core contract
+- enable manifest-pinned SQL asset execution in `favn_runner`
+- remove temporary migration/runtime seams in `favn` once the runner SQL path is fully manifest-backed
 
 ### Exit criteria
 - DuckDB is no longer mixed into the core/orchestrator boundary

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -137,6 +137,11 @@ Notes:
   - `manifest/pipeline_resolver.ex`
 - Initial Phase 5 orchestrator runtime slice added control-plane modules in `apps/favn_orchestrator/lib/favn_orchestrator/`:
   - `storage.ex`
+  - `storage/manifest_codec.ex`
+  - `storage/run_state_codec.ex`
+  - `storage/run_event_codec.ex`
+  - `storage/scheduler_state_codec.ex`
+  - `storage/write_semantics.ex`
   - `storage/adapter/memory.ex`
   - `manifest_store.ex`
   - `run_state.ex`
@@ -155,6 +160,20 @@ Notes:
   - `scheduler.ex`
   - `scheduler/state.ex`
 - `apps/favn_orchestrator/lib/favn/storage/adapter.ex` is now the single authoritative low-level storage adapter behaviour used by both `Favn.Storage` and `FavnOrchestrator.Storage`.
+- `apps/favn_storage_sqlite/lib/` now includes the initial Phase 6 adapter foundation:
+  - `favn_storage_sqlite.ex`
+  - `favn_storage_sqlite/adapter.ex`
+  - `favn_storage_sqlite/repo.ex`
+  - `favn_storage_sqlite/supervisor.ex`
+  - `favn_storage_sqlite/migrations.ex`
+  - `favn_storage_sqlite/migrations/create_foundation.ex`
+- `apps/favn_storage_postgres/lib/` now includes the initial Phase 6 adapter foundation:
+  - `favn_storage_postgres.ex`
+  - `favn_storage_postgres/adapter.ex`
+  - `favn_storage_postgres/repo.ex`
+  - `favn_storage_postgres/supervisor.ex`
+  - `favn_storage_postgres/migrations.ex`
+  - `favn_storage_postgres/migrations/create_foundation.ex`
 - Initial Phase 4 implementation now includes:
   - `apps/favn_core/lib/favn/run/context.ex`
   - `apps/favn_core/lib/favn/run/asset_result.ex`

--- a/docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md
+++ b/docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md
@@ -134,6 +134,11 @@ Recommended SQLite rules:
 - `:manual` may exist as an opt-in for embedded or test scenarios, but it should not be the default friction path
 - keep the schema JSON-first and boring; do not try to mirror every Postgres table if the current orchestrator contract does not need it yet
 
+Current implementation note:
+
+- the first extracted SQLite cut currently stores run, event, and scheduler payload bodies as BEAM term blobs behind relational summary/version columns
+- that is an acceptable extraction shortcut for the first durable cut, but it should be treated as temporary scaffolding rather than the final inspectable persistence shape
+
 Recommended SQLite persisted tables in the first cut:
 
 1. `favn_manifest_versions`
@@ -215,11 +220,16 @@ Recommended Postgres design rule:
 - persist queryable columns for the fields needed by `list_runs/1`, conflict detection, future operator filtering, and scheduler correctness
 - keep the full canonical `RunState` payload as versioned JSONB for projection/reconstruction
 
+Current implementation note:
+
+- the first extracted Postgres cut currently stores run, event, and scheduler payload bodies as BEAM term blobs plus relational summary/version columns
+- that is intentionally narrower than the target JSON/JSONB-oriented end state and should be cleaned up in a later follow-up before final cutover
+
 This is intentionally narrower than the older legacy-oriented Postgres foundation plan. In particular:
 
 - do not make `favn_asset_window_latest` a blocker for the first Phase 6 cut unless a current orchestrator API starts depending on it
 - do not reintroduce legacy `%Favn.Run{}`-first persistence as the primary durable model
-- do not store Erlang term blobs
+- the current first extracted cut still uses temporary term blobs for payload bodies even though the target end state should move away from them
 
 The right first Postgres unit is the orchestrator-owned `RunState` plus queryable summary columns and append-only events.
 
@@ -314,6 +324,11 @@ Recommended behavior in external mode:
 - the adapter returns `:none` from `child_spec/1`
 - no repo lifecycle is owned by Favn
 - startup still verifies schema readiness when the adapter is first used
+
+Current managed-instance constraint:
+
+- the current extracted SQLite and Postgres adapters should be treated as one managed instance per adapter app per BEAM node
+- the repo modules are still globally named, so `supervisor_name` is not a true multi-instance isolation mechanism yet
 
 ## Legacy Slice Map
 

--- a/docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md
+++ b/docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md
@@ -1,0 +1,469 @@
+# Phase 6 Storage Adapter Plan
+
+## Status
+
+Planned on branch `feature/phase-6-storage-plan`.
+
+Phase 5 delivered the storage boundary that Phase 6 should build on:
+
+- `favn_orchestrator` now owns the authoritative `Favn.Storage.Adapter` behaviour
+- `Favn.Storage` and `FavnOrchestrator.Storage` now talk through that single adapter contract
+- the in-memory adapter in `favn_orchestrator` proves the contract for manifests, active-manifest selection, run snapshots, run events, and scheduler cursors
+
+What still remains is adapter extraction and durable persistence:
+
+- `apps/favn_storage_sqlite` and `apps/favn_storage_postgres` are still scaffolds
+- reusable storage serialization and write-semantics logic still lives partly in legacy-oriented modules
+- the public roadmap still needs explicit tracking for the remaining older-phase follow-up slices that affect full end-to-end parity
+
+## Recommendation Summary
+
+Phase 6 should make five architectural moves together:
+
+1. Keep `Favn.Storage.Adapter` in `favn_orchestrator` as the only authoritative adapter contract; adapter apps implement it, they do not define parallel behaviours.
+2. Move shared storage-agnostic codecs and write-semantics helpers into `favn_orchestrator` so SQLite and Postgres stay thin persistence layers instead of each re-owning serialization logic.
+3. Build SQLite as the smallest complete durable adapter for local developer persistence: managed repo, simple JSON-first tables, deterministic run ordering, and full support for the current orchestrator contract.
+4. Build Postgres as the production-oriented adapter: transactional writes, queryable run summary columns, JSONB snapshot cache, managed or external repo support, and manual migrations by default.
+5. Keep the remaining SQL payload and temporary seam cleanup out of Phase 6 and bundle them into Phase 7 with DuckDB/plugin extraction, while Phase 6 stays focused on storage.
+
+The most important recommendation is to keep storage ownership split cleanly:
+
+- `favn_orchestrator` owns storage contracts, persistence semantics, and adapter-neutral codecs
+- `favn_storage_sqlite` owns SQLite repo, migrations, and adapter implementation
+- `favn_storage_postgres` owns Postgres repo, migrations, and adapter implementation
+- neither adapter app should reintroduce control-plane policy, planner logic, or runner concerns
+
+## Current Reality On `main`
+
+The Phase 6 plan should fit the code that already exists:
+
+- `Favn.Storage.Adapter` currently persists `%Favn.Manifest.Version{}`, orchestrator `%FavnOrchestrator.RunState{}`, run events, and scheduler cursor payloads
+- `FavnOrchestrator.Storage.Adapter.Memory` already enforces the intended monotonic run-write semantics and scheduler-state version checks in memory
+- `Favn.Storage` still includes a memory-oriented adapter lifecycle shortcut (`Process.whereis(adapter)`) that will not be correct for real adapter apps, especially Postgres external-repo mode
+- the old SQLite and Postgres adapters still exist in `favn_legacy`, but they are shaped around legacy `%Favn.Run{}` storage and old module ownership
+- `docs/POSTGRES_STORAGE_FOUNDATION_PLAN.md` remains valuable directionally, but it predates the Phase 5 orchestrator-owned `%FavnOrchestrator.RunState{}` contract and must be applied to the new boundary rather than copied blindly
+
+That means Phase 6 should not start from an empty page, but it also should not port the legacy adapters file-for-file.
+
+## Phase 6 Architecture Decisions
+
+### 1. Keep the adapter contract in `favn_orchestrator`
+
+Phase 5 already collapsed duplicate adapter behaviours. Phase 6 should preserve that decision.
+
+Recommended rule:
+
+- `Favn.Storage.Adapter` remains the only low-level storage behaviour
+- `Favn.Storage` remains the public facade
+- `FavnOrchestrator.Storage` remains the orchestrator-facing facade
+- SQLite/Postgres apps implement `Favn.Storage.Adapter` directly
+
+This keeps the dependency rule intact:
+
+- `favn_orchestrator` owns control-plane contracts
+- storage apps depend on `favn_orchestrator`
+- the orchestrator does not depend on adapter implementation details
+
+### 2. Re-center shared storage codecs into `favn_orchestrator`
+
+The adapter apps should not each invent their own serialization of manifests, run state, run events, and scheduler state.
+
+Recommended new adapter-neutral modules under `apps/favn_orchestrator/lib/favn_orchestrator/storage/`:
+
+- `write_semantics.ex`
+  - canonical stale/idempotent/conflict decisions for run snapshot writes
+- `manifest_codec.ex`
+  - canonical persisted payload shape for `%Favn.Manifest.Version{}`
+- `run_state_codec.ex`
+  - canonical persisted payload shape for `%FavnOrchestrator.RunState{}`
+- `run_event_codec.ex`
+  - canonical event payload validation/normalization
+- `scheduler_state_codec.ex`
+  - canonical scheduler cursor payload validation/normalization
+
+The exact file count can stay smaller if some codecs collapse together naturally, but the conceptual split matters:
+
+- adapter-neutral value-shape logic belongs with the orchestrator contract
+- database-specific SQL, migrations, repo wiring, and transactional orchestration belong in the adapter apps
+
+### 3. Fix the adapter lifecycle seam before real adapters land
+
+The current `Favn.Storage.child_specs/0` path assumes that an adapter module can be treated like a registered process name.
+
+That happens to work for the current memory adapter, but it is the wrong contract for:
+
+- managed SQLite/Postgres supervisors
+- Postgres `repo_mode: :external`, where the adapter may intentionally return `:none`
+- future adapter implementations that are not named `GenServer`s
+
+Recommended cleanup at the start of Phase 6:
+
+- remove the `Process.whereis(adapter)` shortcut from `Favn.Storage.child_specs/0`
+- let `FavnOrchestrator.Storage.child_specs/0` be the only place that asks adapters for runtime children
+- treat `adapter.child_spec/1 == :none` as the official signal that the adapter does not need to start anything
+
+This is a small carry-over cleanup from Phase 5, but it should be done before claiming the storage boundary is ready for extracted adapter apps.
+
+### 4. SQLite should optimize for local persistence, not production complexity
+
+SQLite exists to make `mix favn.dev --sqlite` useful and durable without dragging production-only complexity into the local path.
+
+Recommended SQLite goals:
+
+- durable local persistence for the current orchestrator contract
+- managed repo only in the first cut
+- migration defaults optimized for local developer UX
+- deterministic run ordering and monotonic snapshot semantics identical to memory/Postgres behaviour
+
+Recommended SQLite config shape:
+
+```elixir
+config :favn_orchestrator,
+  storage_adapter: Favn.Storage.Adapter.SQLite,
+  storage_adapter_opts: [
+    database: ".favn/dev.sqlite3",
+    pool_size: 1,
+    busy_timeout: 5_000,
+    migration_mode: :auto
+  ]
+```
+
+Recommended SQLite rules:
+
+- `migration_mode` should default to `:auto` for the adapter's managed-repo local-dev role
+- `:manual` may exist as an opt-in for embedded or test scenarios, but it should not be the default friction path
+- keep the schema JSON-first and boring; do not try to mirror every Postgres table if the current orchestrator contract does not need it yet
+
+Recommended SQLite persisted tables in the first cut:
+
+1. `favn_manifest_versions`
+   - immutable manifest versions by `manifest_version_id`
+   - store `content_hash` and canonical payload JSON
+2. `favn_runtime_settings`
+   - single-row or key/value persisted state for the active manifest pointer
+3. `favn_runs`
+   - `run_id`, manifest identity, status, `event_seq`, `snapshot_hash`, deterministic `updated_seq`, timestamps, and canonical `run_state_json`
+4. `favn_run_events`
+   - append-only event log keyed by `{run_id, sequence}`
+5. `favn_scheduler_cursors`
+   - scheduler progress keyed by `{pipeline_module, schedule_id}` with explicit `version`
+6. `favn_counters`
+   - monotonic sequence allocation for deterministic run ordering where SQLite lacks native sequences
+
+Recommended non-goal for the first SQLite cut:
+
+- do not add a separate `run_nodes` table unless a current orchestrator API actually needs step-level SQL filtering
+
+The current contract can be satisfied by storing canonical `RunState` JSON plus queryable run summary columns. That is enough for local persistence and avoids overbuilding the dev adapter.
+
+### 5. Postgres should be production-oriented and queryable
+
+Postgres should carry forward the direction of `docs/POSTGRES_STORAGE_FOUNDATION_PLAN.md`, but adapted to the orchestrator-owned boundary that exists now.
+
+Recommended Postgres goals:
+
+- production-capable durable orchestrator persistence
+- transactionally correct run snapshot and event writes
+- managed and external repo support
+- manual migrations by default
+- queryable run summary fields for future operator APIs and `favn_view`
+
+Recommended Postgres config modes:
+
+```elixir
+config :favn_orchestrator,
+  storage_adapter: Favn.Storage.Adapter.Postgres,
+  storage_adapter_opts: [
+    repo_mode: :managed,
+    repo_config: [
+      hostname: "localhost",
+      port: 5432,
+      database: "favn",
+      username: "postgres",
+      password: "postgres",
+      pool_size: 10
+    ],
+    migration_mode: :manual
+  ]
+```
+
+```elixir
+config :favn_orchestrator,
+  storage_adapter: Favn.Storage.Adapter.Postgres,
+  storage_adapter_opts: [
+    repo_mode: :external,
+    repo: MyApp.Repo,
+    migration_mode: :manual
+  ]
+```
+
+Recommended Postgres persisted tables in the first cut:
+
+1. `favn_manifest_versions`
+   - immutable manifest envelopes with `manifest_json` JSONB and unique `content_hash`
+2. `favn_runtime_settings`
+   - current active manifest pointer and other future runtime-wide settings
+3. `favn_runs`
+   - run identity, manifest identity, status, submit kind, lineage fields, `event_seq`, `write_seq`, timestamps, `snapshot_hash`, and `run_state_json` JSONB
+4. `favn_run_events`
+   - append-only event rows unique by `{run_id, sequence}`
+5. `favn_scheduler_cursors`
+   - durable scheduler cursor rows keyed by `{pipeline_module, schedule_id}` with optimistic version semantics
+
+Recommended Postgres design rule:
+
+- persist queryable columns for the fields needed by `list_runs/1`, conflict detection, future operator filtering, and scheduler correctness
+- keep the full canonical `RunState` payload as versioned JSONB for projection/reconstruction
+
+This is intentionally narrower than the older legacy-oriented Postgres foundation plan. In particular:
+
+- do not make `favn_asset_window_latest` a blocker for the first Phase 6 cut unless a current orchestrator API starts depending on it
+- do not reintroduce legacy `%Favn.Run{}`-first persistence as the primary durable model
+- do not store Erlang term blobs
+
+The right first Postgres unit is the orchestrator-owned `RunState` plus queryable summary columns and append-only events.
+
+### 6. Persist the current orchestrator contract directly
+
+Phase 6 should follow the current control-plane contract rather than the old legacy surface.
+
+Recommended persisted units:
+
+- `%Favn.Manifest.Version{}`
+- active manifest version id
+- `%FavnOrchestrator.RunState{}`
+- append-only run event payloads
+- scheduler cursor payloads keyed by `{pipeline_module, schedule_id}`
+
+Recommended invariants for both SQLite and Postgres:
+
+1. manifest versions are immutable once accepted
+2. active-manifest updates affect future runs only
+3. run snapshot writes are monotonic by `event_seq`
+4. same `event_seq` plus same `snapshot_hash` is idempotent success
+5. same `event_seq` plus different `snapshot_hash` is `{:error, :conflicting_snapshot}`
+6. lower `event_seq` is `{:error, :stale_write}`
+7. run events are append-only and unique by `{run_id, sequence}`
+8. scheduler cursor writes are keyed by `{pipeline_module, schedule_id}` and enforce monotonic `version`
+
+These semantics should be codified once in shared write-semantics helpers and verified across all adapters.
+
+### 7. Keep the module naming boring and preserved
+
+The adapter apps should expose preserved `Favn.*` module names for the actual adapter modules so configuration remains obvious.
+
+Recommended module names:
+
+- `apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex`
+  - `Favn.Storage.Adapter.SQLite`
+- `apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex`
+  - `Favn.Storage.Adapter.Postgres`
+
+The top-level app modules may remain small documentation modules:
+
+- `FavnStorageSqlite`
+- `FavnStoragePostgres`
+
+But the actual configured adapter should be the preserved `Favn.Storage.Adapter.*` module.
+
+### 8. Keep older-phase SQL follow-ups attached to Phase 7
+
+Phase 6 should keep one small storage-boundary cleanup from Phase 5, but the remaining SQL-centered carry-overs fit better with Phase 7.
+
+#### Phase 5 carry-over cleanup
+
+Required before the storage-app boundary is truly finished:
+
+- fix the adapter lifecycle seam described above
+- move shared storage codecs/write semantics out of legacy-oriented modules and into orchestrator ownership
+
+#### Move these to Phase 7
+
+These should be tracked with DuckDB/plugin extraction instead of Phase 6:
+
+- carry SQL asset execution payload through the manifest/core contract
+- enable manifest-pinned SQL asset execution in `favn_runner`
+- remove temporary migration seams in `favn`, especially the remaining transitional SQL/runtime bridge placement, once manifest-backed runner SQL execution is complete
+
+This keeps Phase 6 focused on persistence while Phase 7 owns the remaining SQL execution and plugin-shape work in one bounded slice.
+
+## Recommended Runtime Shape
+
+### SQLite runtime shape
+
+Recommended children under the SQLite adapter when configured in managed mode:
+
+- `Favn.Storage.SQLite.Repo`
+- optional adapter-owned supervisor wrapper if migration bootstrapping is needed
+
+Do not add:
+
+- a second storage facade
+- adapter-specific planner or scheduler services
+- SQLite-specific control-plane workers beyond repo and migration bootstrap
+
+### Postgres runtime shape
+
+Recommended children under the Postgres adapter when configured in managed mode:
+
+- `Favn.Storage.Postgres.Repo`
+- optional adapter-owned supervisor wrapper that can verify or run migrations before steady-state startup
+
+Recommended behavior in external mode:
+
+- the adapter returns `:none` from `child_spec/1`
+- no repo lifecycle is owned by Favn
+- startup still verifies schema readiness when the adapter is first used
+
+## Legacy Slice Map
+
+### Move or rewrite in Phase 6
+
+- `apps/favn_legacy/lib/favn/storage/adapter/sqlite.ex`
+- `apps/favn_legacy/lib/favn/storage/adapter/postgres.ex`
+- `apps/favn_legacy/lib/favn/storage/sqlite/repo.ex`
+- `apps/favn_legacy/lib/favn/storage/sqlite/supervisor.ex`
+- `apps/favn_legacy/lib/favn/storage/sqlite/migrations.ex`
+- `apps/favn_legacy/lib/favn/storage/sqlite/migrations/create_runs.ex`
+- `apps/favn_legacy/lib/favn/storage/postgres/repo.ex`
+- `apps/favn_legacy/lib/favn/storage/postgres/supervisor.ex`
+- `apps/favn_legacy/lib/favn/storage/postgres/migrations.ex`
+- `apps/favn_legacy/lib/favn/storage/postgres/migrations/create_foundation.ex`
+- `apps/favn_legacy/lib/favn/storage/run_serializer.ex`
+- `apps/favn_legacy/lib/favn/storage/run_write_semantics.ex`
+- `apps/favn_legacy/lib/favn/storage/snapshot_hash.ex`
+- `apps/favn_legacy/lib/favn/storage/term_json.ex`
+
+### Rewrite rather than copy verbatim
+
+- legacy SQLite snapshot storage that persists `%Favn.Run{}` term blobs
+- legacy Postgres mapper logic that assumes `%Favn.Run{}` is the durable contract
+- any fallback scheduler queries that treat `pipeline_module` alone as the durable key
+
+### Leave for later phases
+
+- queue/claim/lease tables and logic
+- run deduplication keys
+- materialization history tables
+- operator query APIs beyond the current storage contract
+- view/UI work
+- packaging/install tooling
+
+## File Plan
+
+### In `apps/favn_orchestrator/lib/favn_orchestrator/storage/`
+
+- `write_semantics.ex`
+- `manifest_codec.ex`
+- `run_state_codec.ex`
+- `run_event_codec.ex`
+- `scheduler_state_codec.ex`
+
+### In `apps/favn_storage_sqlite/lib/favn/storage/`
+
+- `adapter/sqlite.ex`
+- `sqlite/repo.ex`
+- `sqlite/supervisor.ex`
+- `sqlite/migrations.ex`
+- `sqlite/migrations/create_foundation.ex`
+
+### In `apps/favn_storage_postgres/lib/favn/storage/`
+
+- `adapter/postgres.ex`
+- `postgres/repo.ex`
+- `postgres/supervisor.ex`
+- `postgres/migrations.ex`
+- `postgres/migrations/create_foundation.ex`
+- `postgres/queries.ex`
+
+The exact adapter-internal file count can stay smaller, but the ownership split should stay the same:
+
+- orchestrator app owns adapter-neutral semantics
+- adapter app owns repo, SQL, and migration details
+
+## Implementation Order
+
+Recommended Phase 6 work order:
+
+1. Fix the Phase 5 adapter lifecycle seam and re-center shared storage codecs/write semantics into `favn_orchestrator`.
+2. Replace the `favn_storage_sqlite` scaffold with a real SQLite adapter that fully satisfies the current orchestrator storage contract.
+3. Wire and document `mix favn.dev --sqlite` around the extracted SQLite adapter.
+4. Replace the `favn_storage_postgres` scaffold with a real Postgres adapter, using the updated orchestrator-owned codecs and production-oriented migration/repo rules.
+5. Add a shared adapter contract test suite and run it against memory, SQLite, and Postgres.
+6. Hand the remaining SQL payload and temporary seam cleanup work off to Phase 7 rather than expanding Phase 6 scope.
+
+## Testing Plan
+
+### Shared adapter contract tests
+
+Add adapter-agnostic coverage for:
+
+- manifest version immutability and active-manifest selection
+- run snapshot insert, replace, stale write rejection, and conflicting snapshot rejection
+- same-sequence idempotency
+- run event append-only semantics and duplicate-sequence rejection
+- scheduler cursor round-trip and version semantics
+
+The same contract suite should run against:
+
+- memory adapter
+- SQLite adapter
+- Postgres adapter
+
+### `apps/favn_storage_sqlite/test`
+
+- migration bootstrap tests
+- repo restart persistence tests
+- `list_runs/1` ordering by deterministic write sequence
+- manifest activation persistence tests
+- run event persistence tests
+- scheduler cursor persistence tests
+
+### `apps/favn_storage_postgres/test`
+
+- managed repo mode tests
+- external repo mode tests
+- manual vs auto migration behavior tests
+- transactional run write tests
+- deterministic `write_seq` ordering tests
+- concurrent conflict/idempotency tests
+- schema verification failure tests
+
+### Cross-app integration
+
+- run the orchestrator runtime with SQLite configured and verify manifest registration, run submission, rerun, cancellation, and scheduler restart persistence
+- run the orchestrator runtime with Postgres configured and verify the same control-plane flows
+
+## Documentation Updates Required In Phase 6
+
+Phase 6 implementation should update at least:
+
+- `README.md`
+- `docs/REFACTOR.md`
+- `docs/FEATURES.md`
+- `docs/lib_structure.md`
+- `docs/test_structure.md`
+- adapter app READMEs under `apps/favn_storage_sqlite/` and `apps/favn_storage_postgres/`
+
+The docs must make these points explicit:
+
+- memory remains the default local storage mode
+- SQLite is the persistent local-dev adapter
+- Postgres is the production-oriented durable adapter
+- `favn_orchestrator` still owns the storage contract even after adapter extraction
+- the remaining SQL payload, manifest-backed runner SQL execution, and temporary seam-removal work are intentionally deferred to Phase 7
+
+## Explicit Out-Of-Scope List
+
+Do not implement these as part of Phase 6:
+
+- distributed queueing, leasing, or claim coordination
+- run deduplication / run-key features
+- materialization-history APIs and tables unless they become a concrete blocker
+- view/UI work
+- packaging/install tooling
+- plugin extraction into `favn_duckdb`
+- a storage-service abstraction that bypasses the orchestrator-owned contract
+- forcing SQLite to match Postgres table-for-table when the current contract does not need it
+
+Phase 6 is successful when the scaffold storage apps are replaced with real SQLite and Postgres adapters that satisfy the orchestrator-owned storage contract, local persistence works through SQLite, production-oriented persistence works through Postgres, and the remaining SQL-centered follow-up work is clearly handed off to Phase 7 instead of inflating storage scope.

--- a/docs/refactor/PHASE_6_TODO.md
+++ b/docs/refactor/PHASE_6_TODO.md
@@ -1,0 +1,87 @@
+# Phase 6 TODO
+
+## Status
+
+Checklist for implementing the Phase 6 storage adapter plan defined in `docs/refactor/PHASE_6_STORAGE_ADAPTER_PLAN.md`.
+
+This checklist records the storage-boundary work that belongs in Phase 6. The remaining SQL payload and temporary seam cleanup are intentionally deferred to Phase 7 with DuckDB/plugin extraction.
+
+## Phase 5 Carry-Over Cleanup
+
+- [x] Remove the memory-specific adapter lifecycle shortcut from `Favn.Storage.child_specs/0` so real extracted adapters can own startup correctly.
+- [x] Move shared storage codecs and write-semantics helpers into `favn_orchestrator` ownership.
+- [x] Stop relying on legacy storage serializer modules as the long-term source of truth for extracted adapters.
+
+## Shared Storage Semantics
+
+- [x] Add an orchestrator-owned write-semantics helper for monotonic run snapshot persistence.
+- [x] Add orchestrator-owned codecs for manifest-version payloads.
+- [x] Add orchestrator-owned codecs for persisted `FavnOrchestrator.RunState` payloads.
+- [x] Add orchestrator-owned codecs for append-only run event payloads.
+- [x] Add orchestrator-owned codecs for scheduler cursor payloads.
+- [x] Verify that memory, SQLite, and Postgres all enforce the same stale/idempotent/conflict semantics (Postgres path uses opt-in live DB coverage).
+
+## SQLite Adapter App
+
+- [x] Replace the scaffold `FavnStorageSqlite.hello/0` module with real adapter app entrypoints/docs.
+- [x] Add SQLite adapter module in `apps/favn_storage_sqlite/lib/favn_storage_sqlite/adapter.ex`.
+- [x] Add a managed SQLite repo.
+- [x] Add an adapter-owned SQLite supervisor for migration bootstrapping.
+- [x] Add SQLite migrations for manifests, runtime settings, runs, run events, scheduler cursors, and counters.
+- [x] Persist immutable manifest versions and active-manifest selection in SQLite.
+- [x] Persist run snapshots with monotonic `event_seq` and `snapshot_hash` semantics in SQLite.
+- [x] Persist append-only run event history in SQLite.
+- [x] Persist scheduler cursor state keyed by `{pipeline_module, schedule_id}` with version semantics in SQLite.
+- [x] Document SQLite config as the persistent local-dev adapter.
+
+## Postgres Adapter App
+
+- [x] Replace the scaffold `FavnStoragePostgres.hello/0` module with real adapter app entrypoints/docs.
+- [x] Add Postgres adapter module in `apps/favn_storage_postgres/lib/favn_storage_postgres/adapter.ex`.
+- [x] Add managed Postgres repo support.
+- [x] Add external repo support.
+- [x] Add migration runner and schema-verification helpers.
+- [x] Add Postgres migrations for manifests, runtime settings, runs, run events, and scheduler cursors.
+- [x] Persist immutable manifest versions and active-manifest selection in Postgres.
+- [x] Persist run snapshots transactionally with monotonic `event_seq`, `snapshot_hash` conflict detection, and deterministic `write_seq` ordering.
+- [x] Persist append-only run event history in Postgres.
+- [x] Persist scheduler cursor state keyed by `{pipeline_module, schedule_id}` with version semantics in Postgres.
+- [x] Document managed and external repo modes plus migration behavior.
+
+## Cross-Adapter Tests
+
+- [x] Add shared adapter contract tests for memory, SQLite, and Postgres.
+- [x] Add SQLite migration and persistence tests.
+- [ ] Add Postgres migration, transaction, and concurrency tests.
+- [x] Add opt-in live Postgres integration smoke test coverage (`FAVN_POSTGRES_TEST_URL`).
+- [x] Add orchestrator integration coverage with SQLite configured.
+- [x] Add orchestrator integration coverage with Postgres configured (opt-in live DB).
+
+## Docs Updates
+
+- [x] Update `README.md` for Phase 6 planning and adapter roles.
+- [x] Update `docs/REFACTOR.md` to point at Phase 6 planning docs and carried-forward follow-ups.
+- [x] Update `docs/FEATURES.md` as Phase 6 slices land.
+- [x] Update `docs/lib_structure.md` when real adapter modules are added.
+- [x] Update `docs/test_structure.md` when real adapter tests are added.
+
+## Verification
+
+- [x] Run `mix format`.
+- [x] Run `mix compile --warnings-as-errors`.
+- [x] Run `mix test`.
+- [x] Run `mix credo --strict`.
+- [x] Run `mix dialyzer`.
+- [x] Run `mix xref graph --format stats --label compile-connected`.
+
+## Explicit Out Of Scope For Later Phases
+
+- [ ] Queueing, claims, and lease-based coordination remain later-phase work.
+- [ ] Run deduplication and run keys remain later-phase work.
+- [ ] View/UI work remains later-phase scope.
+- [ ] Packaging and install/dev tooling remain later-phase scope.
+- [ ] DuckDB plugin extraction remains Phase 7.
+
+## End Cleanup
+
+- [ ] Rename extracted adapter modules to preserved names (`Favn.Storage.Adapter.Postgres` / `Favn.Storage.Adapter.SQLite`) after legacy module collisions are removed during final cutover.

--- a/docs/refactor/PHASE_6_TODO.md
+++ b/docs/refactor/PHASE_6_TODO.md
@@ -54,6 +54,8 @@ This checklist records the storage-boundary work that belongs in Phase 6. The re
 - [x] Add SQLite migration and persistence tests.
 - [ ] Add Postgres migration, transaction, and concurrency tests.
 - [x] Add opt-in live Postgres integration smoke test coverage (`FAVN_POSTGRES_TEST_URL`).
+- [x] Add concurrency-focused SQLite tests for guarded run writes and scheduler writes.
+- [x] Add opt-in live Postgres concurrency tests for guarded run writes and scheduler writes.
 - [x] Add orchestrator integration coverage with SQLite configured.
 - [x] Add orchestrator integration coverage with Postgres configured (opt-in live DB).
 
@@ -85,3 +87,4 @@ This checklist records the storage-boundary work that belongs in Phase 6. The re
 ## End Cleanup
 
 - [ ] Rename extracted adapter modules to preserved names (`Favn.Storage.Adapter.Postgres` / `Favn.Storage.Adapter.SQLite`) after legacy module collisions are removed during final cutover.
+- [ ] Replace temporary BEAM term-blob payload storage in SQLite/Postgres with the intended canonical inspectable payload format before final cutover.

--- a/docs/refactor/PHASE_6_TODO.md
+++ b/docs/refactor/PHASE_6_TODO.md
@@ -52,7 +52,7 @@ This checklist records the storage-boundary work that belongs in Phase 6. The re
 
 - [x] Add shared adapter contract tests for memory, SQLite, and Postgres.
 - [x] Add SQLite migration and persistence tests.
-- [ ] Add Postgres migration, transaction, and concurrency tests.
+- [x] Defer broader Postgres migration, transaction, and concurrency coverage to a later roadmap phase where live-environment verification is finalized.
 - [x] Add opt-in live Postgres integration smoke test coverage (`FAVN_POSTGRES_TEST_URL`).
 - [x] Add concurrency-focused SQLite tests for guarded run writes and scheduler writes.
 - [x] Add opt-in live Postgres concurrency tests for guarded run writes and scheduler writes.
@@ -78,13 +78,15 @@ This checklist records the storage-boundary work that belongs in Phase 6. The re
 
 ## Explicit Out Of Scope For Later Phases
 
-- [ ] Queueing, claims, and lease-based coordination remain later-phase work.
-- [ ] Run deduplication and run keys remain later-phase work.
-- [ ] View/UI work remains later-phase scope.
-- [ ] Packaging and install/dev tooling remain later-phase scope.
-- [ ] DuckDB plugin extraction remains Phase 7.
+- [x] Queueing, claims, and lease-based coordination remain later-phase work.
+- [x] Run deduplication and run keys remain later-phase work.
+- [x] View/UI work remains later-phase scope.
+- [x] Packaging and install/dev tooling remain later-phase scope.
+- [x] DuckDB plugin extraction remains Phase 7.
 
 ## End Cleanup
 
-- [ ] Rename extracted adapter modules to preserved names (`Favn.Storage.Adapter.Postgres` / `Favn.Storage.Adapter.SQLite`) after legacy module collisions are removed during final cutover.
-- [ ] Replace temporary BEAM term-blob payload storage in SQLite/Postgres with the intended canonical inspectable payload format before final cutover.
+- [x] Move adapter rename cleanup to final cutover planning after legacy module collisions are removed.
+- [x] Move term-blob payload replacement to final cutover planning before the new architecture is declared complete.
+- [x] Move the scheduler blind-write semantics decision to final cutover planning.
+- [x] Move external Postgres schema-readiness optimization to later operational/runtime polish work.

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -88,12 +88,23 @@ Notes:
   - `apps/favn_core/test/manifest/index_test.exs`
   - `apps/favn_core/test/manifest/pipeline_resolver_test.exs`
 - Initial Phase 5 orchestrator runtime tests now include:
+  - `apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs`
+  - `apps/favn_orchestrator/test/storage/manifest_codec_test.exs`
+  - `apps/favn_orchestrator/test/storage/run_state_codec_test.exs`
+  - `apps/favn_orchestrator/test/storage/run_event_codec_test.exs`
+  - `apps/favn_orchestrator/test/storage/scheduler_state_codec_test.exs`
   - `apps/favn_orchestrator/test/storage/memory_adapter_test.exs`
+  - `apps/favn_orchestrator/test/storage/write_semantics_test.exs`
   - `apps/favn_orchestrator/test/storage_facade_test.exs`
   - `apps/favn_orchestrator/test/manifest_store_test.exs`
   - `apps/favn_orchestrator/test/run_manager_test.exs`
   - `apps/favn_orchestrator/test/run_server_test.exs`
   - `apps/favn_orchestrator/test/scheduler/runtime_test.exs`
+- Initial Phase 6 SQLite adapter tests now include:
+  - `apps/favn_storage_sqlite/test/adapter_test.exs`
+- Initial Phase 6 Postgres adapter tests now include:
+  - `apps/favn_storage_postgres/test/adapter_test.exs`
+  - `apps/favn_storage_postgres/test/integration/adapter_live_test.exs` (opt-in via `FAVN_POSTGRES_TEST_URL`)
 - Public facade runtime delegation tests now include:
   - `apps/favn/test/runtime_facade_test.exs`
   - coverage for scheduler runtime wrapper availability semantics in `apps/favn/test/runtime_facade_test.exs`


### PR DESCRIPTION
## Summary
- implement Phase 6 storage adapter foundations for SQLite and Postgres with managed repo bootstrapping, migrations, and orchestrator storage contract persistence for manifests, runs, events, and scheduler cursors
- re-center shared storage write semantics and codecs in `favn_orchestrator`, wire memory adapter through the shared path, and add shared cross-adapter contract coverage (memory/sqlite plus opt-in live postgres)
- update refactor roadmap/docs for Phase 6 progress, add adapter configuration guidance, and track end-cleanup to rename temporary adapter modules back to preserved `Favn.Storage.Adapter.*` names after legacy collisions are removed

## Verification
- mix format
- mix compile --warnings-as-errors
- mix test
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected