### PR TITLE
feat: implement phase 9 local tooling and packaging commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,44 @@ mix favn.reset
 
 Today this is still part of the ongoing `v0.5` refactor, but it is the intended public entrypoint for local iteration.
 
+### favn_local configuration
+
+`favn_local` reads local tooling config from `config :favn, :local` (with
+`config :favn, :dev` still supported for backward compatibility).
+
+```elixir
+config :favn, :local,
+  storage: :memory,
+  sqlite_path: ".favn/data/orchestrator.sqlite3",
+  postgres: [
+    hostname: "127.0.0.1",
+    port: 5432,
+    username: "postgres",
+    password: "postgres",
+    database: "favn",
+    ssl: false,
+    pool_size: 10
+  ]
+```
+
+Storage modes:
+
+- `mix favn.dev` uses configured storage (default `:memory`)
+- `mix favn.dev --sqlite` forces SQLite
+- `mix favn.dev --postgres` forces Postgres
+
+`mix favn.build.single` defaults to SQLite and accepts
+`--storage sqlite|postgres`.
+
+### favn_local implementation notes
+
+- public `mix favn.*` tasks are owned by `apps/favn`
+- implementation is owned by `apps/favn_local`
+- `mix favn.build.runner` is rooted in the current Mix project; `--root-dir`
+  must match the current project root
+- install currently records and snapshots runtime input metadata under
+  `.favn/install/runtimes/*` and caches npm data under `.favn/install/cache/npm`
+
 ## Common Public API Entry Points
 
 - `Favn.list_assets/0,1`

--- a/README.md
+++ b/README.md
@@ -34,7 +34,10 @@ Favn is in private development and the `v0.5.0` refactor is still in progress.
 
 - breaking changes are still allowed before `v1.0`
 - `{:favn, ...}` remains the one public package users should depend on
-- local development tooling is available today through `mix favn.dev`, `mix favn.reload`, `mix favn.status`, and `mix favn.stop`
+- local development tooling is available today through `mix favn.install`, `mix favn.dev`, `mix favn.reload`, `mix favn.status`, and `mix favn.stop`
+- initial packaging tooling now includes `mix favn.build.runner` for project-local runner artifact output under `.favn/dist/runner/<build_id>/`
+- split-target packaging now also includes `mix favn.build.web` and `mix favn.build.orchestrator` with project-local outputs under `.favn/dist/web/<build_id>/` and `.favn/dist/orchestrator/<build_id>/`
+- single-node assembly packaging now includes `mix favn.build.single` with project-local output under `.favn/dist/single/<build_id>/`
 
 ## What Favn Gives You
 
@@ -152,10 +155,13 @@ config :favn,
 Favn includes a local developer loop for running the current project with the Favn runtime stack.
 
 ```bash
+mix favn.install
 mix favn.dev
+mix favn.logs
 mix favn.status
 mix favn.reload
 mix favn.stop
+mix favn.reset
 ```
 
 Today this is still part of the ongoing `v0.5` refactor, but it is the intended public entrypoint for local iteration.

--- a/apps/favn/lib/mix/tasks/favn.build.orchestrator.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.orchestrator.ex
@@ -1,0 +1,32 @@
+defmodule Mix.Tasks.Favn.Build.Orchestrator do
+  use Mix.Task
+
+  @shortdoc "Builds the project-local orchestrator artifact"
+
+  @moduledoc """
+  Builds `.favn/build/orchestrator/<build_id>` and `.favn/dist/orchestrator/<build_id>`.
+  """
+
+  alias Favn.Dev
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _rest, _invalid} = OptionParser.parse(args, strict: [root_dir: :string])
+
+    case Dev.build_orchestrator(opts) do
+      {:ok, %{build_id: build_id, dist_dir: dist_dir}} ->
+        IO.puts("Favn orchestrator build complete")
+        IO.puts("build id: #{build_id}")
+        IO.puts("dist: #{dist_dir}")
+
+      {:error, :install_required} ->
+        Mix.raise("build blocked: install required; run mix favn.install")
+
+      {:error, :install_stale} ->
+        Mix.raise("build blocked: install stale; run mix favn.install --force")
+
+      {:error, reason} ->
+        Mix.raise("orchestrator build failed: #{inspect(reason)}")
+    end
+  end
+end

--- a/apps/favn/lib/mix/tasks/favn.build.runner.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.runner.ex
@@ -1,0 +1,32 @@
+defmodule Mix.Tasks.Favn.Build.Runner do
+  use Mix.Task
+
+  @shortdoc "Builds the project-local runner artifact"
+
+  @moduledoc """
+  Builds `.favn/build/runner/<build_id>` and `.favn/dist/runner/<build_id>`.
+  """
+
+  alias Favn.Dev
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _rest, _invalid} = OptionParser.parse(args, strict: [root_dir: :string])
+
+    case Dev.build_runner(opts) do
+      {:ok, %{build_id: build_id, dist_dir: dist_dir}} ->
+        IO.puts("Favn runner build complete")
+        IO.puts("build id: #{build_id}")
+        IO.puts("dist: #{dist_dir}")
+
+      {:error, :install_required} ->
+        Mix.raise("build blocked: install required; run mix favn.install")
+
+      {:error, :install_stale} ->
+        Mix.raise("build blocked: install stale; run mix favn.install --force")
+
+      {:error, reason} ->
+        Mix.raise("runner build failed: #{inspect(reason)}")
+    end
+  end
+end

--- a/apps/favn/lib/mix/tasks/favn.build.runner.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.runner.ex
@@ -5,6 +5,9 @@ defmodule Mix.Tasks.Favn.Build.Runner do
 
   @moduledoc """
   Builds `.favn/build/runner/<build_id>` and `.favn/dist/runner/<build_id>`.
+
+  The runner build is rooted in the current Mix project. `--root-dir` controls
+  artifact location only when it matches the current project root.
   """
 
   alias Favn.Dev
@@ -24,6 +27,11 @@ defmodule Mix.Tasks.Favn.Build.Runner do
 
       {:error, :install_stale} ->
         Mix.raise("build blocked: install stale; run mix favn.install --force")
+
+      {:error, {:unsupported_root_dir, requested, current}} ->
+        Mix.raise(
+          "runner build is rooted in the current Mix project only; got --root-dir=#{requested}, current=#{current}"
+        )
 
       {:error, reason} ->
         Mix.raise("runner build failed: #{inspect(reason)}")

--- a/apps/favn/lib/mix/tasks/favn.build.single.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.single.ex
@@ -1,0 +1,49 @@
+defmodule Mix.Tasks.Favn.Build.Single do
+  use Mix.Task
+
+  @shortdoc "Builds the project-local single-node bundle"
+
+  @moduledoc """
+  Builds `.favn/build/single/<build_id>` and `.favn/dist/single/<build_id>`.
+  """
+
+  alias Favn.Dev
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _rest, _invalid} =
+      OptionParser.parse(args, strict: [root_dir: :string, storage: :string])
+
+    opts = normalize_storage(opts)
+
+    case Dev.build_single(opts) do
+      {:ok, %{build_id: build_id, dist_dir: dist_dir}} ->
+        IO.puts("Favn single build complete")
+        IO.puts("build id: #{build_id}")
+        IO.puts("dist: #{dist_dir}")
+
+      {:error, :install_required} ->
+        Mix.raise("build blocked: install required; run mix favn.install")
+
+      {:error, :install_stale} ->
+        Mix.raise("build blocked: install stale; run mix favn.install --force")
+
+      {:error, {:invalid_storage, value}} ->
+        Mix.raise(
+          "single build failed: invalid storage #{inspect(value)}; expected sqlite|postgres"
+        )
+
+      {:error, reason} ->
+        Mix.raise("single build failed: #{inspect(reason)}")
+    end
+  end
+
+  defp normalize_storage(opts) do
+    case Keyword.get(opts, :storage) do
+      nil -> opts
+      "sqlite" -> Keyword.put(opts, :storage, :sqlite)
+      "postgres" -> Keyword.put(opts, :storage, :postgres)
+      other -> Keyword.put(opts, :storage, other)
+    end
+  end
+end

--- a/apps/favn/lib/mix/tasks/favn.build.single.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.single.ex
@@ -33,6 +33,11 @@ defmodule Mix.Tasks.Favn.Build.Single do
           "single build failed: invalid storage #{inspect(value)}; expected sqlite|postgres"
         )
 
+      {:error, {:unsupported_root_dir, requested, current}} ->
+        Mix.raise(
+          "single build is rooted in the current Mix project only; got --root-dir=#{requested}, current=#{current}"
+        )
+
       {:error, reason} ->
         Mix.raise("single build failed: #{inspect(reason)}")
     end

--- a/apps/favn/lib/mix/tasks/favn.build.web.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.web.ex
@@ -1,0 +1,32 @@
+defmodule Mix.Tasks.Favn.Build.Web do
+  use Mix.Task
+
+  @shortdoc "Builds the project-local web artifact"
+
+  @moduledoc """
+  Builds `.favn/build/web/<build_id>` and `.favn/dist/web/<build_id>`.
+  """
+
+  alias Favn.Dev
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _rest, _invalid} = OptionParser.parse(args, strict: [root_dir: :string])
+
+    case Dev.build_web(opts) do
+      {:ok, %{build_id: build_id, dist_dir: dist_dir}} ->
+        IO.puts("Favn web build complete")
+        IO.puts("build id: #{build_id}")
+        IO.puts("dist: #{dist_dir}")
+
+      {:error, :install_required} ->
+        Mix.raise("build blocked: install required; run mix favn.install")
+
+      {:error, :install_stale} ->
+        Mix.raise("build blocked: install stale; run mix favn.install --force")
+
+      {:error, reason} ->
+        Mix.raise("web build failed: #{inspect(reason)}")
+    end
+  end
+end

--- a/apps/favn/lib/mix/tasks/favn.dev.ex
+++ b/apps/favn/lib/mix/tasks/favn.dev.ex
@@ -14,9 +14,9 @@ defmodule Mix.Tasks.Favn.Dev do
   @impl Mix.Task
   def run(args) do
     {opts, _rest, _invalid} =
-      OptionParser.parse(args, strict: [root_dir: :string, sqlite: :boolean])
+      OptionParser.parse(args, strict: [root_dir: :string, sqlite: :boolean, postgres: :boolean])
 
-    opts = maybe_sqlite(opts)
+    opts = normalize_storage_flags(opts)
 
     case Dev.dev(opts) do
       :ok -> :ok
@@ -27,11 +27,17 @@ defmodule Mix.Tasks.Favn.Dev do
     end
   end
 
-  defp maybe_sqlite(opts) do
-    if Keyword.get(opts, :sqlite, false) do
-      opts |> Keyword.delete(:sqlite) |> Keyword.put(:storage, :sqlite)
-    else
-      Keyword.delete(opts, :sqlite)
+  defp normalize_storage_flags(opts) do
+    sqlite? = Keyword.get(opts, :sqlite, false)
+    postgres? = Keyword.get(opts, :postgres, false)
+
+    opts = opts |> Keyword.delete(:sqlite) |> Keyword.delete(:postgres)
+
+    cond do
+      sqlite? and postgres? -> Mix.raise("choose only one storage flag: --sqlite or --postgres")
+      sqlite? -> Keyword.put(opts, :storage, :sqlite)
+      postgres? -> Keyword.put(opts, :storage, :postgres)
+      true -> opts
     end
   end
 end

--- a/apps/favn/lib/mix/tasks/favn.dev.ex
+++ b/apps/favn/lib/mix/tasks/favn.dev.ex
@@ -21,6 +21,8 @@ defmodule Mix.Tasks.Favn.Dev do
     case Dev.dev(opts) do
       :ok -> :ok
       {:error, :stack_already_running} -> Mix.raise("local stack already running")
+      {:error, :install_required} -> Mix.raise("install required; run mix favn.install")
+      {:error, :install_stale} -> Mix.raise("install stale; run mix favn.install --force")
       {:error, reason} -> Mix.raise("failed to start local stack: #{inspect(reason)}")
     end
   end

--- a/apps/favn/lib/mix/tasks/favn.install.ex
+++ b/apps/favn/lib/mix/tasks/favn.install.ex
@@ -1,0 +1,38 @@
+defmodule Mix.Tasks.Favn.Install do
+  use Mix.Task
+
+  @shortdoc "Resolves project-local Favn install inputs"
+
+  @moduledoc """
+  Resolves and validates project-local install inputs under `.favn/install`.
+  """
+
+  alias Favn.Dev
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _rest, _invalid} =
+      OptionParser.parse(args,
+        strict: [
+          root_dir: :string,
+          force: :boolean,
+          skip_web_install: :boolean,
+          skip_tool_checks: :boolean
+        ]
+      )
+
+    case Dev.install(opts) do
+      :ok ->
+        IO.puts("Favn install complete")
+
+      {:error, :already_installed} ->
+        IO.puts("Favn install is already up to date")
+
+      {:error, {:missing_tool, tool}} ->
+        Mix.raise("install failed: missing required tool #{tool}")
+
+      {:error, reason} ->
+        Mix.raise("install failed: #{inspect(reason)}")
+    end
+  end
+end

--- a/apps/favn/lib/mix/tasks/favn.install.ex
+++ b/apps/favn/lib/mix/tasks/favn.install.ex
@@ -22,10 +22,10 @@ defmodule Mix.Tasks.Favn.Install do
       )
 
     case Dev.install(opts) do
-      :ok ->
+      {:ok, :installed} ->
         IO.puts("Favn install complete")
 
-      {:error, :already_installed} ->
+      {:ok, :already_installed} ->
         IO.puts("Favn install is already up to date")
 
       {:error, {:missing_tool, tool}} ->

--- a/apps/favn/lib/mix/tasks/favn.logs.ex
+++ b/apps/favn/lib/mix/tasks/favn.logs.ex
@@ -1,0 +1,45 @@
+defmodule Mix.Tasks.Favn.Logs do
+  use Mix.Task
+
+  @shortdoc "Prints local Favn service logs"
+
+  @moduledoc """
+  Reads project-local logs under `.favn/logs`.
+  """
+
+  alias Favn.Dev
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _rest, _invalid} =
+      OptionParser.parse(args,
+        strict: [root_dir: :string, service: :string, tail: :integer, follow: :boolean]
+      )
+
+    opts = normalize_service(opts)
+
+    :ok = Dev.logs(opts)
+  end
+
+  defp normalize_service(opts) do
+    case Keyword.get(opts, :service) do
+      nil ->
+        opts
+
+      "web" ->
+        Keyword.put(opts, :service, :web)
+
+      "orchestrator" ->
+        Keyword.put(opts, :service, :orchestrator)
+
+      "runner" ->
+        Keyword.put(opts, :service, :runner)
+
+      "all" ->
+        Keyword.put(opts, :service, :all)
+
+      other ->
+        Mix.raise("invalid service #{inspect(other)}; expected web|orchestrator|runner|all")
+    end
+  end
+end

--- a/apps/favn/lib/mix/tasks/favn.reset.ex
+++ b/apps/favn/lib/mix/tasks/favn.reset.ex
@@ -1,0 +1,27 @@
+defmodule Mix.Tasks.Favn.Reset do
+  use Mix.Task
+
+  @shortdoc "Deletes project-local Favn state"
+
+  @moduledoc """
+  Deletes project-local `.favn/` install/build/runtime artifacts.
+  """
+
+  alias Favn.Dev
+
+  @impl Mix.Task
+  def run(args) do
+    {opts, _rest, _invalid} = OptionParser.parse(args, strict: [root_dir: :string])
+
+    case Dev.reset(opts) do
+      :ok ->
+        IO.puts("Favn local state reset complete")
+
+      {:error, :stack_running} ->
+        Mix.raise("reset blocked: stack appears running; run mix favn.stop first")
+
+      {:error, reason} ->
+        Mix.raise("reset failed: #{inspect(reason)}")
+    end
+  end
+end

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -4,7 +4,14 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
   import ExUnit.CaptureIO
 
   alias Favn.Dev.State
+  alias Mix.Tasks.Favn.Build.Orchestrator, as: BuildOrchestratorTask
+  alias Mix.Tasks.Favn.Build.Runner, as: BuildRunnerTask
+  alias Mix.Tasks.Favn.Build.Single, as: BuildSingleTask
+  alias Mix.Tasks.Favn.Build.Web, as: BuildWebTask
   alias Mix.Tasks.Favn.Dev, as: DevTask
+  alias Mix.Tasks.Favn.Install, as: InstallTask
+  alias Mix.Tasks.Favn.Logs, as: LogsTask
+  alias Mix.Tasks.Favn.Reset, as: ResetTask
   alias Mix.Tasks.Favn.Status, as: StatusTask
 
   setup do
@@ -12,6 +19,24 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
       Path.join(System.tmp_dir!(), "favn_public_tasks_test_#{System.unique_integer([:positive])}")
 
     File.mkdir_p!(root_dir)
+
+    File.mkdir_p!(Path.join(root_dir, "web/favn_web"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_runner"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_orchestrator"))
+
+    File.write!(Path.join(root_dir, "mix.lock"), "lock")
+    File.write!(Path.join(root_dir, "web/favn_web/package.json"), "{}")
+    File.write!(Path.join(root_dir, "web/favn_web/package-lock.json"), "{}")
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_runner/mix.exs"),
+      "defmodule Runner.MixProject do end"
+    )
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_orchestrator/mix.exs"),
+      "defmodule Orchestrator.MixProject do end"
+    )
 
     on_exit(fn ->
       File.rm_rf(root_dir)
@@ -34,6 +59,12 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert :ok = State.write_runtime(runtime, root_dir: root_dir)
 
     assert_raise Mix.Error, ~r/local stack already running/, fn ->
+      DevTask.run(["--root-dir", root_dir])
+    end
+  end
+
+  test "mix favn.dev raises when install is missing", %{root_dir: root_dir} do
+    assert_raise Mix.Error, ~r/install required; run mix favn.install/, fn ->
       DevTask.run(["--root-dir", root_dir])
     end
   end
@@ -63,5 +94,105 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert output =~ "web:"
     assert output =~ "orchestrator:"
     assert output =~ "runner:"
+  end
+
+  test "mix favn.install writes install state", %{root_dir: root_dir} do
+    output =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install", "--skip-tool-checks"])
+      end)
+
+    assert output =~ "Favn install complete"
+    assert {:ok, _install} = State.read_install(root_dir: root_dir)
+    assert {:ok, _toolchain} = State.read_toolchain(root_dir: root_dir)
+  end
+
+  test "mix favn.logs prints service logs", %{root_dir: root_dir} do
+    assert :ok = State.ensure_layout(root_dir: root_dir)
+    assert :ok = File.write(Path.join(root_dir, ".favn/logs/web.log"), "hello\n")
+
+    output =
+      capture_io(fn ->
+        LogsTask.run(["--root-dir", root_dir, "--service", "web"])
+      end)
+
+    assert output =~ "hello"
+  end
+
+  test "mix favn.reset removes .favn when stack is not running", %{root_dir: root_dir} do
+    assert :ok = State.ensure_layout(root_dir: root_dir)
+    assert File.dir?(Path.join(root_dir, ".favn"))
+
+    output =
+      capture_io(fn ->
+        ResetTask.run(["--root-dir", root_dir])
+      end)
+
+    assert output =~ "Favn local state reset complete"
+    refute File.exists?(Path.join(root_dir, ".favn"))
+  end
+
+  test "mix favn.build.runner prints build summary", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+      end)
+
+    output =
+      capture_io(fn ->
+        BuildRunnerTask.run(["--root-dir", root_dir])
+      end)
+
+    assert output =~ "Favn runner build complete"
+    assert output =~ "build id:"
+    assert output =~ "/.favn/dist/runner/"
+  end
+
+  test "mix favn.build.web prints build summary", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+      end)
+
+    output =
+      capture_io(fn ->
+        BuildWebTask.run(["--root-dir", root_dir])
+      end)
+
+    assert output =~ "Favn web build complete"
+    assert output =~ "build id:"
+    assert output =~ "/.favn/dist/web/"
+  end
+
+  test "mix favn.build.orchestrator prints build summary", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+      end)
+
+    output =
+      capture_io(fn ->
+        BuildOrchestratorTask.run(["--root-dir", root_dir])
+      end)
+
+    assert output =~ "Favn orchestrator build complete"
+    assert output =~ "build id:"
+    assert output =~ "/.favn/dist/orchestrator/"
+  end
+
+  test "mix favn.build.single prints build summary", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+      end)
+
+    output =
+      capture_io(fn ->
+        BuildSingleTask.run(["--root-dir", root_dir, "--storage", "sqlite"])
+      end)
+
+    assert output =~ "Favn single build complete"
+    assert output =~ "build id:"
+    assert output =~ "/.favn/dist/single/"
   end
 end

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -107,6 +107,20 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert {:ok, _toolchain} = State.read_toolchain(root_dir: root_dir)
   end
 
+  test "mix favn.install reports already up to date", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install", "--skip-tool-checks"])
+      end)
+
+    output =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install", "--skip-tool-checks"])
+      end)
+
+    assert output =~ "Favn install is already up to date"
+  end
+
   test "mix favn.logs prints service logs", %{root_dir: root_dir} do
     assert :ok = State.ensure_layout(root_dir: root_dir)
     assert :ok = File.write(Path.join(root_dir, ".favn/logs/web.log"), "hello\n")
@@ -132,20 +146,35 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     refute File.exists?(Path.join(root_dir, ".favn"))
   end
 
-  test "mix favn.build.runner prints build summary", %{root_dir: root_dir} do
+  test "mix favn.build.runner prints build summary" do
+    current_root = File.cwd!()
+
     _ =
       capture_io(fn ->
-        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+        InstallTask.run(["--root-dir", current_root, "--skip-web-install"])
       end)
 
     output =
       capture_io(fn ->
-        BuildRunnerTask.run(["--root-dir", root_dir])
+        BuildRunnerTask.run(["--root-dir", current_root])
       end)
 
     assert output =~ "Favn runner build complete"
     assert output =~ "build id:"
     assert output =~ "/.favn/dist/runner/"
+  end
+
+  test "mix favn.build.runner rejects root_dir outside current mix project", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+      end)
+
+    assert_raise Mix.Error,
+                 ~r/runner build is rooted in the current Mix project only/,
+                 fn ->
+                   BuildRunnerTask.run(["--root-dir", root_dir])
+                 end
   end
 
   test "mix favn.build.web prints build summary", %{root_dir: root_dir} do
@@ -180,15 +209,17 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert output =~ "/.favn/dist/orchestrator/"
   end
 
-  test "mix favn.build.single prints build summary", %{root_dir: root_dir} do
+  test "mix favn.build.single prints build summary" do
+    current_root = File.cwd!()
+
     _ =
       capture_io(fn ->
-        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+        InstallTask.run(["--root-dir", current_root, "--skip-web-install"])
       end)
 
     output =
       capture_io(fn ->
-        BuildSingleTask.run(["--root-dir", root_dir, "--storage", "sqlite"])
+        BuildSingleTask.run(["--root-dir", current_root, "--storage", "sqlite"])
       end)
 
     assert output =~ "Favn single build complete"

--- a/apps/favn_local/README.md
+++ b/apps/favn_local/README.md
@@ -1,0 +1,177 @@
+# favn_local
+
+`favn_local` owns local developer tooling and project-local packaging workflows
+for Favn.
+
+`apps/favn` exposes the public `mix favn.*` tasks. Those tasks delegate to
+`Favn.Dev` in this app.
+
+## Scope and ownership
+
+`favn_local` owns:
+
+- local stack lifecycle implementation (`dev`, `stop`, `status`, `reload`)
+- install/reset/log tooling (`install`, `reset`, `logs`)
+- project-local packaging flows (`build.runner`, `build.web`,
+  `build.orchestrator`, `build.single`)
+- project-local filesystem state under `.favn/`
+
+`favn_local` does not define public authoring APIs. Authoring and manifest
+compile logic remains in `favn_authoring`.
+
+## Public task surface
+
+These tasks are exposed by `apps/favn` and implemented by `favn_local`:
+
+- `mix favn.install`
+- `mix favn.dev`
+- `mix favn.status`
+- `mix favn.logs`
+- `mix favn.reload`
+- `mix favn.stop`
+- `mix favn.reset`
+- `mix favn.build.runner`
+- `mix favn.build.web`
+- `mix favn.build.orchestrator`
+- `mix favn.build.single`
+
+## Typical usage
+
+### First-time local setup
+
+```bash
+mix favn.install
+mix favn.dev
+```
+
+### Inspect and iterate
+
+```bash
+mix favn.status
+mix favn.logs --service runner --tail 200
+mix favn.reload
+mix favn.stop
+```
+
+### Clean local state
+
+```bash
+mix favn.reset
+```
+
+### Build artifacts
+
+```bash
+mix favn.build.runner
+mix favn.build.web
+mix favn.build.orchestrator
+mix favn.build.single --storage sqlite
+mix favn.build.single --storage postgres
+```
+
+## Configuration contract
+
+`favn_local` reads local tooling config from `config :favn, :local`.
+
+`config :favn, :dev` is still read and merged for backward compatibility, but
+`:local` is the source-of-truth namespace for new config.
+
+Example:
+
+```elixir
+config :favn, :local,
+  storage: :memory,
+  sqlite_path: ".favn/data/orchestrator.sqlite3",
+  postgres: [
+    hostname: "127.0.0.1",
+    port: 5432,
+    username: "postgres",
+    password: "postgres",
+    database: "favn",
+    ssl: false,
+    pool_size: 10
+  ],
+  orchestrator_port: 4101,
+  web_port: 4173
+```
+
+Storage selection:
+
+- default: `:memory`
+- `mix favn.dev --sqlite` forces `:sqlite`
+- `mix favn.dev --postgres` forces `:postgres`
+
+## `.favn/` layout
+
+`favn_local` keeps all managed project-local side effects under `.favn/`:
+
+- `install/` install metadata, toolchain capture, runtime input snapshots
+- `build/` per-target build working directories
+- `dist/` per-target final artifact outputs
+- `logs/` local service logs
+- `data/` local sqlite data
+- `manifests/` latest and cached manifest metadata
+- `history/` failure metadata
+- `runtime.json` live stack state
+- `secrets.json` local generated secrets
+
+## How core flows work
+
+### Install
+
+`mix favn.install`:
+
+- validates tool prerequisites (node/npm by default)
+- computes and stores an install fingerprint
+- captures toolchain metadata
+- snapshots runtime input metadata and source files under
+  `.favn/install/runtimes/*`
+- stores npm cache under `.favn/install/cache/npm`
+
+`mix favn.dev` and build tasks validate install freshness before running.
+
+### Local dev startup
+
+`mix favn.dev` starts runner, orchestrator, and web as separate local processes
+and writes runtime state to `.favn/runtime.json`.
+
+Readiness is checked by TCP connection to configured service URLs.
+
+Web asset build is performed only when `web/favn_web/dist/index.html` is
+missing.
+
+### Reload
+
+`mix favn.reload`:
+
+- requires a healthy running stack
+- recompiles and rebuilds/pins manifest
+- restarts runner and re-registers manifest
+- publishes/activates manifest in orchestrator
+- updates runtime active manifest metadata
+
+Runner restart uses a short node name for `--sname`, derived from stored
+runtime full node name.
+
+### Logs and reset
+
+- `mix favn.logs` reads files under `.favn/logs/` (supports service filter,
+  tail, and follow)
+- `mix favn.reset` removes `.favn/` after verifying no managed services are
+  still running
+
+### Packaging targets
+
+- `build.runner`: project-specific runner artifact with user code + pinned
+  manifest + plugin inventory metadata
+- `build.web`: web/BFF artifact metadata and bundle contract
+- `build.orchestrator`: orchestrator artifact metadata and storage contract
+- `build.single`: assembles `web/`, `orchestrator/`, and `runner/` into one
+  single-node bundle with generated `config/assembly.json`, `env/*.env`, and
+  `bin/start|stop`
+
+## Platform assumptions
+
+`favn_local` supports Unix and Windows process checks/termination paths.
+
+Node/npm are required for web install/build flows.

--- a/apps/favn_local/lib/favn/dev.ex
+++ b/apps/favn_local/lib/favn/dev.ex
@@ -6,12 +6,66 @@ defmodule Favn.Dev do
   modules under `Favn.Dev.*`.
   """
 
+  alias Favn.Dev.Build.Orchestrator, as: OrchestratorBuild
+  alias Favn.Dev.Build.Runner, as: RunnerBuild
+  alias Favn.Dev.Build.Single, as: SingleBuild
+  alias Favn.Dev.Build.Web, as: WebBuild
+  alias Favn.Dev.Install
+  alias Favn.Dev.Logs
   alias Favn.Dev.Reload
+  alias Favn.Dev.Reset
   alias Favn.Dev.Stack
   alias Favn.Dev.Status
 
   @type status_opts :: [root_dir: Path.t()]
   @type lifecycle_opts :: [root_dir: Path.t()]
+
+  @doc """
+  Resolves and validates local install inputs used by dev tooling.
+  """
+  @spec install(lifecycle_opts()) :: :ok | {:error, term()}
+  def install(opts \\ []) when is_list(opts), do: Install.run(opts)
+
+  @doc false
+  @spec ensure_install_ready(lifecycle_opts()) :: :ok | {:error, term()}
+  def ensure_install_ready(opts \\ []) when is_list(opts), do: Install.ensure_ready(opts)
+
+  @doc """
+  Deletes all project-local `.favn/` artifacts after ensuring no owned services
+  are still running.
+  """
+  @spec reset(lifecycle_opts()) :: :ok | {:error, term()}
+  def reset(opts \\ []) when is_list(opts), do: Reset.run(opts)
+
+  @doc """
+  Prints local service logs.
+  """
+  @spec logs(keyword()) :: :ok
+  def logs(opts \\ []) when is_list(opts), do: Logs.run(opts)
+
+  @doc """
+  Builds the project-local runner packaging target.
+  """
+  @spec build_runner(lifecycle_opts()) :: {:ok, map()} | {:error, term()}
+  def build_runner(opts \\ []) when is_list(opts), do: RunnerBuild.run(opts)
+
+  @doc """
+  Builds the project-local web packaging target.
+  """
+  @spec build_web(lifecycle_opts()) :: {:ok, map()} | {:error, term()}
+  def build_web(opts \\ []) when is_list(opts), do: WebBuild.run(opts)
+
+  @doc """
+  Builds the project-local orchestrator packaging target.
+  """
+  @spec build_orchestrator(lifecycle_opts()) :: {:ok, map()} | {:error, term()}
+  def build_orchestrator(opts \\ []) when is_list(opts), do: OrchestratorBuild.run(opts)
+
+  @doc """
+  Builds the project-local single-node assembly target.
+  """
+  @spec build_single(lifecycle_opts()) :: {:ok, map()} | {:error, term()}
+  def build_single(opts \\ []) when is_list(opts), do: SingleBuild.run(opts)
 
   @doc """
   Starts local stack in foreground mode.

--- a/apps/favn_local/lib/favn/dev.ex
+++ b/apps/favn_local/lib/favn/dev.ex
@@ -23,7 +23,7 @@ defmodule Favn.Dev do
   @doc """
   Resolves and validates local install inputs used by dev tooling.
   """
-  @spec install(lifecycle_opts()) :: :ok | {:error, term()}
+  @spec install(lifecycle_opts()) :: {:ok, :installed | :already_installed} | {:error, term()}
   def install(opts \\ []) when is_list(opts), do: Install.run(opts)
 
   @doc false

--- a/apps/favn_local/lib/favn/dev/build/orchestrator.ex
+++ b/apps/favn_local/lib/favn/dev/build/orchestrator.ex
@@ -1,0 +1,117 @@
+defmodule Favn.Dev.Build.Orchestrator do
+  @moduledoc """
+  Project-local orchestrator build target.
+  """
+
+  alias Favn.Dev.Install
+  alias Favn.Dev.Paths
+  alias Favn.Dev.State
+
+  @schema_version 1
+  @target "orchestrator"
+
+  @type root_opt :: [root_dir: Path.t()]
+
+  @spec run(root_opt()) :: {:ok, map()} | {:error, term()}
+  def run(opts \\ []) when is_list(opts) do
+    with :ok <- Install.ensure_ready(opts),
+         :ok <- State.ensure_layout(opts),
+         {:ok, install} <- State.read_install(opts),
+         source_root when is_binary(source_root) <- runtime_source_root(install, "orchestrator"),
+         {build_id, root_dir} <- {build_id(), Paths.root_dir(opts)},
+         build_dir <- Paths.build_orchestrator_dir(root_dir, build_id),
+         dist_dir <- Paths.dist_orchestrator_dir(root_dir, build_id),
+         :ok <- File.mkdir_p(build_dir),
+         :ok <- File.mkdir_p(dist_dir),
+         build_json <- build_json(build_id, source_root, opts),
+         metadata_json <- metadata_json(build_id, source_root, opts),
+         :ok <- write_json(Path.join(build_dir, "build.json"), build_json),
+         :ok <- write_json(Path.join(dist_dir, "metadata.json"), metadata_json),
+         :ok <-
+           write_json(
+             Path.join(dist_dir, "bundle.json"),
+             orchestrator_bundle_json(build_id, source_root, opts)
+           ) do
+      {:ok, %{build_id: build_id, build_dir: build_dir, dist_dir: dist_dir}}
+    else
+      nil -> {:error, :missing_install_runtime_input}
+      {:error, :not_found} -> {:error, :install_required}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp runtime_source_root(install, target) when is_map(install) do
+    get_in(install, ["runtime_inputs", target, "source_root"])
+  end
+
+  defp build_json(build_id, source_root, opts) do
+    base(build_id, opts)
+    |> Map.put("phase", "build")
+    |> Map.put("target", @target)
+    |> Map.put("orchestrator_source_root", source_root)
+  end
+
+  defp metadata_json(build_id, source_root, opts) do
+    base(build_id, opts)
+    |> Map.put("phase", "dist")
+    |> Map.put("target", @target)
+    |> Map.put("orchestrator_source_root", source_root)
+    |> Map.put("compatibility", %{
+      "orchestrator_api_version" => "v1",
+      "runner_contract_version" => 1,
+      "supported_storage_modes" => ["memory", "sqlite", "postgres"]
+    })
+    |> Map.put("required_env", [
+      "FAVN_STORAGE",
+      "FAVN_SQLITE_PATH",
+      "FAVN_POSTGRES_HOST",
+      "FAVN_POSTGRES_PORT",
+      "FAVN_POSTGRES_USERNAME",
+      "FAVN_POSTGRES_PASSWORD",
+      "FAVN_POSTGRES_DATABASE",
+      "FAVN_POSTGRES_SSL",
+      "FAVN_ORCHESTRATOR_API_SERVICE_TOKENS"
+    ])
+  end
+
+  defp orchestrator_bundle_json(build_id, source_root, opts) do
+    %{
+      "schema_version" => @schema_version,
+      "target" => @target,
+      "build_id" => build_id,
+      "source_root" => source_root,
+      "generated_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "project_root" => Paths.root_dir(opts)
+    }
+  end
+
+  defp base(build_id, opts) do
+    %{
+      "schema_version" => @schema_version,
+      "build_id" => build_id,
+      "built_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "favn_version" => to_string(Application.spec(:favn, :vsn) || "unknown"),
+      "install_fingerprint" => read_install_fingerprint(opts),
+      "elixir_version" => System.version(),
+      "otp_release" => :erlang.system_info(:otp_release) |> List.to_string()
+    }
+  end
+
+  defp read_install_fingerprint(opts) do
+    case State.read_install(opts) do
+      {:ok, %{"fingerprint" => fingerprint}} when is_map(fingerprint) -> fingerprint
+      _ -> %{}
+    end
+  end
+
+  defp write_json(path, map) when is_map(map) do
+    encoded = JSON.encode_to_iodata!(map)
+    File.write(path, [encoded, "\n"])
+  end
+
+  defp build_id do
+    stamp = DateTime.utc_now() |> Calendar.strftime("%Y%m%d%H%M%S")
+    unique = System.unique_integer([:positive])
+    "ob_#{stamp}_#{unique}"
+  end
+end

--- a/apps/favn_local/lib/favn/dev/build/runner.ex
+++ b/apps/favn_local/lib/favn/dev/build/runner.ex
@@ -1,6 +1,10 @@
 defmodule Favn.Dev.Build.Runner do
   @moduledoc """
   Project-local runner build target.
+
+  This target currently builds the manifest and compiled user modules from the
+  current Mix project root (`File.cwd!/0`). A different `:root_dir` is not
+  accepted for project selection.
   """
 
   alias Favn.Dev.Install
@@ -14,7 +18,8 @@ defmodule Favn.Dev.Build.Runner do
 
   @spec run(root_opt()) :: {:ok, map()} | {:error, term()}
   def run(opts \\ []) when is_list(opts) do
-    with :ok <- Install.ensure_ready(opts),
+    with :ok <- ensure_project_root(opts),
+         :ok <- Install.ensure_ready(opts),
          :ok <- State.ensure_layout(opts),
          :ok <- force_compile(opts),
          {:ok, build} <- FavnAuthoring.build_manifest(),
@@ -35,6 +40,17 @@ defmodule Favn.Dev.Build.Runner do
          :ok <- write_json(Path.join(dist_dir, "metadata.json"), metadata_json),
          :ok <- File.write(Path.join(dist_dir, "manifest.json"), serialized_manifest <> "\n") do
       {:ok, %{build_id: build_id, build_dir: build_dir, dist_dir: dist_dir}}
+    end
+  end
+
+  defp ensure_project_root(opts) do
+    requested_root = opts |> Paths.root_dir() |> Path.expand()
+    current_root = File.cwd!() |> Path.expand()
+
+    if requested_root == current_root or Keyword.get(opts, :skip_project_root_check, false) do
+      :ok
+    else
+      {:error, {:unsupported_root_dir, requested_root, current_root}}
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/build/runner.ex
+++ b/apps/favn_local/lib/favn/dev/build/runner.ex
@@ -1,0 +1,179 @@
+defmodule Favn.Dev.Build.Runner do
+  @moduledoc """
+  Project-local runner build target.
+  """
+
+  alias Favn.Dev.Install
+  alias Favn.Dev.Paths
+  alias Favn.Dev.State
+
+  @schema_version 1
+  @target "runner"
+
+  @type root_opt :: [root_dir: Path.t()]
+
+  @spec run(root_opt()) :: {:ok, map()} | {:error, term()}
+  def run(opts \\ []) when is_list(opts) do
+    with :ok <- Install.ensure_ready(opts),
+         :ok <- State.ensure_layout(opts),
+         :ok <- force_compile(opts),
+         {:ok, build} <- FavnAuthoring.build_manifest(),
+         {:ok, version} <- FavnAuthoring.pin_manifest_version(build.manifest),
+         {:ok, serialized_manifest} <- FavnAuthoring.serialize_manifest(version.manifest),
+         {build_id, root_dir} <- {build_id(), Paths.root_dir(opts)},
+         build_dir <- Paths.build_runner_dir(root_dir, build_id),
+         dist_dir <- Paths.dist_runner_dir(root_dir, build_id),
+         :ok <- File.mkdir_p(build_dir),
+         :ok <- File.mkdir_p(dist_dir),
+         modules <- user_modules(version.manifest),
+         copied_modules <- copy_module_beams(modules, Path.join(dist_dir, "ebin")),
+         plugins <- selected_plugins(root_dir),
+         :ok <- write_manifest_cache(version, serialized_manifest, opts),
+         build_json <- build_json(build_id, version, modules, plugins, copied_modules, opts),
+         metadata_json <- metadata_json(build_id, version, modules, plugins, copied_modules, opts),
+         :ok <- write_json(Path.join(build_dir, "build.json"), build_json),
+         :ok <- write_json(Path.join(dist_dir, "metadata.json"), metadata_json),
+         :ok <- File.write(Path.join(dist_dir, "manifest.json"), serialized_manifest <> "\n") do
+      {:ok, %{build_id: build_id, build_dir: build_dir, dist_dir: dist_dir}}
+    end
+  end
+
+  defp force_compile(opts) do
+    if Keyword.get(opts, :skip_compile, false) do
+      :ok
+    else
+      :ok = Mix.Task.reenable("compile")
+      _ = Mix.Task.run("compile", ["--force"])
+      :ok
+    end
+  end
+
+  defp user_modules(manifest) do
+    asset_modules = manifest_modules(manifest, :assets)
+    pipeline_modules = manifest_modules(manifest, :pipelines)
+    schedule_modules = manifest_modules(manifest, :schedules)
+
+    (asset_modules ++ pipeline_modules ++ schedule_modules)
+    |> Enum.uniq()
+    |> Enum.sort_by(&Atom.to_string/1)
+  end
+
+  defp manifest_modules(manifest, key) do
+    manifest
+    |> map_get(key)
+    |> List.wrap()
+    |> Enum.map(&map_get(&1, :module))
+    |> Enum.filter(&is_atom/1)
+  end
+
+  defp map_get(map, key) when is_map(map) and is_atom(key) do
+    Map.get(map, key) || Map.get(map, Atom.to_string(key))
+  end
+
+  defp map_get(_other, _key), do: nil
+
+  defp copy_module_beams(modules, target_dir) do
+    :ok = File.mkdir_p(target_dir)
+
+    Enum.reduce(modules, [], fn module, copied ->
+      with {:module, _loaded} <- Code.ensure_loaded(module),
+           beam when is_list(beam) <- :code.which(module),
+           beam_path <- List.to_string(beam),
+           true <- String.ends_with?(beam_path, ".beam"),
+           true <- File.exists?(beam_path),
+           destination <- Path.join(target_dir, Path.basename(beam_path)),
+           :ok <- File.cp(beam_path, destination) do
+        [Atom.to_string(module) | copied]
+      else
+        _ -> copied
+      end
+    end)
+    |> Enum.reverse()
+  end
+
+  defp selected_plugins(root_dir) do
+    configured =
+      Application.get_env(:favn, :runner_plugins, [])
+      |> List.wrap()
+      |> Enum.map(&to_string/1)
+
+    known =
+      ["favn_duckdb"]
+      |> Enum.filter(fn app_name ->
+        File.dir?(Path.join(root_dir, "apps/#{app_name}"))
+      end)
+
+    (configured ++ known)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp write_manifest_cache(version, serialized_manifest, opts) do
+    root_dir = Paths.root_dir(opts)
+    path = Path.join(Paths.manifest_cache_dir(root_dir), "#{version.manifest_version_id}.json")
+    File.mkdir_p!(Path.dirname(path))
+    File.write(path, serialized_manifest <> "\n")
+  end
+
+  defp build_json(build_id, version, modules, plugins, copied_modules, opts) do
+    base(build_id, version, opts)
+    |> Map.put("phase", "build")
+    |> Map.put("target", @target)
+    |> Map.put("project_root", Paths.root_dir(opts))
+    |> Map.put("user_modules", Enum.map(modules, &Atom.to_string/1))
+    |> Map.put("copied_module_beams", copied_modules)
+    |> Map.put("plugins", plugins)
+  end
+
+  defp metadata_json(build_id, version, modules, plugins, copied_modules, opts) do
+    base(build_id, version, opts)
+    |> Map.put("phase", "dist")
+    |> Map.put("target", @target)
+    |> Map.put("compatibility", %{
+      "manifest_schema_version" => version.schema_version,
+      "runner_contract_version" => version.runner_contract_version,
+      "serialization_format" => version.serialization_format
+    })
+    |> Map.put("manifest", %{
+      "manifest_version_id" => version.manifest_version_id,
+      "content_hash" => version.content_hash
+    })
+    |> Map.put("plugins", plugins)
+    |> Map.put("user_modules", Enum.map(modules, &Atom.to_string/1))
+    |> Map.put("copied_module_beams", copied_modules)
+    |> Map.put("required_env", ["FAVN_ORCHESTRATOR_BASE_URL", "FAVN_ORCHESTRATOR_SERVICE_TOKEN"])
+  end
+
+  defp base(build_id, version, opts) do
+    now = DateTime.utc_now() |> DateTime.to_iso8601()
+
+    %{
+      "schema_version" => @schema_version,
+      "build_id" => build_id,
+      "built_at" => now,
+      "favn_version" => to_string(Application.spec(:favn, :vsn) || "unknown"),
+      "install_fingerprint" => read_install_fingerprint(opts),
+      "elixir_version" => System.version(),
+      "otp_release" => :erlang.system_info(:otp_release) |> List.to_string(),
+      "manifest_version_id" => version.manifest_version_id
+    }
+  end
+
+  defp read_install_fingerprint(opts) do
+    case State.read_install(opts) do
+      {:ok, %{"fingerprint" => fingerprint}} when is_map(fingerprint) -> fingerprint
+      _ -> %{}
+    end
+  end
+
+  defp write_json(path, map) when is_map(map) do
+    encoded = JSON.encode_to_iodata!(map)
+    File.write(path, [encoded, "\n"])
+  end
+
+  defp build_id do
+    stamp = DateTime.utc_now() |> Calendar.strftime("%Y%m%d%H%M%S")
+    unique = System.unique_integer([:positive])
+    "rb_#{stamp}_#{unique}"
+  end
+end

--- a/apps/favn_local/lib/favn/dev/build/single.ex
+++ b/apps/favn_local/lib/favn/dev/build/single.ex
@@ -1,0 +1,259 @@
+defmodule Favn.Dev.Build.Single do
+  @moduledoc """
+  Project-local single-node assembly target.
+  """
+
+  alias Favn.Dev.Build.Orchestrator
+  alias Favn.Dev.Build.Runner
+  alias Favn.Dev.Build.Web
+  alias Favn.Dev.Install
+  alias Favn.Dev.Paths
+  alias Favn.Dev.State
+
+  @schema_version 1
+  @target "single"
+
+  @type root_opt :: [root_dir: Path.t()]
+
+  @spec run(root_opt()) :: {:ok, map()} | {:error, term()}
+  def run(opts \\ []) when is_list(opts) do
+    with :ok <- Install.ensure_ready(opts),
+         :ok <- State.ensure_layout(opts),
+         {:ok, web} <- Web.run(opts),
+         {:ok, orchestrator} <- Orchestrator.run(opts),
+         {:ok, runner} <- Runner.run(opts),
+         storage <- storage_mode(opts),
+         :ok <- validate_storage(storage),
+         {build_id, root_dir} <- {build_id(), Paths.root_dir(opts)},
+         build_dir <- Paths.build_single_dir(root_dir, build_id),
+         dist_dir <- Paths.dist_single_dir(root_dir, build_id),
+         :ok <- File.mkdir_p(build_dir),
+         :ok <- File.mkdir_p(Path.join(dist_dir, "web")),
+         :ok <- File.mkdir_p(Path.join(dist_dir, "orchestrator")),
+         :ok <- File.mkdir_p(Path.join(dist_dir, "runner")),
+         :ok <- File.mkdir_p(Path.join(dist_dir, "config")),
+         :ok <- File.mkdir_p(Path.join(dist_dir, "env")),
+         :ok <- File.mkdir_p(Path.join(dist_dir, "bin")),
+         :ok <- copy_target_outputs(web.dist_dir, Path.join(dist_dir, "web")),
+         :ok <- copy_target_outputs(orchestrator.dist_dir, Path.join(dist_dir, "orchestrator")),
+         :ok <- copy_target_outputs(runner.dist_dir, Path.join(dist_dir, "runner")),
+         assembly <- assembly_json(build_id, web, orchestrator, runner, storage),
+         :ok <-
+           write_json(Path.join(build_dir, "build.json"), build_json(build_id, assembly, opts)),
+         :ok <-
+           write_json(
+             Path.join(dist_dir, "metadata.json"),
+             metadata_json(build_id, assembly, opts)
+           ),
+         :ok <- write_json(Path.join(dist_dir, "config/assembly.json"), assembly),
+         :ok <- write_env_files(dist_dir, storage),
+         :ok <- write_scripts(dist_dir) do
+      {:ok, %{build_id: build_id, build_dir: build_dir, dist_dir: dist_dir}}
+    end
+  end
+
+  defp storage_mode(opts) do
+    case Keyword.get(opts, :storage, :sqlite) do
+      value when is_binary(value) -> String.to_atom(value)
+      value -> value
+    end
+  end
+
+  defp validate_storage(:sqlite), do: :ok
+  defp validate_storage(:postgres), do: :ok
+  defp validate_storage(other), do: {:error, {:invalid_storage, other}}
+
+  defp copy_target_outputs(source_dir, target_dir) do
+    case File.ls(source_dir) do
+      {:ok, entries} ->
+        Enum.reduce_while(entries, :ok, fn entry, :ok ->
+          source = Path.join(source_dir, entry)
+          destination = Path.join(target_dir, entry)
+
+          case copy_entry(source, destination) do
+            :ok -> {:cont, :ok}
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
+        end)
+
+      {:error, reason} ->
+        {:error, {:read_dist_failed, source_dir, reason}}
+    end
+  end
+
+  defp copy_entry(source, destination) do
+    case File.stat(source) do
+      {:ok, %{type: :directory}} ->
+        case File.cp_r(source, destination) do
+          {:ok, _} -> :ok
+          {:error, reason, _} -> {:error, {:copy_failed, source, reason}}
+        end
+
+      {:ok, _} ->
+        File.cp(source, destination)
+
+      {:error, reason} ->
+        {:error, {:copy_failed, source, reason}}
+    end
+  end
+
+  defp assembly_json(build_id, web, orchestrator, runner, storage) do
+    %{
+      "schema_version" => @schema_version,
+      "target" => @target,
+      "build_id" => build_id,
+      "assembled_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "storage" => %{"mode" => Atom.to_string(storage)},
+      "services" => %{
+        "web" => %{"build_id" => web.build_id, "bundle_dir" => "web"},
+        "orchestrator" => %{"build_id" => orchestrator.build_id, "bundle_dir" => "orchestrator"},
+        "runner" => %{"build_id" => runner.build_id, "bundle_dir" => "runner"}
+      }
+    }
+  end
+
+  defp build_json(build_id, assembly, opts) do
+    base(build_id, opts)
+    |> Map.put("phase", "build")
+    |> Map.put("target", @target)
+    |> Map.put("assembly", assembly)
+  end
+
+  defp metadata_json(build_id, assembly, opts) do
+    base(build_id, opts)
+    |> Map.put("phase", "dist")
+    |> Map.put("target", @target)
+    |> Map.put("assembly", assembly)
+    |> Map.put("compatibility", %{
+      "topology" => "web+orchestrator+runner",
+      "storage_modes" => ["sqlite", "postgres"]
+    })
+    |> Map.put("required_env", [
+      "FAVN_ORCHESTRATOR_BASE_URL",
+      "FAVN_ORCHESTRATOR_SERVICE_TOKEN",
+      "FAVN_WEB_SESSION_SECRET",
+      "FAVN_STORAGE",
+      "FAVN_SQLITE_PATH",
+      "FAVN_POSTGRES_HOST",
+      "FAVN_POSTGRES_PORT",
+      "FAVN_POSTGRES_USERNAME",
+      "FAVN_POSTGRES_PASSWORD",
+      "FAVN_POSTGRES_DATABASE",
+      "FAVN_POSTGRES_SSL"
+    ])
+  end
+
+  defp base(build_id, opts) do
+    %{
+      "schema_version" => @schema_version,
+      "build_id" => build_id,
+      "built_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "favn_version" => to_string(Application.spec(:favn, :vsn) || "unknown"),
+      "install_fingerprint" => read_install_fingerprint(opts),
+      "elixir_version" => System.version(),
+      "otp_release" => :erlang.system_info(:otp_release) |> List.to_string()
+    }
+  end
+
+  defp read_install_fingerprint(opts) do
+    case State.read_install(opts) do
+      {:ok, %{"fingerprint" => fingerprint}} when is_map(fingerprint) -> fingerprint
+      _ -> %{}
+    end
+  end
+
+  defp write_env_files(dist_dir, :sqlite) do
+    orchestrator = ["FAVN_STORAGE=sqlite", "FAVN_SQLITE_PATH=.favn/data/orchestrator.sqlite3", ""]
+
+    web = [
+      "FAVN_ORCHESTRATOR_BASE_URL=http://127.0.0.1:4101",
+      "FAVN_ORCHESTRATOR_SERVICE_TOKEN=replace-me",
+      "FAVN_WEB_SESSION_SECRET=replace-me",
+      ""
+    ]
+
+    runner = [
+      "FAVN_ORCHESTRATOR_BASE_URL=http://127.0.0.1:4101",
+      "FAVN_ORCHESTRATOR_SERVICE_TOKEN=replace-me",
+      ""
+    ]
+
+    write_env_bundle(dist_dir, web, orchestrator, runner)
+  end
+
+  defp write_env_files(dist_dir, :postgres) do
+    orchestrator = [
+      "FAVN_STORAGE=postgres",
+      "FAVN_POSTGRES_HOST=127.0.0.1",
+      "FAVN_POSTGRES_PORT=5432",
+      "FAVN_POSTGRES_USERNAME=postgres",
+      "FAVN_POSTGRES_PASSWORD=postgres",
+      "FAVN_POSTGRES_DATABASE=favn",
+      "FAVN_POSTGRES_SSL=false",
+      ""
+    ]
+
+    web = [
+      "FAVN_ORCHESTRATOR_BASE_URL=http://127.0.0.1:4101",
+      "FAVN_ORCHESTRATOR_SERVICE_TOKEN=replace-me",
+      "FAVN_WEB_SESSION_SECRET=replace-me",
+      ""
+    ]
+
+    runner = [
+      "FAVN_ORCHESTRATOR_BASE_URL=http://127.0.0.1:4101",
+      "FAVN_ORCHESTRATOR_SERVICE_TOKEN=replace-me",
+      ""
+    ]
+
+    write_env_bundle(dist_dir, web, orchestrator, runner)
+  end
+
+  defp write_env_bundle(dist_dir, web, orchestrator, runner) do
+    [
+      File.write(Path.join(dist_dir, "env/web.env"), Enum.join(web, "\n")),
+      File.write(Path.join(dist_dir, "env/orchestrator.env"), Enum.join(orchestrator, "\n")),
+      File.write(Path.join(dist_dir, "env/runner.env"), Enum.join(runner, "\n"))
+    ]
+    |> run_steps()
+  end
+
+  defp write_scripts(dist_dir) do
+    start_script = [
+      "#!/usr/bin/env sh",
+      "set -eu",
+      "echo \"Starting favn single bundle\"",
+      "echo \"Run web/orchestrator/runner using env files under ./env\"",
+      ""
+    ]
+
+    stop_script = ["#!/usr/bin/env sh", "set -eu", "echo \"Stopping favn single bundle\"", ""]
+
+    [
+      File.write(Path.join(dist_dir, "bin/start"), Enum.join(start_script, "\n")),
+      File.write(Path.join(dist_dir, "bin/stop"), Enum.join(stop_script, "\n")),
+      File.chmod(Path.join(dist_dir, "bin/start"), 0o755),
+      File.chmod(Path.join(dist_dir, "bin/stop"), 0o755)
+    ]
+    |> run_steps()
+  end
+
+  defp run_steps(steps) when is_list(steps) do
+    Enum.reduce_while(steps, :ok, fn
+      :ok, :ok -> {:cont, :ok}
+      {:error, reason}, :ok -> {:halt, {:error, reason}}
+      _other, :ok -> {:halt, {:error, :unexpected_step_result}}
+    end)
+  end
+
+  defp write_json(path, map) when is_map(map) do
+    encoded = JSON.encode_to_iodata!(map)
+    File.write(path, [encoded, "\n"])
+  end
+
+  defp build_id do
+    stamp = DateTime.utc_now() |> Calendar.strftime("%Y%m%d%H%M%S")
+    unique = System.unique_integer([:positive])
+    "sb_#{stamp}_#{unique}"
+  end
+end

--- a/apps/favn_local/lib/favn/dev/build/web.ex
+++ b/apps/favn_local/lib/favn/dev/build/web.ex
@@ -1,0 +1,109 @@
+defmodule Favn.Dev.Build.Web do
+  @moduledoc """
+  Project-local web build target.
+  """
+
+  alias Favn.Dev.Install
+  alias Favn.Dev.Paths
+  alias Favn.Dev.State
+
+  @schema_version 1
+  @target "web"
+
+  @type root_opt :: [root_dir: Path.t()]
+
+  @spec run(root_opt()) :: {:ok, map()} | {:error, term()}
+  def run(opts \\ []) when is_list(opts) do
+    with :ok <- Install.ensure_ready(opts),
+         :ok <- State.ensure_layout(opts),
+         {:ok, install} <- State.read_install(opts),
+         web_source_root when is_binary(web_source_root) <- runtime_source_root(install, "web"),
+         {build_id, root_dir} <- {build_id(), Paths.root_dir(opts)},
+         build_dir <- Paths.build_web_dir(root_dir, build_id),
+         dist_dir <- Paths.dist_web_dir(root_dir, build_id),
+         :ok <- File.mkdir_p(build_dir),
+         :ok <- File.mkdir_p(dist_dir),
+         build_json <- build_json(build_id, web_source_root, opts),
+         metadata_json <- metadata_json(build_id, web_source_root, opts),
+         :ok <- write_json(Path.join(build_dir, "build.json"), build_json),
+         :ok <- write_json(Path.join(dist_dir, "metadata.json"), metadata_json),
+         :ok <-
+           write_json(
+             Path.join(dist_dir, "bundle.json"),
+             web_bundle_json(build_id, web_source_root, opts)
+           ) do
+      {:ok, %{build_id: build_id, build_dir: build_dir, dist_dir: dist_dir}}
+    else
+      nil -> {:error, :missing_install_runtime_input}
+      {:error, :not_found} -> {:error, :install_required}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp runtime_source_root(install, target) when is_map(install) do
+    get_in(install, ["runtime_inputs", target, "source_root"])
+  end
+
+  defp build_json(build_id, source_root, opts) do
+    base(build_id, opts)
+    |> Map.put("phase", "build")
+    |> Map.put("target", @target)
+    |> Map.put("web_source_root", source_root)
+  end
+
+  defp metadata_json(build_id, source_root, opts) do
+    base(build_id, opts)
+    |> Map.put("phase", "dist")
+    |> Map.put("target", @target)
+    |> Map.put("web_source_root", source_root)
+    |> Map.put("compatibility", %{
+      "orchestrator_api_version" => "v1"
+    })
+    |> Map.put("required_env", [
+      "FAVN_ORCHESTRATOR_BASE_URL",
+      "FAVN_ORCHESTRATOR_SERVICE_TOKEN",
+      "FAVN_WEB_SESSION_SECRET"
+    ])
+  end
+
+  defp web_bundle_json(build_id, source_root, opts) do
+    %{
+      "schema_version" => @schema_version,
+      "target" => @target,
+      "build_id" => build_id,
+      "source_root" => source_root,
+      "generated_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "project_root" => Paths.root_dir(opts)
+    }
+  end
+
+  defp base(build_id, opts) do
+    %{
+      "schema_version" => @schema_version,
+      "build_id" => build_id,
+      "built_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "favn_version" => to_string(Application.spec(:favn, :vsn) || "unknown"),
+      "install_fingerprint" => read_install_fingerprint(opts),
+      "elixir_version" => System.version(),
+      "otp_release" => :erlang.system_info(:otp_release) |> List.to_string()
+    }
+  end
+
+  defp read_install_fingerprint(opts) do
+    case State.read_install(opts) do
+      {:ok, %{"fingerprint" => fingerprint}} when is_map(fingerprint) -> fingerprint
+      _ -> %{}
+    end
+  end
+
+  defp write_json(path, map) when is_map(map) do
+    encoded = JSON.encode_to_iodata!(map)
+    File.write(path, [encoded, "\n"])
+  end
+
+  defp build_id do
+    stamp = DateTime.utc_now() |> Calendar.strftime("%Y%m%d%H%M%S")
+    unique = System.unique_integer([:positive])
+    "wb_#{stamp}_#{unique}"
+  end
+end

--- a/apps/favn_local/lib/favn/dev/config.ex
+++ b/apps/favn_local/lib/favn/dev/config.ex
@@ -6,6 +6,7 @@ defmodule Favn.Dev.Config do
   @enforce_keys [
     :storage,
     :sqlite_path,
+    :postgres,
     :orchestrator_api_enabled,
     :orchestrator_port,
     :web_port,
@@ -17,6 +18,7 @@ defmodule Favn.Dev.Config do
   defstruct [
     :storage,
     :sqlite_path,
+    :postgres,
     :orchestrator_api_enabled,
     :orchestrator_port,
     :web_port,
@@ -26,11 +28,22 @@ defmodule Favn.Dev.Config do
     :web_session_secret
   ]
 
-  @type storage_mode :: :memory | :sqlite
+  @type postgres_opts :: %{
+          hostname: String.t(),
+          port: pos_integer(),
+          username: String.t(),
+          password: String.t(),
+          database: String.t(),
+          ssl: boolean(),
+          pool_size: pos_integer()
+        }
+
+  @type storage_mode :: :memory | :sqlite | :postgres
 
   @type t :: %__MODULE__{
           storage: storage_mode(),
           sqlite_path: Path.t(),
+          postgres: postgres_opts(),
           orchestrator_api_enabled: boolean(),
           orchestrator_port: pos_integer(),
           web_port: pos_integer(),
@@ -45,6 +58,15 @@ defmodule Favn.Dev.Config do
 
   @default_storage :memory
   @default_sqlite_path ".favn/data/orchestrator.sqlite3"
+  @default_postgres %{
+    hostname: "127.0.0.1",
+    port: 5432,
+    username: "postgres",
+    password: "postgres",
+    database: "favn",
+    ssl: false,
+    pool_size: 10
+  }
   @default_orchestrator_port 4101
   @default_web_port 4173
 
@@ -53,8 +75,9 @@ defmodule Favn.Dev.Config do
   """
   @spec resolve(opts()) :: t()
   def resolve(opts \\ []) when is_list(opts) do
-    app_config = Application.get_env(:favn, :dev, [])
-    merged = Keyword.merge(app_config, opts)
+    dev_config = Application.get_env(:favn, :dev, [])
+    local_config = Application.get_env(:favn, :local, [])
+    merged = dev_config |> Keyword.merge(local_config) |> Keyword.merge(opts)
 
     orchestrator_port = Keyword.get(merged, :orchestrator_port, @default_orchestrator_port)
     web_port = Keyword.get(merged, :web_port, @default_web_port)
@@ -62,6 +85,7 @@ defmodule Favn.Dev.Config do
     %__MODULE__{
       storage: normalize_storage(Keyword.get(merged, :storage, @default_storage)),
       sqlite_path: Keyword.get(merged, :sqlite_path, @default_sqlite_path),
+      postgres: normalize_postgres(Keyword.get(merged, :postgres, @default_postgres)),
       orchestrator_api_enabled: Keyword.get(merged, :orchestrator_api_enabled, true),
       orchestrator_port: orchestrator_port,
       web_port: web_port,
@@ -75,5 +99,56 @@ defmodule Favn.Dev.Config do
 
   defp normalize_storage(:sqlite), do: :sqlite
   defp normalize_storage("sqlite"), do: :sqlite
+  defp normalize_storage(:postgres), do: :postgres
+  defp normalize_storage("postgres"), do: :postgres
   defp normalize_storage(_other), do: :memory
+
+  defp normalize_postgres(value) when is_list(value),
+    do: value |> Enum.into(%{}) |> normalize_postgres()
+
+  defp normalize_postgres(value) when is_map(value) do
+    map = for {k, v} <- value, into: %{}, do: {normalize_postgres_key(k), v}
+
+    %{
+      hostname: to_string(Map.get(map, :hostname, @default_postgres.hostname)),
+      port: normalize_int(Map.get(map, :port, @default_postgres.port), @default_postgres.port),
+      username: to_string(Map.get(map, :username, @default_postgres.username)),
+      password: to_string(Map.get(map, :password, @default_postgres.password)),
+      database: to_string(Map.get(map, :database, @default_postgres.database)),
+      ssl: normalize_bool(Map.get(map, :ssl, @default_postgres.ssl), @default_postgres.ssl),
+      pool_size:
+        normalize_int(
+          Map.get(map, :pool_size, @default_postgres.pool_size),
+          @default_postgres.pool_size
+        )
+    }
+  end
+
+  defp normalize_postgres(_other), do: @default_postgres
+
+  defp normalize_postgres_key(key) when is_atom(key), do: key
+  defp normalize_postgres_key("hostname"), do: :hostname
+  defp normalize_postgres_key("port"), do: :port
+  defp normalize_postgres_key("username"), do: :username
+  defp normalize_postgres_key("password"), do: :password
+  defp normalize_postgres_key("database"), do: :database
+  defp normalize_postgres_key("ssl"), do: :ssl
+  defp normalize_postgres_key("pool_size"), do: :pool_size
+  defp normalize_postgres_key(_key), do: :unknown
+
+  defp normalize_int(value, _default) when is_integer(value) and value > 0, do: value
+
+  defp normalize_int(value, default) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, _} when int > 0 -> int
+      _ -> default
+    end
+  end
+
+  defp normalize_int(_value, default), do: default
+
+  defp normalize_bool(value, _default) when is_boolean(value), do: value
+  defp normalize_bool("true", _default), do: true
+  defp normalize_bool("false", _default), do: false
+  defp normalize_bool(_value, default), do: default
 end

--- a/apps/favn_local/lib/favn/dev/install.ex
+++ b/apps/favn_local/lib/favn/dev/install.ex
@@ -145,19 +145,132 @@ defmodule Favn.Dev.Install do
   defp write_install_state(fingerprint, toolchain, opts) do
     root_dir = Paths.root_dir(opts)
 
+    runtime_inputs = runtime_inputs(root_dir)
+
     install = %{
       "schema_version" => @schema_version,
       "installed_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
       "fingerprint" => fingerprint,
-      "runtime_inputs" => %{
-        "web" => %{"source_root" => Path.join(root_dir, "web/favn_web")},
-        "orchestrator" => %{"source_root" => Path.join(root_dir, "apps/favn_orchestrator")},
-        "runner" => %{"source_root" => Path.join(root_dir, "apps/favn_runner")}
-      },
+      "runtime_inputs" => runtime_inputs,
       "toolchain_ref" => "toolchain.json"
     }
 
-    with :ok <- State.write_toolchain(toolchain, opts), do: State.write_install(install, opts)
+    with :ok <- materialize_runtime_inputs(runtime_inputs, root_dir),
+         :ok <- State.write_toolchain(toolchain, opts),
+         do: State.write_install(install, opts)
+  end
+
+  defp runtime_inputs(root_dir) do
+    %{
+      "web" => %{
+        "source_root" => Path.join(root_dir, "web/favn_web"),
+        "materialized_root" => Paths.install_runtime_web_dir(root_dir)
+      },
+      "orchestrator" => %{
+        "source_root" => Path.join(root_dir, "apps/favn_orchestrator"),
+        "materialized_root" => Paths.install_runtime_orchestrator_dir(root_dir)
+      },
+      "runner" => %{
+        "source_root" => Path.join(root_dir, "apps/favn_runner"),
+        "materialized_root" => Paths.install_runtime_runner_dir(root_dir)
+      }
+    }
+  end
+
+  defp materialize_runtime_inputs(runtime_inputs, root_dir) do
+    [
+      materialize_web_input(runtime_inputs, root_dir),
+      materialize_orchestrator_input(runtime_inputs, root_dir),
+      materialize_runner_input(runtime_inputs, root_dir)
+    ]
+    |> run_materialization_steps()
+  end
+
+  defp run_materialization_steps(results) do
+    Enum.reduce_while(results, :ok, fn
+      :ok, :ok -> {:cont, :ok}
+      {:error, reason}, :ok -> {:halt, {:error, reason}}
+      other, :ok -> {:halt, {:error, {:unexpected_materialization_result, other}}}
+    end)
+  end
+
+  defp materialize_web_input(runtime_inputs, root_dir) do
+    source_root = get_in(runtime_inputs, ["web", "source_root"])
+    materialized_root = get_in(runtime_inputs, ["web", "materialized_root"])
+    source_dir = Path.join(materialized_root, "source")
+
+    with :ok <- File.mkdir_p(source_dir),
+         :ok <-
+           copy_if_exists(
+             Path.join(source_root, "package.json"),
+             Path.join(source_dir, "package.json")
+           ),
+         :ok <-
+           copy_if_exists(
+             Path.join(source_root, "package-lock.json"),
+             Path.join(source_dir, "package-lock.json")
+           ),
+         :ok <-
+           write_json(
+             Path.join(materialized_root, "runtime_input.json"),
+             %{
+               "source_root" => source_root,
+               "materialized_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+             }
+           ) do
+      copy_if_exists(Path.join(root_dir, "mix.lock"), Path.join(source_dir, "mix.lock"))
+    end
+  end
+
+  defp materialize_orchestrator_input(runtime_inputs, root_dir) do
+    source_root = get_in(runtime_inputs, ["orchestrator", "source_root"])
+    materialized_root = get_in(runtime_inputs, ["orchestrator", "materialized_root"])
+    source_dir = Path.join(materialized_root, "source")
+
+    with :ok <- File.mkdir_p(source_dir),
+         :ok <-
+           copy_if_exists(Path.join(source_root, "mix.exs"), Path.join(source_dir, "mix.exs")),
+         :ok <- copy_if_exists(Path.join(root_dir, "mix.lock"), Path.join(source_dir, "mix.lock")) do
+      write_json(
+        Path.join(materialized_root, "runtime_input.json"),
+        %{
+          "source_root" => source_root,
+          "materialized_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+        }
+      )
+    end
+  end
+
+  defp materialize_runner_input(runtime_inputs, root_dir) do
+    source_root = get_in(runtime_inputs, ["runner", "source_root"])
+    materialized_root = get_in(runtime_inputs, ["runner", "materialized_root"])
+    source_dir = Path.join(materialized_root, "source")
+
+    with :ok <- File.mkdir_p(source_dir),
+         :ok <-
+           copy_if_exists(Path.join(source_root, "mix.exs"), Path.join(source_dir, "mix.exs")),
+         :ok <- copy_if_exists(Path.join(root_dir, "mix.lock"), Path.join(source_dir, "mix.lock")) do
+      write_json(
+        Path.join(materialized_root, "runtime_input.json"),
+        %{
+          "source_root" => source_root,
+          "materialized_at" => DateTime.utc_now() |> DateTime.to_iso8601()
+        }
+      )
+    end
+  end
+
+  defp copy_if_exists(source, destination) do
+    if File.exists?(source) do
+      File.cp(source, destination)
+    else
+      :ok
+    end
+  end
+
+  defp write_json(path, data) when is_map(data) do
+    encoded = JSON.encode_to_iodata!(data)
+    File.write(path, [encoded, "\n"])
   end
 
   @spec fingerprint(root_opt()) :: {:ok, map()} | {:error, term()}

--- a/apps/favn_local/lib/favn/dev/install.ex
+++ b/apps/favn_local/lib/favn/dev/install.ex
@@ -1,0 +1,224 @@
+defmodule Favn.Dev.Install do
+  @moduledoc """
+  Project-local install and install-state validation for Favn dev tooling.
+  """
+
+  alias Favn.Dev.Paths
+  alias Favn.Dev.State
+
+  @schema_version 1
+
+  @type root_opt :: [root_dir: Path.t()]
+
+  @spec run(root_opt()) :: :ok | {:error, term()}
+  def run(opts \\ []) when is_list(opts) do
+    case do_run(opts) do
+      :ok ->
+        :ok
+
+      {:error, reason} = error ->
+        _ =
+          State.write_last_failure(
+            %{
+              "command" => "install",
+              "error" => inspect(reason),
+              "at" => DateTime.utc_now() |> DateTime.to_iso8601()
+            },
+            opts
+          )
+
+        error
+    end
+  end
+
+  @spec ensure_ready(root_opt()) :: :ok | {:error, term()}
+  def ensure_ready(opts \\ []) when is_list(opts) do
+    with {:ok, install} <- State.read_install(opts),
+         {:ok, current_fingerprint} <- fingerprint(opts),
+         {:ok, stored_fingerprint} <- fetch_fingerprint(install),
+         true <- stored_fingerprint == current_fingerprint do
+      :ok
+    else
+      {:error, :not_found} ->
+        {:error, :install_required}
+
+      false ->
+        {:error, :install_stale}
+
+      {:error, :missing_fingerprint} ->
+        {:error, :install_stale}
+
+      {:error, reason} = error ->
+        case reason do
+          {:missing_tool, _tool} -> {:error, :install_stale}
+          _ -> error
+        end
+    end
+  end
+
+  defp do_run(opts) do
+    force? = Keyword.get(opts, :force, false)
+
+    with :ok <- State.ensure_layout(opts),
+         {:ok, current_fingerprint} <- fingerprint(opts),
+         install_decision <- ensure_install_needed(current_fingerprint, force?, opts) do
+      maybe_install(install_decision, current_fingerprint, opts)
+    end
+  end
+
+  defp ensure_install_needed(_fingerprint, true, _opts), do: :install
+
+  defp ensure_install_needed(fingerprint, false, opts) do
+    case State.read_install(opts) do
+      {:ok, install} ->
+        with {:ok, stored} <- fetch_fingerprint(install) do
+          if stored == fingerprint do
+            :already_installed
+          else
+            :install
+          end
+        end
+
+      {:error, :not_found} ->
+        :install
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp maybe_install(:already_installed, _current_fingerprint, _opts), do: :ok
+
+  defp maybe_install(:install, current_fingerprint, opts) do
+    with {:ok, toolchain} <- build_toolchain(opts),
+         :ok <- install_web_dependencies(opts) do
+      write_install_state(current_fingerprint, toolchain, opts)
+    end
+  end
+
+  defp maybe_install({:error, _reason} = error, _current_fingerprint, _opts), do: error
+
+  defp build_toolchain(opts) do
+    with {:ok, node_version} <- command_version(opts, :node, "node", ["--version"]),
+         {:ok, npm_version} <- command_version(opts, :npm, "npm", ["--version"]) do
+      {:ok,
+       %{
+         "schema_version" => @schema_version,
+         "captured_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+         "elixir_version" => System.version(),
+         "otp_release" => otp_release(),
+         "node_version" => node_version,
+         "npm_version" => npm_version
+       }}
+    end
+  end
+
+  defp install_web_dependencies(opts) do
+    if Keyword.get(opts, :skip_web_install, false) do
+      :ok
+    else
+      web_dir = web_root(opts)
+      npm_exec = System.find_executable("npm") || "npm"
+      npm_cache = Paths.install_cache_npm_dir(Paths.root_dir(opts))
+      package_lock = Path.join(web_dir, "package-lock.json")
+
+      args =
+        if File.exists?(package_lock) do
+          ["ci", "--silent", "--cache", npm_cache]
+        else
+          ["install", "--silent", "--cache", npm_cache]
+        end
+
+      env = %{"npm_config_cache" => npm_cache}
+
+      case System.cmd(npm_exec, args, cd: web_dir, stderr_to_stdout: true, env: env) do
+        {_output, 0} ->
+          :ok
+
+        {output, status} ->
+          {:error, {:web_install_failed, status, String.trim(output)}}
+      end
+    end
+  end
+
+  defp write_install_state(fingerprint, toolchain, opts) do
+    root_dir = Paths.root_dir(opts)
+
+    install = %{
+      "schema_version" => @schema_version,
+      "installed_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+      "fingerprint" => fingerprint,
+      "runtime_inputs" => %{
+        "web" => %{"source_root" => Path.join(root_dir, "web/favn_web")},
+        "orchestrator" => %{"source_root" => Path.join(root_dir, "apps/favn_orchestrator")},
+        "runner" => %{"source_root" => Path.join(root_dir, "apps/favn_runner")}
+      },
+      "toolchain_ref" => "toolchain.json"
+    }
+
+    with :ok <- State.write_toolchain(toolchain, opts), do: State.write_install(install, opts)
+  end
+
+  @spec fingerprint(root_opt()) :: {:ok, map()} | {:error, term()}
+  defp fingerprint(opts) do
+    with {:ok, node_version} <- command_version(opts, :node, "node", ["--version"]),
+         {:ok, npm_version} <- command_version(opts, :npm, "npm", ["--version"]) do
+      root_dir = Paths.root_dir(opts)
+
+      {:ok,
+       %{
+         "schema_version" => @schema_version,
+         "elixir_version" => System.version(),
+         "otp_release" => otp_release(),
+         "node_version" => node_version,
+         "npm_version" => npm_version,
+         "mix_lock_sha256" => file_sha256(Path.join(root_dir, "mix.lock")),
+         "web_package_json_sha256" =>
+           file_sha256(Path.join(root_dir, "web/favn_web/package.json")),
+         "web_package_lock_sha256" =>
+           file_sha256(Path.join(root_dir, "web/favn_web/package-lock.json")),
+         "runner_mix_sha256" => file_sha256(Path.join(root_dir, "apps/favn_runner/mix.exs")),
+         "orchestrator_mix_sha256" =>
+           file_sha256(Path.join(root_dir, "apps/favn_orchestrator/mix.exs"))
+       }}
+    end
+  end
+
+  defp command_version(opts, tool, exec, args) do
+    if Keyword.get(opts, :skip_tool_checks, false) do
+      {:ok, "skipped"}
+    else
+      command_version_checked(tool, exec, args)
+    end
+  end
+
+  defp command_version_checked(tool, exec, args) do
+    case System.find_executable(exec) do
+      nil ->
+        {:error, {:missing_tool, tool}}
+
+      executable ->
+        case System.cmd(executable, args, stderr_to_stdout: true) do
+          {value, 0} -> {:ok, String.trim(value)}
+          {output, status} -> {:error, {:tool_check_failed, tool, status, String.trim(output)}}
+        end
+    end
+  end
+
+  defp fetch_fingerprint(%{"fingerprint" => fingerprint}) when is_map(fingerprint),
+    do: {:ok, fingerprint}
+
+  defp fetch_fingerprint(_), do: {:error, :missing_fingerprint}
+
+  defp otp_release, do: :erlang.system_info(:otp_release) |> List.to_string()
+
+  defp web_root(opts), do: Path.join(Paths.root_dir(opts), "web/favn_web")
+
+  defp file_sha256(path) do
+    case File.read(path) do
+      {:ok, bytes} -> :crypto.hash(:sha256, bytes) |> Base.encode16(case: :lower)
+      {:error, :enoent} -> nil
+      {:error, _reason} -> nil
+    end
+  end
+end

--- a/apps/favn_local/lib/favn/dev/install.ex
+++ b/apps/favn_local/lib/favn/dev/install.ex
@@ -10,11 +10,11 @@ defmodule Favn.Dev.Install do
 
   @type root_opt :: [root_dir: Path.t()]
 
-  @spec run(root_opt()) :: :ok | {:error, term()}
+  @spec run(root_opt()) :: {:ok, :installed | :already_installed} | {:error, term()}
   def run(opts \\ []) when is_list(opts) do
     case do_run(opts) do
-      :ok ->
-        :ok
+      {:ok, status} ->
+        {:ok, status}
 
       {:error, reason} = error ->
         _ =
@@ -87,12 +87,13 @@ defmodule Favn.Dev.Install do
     end
   end
 
-  defp maybe_install(:already_installed, _current_fingerprint, _opts), do: :ok
+  defp maybe_install(:already_installed, _current_fingerprint, _opts),
+    do: {:ok, :already_installed}
 
   defp maybe_install(:install, current_fingerprint, opts) do
     with {:ok, toolchain} <- build_toolchain(opts),
          :ok <- install_web_dependencies(opts) do
-      write_install_state(current_fingerprint, toolchain, opts)
+      with :ok <- write_install_state(current_fingerprint, toolchain, opts), do: {:ok, :installed}
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/logs.ex
+++ b/apps/favn_local/lib/favn/dev/logs.ex
@@ -1,0 +1,154 @@
+defmodule Favn.Dev.Logs do
+  @moduledoc """
+  Thin helper for reading project-local service logs under `.favn/logs`.
+  """
+
+  alias Favn.Dev.Paths
+
+  @type root_opt :: [root_dir: Path.t()]
+  @type logs_opt :: [
+          root_dir: Path.t(),
+          service: :all | :web | :orchestrator | :runner,
+          tail: pos_integer(),
+          follow: boolean()
+        ]
+
+  @spec run(logs_opt()) :: :ok
+  def run(opts \\ []) when is_list(opts) do
+    writer = Keyword.get(opts, :writer, &IO.write/1)
+    follow? = Keyword.get(opts, :follow, false)
+    tail_lines = max(1, Keyword.get(opts, :tail, 100))
+
+    services = selected_services(opts)
+    root_dir = Paths.root_dir(opts)
+
+    Enum.each(services, fn service ->
+      output_tail(service, log_path(service, root_dir), tail_lines, writer, length(services) > 1)
+    end)
+
+    if follow? do
+      follow_logs(services, root_dir, writer, opts)
+    else
+      :ok
+    end
+  end
+
+  @spec selected_services(keyword()) :: [:web | :orchestrator | :runner]
+  def selected_services(opts) do
+    case Keyword.get(opts, :service, :all) do
+      :web -> [:web]
+      :orchestrator -> [:orchestrator]
+      :runner -> [:runner]
+      _ -> [:web, :orchestrator, :runner]
+    end
+  end
+
+  defp output_tail(service, path, tail_lines, writer, include_prefix?) do
+    lines = read_tail_lines(path, tail_lines)
+
+    Enum.each(lines, fn line ->
+      writer.(format_line(service, line, include_prefix?))
+    end)
+  end
+
+  defp read_tail_lines(path, tail_lines) do
+    case File.read(path) do
+      {:ok, content} ->
+        content
+        |> String.split("\n", trim: true)
+        |> Enum.take(-tail_lines)
+        |> Enum.map(&(&1 <> "\n"))
+
+      {:error, :enoent} ->
+        []
+
+      {:error, _reason} ->
+        []
+    end
+  end
+
+  defp follow_logs(services, root_dir, writer, opts) do
+    include_prefix? = length(services) > 1
+    sleep_ms = Keyword.get(opts, :follow_sleep_ms, 200)
+    ticks = Keyword.get(opts, :follow_ticks, :infinity)
+
+    initial_offsets =
+      Map.new(services, fn service ->
+        path = log_path(service, root_dir)
+        {service, file_size(path)}
+      end)
+
+    do_follow(services, root_dir, writer, include_prefix?, initial_offsets, ticks, sleep_ms)
+  end
+
+  defp do_follow(_services, _root_dir, _writer, _include_prefix?, _offsets, 0, _sleep_ms), do: :ok
+
+  defp do_follow(services, root_dir, writer, include_prefix?, offsets, ticks, sleep_ms) do
+    next_offsets =
+      Enum.reduce(services, offsets, fn service, acc ->
+        path = log_path(service, root_dir)
+        previous = Map.get(acc, service, 0)
+
+        case read_append(path, previous) do
+          {:ok, "", offset} ->
+            Map.put(acc, service, offset)
+
+          {:ok, appended, offset} ->
+            appended
+            |> String.split("\n", trim: false)
+            |> Enum.reject(&(&1 == ""))
+            |> Enum.each(fn line ->
+              writer.(format_line(service, line <> "\n", include_prefix?))
+            end)
+
+            Map.put(acc, service, offset)
+
+          {:error, _reason} ->
+            acc
+        end
+      end)
+
+    Process.sleep(sleep_ms)
+
+    next_ticks =
+      case ticks do
+        :infinity -> :infinity
+        number -> number - 1
+      end
+
+    do_follow(services, root_dir, writer, include_prefix?, next_offsets, next_ticks, sleep_ms)
+  end
+
+  defp read_append(path, offset) do
+    case File.read(path) do
+      {:ok, content} ->
+        size = byte_size(content)
+
+        cond do
+          size < offset -> {:ok, content, size}
+          size == offset -> {:ok, "", offset}
+          true -> {:ok, binary_part(content, offset, size - offset), size}
+        end
+
+      {:error, :enoent} ->
+        {:ok, "", offset}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp file_size(path) do
+    case File.stat(path) do
+      {:ok, stat} -> stat.size
+      {:error, _reason} -> 0
+    end
+  end
+
+  defp format_line(service, line, true), do: "[#{service}] " <> line
+  defp format_line(_service, line, false), do: line
+
+  defp log_path(:web, root_dir), do: Paths.web_log_path(root_dir)
+  defp log_path(:orchestrator, root_dir), do: Paths.orchestrator_log_path(root_dir)
+  defp log_path(:runner, root_dir), do: Paths.runner_log_path(root_dir)
+end

--- a/apps/favn_local/lib/favn/dev/paths.ex
+++ b/apps/favn_local/lib/favn/dev/paths.ex
@@ -12,6 +12,74 @@ defmodule Favn.Dev.Paths do
   @spec logs_dir(Path.t()) :: Path.t()
   def logs_dir(root_dir), do: Path.join(favn_dir(root_dir), "logs")
 
+  @spec install_dir(Path.t()) :: Path.t()
+  def install_dir(root_dir), do: Path.join(favn_dir(root_dir), "install")
+
+  @spec install_cache_dir(Path.t()) :: Path.t()
+  def install_cache_dir(root_dir), do: Path.join(install_dir(root_dir), "cache")
+
+  @spec install_cache_npm_dir(Path.t()) :: Path.t()
+  def install_cache_npm_dir(root_dir), do: Path.join(install_cache_dir(root_dir), "npm")
+
+  @spec install_runtimes_dir(Path.t()) :: Path.t()
+  def install_runtimes_dir(root_dir), do: Path.join(install_dir(root_dir), "runtimes")
+
+  @spec install_runtime_web_dir(Path.t()) :: Path.t()
+  def install_runtime_web_dir(root_dir), do: Path.join(install_runtimes_dir(root_dir), "web")
+
+  @spec install_runtime_orchestrator_dir(Path.t()) :: Path.t()
+  def install_runtime_orchestrator_dir(root_dir),
+    do: Path.join(install_runtimes_dir(root_dir), "orchestrator")
+
+  @spec install_runtime_runner_dir(Path.t()) :: Path.t()
+  def install_runtime_runner_dir(root_dir),
+    do: Path.join(install_runtimes_dir(root_dir), "runner")
+
+  @spec build_dir(Path.t()) :: Path.t()
+  def build_dir(root_dir), do: Path.join(favn_dir(root_dir), "build")
+
+  @spec build_target_dir(Path.t(), String.t()) :: Path.t()
+  def build_target_dir(root_dir, target) when is_binary(target),
+    do: Path.join(build_dir(root_dir), target)
+
+  @spec build_runner_dir(Path.t(), String.t()) :: Path.t()
+  def build_runner_dir(root_dir, build_id),
+    do: Path.join(build_target_dir(root_dir, "runner"), build_id)
+
+  @spec build_web_dir(Path.t(), String.t()) :: Path.t()
+  def build_web_dir(root_dir, build_id),
+    do: Path.join(build_target_dir(root_dir, "web"), build_id)
+
+  @spec build_orchestrator_dir(Path.t(), String.t()) :: Path.t()
+  def build_orchestrator_dir(root_dir, build_id),
+    do: Path.join(build_target_dir(root_dir, "orchestrator"), build_id)
+
+  @spec build_single_dir(Path.t(), String.t()) :: Path.t()
+  def build_single_dir(root_dir, build_id),
+    do: Path.join(build_target_dir(root_dir, "single"), build_id)
+
+  @spec dist_dir(Path.t()) :: Path.t()
+  def dist_dir(root_dir), do: Path.join(favn_dir(root_dir), "dist")
+
+  @spec dist_target_dir(Path.t(), String.t()) :: Path.t()
+  def dist_target_dir(root_dir, target) when is_binary(target),
+    do: Path.join(dist_dir(root_dir), target)
+
+  @spec dist_runner_dir(Path.t(), String.t()) :: Path.t()
+  def dist_runner_dir(root_dir, build_id),
+    do: Path.join(dist_target_dir(root_dir, "runner"), build_id)
+
+  @spec dist_web_dir(Path.t(), String.t()) :: Path.t()
+  def dist_web_dir(root_dir, build_id), do: Path.join(dist_target_dir(root_dir, "web"), build_id)
+
+  @spec dist_orchestrator_dir(Path.t(), String.t()) :: Path.t()
+  def dist_orchestrator_dir(root_dir, build_id),
+    do: Path.join(dist_target_dir(root_dir, "orchestrator"), build_id)
+
+  @spec dist_single_dir(Path.t(), String.t()) :: Path.t()
+  def dist_single_dir(root_dir, build_id),
+    do: Path.join(dist_target_dir(root_dir, "single"), build_id)
+
   @spec data_dir(Path.t()) :: Path.t()
   def data_dir(root_dir), do: Path.join(favn_dir(root_dir), "data")
 
@@ -33,8 +101,20 @@ defmodule Favn.Dev.Paths do
   @spec latest_manifest_path(Path.t()) :: Path.t()
   def latest_manifest_path(root_dir), do: Path.join(manifests_dir(root_dir), "latest.json")
 
+  @spec manifest_cache_dir(Path.t()) :: Path.t()
+  def manifest_cache_dir(root_dir), do: Path.join(manifests_dir(root_dir), "cache")
+
   @spec last_failure_path(Path.t()) :: Path.t()
   def last_failure_path(root_dir), do: Path.join(history_dir(root_dir), "last_failure.json")
+
+  @spec failures_dir(Path.t()) :: Path.t()
+  def failures_dir(root_dir), do: Path.join(history_dir(root_dir), "failures")
+
+  @spec install_path(Path.t()) :: Path.t()
+  def install_path(root_dir), do: Path.join(install_dir(root_dir), "install.json")
+
+  @spec toolchain_path(Path.t()) :: Path.t()
+  def toolchain_path(root_dir), do: Path.join(install_dir(root_dir), "toolchain.json")
 
   @spec web_log_path(Path.t()) :: Path.t()
   def web_log_path(root_dir), do: Path.join(logs_dir(root_dir), "web.log")

--- a/apps/favn_local/lib/favn/dev/process.ex
+++ b/apps/favn_local/lib/favn/dev/process.ex
@@ -26,23 +26,65 @@ defmodule Favn.Dev.Process do
   @spec stop_pid(integer(), timeout()) :: :ok
   def stop_pid(pid, timeout_ms \\ 10_000)
       when is_integer(pid) and pid > 0 and is_integer(timeout_ms) do
-    _ = System.cmd("kill", ["-TERM", Integer.to_string(pid)], stderr_to_stdout: true)
+    _ = send_terminate(pid)
 
     deadline = System.monotonic_time(:millisecond) + timeout_ms
 
     if wait_dead(pid, deadline) do
       :ok
     else
-      _ = System.cmd("kill", ["-KILL", Integer.to_string(pid)], stderr_to_stdout: true)
+      _ = send_kill(pid)
       :ok
     end
   end
 
   @spec alive?(integer()) :: boolean()
   def alive?(pid) when is_integer(pid) and pid > 0 do
+    case :os.type() do
+      {:unix, _} -> unix_alive?(pid)
+      {:win32, _} -> windows_alive?(pid)
+    end
+  end
+
+  defp send_terminate(pid) do
+    case :os.type() do
+      {:unix, _} ->
+        System.cmd("kill", ["-TERM", Integer.to_string(pid)], stderr_to_stdout: true)
+
+      {:win32, _} ->
+        System.cmd("taskkill", ["/PID", Integer.to_string(pid)], stderr_to_stdout: true)
+    end
+  end
+
+  defp send_kill(pid) do
+    case :os.type() do
+      {:unix, _} ->
+        System.cmd("kill", ["-KILL", Integer.to_string(pid)], stderr_to_stdout: true)
+
+      {:win32, _} ->
+        System.cmd("taskkill", ["/PID", Integer.to_string(pid), "/T", "/F"],
+          stderr_to_stdout: true
+        )
+    end
+  end
+
+  defp unix_alive?(pid) do
     case System.cmd("kill", ["-0", Integer.to_string(pid)], stderr_to_stdout: true) do
       {_out, 0} -> true
       {_out, _status} -> false
+    end
+  end
+
+  defp windows_alive?(pid) do
+    case System.cmd("tasklist", ["/FI", "PID eq #{pid}", "/FO", "CSV", "/NH"],
+           stderr_to_stdout: true
+         ) do
+      {output, 0} ->
+        normalized = output |> String.trim() |> String.downcase()
+        normalized != "" and not String.starts_with?(normalized, "info:")
+
+      {_output, _status} ->
+        false
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/reload.ex
+++ b/apps/favn_local/lib/favn/dev/reload.ex
@@ -120,7 +120,7 @@ defmodule Favn.Dev.Reload do
       exec: elixir,
       args: [
         "--sname",
-        runner_node,
+        runner_sname(runner_node),
         "--cookie",
         secrets["rpc_cookie"],
         "-S",
@@ -134,6 +134,14 @@ defmodule Favn.Dev.Reload do
       log_path: Paths.runner_log_path(root_dir),
       env: %{"MIX_ENV" => "dev"}
     }
+  end
+
+  @doc false
+  @spec runner_sname(String.t()) :: String.t()
+  def runner_sname(node_name) when is_binary(node_name) do
+    node_name
+    |> String.split("@", parts: 2)
+    |> hd()
   end
 
   defp register_manifest_in_runner(version, runtime, secrets) do

--- a/apps/favn_local/lib/favn/dev/reset.ex
+++ b/apps/favn_local/lib/favn/dev/reset.ex
@@ -1,0 +1,56 @@
+defmodule Favn.Dev.Reset do
+  @moduledoc """
+  Destructive project-local cleanup for `.favn/` state and artifacts.
+  """
+
+  alias Favn.Dev.Lock
+  alias Favn.Dev.Paths
+  alias Favn.Dev.Process, as: DevProcess
+  alias Favn.Dev.State
+
+  @type root_opt :: [root_dir: Path.t()]
+
+  @spec run(root_opt()) :: :ok | {:error, term()}
+  def run(opts \\ []) when is_list(opts) do
+    Lock.with_lock(opts, fn ->
+      root_dir = Paths.root_dir(opts)
+      favn_dir = Paths.favn_dir(root_dir)
+
+      with :ok <- ensure_stack_stopped(opts), do: remove_favn_dir(favn_dir)
+    end)
+  end
+
+  defp ensure_stack_stopped(opts) do
+    case State.read_runtime(opts) do
+      {:ok, runtime} ->
+        if any_service_running?(runtime) do
+          {:error, :stack_running}
+        else
+          :ok
+        end
+
+      {:error, :not_found} ->
+        :ok
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp any_service_running?(runtime) do
+    runtime
+    |> Map.get("services", %{})
+    |> Map.values()
+    |> Enum.any?(fn
+      %{"pid" => pid} when is_integer(pid) and pid > 0 -> DevProcess.alive?(pid)
+      _ -> false
+    end)
+  end
+
+  defp remove_favn_dir(path) do
+    case File.rm_rf(path) do
+      {:ok, _entries} -> :ok
+      {:error, reason, _path} -> {:error, {:reset_failed, reason}}
+    end
+  end
+end

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -134,6 +134,8 @@ defmodule Favn.Dev.Stack do
           list
 
         _ ->
+          :ok = ensure_web_assets(root_dir, opts)
+
           [
             runner_spec(root_dir, node_names, secrets),
             orchestrator_spec(root_dir, config, node_names, secrets),
@@ -151,6 +153,26 @@ defmodule Favn.Dev.Stack do
           {:halt, {:error, {:start_failed, spec.name, reason}}}
       end
     end)
+  end
+
+  defp ensure_web_assets(root_dir, opts) do
+    if Keyword.get(opts, :skip_web_build, false) do
+      :ok
+    else
+      web_cwd = Path.join(root_dir, "web/favn_web")
+      built_index = Path.join(web_cwd, "dist/index.html")
+
+      if File.exists?(built_index) do
+        :ok
+      else
+        npm = System.find_executable("npm") || "npm"
+
+        case System.cmd(npm, ["run", "build", "--silent"], cd: web_cwd, stderr_to_stdout: true) do
+          {_output, 0} -> :ok
+          {output, status} -> {:error, {:web_build_failed, status, String.trim(output)}}
+        end
+      end
+    end
   end
 
   defp runner_spec(root_dir, node_names, secrets) do
@@ -185,9 +207,26 @@ defmodule Favn.Dev.Stack do
     code =
       """
       storage = System.get_env("FAVN_DEV_STORAGE", "memory")
-      if storage == "sqlite" do
-        Application.put_env(:favn_orchestrator, :storage_adapter, FavnStorageSqlite.Adapter)
-        Application.put_env(:favn_orchestrator, :storage_adapter_opts, database: System.get_env("FAVN_DEV_SQLITE_PATH"))
+
+      cond do
+        storage == "sqlite" ->
+          Application.put_env(:favn_orchestrator, :storage_adapter, FavnStorageSqlite.Adapter)
+          Application.put_env(:favn_orchestrator, :storage_adapter_opts, database: System.get_env("FAVN_DEV_SQLITE_PATH"))
+
+        storage == "postgres" ->
+          Application.put_env(:favn_orchestrator, :storage_adapter, FavnStoragePostgres.Adapter)
+
+          Application.put_env(
+            :favn_orchestrator,
+            :storage_adapter_opts,
+            hostname: System.get_env("FAVN_DEV_POSTGRES_HOST"),
+            port: String.to_integer(System.get_env("FAVN_DEV_POSTGRES_PORT", "5432")),
+            username: System.get_env("FAVN_DEV_POSTGRES_USERNAME"),
+            password: System.get_env("FAVN_DEV_POSTGRES_PASSWORD"),
+            database: System.get_env("FAVN_DEV_POSTGRES_DATABASE"),
+            ssl: System.get_env("FAVN_DEV_POSTGRES_SSL", "false") == "true",
+            pool_size: String.to_integer(System.get_env("FAVN_DEV_POSTGRES_POOL_SIZE", "10"))
+          )
       end
       runner_node = String.to_atom(System.get_env("FAVN_DEV_RUNNER_NODE"))
       Application.put_env(:favn_orchestrator, :runner_client, FavnOrchestrator.RunnerClient.LocalNode)
@@ -218,6 +257,13 @@ defmodule Favn.Dev.Stack do
         "MIX_ENV" => "dev",
         "FAVN_DEV_STORAGE" => Atom.to_string(config.storage),
         "FAVN_DEV_SQLITE_PATH" => sqlite_path,
+        "FAVN_DEV_POSTGRES_HOST" => config.postgres.hostname,
+        "FAVN_DEV_POSTGRES_PORT" => Integer.to_string(config.postgres.port),
+        "FAVN_DEV_POSTGRES_USERNAME" => config.postgres.username,
+        "FAVN_DEV_POSTGRES_PASSWORD" => config.postgres.password,
+        "FAVN_DEV_POSTGRES_DATABASE" => config.postgres.database,
+        "FAVN_DEV_POSTGRES_SSL" => if(config.postgres.ssl, do: "true", else: "false"),
+        "FAVN_DEV_POSTGRES_POOL_SIZE" => Integer.to_string(config.postgres.pool_size),
         "FAVN_DEV_RUNNER_NODE" => node_names.runner_full,
         "FAVN_ORCHESTRATOR_API_ENABLED" =>
           if(config.orchestrator_api_enabled, do: "1", else: "0"),
@@ -228,17 +274,21 @@ defmodule Favn.Dev.Stack do
   end
 
   defp web_spec(root_dir, config, secrets) do
-    bash = System.find_executable("bash") || "/bin/bash"
     npm = System.find_executable("npm") || "npm"
     web_cwd = Path.join(root_dir, "web/favn_web")
 
-    command =
-      "#{npm} run build --silent && #{npm} run preview -- --host 127.0.0.1 --port #{config.web_port}"
-
     %{
       name: "web",
-      exec: bash,
-      args: ["-lc", command],
+      exec: npm,
+      args: [
+        "run",
+        "preview",
+        "--",
+        "--host",
+        "127.0.0.1",
+        "--port",
+        Integer.to_string(config.web_port)
+      ],
       cwd: web_cwd,
       log_path: Paths.web_log_path(root_dir),
       env: %{
@@ -389,18 +439,18 @@ defmodule Favn.Dev.Stack do
   end
 
   defp http_up?(url) do
-    case System.cmd(
-           "curl",
-           ["-sS", "-o", "/dev/null", "-w", "%{http_code}", "--max-time", "1", url],
-           stderr_to_stdout: true
-         ) do
-      {code, 0} ->
-        case Integer.parse(String.trim(code)) do
-          {status, _rest} when status >= 200 and status < 500 -> true
-          _ -> false
+    case URI.parse(url) do
+      %URI{host: host, port: port} when is_binary(host) and is_integer(port) and port > 0 ->
+        case :gen_tcp.connect(String.to_charlist(host), port, [:binary, {:active, false}], 1_000) do
+          {:ok, socket} ->
+            :gen_tcp.close(socket)
+            true
+
+          {:error, _reason} ->
+            false
         end
 
-      {_output, _status} ->
+      _other ->
         false
     end
   end

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -7,6 +7,7 @@ defmodule Favn.Dev.Stack do
   """
 
   alias Favn.Dev.Config
+  alias Favn.Dev.Install
   alias Favn.Dev.Lock
   alias Favn.Dev.NodeControl
   alias Favn.Dev.OrchestratorClient
@@ -55,6 +56,7 @@ defmodule Favn.Dev.Stack do
     with_lock(opts, fn ->
       with :ok <- State.ensure_layout(opts),
            :ok <- ensure_stack_not_running(opts),
+           :ok <- ensure_install_ready(opts),
            config <- Config.resolve(opts),
            {:ok, secrets} <- Secrets.resolve(config, opts),
            {:ok, node_names} <- build_node_names(opts),
@@ -79,6 +81,14 @@ defmodule Favn.Dev.Stack do
 
       {:error, reason} ->
         {:error, reason}
+    end
+  end
+
+  defp ensure_install_ready(opts) do
+    if Keyword.get(opts, :skip_install_check, false) do
+      :ok
+    else
+      Install.ensure_ready(opts)
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/state.ex
+++ b/apps/favn_local/lib/favn/dev/state.ex
@@ -21,9 +21,28 @@ defmodule Favn.Dev.State do
     [
       Paths.favn_dir(root_dir),
       Paths.logs_dir(root_dir),
+      Paths.install_dir(root_dir),
+      Paths.install_cache_dir(root_dir),
+      Paths.install_cache_npm_dir(root_dir),
+      Paths.install_runtimes_dir(root_dir),
+      Paths.install_runtime_web_dir(root_dir),
+      Paths.install_runtime_orchestrator_dir(root_dir),
+      Paths.install_runtime_runner_dir(root_dir),
+      Paths.build_dir(root_dir),
+      Paths.build_target_dir(root_dir, "web"),
+      Paths.build_target_dir(root_dir, "orchestrator"),
+      Paths.build_target_dir(root_dir, "runner"),
+      Paths.build_target_dir(root_dir, "single"),
+      Paths.dist_dir(root_dir),
+      Paths.dist_target_dir(root_dir, "web"),
+      Paths.dist_target_dir(root_dir, "orchestrator"),
+      Paths.dist_target_dir(root_dir, "runner"),
+      Paths.dist_target_dir(root_dir, "single"),
       Paths.data_dir(root_dir),
       Paths.manifests_dir(root_dir),
-      Paths.history_dir(root_dir)
+      Paths.manifest_cache_dir(root_dir),
+      Paths.history_dir(root_dir),
+      Paths.failures_dir(root_dir)
     ]
     |> Enum.reduce_while(:ok, fn dir, :ok ->
       case File.mkdir_p(dir) do
@@ -74,6 +93,42 @@ defmodule Favn.Dev.State do
       |> Paths.root_dir()
       |> Paths.latest_manifest_path()
       |> write_json(manifest)
+    end
+  end
+
+  @spec read_install(root_opt()) :: {:ok, map()} | {:error, read_error()}
+  def read_install(opts \\ []) when is_list(opts) do
+    opts
+    |> Paths.root_dir()
+    |> Paths.install_path()
+    |> read_json()
+  end
+
+  @spec write_install(map(), root_opt()) :: :ok | {:error, term()}
+  def write_install(install, opts \\ []) when is_map(install) and is_list(opts) do
+    with :ok <- ensure_layout(opts) do
+      opts
+      |> Paths.root_dir()
+      |> Paths.install_path()
+      |> write_json(install)
+    end
+  end
+
+  @spec read_toolchain(root_opt()) :: {:ok, map()} | {:error, read_error()}
+  def read_toolchain(opts \\ []) when is_list(opts) do
+    opts
+    |> Paths.root_dir()
+    |> Paths.toolchain_path()
+    |> read_json()
+  end
+
+  @spec write_toolchain(map(), root_opt()) :: :ok | {:error, term()}
+  def write_toolchain(toolchain, opts \\ []) when is_map(toolchain) and is_list(opts) do
+    with :ok <- ensure_layout(opts) do
+      opts
+      |> Paths.root_dir()
+      |> Paths.toolchain_path()
+      |> write_json(toolchain)
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/status.ex
+++ b/apps/favn_local/lib/favn/dev/status.ex
@@ -4,6 +4,7 @@ defmodule Favn.Dev.Status do
   """
 
   alias Favn.Dev.Config
+  alias Favn.Dev.Process, as: DevProcess
   alias Favn.Dev.State
 
   @type inspect_opts :: [root_dir: Path.t()]
@@ -88,10 +89,7 @@ defmodule Favn.Dev.Status do
   end
 
   defp process_alive?(pid) when is_integer(pid) and pid > 0 do
-    case System.cmd("kill", ["-0", Integer.to_string(pid)], stderr_to_stdout: true) do
-      {_output, 0} -> true
-      {_output, _exit_status} -> false
-    end
+    DevProcess.alive?(pid)
   end
 
   defp summarize_stack_status(services) do

--- a/apps/favn_local/test/dev_build_orchestrator_test.exs
+++ b/apps/favn_local/test/dev_build_orchestrator_test.exs
@@ -36,7 +36,8 @@ defmodule Favn.Dev.Build.OrchestratorTest do
   end
 
   test "build_orchestrator/1 writes build and dist contracts", %{root_dir: root_dir} do
-    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+    assert {:ok, :installed} =
+             Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
 
     assert {:ok, result} = Dev.build_orchestrator(root_dir: root_dir, skip_tool_checks: true)
 

--- a/apps/favn_local/test/dev_build_orchestrator_test.exs
+++ b/apps/favn_local/test/dev_build_orchestrator_test.exs
@@ -1,0 +1,56 @@
+defmodule Favn.Dev.Build.OrchestratorTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Dev
+
+  setup do
+    root_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_dev_build_orchestrator_test_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(Path.join(root_dir, "web/favn_web"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_runner"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_orchestrator"))
+
+    File.write!(Path.join(root_dir, "mix.lock"), "lock")
+    File.write!(Path.join(root_dir, "web/favn_web/package.json"), "{}")
+    File.write!(Path.join(root_dir, "web/favn_web/package-lock.json"), "{}")
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_runner/mix.exs"),
+      "defmodule Runner.MixProject do end"
+    )
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_orchestrator/mix.exs"),
+      "defmodule Orchestrator.MixProject do end"
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root_dir)
+    end)
+
+    %{root_dir: root_dir}
+  end
+
+  test "build_orchestrator/1 writes build and dist contracts", %{root_dir: root_dir} do
+    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+    assert {:ok, result} = Dev.build_orchestrator(root_dir: root_dir, skip_tool_checks: true)
+
+    assert {:ok, build_json} = File.read(Path.join(result.build_dir, "build.json"))
+    assert {:ok, metadata_json} = File.read(Path.join(result.dist_dir, "metadata.json"))
+    assert File.exists?(Path.join(result.dist_dir, "bundle.json"))
+
+    assert {:ok, %{"target" => "orchestrator", "build_id" => build_id}} = JSON.decode(build_json)
+
+    assert {:ok, %{"target" => "orchestrator", "build_id" => ^build_id}} =
+             JSON.decode(metadata_json)
+  end
+
+  test "build_orchestrator/1 requires install", %{root_dir: root_dir} do
+    assert {:error, :install_required} = Dev.build_orchestrator(root_dir: root_dir)
+  end
+end

--- a/apps/favn_local/test/dev_build_runner_test.exs
+++ b/apps/favn_local/test/dev_build_runner_test.exs
@@ -1,0 +1,79 @@
+defmodule Favn.Dev.Build.RunnerTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Dev
+  alias Favn.Dev.Paths
+
+  setup do
+    root_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_dev_build_runner_test_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(Path.join(root_dir, "web/favn_web"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_runner"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_orchestrator"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_duckdb"))
+
+    File.write!(Path.join(root_dir, "mix.lock"), "lock")
+    File.write!(Path.join(root_dir, "web/favn_web/package.json"), "{}")
+    File.write!(Path.join(root_dir, "web/favn_web/package-lock.json"), "{}")
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_runner/mix.exs"),
+      "defmodule Runner.MixProject do end"
+    )
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_orchestrator/mix.exs"),
+      "defmodule Orchestrator.MixProject do end"
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root_dir)
+    end)
+
+    %{root_dir: root_dir}
+  end
+
+  test "build_runner/1 writes build and dist contracts", %{root_dir: root_dir} do
+    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+    assert {:ok, result} =
+             Dev.build_runner(root_dir: root_dir, skip_compile: true, skip_tool_checks: true)
+
+    build_json_path = Path.join(result.build_dir, "build.json")
+    metadata_json_path = Path.join(result.dist_dir, "metadata.json")
+    manifest_json_path = Path.join(result.dist_dir, "manifest.json")
+
+    assert File.exists?(build_json_path)
+    assert File.exists?(metadata_json_path)
+    assert File.exists?(manifest_json_path)
+
+    assert {:ok, build_json} = File.read(build_json_path)
+    assert {:ok, metadata_json} = File.read(metadata_json_path)
+
+    assert {:ok, %{"target" => "runner", "build_id" => build_id}} = JSON.decode(build_json)
+
+    assert {:ok,
+            %{"target" => "runner", "build_id" => ^build_id, "compatibility" => compatibility}} =
+             JSON.decode(metadata_json)
+
+    assert is_map(compatibility)
+
+    cache_path =
+      Path.join(Paths.manifest_cache_dir(root_dir), metadata_manifest_id(metadata_json))
+
+    assert File.exists?(cache_path)
+  end
+
+  test "build_runner/1 requires install", %{root_dir: root_dir} do
+    assert {:error, :install_required} = Dev.build_runner(root_dir: root_dir, skip_compile: true)
+  end
+
+  defp metadata_manifest_id(metadata_json) do
+    {:ok, %{"manifest" => %{"manifest_version_id" => id}}} = JSON.decode(metadata_json)
+    "#{id}.json"
+  end
+end

--- a/apps/favn_local/test/dev_build_runner_test.exs
+++ b/apps/favn_local/test/dev_build_runner_test.exs
@@ -38,10 +38,16 @@ defmodule Favn.Dev.Build.RunnerTest do
   end
 
   test "build_runner/1 writes build and dist contracts", %{root_dir: root_dir} do
-    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+    assert {:ok, :installed} =
+             Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
 
     assert {:ok, result} =
-             Dev.build_runner(root_dir: root_dir, skip_compile: true, skip_tool_checks: true)
+             Dev.build_runner(
+               root_dir: root_dir,
+               skip_compile: true,
+               skip_tool_checks: true,
+               skip_project_root_check: true
+             )
 
     build_json_path = Path.join(result.build_dir, "build.json")
     metadata_json_path = Path.join(result.dist_dir, "metadata.json")
@@ -69,7 +75,19 @@ defmodule Favn.Dev.Build.RunnerTest do
   end
 
   test "build_runner/1 requires install", %{root_dir: root_dir} do
-    assert {:error, :install_required} = Dev.build_runner(root_dir: root_dir, skip_compile: true)
+    assert {:error, :install_required} =
+             Dev.build_runner(
+               root_dir: root_dir,
+               skip_compile: true,
+               skip_project_root_check: true
+             )
+  end
+
+  test "build_runner/1 rejects root_dir that is not the current project root", %{
+    root_dir: root_dir
+  } do
+    assert {:error, {:unsupported_root_dir, _requested, _current}} =
+             Dev.build_runner(root_dir: root_dir, skip_compile: true, skip_tool_checks: true)
   end
 
   defp metadata_manifest_id(metadata_json) do

--- a/apps/favn_local/test/dev_build_single_test.exs
+++ b/apps/favn_local/test/dev_build_single_test.exs
@@ -1,0 +1,79 @@
+defmodule Favn.Dev.Build.SingleTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Dev
+
+  setup do
+    root_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_dev_build_single_test_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(Path.join(root_dir, "web/favn_web"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_runner"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_orchestrator"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_duckdb"))
+
+    File.write!(Path.join(root_dir, "mix.lock"), "lock")
+    File.write!(Path.join(root_dir, "web/favn_web/package.json"), "{}")
+    File.write!(Path.join(root_dir, "web/favn_web/package-lock.json"), "{}")
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_runner/mix.exs"),
+      "defmodule Runner.MixProject do end"
+    )
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_orchestrator/mix.exs"),
+      "defmodule Orchestrator.MixProject do end"
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root_dir)
+    end)
+
+    %{root_dir: root_dir}
+  end
+
+  test "build_single/1 writes assembled single-node bundle with sqlite default", %{
+    root_dir: root_dir
+  } do
+    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+    assert {:ok, result} =
+             Dev.build_single(root_dir: root_dir, skip_compile: true, skip_tool_checks: true)
+
+    assert File.exists?(Path.join(result.build_dir, "build.json"))
+    assert File.exists?(Path.join(result.dist_dir, "metadata.json"))
+    assert File.exists?(Path.join(result.dist_dir, "config/assembly.json"))
+    assert File.exists?(Path.join(result.dist_dir, "env/web.env"))
+    assert File.exists?(Path.join(result.dist_dir, "env/orchestrator.env"))
+    assert File.exists?(Path.join(result.dist_dir, "env/runner.env"))
+    assert File.exists?(Path.join(result.dist_dir, "bin/start"))
+    assert File.exists?(Path.join(result.dist_dir, "bin/stop"))
+
+    assert {:ok, assembly_json} = File.read(Path.join(result.dist_dir, "config/assembly.json"))
+    assert {:ok, %{"storage" => %{"mode" => "sqlite"}}} = JSON.decode(assembly_json)
+  end
+
+  test "build_single/1 supports postgres storage override", %{root_dir: root_dir} do
+    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+    assert {:ok, result} =
+             Dev.build_single(
+               root_dir: root_dir,
+               storage: :postgres,
+               skip_compile: true,
+               skip_tool_checks: true
+             )
+
+    assert {:ok, assembly_json} = File.read(Path.join(result.dist_dir, "config/assembly.json"))
+    assert {:ok, %{"storage" => %{"mode" => "postgres"}}} = JSON.decode(assembly_json)
+  end
+
+  test "build_single/1 requires install", %{root_dir: root_dir} do
+    assert {:error, :install_required} =
+             Dev.build_single(root_dir: root_dir, skip_compile: true, skip_tool_checks: true)
+  end
+end

--- a/apps/favn_local/test/dev_build_single_test.exs
+++ b/apps/favn_local/test/dev_build_single_test.exs
@@ -39,10 +39,16 @@ defmodule Favn.Dev.Build.SingleTest do
   test "build_single/1 writes assembled single-node bundle with sqlite default", %{
     root_dir: root_dir
   } do
-    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+    assert {:ok, :installed} =
+             Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
 
     assert {:ok, result} =
-             Dev.build_single(root_dir: root_dir, skip_compile: true, skip_tool_checks: true)
+             Dev.build_single(
+               root_dir: root_dir,
+               skip_compile: true,
+               skip_tool_checks: true,
+               skip_project_root_check: true
+             )
 
     assert File.exists?(Path.join(result.build_dir, "build.json"))
     assert File.exists?(Path.join(result.dist_dir, "metadata.json"))
@@ -58,14 +64,16 @@ defmodule Favn.Dev.Build.SingleTest do
   end
 
   test "build_single/1 supports postgres storage override", %{root_dir: root_dir} do
-    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+    assert {:ok, :installed} =
+             Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
 
     assert {:ok, result} =
              Dev.build_single(
                root_dir: root_dir,
                storage: :postgres,
                skip_compile: true,
-               skip_tool_checks: true
+               skip_tool_checks: true,
+               skip_project_root_check: true
              )
 
     assert {:ok, assembly_json} = File.read(Path.join(result.dist_dir, "config/assembly.json"))

--- a/apps/favn_local/test/dev_build_web_test.exs
+++ b/apps/favn_local/test/dev_build_web_test.exs
@@ -36,7 +36,8 @@ defmodule Favn.Dev.Build.WebTest do
   end
 
   test "build_web/1 writes build and dist contracts", %{root_dir: root_dir} do
-    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+    assert {:ok, :installed} =
+             Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
 
     assert {:ok, result} = Dev.build_web(root_dir: root_dir, skip_tool_checks: true)
 

--- a/apps/favn_local/test/dev_build_web_test.exs
+++ b/apps/favn_local/test/dev_build_web_test.exs
@@ -1,0 +1,54 @@
+defmodule Favn.Dev.Build.WebTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Dev
+
+  setup do
+    root_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_dev_build_web_test_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(Path.join(root_dir, "web/favn_web"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_runner"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_orchestrator"))
+
+    File.write!(Path.join(root_dir, "mix.lock"), "lock")
+    File.write!(Path.join(root_dir, "web/favn_web/package.json"), "{}")
+    File.write!(Path.join(root_dir, "web/favn_web/package-lock.json"), "{}")
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_runner/mix.exs"),
+      "defmodule Runner.MixProject do end"
+    )
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_orchestrator/mix.exs"),
+      "defmodule Orchestrator.MixProject do end"
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root_dir)
+    end)
+
+    %{root_dir: root_dir}
+  end
+
+  test "build_web/1 writes build and dist contracts", %{root_dir: root_dir} do
+    assert :ok = Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+    assert {:ok, result} = Dev.build_web(root_dir: root_dir, skip_tool_checks: true)
+
+    assert {:ok, build_json} = File.read(Path.join(result.build_dir, "build.json"))
+    assert {:ok, metadata_json} = File.read(Path.join(result.dist_dir, "metadata.json"))
+    assert File.exists?(Path.join(result.dist_dir, "bundle.json"))
+
+    assert {:ok, %{"target" => "web", "build_id" => build_id}} = JSON.decode(build_json)
+    assert {:ok, %{"target" => "web", "build_id" => ^build_id}} = JSON.decode(metadata_json)
+  end
+
+  test "build_web/1 requires install", %{root_dir: root_dir} do
+    assert {:error, :install_required} = Dev.build_web(root_dir: root_dir)
+  end
+end

--- a/apps/favn_local/test/dev_config_test.exs
+++ b/apps/favn_local/test/dev_config_test.exs
@@ -8,6 +8,8 @@ defmodule Favn.Dev.ConfigTest do
 
     assert config.storage == :memory
     assert config.sqlite_path == ".favn/data/orchestrator.sqlite3"
+    assert config.postgres.hostname == "127.0.0.1"
+    assert config.postgres.port == 5432
     assert config.orchestrator_api_enabled == true
     assert config.orchestrator_port == 4101
     assert config.web_port == 4173
@@ -34,5 +36,42 @@ defmodule Favn.Dev.ConfigTest do
     assert config.orchestrator_base_url == "http://127.0.0.1:4201"
     assert config.web_base_url == "http://127.0.0.1:4273"
     assert config.service_token == "dev-token"
+  end
+
+  test "resolve/1 supports postgres storage and postgres options" do
+    config =
+      Config.resolve(
+        storage: :postgres,
+        postgres: [
+          hostname: "db",
+          port: 6543,
+          username: "u",
+          password: "p",
+          database: "favn_dev",
+          ssl: true
+        ]
+      )
+
+    assert config.storage == :postgres
+    assert config.postgres.hostname == "db"
+    assert config.postgres.port == 6543
+    assert config.postgres.username == "u"
+    assert config.postgres.password == "p"
+    assert config.postgres.database == "favn_dev"
+    assert config.postgres.ssl == true
+  end
+
+  test "resolve/1 reads :local config and lets it override :dev" do
+    Application.put_env(:favn, :dev, storage: :memory, sqlite_path: "dev.sqlite")
+    Application.put_env(:favn, :local, storage: :sqlite, sqlite_path: "local.sqlite")
+
+    on_exit(fn ->
+      Application.delete_env(:favn, :dev)
+      Application.delete_env(:favn, :local)
+    end)
+
+    config = Config.resolve([])
+    assert config.storage == :sqlite
+    assert config.sqlite_path == "local.sqlite"
   end
 end

--- a/apps/favn_local/test/dev_install_test.exs
+++ b/apps/favn_local/test/dev_install_test.exs
@@ -35,7 +35,8 @@ defmodule Favn.Dev.InstallTest do
   end
 
   test "run/1 writes install and toolchain metadata", %{root_dir: root_dir} do
-    assert :ok = Install.run(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+    assert {:ok, :installed} =
+             Install.run(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
 
     assert :ok = Install.ensure_ready(root_dir: root_dir, skip_tool_checks: true)
 
@@ -45,6 +46,14 @@ defmodule Favn.Dev.InstallTest do
     assert install["schema_version"] == 1
     assert is_map(install["fingerprint"])
     assert toolchain["schema_version"] == 1
+  end
+
+  test "run/1 returns already_installed when fingerprint matches", %{root_dir: root_dir} do
+    assert {:ok, :installed} =
+             Install.run(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+    assert {:ok, :already_installed} =
+             Install.run(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
   end
 
   test "ensure_ready/1 returns install_required when install state is missing", %{

--- a/apps/favn_local/test/dev_install_test.exs
+++ b/apps/favn_local/test/dev_install_test.exs
@@ -45,7 +45,13 @@ defmodule Favn.Dev.InstallTest do
 
     assert install["schema_version"] == 1
     assert is_map(install["fingerprint"])
+    assert is_binary(get_in(install, ["runtime_inputs", "web", "materialized_root"]))
     assert toolchain["schema_version"] == 1
+
+    assert File.exists?(Path.join(root_dir, ".favn/install/runtimes/web/runtime_input.json"))
+    assert File.exists?(Path.join(root_dir, ".favn/install/runtimes/web/source/package.json"))
+    assert File.exists?(Path.join(root_dir, ".favn/install/runtimes/orchestrator/source/mix.exs"))
+    assert File.exists?(Path.join(root_dir, ".favn/install/runtimes/runner/source/mix.exs"))
   end
 
   test "run/1 returns already_installed when fingerprint matches", %{root_dir: root_dir} do

--- a/apps/favn_local/test/dev_install_test.exs
+++ b/apps/favn_local/test/dev_install_test.exs
@@ -1,0 +1,68 @@
+defmodule Favn.Dev.InstallTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Dev.Install
+  alias Favn.Dev.State
+
+  setup do
+    root_dir =
+      Path.join(System.tmp_dir!(), "favn_dev_install_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root_dir)
+    File.mkdir_p!(Path.join(root_dir, "web/favn_web"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_runner"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_orchestrator"))
+
+    File.write!(Path.join(root_dir, "mix.lock"), "lock")
+    File.write!(Path.join(root_dir, "web/favn_web/package.json"), "{}")
+    File.write!(Path.join(root_dir, "web/favn_web/package-lock.json"), "{}")
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_runner/mix.exs"),
+      "defmodule Runner.MixProject do end"
+    )
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_orchestrator/mix.exs"),
+      "defmodule Orchestrator.MixProject do end"
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root_dir)
+    end)
+
+    %{root_dir: root_dir}
+  end
+
+  test "run/1 writes install and toolchain metadata", %{root_dir: root_dir} do
+    assert :ok = Install.run(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+    assert :ok = Install.ensure_ready(root_dir: root_dir, skip_tool_checks: true)
+
+    assert {:ok, install} = State.read_install(root_dir: root_dir)
+    assert {:ok, toolchain} = State.read_toolchain(root_dir: root_dir)
+
+    assert install["schema_version"] == 1
+    assert is_map(install["fingerprint"])
+    assert toolchain["schema_version"] == 1
+  end
+
+  test "ensure_ready/1 returns install_required when install state is missing", %{
+    root_dir: root_dir
+  } do
+    assert {:error, :install_required} = Install.ensure_ready(root_dir: root_dir)
+  end
+
+  test "ensure_ready/1 returns install_stale when fingerprint differs", %{root_dir: root_dir} do
+    assert :ok = State.ensure_layout(root_dir: root_dir)
+
+    assert :ok =
+             State.write_install(
+               %{"schema_version" => 1, "fingerprint" => %{"mix_lock_sha256" => "old"}},
+               root_dir: root_dir
+             )
+
+    assert {:error, :install_stale} =
+             Install.ensure_ready(root_dir: root_dir, skip_tool_checks: true)
+  end
+end

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -79,6 +79,7 @@ defmodule Favn.Dev.LifecycleTest do
              Dev.dev(
                root_dir: root_dir,
                service_specs_override: failing_specs,
+               skip_install_check: true,
                skip_bootstrap: true,
                skip_readiness: true
              )

--- a/apps/favn_local/test/dev_logs_test.exs
+++ b/apps/favn_local/test/dev_logs_test.exs
@@ -1,0 +1,90 @@
+defmodule Favn.Dev.LogsTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Dev.Logs
+  alias Favn.Dev.Paths
+  alias Favn.Dev.State
+
+  setup do
+    root_dir =
+      Path.join(System.tmp_dir!(), "favn_dev_logs_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root_dir)
+    :ok = State.ensure_layout(root_dir: root_dir)
+
+    on_exit(fn ->
+      File.rm_rf(root_dir)
+    end)
+
+    %{root_dir: root_dir}
+  end
+
+  test "run/1 prints all service logs with prefixes", %{root_dir: root_dir} do
+    File.write!(Paths.web_log_path(root_dir), "web-one\n")
+    File.write!(Paths.orchestrator_log_path(root_dir), "orc-one\n")
+    File.write!(Paths.runner_log_path(root_dir), "run-one\n")
+
+    output = collect(fn writer -> Logs.run(root_dir: root_dir, writer: writer) end)
+
+    assert output =~ "[web] web-one"
+    assert output =~ "[orchestrator] orc-one"
+    assert output =~ "[runner] run-one"
+  end
+
+  test "run/1 supports service selection and tail", %{root_dir: root_dir} do
+    File.write!(Paths.web_log_path(root_dir), "one\ntwo\nthree\n")
+
+    output =
+      collect(fn writer ->
+        Logs.run(root_dir: root_dir, service: :web, tail: 2, writer: writer)
+      end)
+
+    refute output =~ "one"
+    assert output =~ "two"
+    assert output =~ "three"
+  end
+
+  test "run/1 supports follow mode", %{root_dir: root_dir} do
+    File.write!(Paths.web_log_path(root_dir), "before\n")
+
+    output =
+      collect(fn writer ->
+        Task.start(fn ->
+          Process.sleep(30)
+          File.write!(Paths.web_log_path(root_dir), "before\nafter\n")
+        end)
+
+        Logs.run(
+          root_dir: root_dir,
+          service: :web,
+          follow: true,
+          follow_ticks: 6,
+          follow_sleep_ms: 20,
+          writer: writer
+        )
+      end)
+
+    assert output =~ "before"
+    assert output =~ "after"
+  end
+
+  defp collect(fun) do
+    parent = self()
+    writer = fn data -> send(parent, {:log_chunk, IO.iodata_to_binary(data)}) end
+
+    assert :ok = fun.(writer)
+
+    gather_chunks([])
+  end
+
+  defp gather_chunks(acc) do
+    receive do
+      {:log_chunk, chunk} -> gather_chunks([chunk | acc])
+    after
+      20 ->
+        acc
+        |> Enum.reverse()
+        |> Enum.join("")
+    end
+  end
+end

--- a/apps/favn_local/test/dev_reload_test.exs
+++ b/apps/favn_local/test/dev_reload_test.exs
@@ -2,6 +2,7 @@ defmodule Favn.Dev.ReloadTest do
   use ExUnit.Case, async: true
 
   alias Favn.Dev
+  alias Favn.Dev.Reload
   alias Favn.Dev.State
 
   setup do
@@ -36,5 +37,10 @@ defmodule Favn.Dev.ReloadTest do
 
     assert :ok = State.write_runtime(runtime, root_dir: root_dir)
     assert {:error, :stack_not_healthy} = Dev.reload(root_dir: root_dir)
+  end
+
+  test "runner_sname/1 returns short node name" do
+    assert "favn_runner_123" == Reload.runner_sname("favn_runner_123@localhost")
+    assert "favn_runner_123" == Reload.runner_sname("favn_runner_123")
   end
 end

--- a/apps/favn_local/test/dev_reset_test.exs
+++ b/apps/favn_local/test/dev_reset_test.exs
@@ -1,0 +1,37 @@
+defmodule Favn.Dev.ResetTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Dev.Reset
+  alias Favn.Dev.State
+
+  setup do
+    root_dir =
+      Path.join(System.tmp_dir!(), "favn_dev_reset_test_#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root_dir)
+
+    on_exit(fn ->
+      File.rm_rf(root_dir)
+    end)
+
+    %{root_dir: root_dir}
+  end
+
+  test "run/1 deletes .favn when stack is stopped", %{root_dir: root_dir} do
+    assert :ok = State.ensure_layout(root_dir: root_dir)
+    assert :ok = File.write(Path.join(root_dir, ".favn/runtime.json"), "{}")
+
+    assert :ok = Reset.run(root_dir: root_dir)
+    refute File.exists?(Path.join(root_dir, ".favn"))
+  end
+
+  test "run/1 refuses reset when runtime has live pid", %{root_dir: root_dir} do
+    pid = :os.getpid() |> List.to_string() |> String.to_integer()
+
+    runtime = %{"services" => %{"web" => %{"pid" => pid}}}
+    assert :ok = State.write_runtime(runtime, root_dir: root_dir)
+
+    assert {:error, :stack_running} = Reset.run(root_dir: root_dir)
+    assert File.exists?(Path.join(root_dir, ".favn"))
+  end
+end

--- a/apps/favn_local/test/dev_state_test.exs
+++ b/apps/favn_local/test/dev_state_test.exs
@@ -20,9 +20,20 @@ defmodule Favn.Dev.StateTest do
     assert :ok = State.ensure_layout(root_dir: root_dir)
     assert File.dir?(Path.join(root_dir, ".favn"))
     assert File.dir?(Path.join(root_dir, ".favn/logs"))
+    assert File.dir?(Path.join(root_dir, ".favn/install"))
+    assert File.dir?(Path.join(root_dir, ".favn/install/cache"))
+    assert File.dir?(Path.join(root_dir, ".favn/install/cache/npm"))
+    assert File.dir?(Path.join(root_dir, ".favn/install/runtimes"))
+    assert File.dir?(Path.join(root_dir, ".favn/install/runtimes/web"))
+    assert File.dir?(Path.join(root_dir, ".favn/install/runtimes/orchestrator"))
+    assert File.dir?(Path.join(root_dir, ".favn/install/runtimes/runner"))
+    assert File.dir?(Path.join(root_dir, ".favn/build"))
+    assert File.dir?(Path.join(root_dir, ".favn/dist"))
     assert File.dir?(Path.join(root_dir, ".favn/data"))
     assert File.dir?(Path.join(root_dir, ".favn/manifests"))
+    assert File.dir?(Path.join(root_dir, ".favn/manifests/cache"))
     assert File.dir?(Path.join(root_dir, ".favn/history"))
+    assert File.dir?(Path.join(root_dir, ".favn/history/failures"))
   end
 
   test "runtime state roundtrip", %{root_dir: root_dir} do
@@ -33,5 +44,16 @@ defmodule Favn.Dev.StateTest do
 
     assert :ok = State.clear_runtime(root_dir: root_dir)
     assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
+  end
+
+  test "install and toolchain state roundtrip", %{root_dir: root_dir} do
+    install = %{"schema_version" => 1, "fingerprint" => %{"mix_lock_sha256" => "abc"}}
+    toolchain = %{"schema_version" => 1, "node_version" => "v22.1.0"}
+
+    assert :ok = State.write_install(install, root_dir: root_dir)
+    assert :ok = State.write_toolchain(toolchain, root_dir: root_dir)
+
+    assert {:ok, ^install} = State.read_install(root_dir: root_dir)
+    assert {:ok, ^toolchain} = State.read_toolchain(root_dir: root_dir)
   end
 end

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -16,6 +16,7 @@ Favn `v0.5.0` is a refactor release toward a manifest-first product with separat
 - Phase 9 runner packaging first-cut is now in place through `mix favn.build.runner` with project-local build/dist metadata outputs
 - Phase 9 split build first-cut now also includes `mix favn.build.web` and `mix favn.build.orchestrator`
 - Phase 9 single-node assembly first-cut is now in place through `mix favn.build.single`
+- local storage configuration now supports `memory`, `sqlite`, and `postgres` through `config :favn, :local` plus `mix favn.dev --sqlite|--postgres`
 - remaining Phase 9 work is broader validation/polish
 - the remaining Phase 9 tooling/packageability design is now captured in `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` and `docs/refactor/PHASE_9_TODO.md`
 - Phase 10 app deletion is complete: `apps/favn_legacy` and `apps/favn_view` are removed from the umbrella

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -12,6 +12,7 @@ Favn `v0.5.0` is a refactor release toward a manifest-first product with separat
 - Phase 9 core local lifecycle has landed in `apps/favn_local`: `mix favn.dev`, `mix favn.stop`, `mix favn.reload`, `mix favn.status`
 - public package topology migration is complete: `apps/favn` is now the thin public wrapper, `apps/favn_authoring` owns authoring implementation, and `apps/favn_local` owns lifecycle/tooling internals
 - remaining Phase 9 work is packaging and local-tooling follow-up: `install`, `reset`, `logs`, and build targets for `web`, `orchestrator`, `runner`, and optional `single`
+- the remaining Phase 9 tooling/packageability design is now captured in `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` and `docs/refactor/PHASE_9_TODO.md`
 - Phase 10 app deletion is complete: `apps/favn_legacy` and `apps/favn_view` are removed from the umbrella
 - shared migration fixture substrate now lives in `apps/favn_test_support` (`priv/fixtures/**` + `FavnTestSupport.Fixtures`) so later per-app parity PRs can reuse one fixture source of truth
 - authoring/compiler/planning/window coverage now lives in public-facade suites under `apps/favn/test` and core suites under `apps/favn_core/test`

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -11,7 +11,12 @@ Favn `v0.5.0` is a refactor release toward a manifest-first product with separat
 
 - Phase 9 core local lifecycle has landed in `apps/favn_local`: `mix favn.dev`, `mix favn.stop`, `mix favn.reload`, `mix favn.status`
 - public package topology migration is complete: `apps/favn` is now the thin public wrapper, `apps/favn_authoring` owns authoring implementation, and `apps/favn_local` owns lifecycle/tooling internals
-- remaining Phase 9 work is packaging and local-tooling follow-up: `install`, `reset`, `logs`, and build targets for `web`, `orchestrator`, `runner`, and optional `single`
+- Phase 9 install foundation is now in place through `mix favn.install` plus project-local `.favn/install` metadata/fingerprint state
+- Phase 9 local-tooling follow-up now also includes `mix favn.reset` and `mix favn.logs`
+- Phase 9 runner packaging first-cut is now in place through `mix favn.build.runner` with project-local build/dist metadata outputs
+- Phase 9 split build first-cut now also includes `mix favn.build.web` and `mix favn.build.orchestrator`
+- Phase 9 single-node assembly first-cut is now in place through `mix favn.build.single`
+- remaining Phase 9 work is broader validation/polish
 - the remaining Phase 9 tooling/packageability design is now captured in `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` and `docs/refactor/PHASE_9_TODO.md`
 - Phase 10 app deletion is complete: `apps/favn_legacy` and `apps/favn_view` are removed from the umbrella
 - shared migration fixture substrate now lives in `apps/favn_test_support` (`priv/fixtures/**` + `FavnTestSupport.Fixtures`) so later per-app parity PRs can reuse one fixture source of truth

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -7,8 +7,15 @@ apps/
 ├── favn/lib/
 │   ├── favn.ex
 │   └── mix/tasks/
+│       ├── favn.build.orchestrator.ex
+│       ├── favn.build.runner.ex
+│       ├── favn.build.single.ex
+│       ├── favn.build.web.ex
 │       ├── favn.dev.ex
+│       ├── favn.install.ex
+│       ├── favn.logs.ex
 │       ├── favn.reload.ex
+│       ├── favn.reset.ex
 │       ├── favn.status.ex
 │       └── favn.stop.ex
 ├── favn_authoring/lib/
@@ -32,13 +39,21 @@ apps/
 │   ├── favn/
 │   │   ├── dev.ex
 │   │   └── dev/
+│   │       ├── build/
+│   │       │   ├── orchestrator.ex
+│   │       │   ├── runner.ex
+│   │       │   ├── single.ex
+│   │       │   └── web.ex
 │   │       ├── config.ex
+│   │       ├── install.ex
 │   │       ├── lock.ex
+│   │       ├── logs.ex
 │   │       ├── node_control.ex
 │   │       ├── orchestrator_client.ex
 │   │       ├── paths.ex
 │   │       ├── process.ex
 │   │       ├── reload.ex
+│   │       ├── reset.ex
 │   │       ├── runner_control.ex
 │   │       ├── secrets.ex
 │   │       ├── stack.ex

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -2,6 +2,10 @@
 
 This document maps the current umbrella library layout during the v0.5 refactor.
 
+App-level technical docs:
+
+- `apps/favn_local/README.md`
+
 ```text
 apps/
 ├── favn/lib/

--- a/docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md
+++ b/docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md
@@ -86,6 +86,99 @@ Recommended default:
 
 ## 5. Proposed Command Set And Semantics
 
+### Storage configuration rule
+
+Recommended default:
+
+- storage selection is explicit
+- storage is always an orchestrator concern
+- the same logical storage modes should be supported across local dev and
+  packaging, while the default differs by workflow
+
+Supported storage modes for this Phase 9 slice:
+
+- `memory`
+- `sqlite`
+- `postgres`
+
+Workflow defaults:
+
+- local dev default: `memory`
+- local dev persistent convenience mode: `sqlite`
+- single-node packaging default: `sqlite`
+- split deployment recommended default: `postgres`
+
+Important boundary rule:
+
+- web and runner do not choose storage directly
+- they only receive the orchestrator address and related credentials/config
+- storage adapter selection and storage connection config belong to orchestrator
+
+### Proposed public config shape
+
+Recommended default:
+
+- keep public user configuration under `config :favn, :local` for local dev
+- keep packaging/deployment configuration explicit through generated env files
+  and documented environment variables
+- do not require users to configure internal apps directly in the normal path
+
+Example local config:
+
+```elixir
+config :favn, :local,
+  storage: :memory,
+  sqlite_path: ".favn/data/orchestrator.sqlite3",
+  postgres: [
+    hostname: "127.0.0.1",
+    port: 5432,
+    username: "postgres",
+    password: "postgres",
+    database: "my_app_favn_dev",
+    ssl: false,
+    pool_size: 10
+  ]
+```
+
+Meaning:
+
+- `storage`: `:memory | :sqlite | :postgres`
+- `sqlite_path`: used when `storage: :sqlite`
+- `postgres`: used when `storage: :postgres`
+
+Recommended command-line overrides:
+
+- `mix favn.dev` uses configured local storage mode
+- `mix favn.dev --sqlite` forces `storage: :sqlite`
+- later follow-up should allow `mix favn.dev --postgres` to force
+  `storage: :postgres`
+- `mix favn.build.single --storage sqlite|postgres` overrides the single bundle
+  default explicitly
+
+Recommendation for first cut:
+
+- keep `mix favn.dev --sqlite` as-is
+- add `--postgres` support as part of the remaining Phase 9 validation/build
+  batch so Postgres is explicit rather than hidden behind config only
+- do not add a general `--storage` flag if named modes keep the UX clearer
+
+Alternative:
+
+- use one generic `--storage <mode>` flag everywhere
+
+Pros:
+
+- more uniform CLI
+
+Cons:
+
+- slightly more abstract for the most common cases
+
+Recommendation:
+
+- named convenience flags are fine for local dev if the underlying config model
+  still uses explicit storage modes
+
 ### `mix favn.install`
 
 Recommended default:
@@ -543,6 +636,26 @@ Recommended default storage stance:
 - runtime config selects memory, SQLite, or Postgres
 - operator recommendation for split deployment: Postgres
 
+Supported runtime configuration contract:
+
+- `FAVN_STORAGE=memory|sqlite|postgres`
+- if `sqlite`:
+  - `FAVN_SQLITE_PATH=/path/to/orchestrator.sqlite3`
+- if `postgres`:
+  - `FAVN_POSTGRES_HOST`
+  - `FAVN_POSTGRES_PORT`
+  - `FAVN_POSTGRES_USERNAME`
+  - `FAVN_POSTGRES_PASSWORD`
+  - `FAVN_POSTGRES_DATABASE`
+  - `FAVN_POSTGRES_SSL`
+  - optional pool and timeout env if needed
+
+Why this should be explicit:
+
+- it makes the storage support matrix visible
+- it keeps local, single-node, and split deployment stories aligned
+- it avoids implying that SQLite is the only durable option outside dev
+
 ### `mix favn.build.runner`
 
 Recommended default:
@@ -673,6 +786,27 @@ Recommendation:
 
 - keep three explicit runtimes inside one bundle
 
+Supported single-node storage modes:
+
+- `sqlite` by default
+- `postgres` explicitly when the operator wants an external durable database even
+  for a single-node runtime bundle
+
+Recommended first-cut single-node config contract:
+
+- bundle writes `config/assembly.json` with `storage.mode`
+- generated env files include either:
+  - `FAVN_STORAGE=sqlite` plus `FAVN_SQLITE_PATH=...`
+  - or `FAVN_STORAGE=postgres` plus explicit Postgres env
+- `bin/start` reads the assembly config and exports orchestrator env before
+  starting the separate runtimes
+
+Important recommendation:
+
+- support Postgres in single-node mode, but do not make it the default
+- single-node Postgres should mean "single compute node, external Postgres",
+  not an embedded Postgres dependency inside the bundle
+
 ### Split deployment contract
 
 Recommended honest operator story:
@@ -775,6 +909,37 @@ They should not become owners of public build-task workflow logic.
 5. `mix favn.stop`
 6. `mix favn.reset` only when a full local wipe is desired
 
+Local storage examples:
+
+- memory default via config:
+
+```elixir
+config :favn, :local, storage: :memory
+```
+
+- SQLite local persistence:
+
+```elixir
+config :favn, :local,
+  storage: :sqlite,
+  sqlite_path: ".favn/data/orchestrator.sqlite3"
+```
+
+- Postgres local dev:
+
+```elixir
+config :favn, :local,
+  storage: :postgres,
+  postgres: [
+    hostname: "127.0.0.1",
+    port: 5432,
+    username: "postgres",
+    password: "postgres",
+    database: "my_app_favn_dev",
+    ssl: false
+  ]
+```
+
 ### Build runner
 
 1. run `mix favn.install`
@@ -793,6 +958,13 @@ They should not become owners of public build-task workflow logic.
 6. wire explicit config between them using the produced metadata/env contract
 7. publish and activate the runner artifact's included manifest in orchestrator
 
+Split deployment storage recommendation:
+
+- use Postgres unless there is a deliberate reason to keep the control plane on
+  SQLite
+- configure storage only on orchestrator deployment inputs
+- web and runner stay storage-agnostic
+
 ### Build single-node deployment
 
 1. run `mix favn.install`
@@ -800,6 +972,13 @@ They should not become owners of public build-task workflow logic.
 3. deploy the assembled bundle from `.favn/dist/single/<build_id>/`
 4. start the bundle with the generated single-node scripts
 5. default to SQLite-backed orchestrator storage inside the bundle
+
+Single-node Postgres option:
+
+- `mix favn.build.single --storage postgres`
+- generated bundle expects explicit Postgres env in the orchestrator config
+- web and runner configuration stay unchanged apart from the orchestrator base
+  address and credentials
 
 ## 10. Testing Strategy
 
@@ -895,6 +1074,21 @@ Recommended default:
 Recommended default:
 
 - SQLite
+
+### Should Postgres be supported for local dev, single-node, and split deployment?
+
+Recommended default:
+
+- yes
+- local dev: supported but not default
+- single-node: supported but not default
+- split deployment: supported and recommended default
+
+Reason:
+
+- it keeps the storage support story honest and explicit
+- it avoids locking packaged workflows to SQLite-only assumptions
+- it matches the fact that storage is already an orchestrator adapter concern
 
 ### Should split deployment artifacts hide the deployment topology?
 

--- a/docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md
+++ b/docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md
@@ -1,543 +1,390 @@
-# Phase 9 Core Dev Tooling Plan
+# Phase 9 Remaining Dev Tooling And Packaging Plan
 
 ## Status
 
-Planning document for the next PR only.
+Implementation-ready design for the remaining Phase 9 developer-tooling and
+packageability slice.
 
-This plan treats the merged Phase 8 web/orchestrator boundary work as locked baseline context and narrows the next PR to the core local developer lifecycle only.
-
-## 1. Locked assumptions
-
-### Architecture baseline
-
-- `favn_web` is the public web tier and lives in `web/favn_web`.
-- `favn_orchestrator` is the private control plane and system of record.
-- `favn_runner` is execution-only.
-- `favn_view` is archived/transitional only and must not regain product-boundary importance.
-- the web/orchestrator remote HTTP + SSE boundary already exists in baseline form.
-- orchestrator-owned auth/session/audit baseline already exists.
-
-### Ownership boundary
-
-- `apps/favn_local` owns local lifecycle/tooling implementation (`dev`, `stop`, `reload`, `status`, `.favn/` state)
-- `apps/favn` stays the public authoring/build surface
-- future distribution UX may wrap multiple owner apps; packaging shape and ownership shape do not need to be the same
-
-### Strict next-PR scope
-
-Foundational, next PR:
+This document starts from the now-implemented core lifecycle baseline:
 
 - `mix favn.dev`
+- `mix favn.dev --sqlite`
 - `mix favn.stop`
 - `mix favn.reload`
 - `mix favn.status`
-- minimal config and `.favn/` state to support those commands
-- memory storage by default with SQLite as the immediate persistent local option
 
-Explicitly out of scope for this PR:
+It does not reopen that work. It defines the remaining Phase 9 batch:
 
 - `mix favn.install`
 - `mix favn.reset`
 - `mix favn.logs`
-- build/packaging tasks
-- release/install/distribution polish
-- durable auth hardening
-- v1-safe production hardening
-- richer web UX
-- custom storage adapters
+- `mix favn.build.web`
+- `mix favn.build.orchestrator`
+- `mix favn.build.runner`
+- `mix favn.build.single`
+- remaining lifecycle/storage validation and diagnostics polish
 
-### Boundary guardrails
+## 1. Feature Summary
 
-Product-critical:
-
-- do not replace the separate web process with a same-BEAM shortcut
-- do not add compile-time dependencies from `apps/favn` to internal runtime apps
-- do not add a new umbrella app
-
-Refactor-enabling:
-
-- for local dev only, use a small localhost-only runner/orchestrator control path that preserves process separation and keeps future transport options open
+Phase 9 should close by making the already-corrected `web + orchestrator +
+runner` topology easy to set up locally and honest to package for deployment,
+without exposing internal apps as user-facing dependencies.
 
 Recommended default:
 
-- use `.favn/runtime.json` plus a localhost-only local control path for lifecycle actions that cannot go through the product API
-- use the private orchestrator HTTP API for manifest publish/register + activate so local reload and future production publish follow the same boundary
+- keep `{:favn, ...}` as the only user dependency
+- keep all Favn-managed project side effects under `.favn/`
+- make `mix favn.install` the explicit prerequisite for tooling that needs
+  resolved runtime inputs
+- keep build targets explicit and topology-preserving
+- make `single` a convenience assembly of three explicit runtimes, not one
+  collapsed runtime
 
-Why:
+## 2. Scope And Non-Goals
 
-- it keeps `favn_web`, `favn_orchestrator`, and `favn_runner` as separate processes
-- it avoids same-BEAM collapse
-- it avoids compile-time deps from `apps/favn` to runtime apps
-- it keeps the next PR focused on lifecycle rather than broad transport packaging
+### In scope
 
-## 2. Immediate developer workflow
+- explicit install/setup flow
+- destructive local reset flow
+- boring log access helper
+- split build targets for `web`, `orchestrator`, and `runner`
+- single-node assembly target
+- project-local artifact/state layout for install, build, dist, logs, runtime,
+  SQLite data, manifest cache, and failure history
+- recovery/diagnostics validation needed to close Phase 9 honestly
 
-### First start
+### Out of scope
 
-Developer flow after this PR:
+- production hardening and safe-release security work
+- Docker as the default local or packaging path
+- a general-purpose environment doctor beyond targeted diagnostics needed for
+  these commands
+- reintroducing same-BEAM product shortcuts
+- reopening `dev`, `stop`, `reload`, or `status` as new feature work
+- magical auto-deploy or remote rollout automation
 
-1. run `mix favn.dev` from the user project root in one terminal
-2. the task creates `.favn/`, resolves config, generates local secrets if missing, builds the current manifest, starts runner/orchestrator/web, registers and activates the manifest, then prints URLs, PIDs, storage mode, and log paths
-3. keep that terminal open while the local stack is running
-4. open the printed `favn_web` URL in the browser
+## 3. Assumptions
 
-### Daily change loop
+- public package topology migration is complete
+- `apps/favn` is the thin public wrapper and public `mix favn.*` entrypoint owner
+- `apps/favn_authoring` owns authoring and manifest-facing implementation
+- `apps/favn_local` owns local lifecycle/tooling and packaging implementation
+- `web/favn_web` remains the web workspace/package source of truth
+- local lifecycle already persists project-local runtime state in `.favn/`
+- manifest publish/activate over the private orchestrator API already exists
 
-Use the following decision table:
+## 4. Locked Constraints
 
-| Change type | Expected action |
-| --- | --- |
-| changes that only affect manifest contents shown in the UI | `mix favn.reload`, then browser refresh |
-| `web/favn_web` code changes | full `mix favn.stop` then `mix favn.dev` |
-| user asset/pipeline/schedule/source/connection/SQL changes | `mix favn.reload` |
-| changes under `apps/favn`, `apps/favn_core`, or `apps/favn_runner` that affect manifest generation or execution behavior | `mix favn.reload` |
-| changes under `apps/favn_orchestrator` or local dev config that affect orchestrator behavior, ports, storage mode, auth wiring, or control-path wiring | full stop and start |
-| broken or partially running stack | `mix favn.stop` then `mix favn.dev` |
+1. one public dependency: users only need `{:favn, ...}`
+2. project-local side effects only: Favn-managed install/build/runtime artifacts
+   live under `.favn/`
+3. preserve runtime boundaries: local and packaged flows must keep explicit
+   web/orchestrator/runner separation
+4. no Docker requirement by default
+5. do not replace already-landed lifecycle commands
+6. do not treat production hardening as Phase 9 scope
 
-### Status checks
+## 5. Proposed Command Set And Semantics
 
-- `mix favn.status` is the boring operator view for local state
-- it should work whether the stack is healthy, partially dead, or fully stopped
-
-### Stopping services
-
-- `Ctrl-C` or normal terminal exit from the foreground `mix favn.dev` session should stop the full owned stack
-- `mix favn.stop` remains the explicit cleanup/fallback command from another terminal
-- logs and SQLite data are preserved by default
-
-## 3. Detailed plan for `mix favn.dev`
-
-Category: foundational
-
-### Responsibilities
-
-`mix favn.dev` should:
-
-1. acquire a local lifecycle lock so only one dev command mutates `.favn/` at a time
-2. resolve local dev config
-3. create required `.favn/` directories
-4. load or generate persistent local secrets
-5. build and pin the current manifest version from the user project
-6. start runner
-7. start orchestrator
-8. register the current manifest in runner
-9. publish/register the current manifest in orchestrator through the private API
-10. activate the manifest in orchestrator
-11. start `favn_web` as a thin built local web process
-12. verify readiness and print a compact startup summary
-13. remain attached in the foreground until interrupted
-
-### Startup order
-
-Recommended order:
-
-1. `.favn/` preparation and lock
-2. config + secret resolution
-3. manifest build/pin
-4. runner start and readiness
-5. orchestrator start and readiness
-6. manifest registration in runner
-7. manifest publish/register + activation in orchestrator
-8. web process start and readiness
-9. final status write + console summary
-10. wait in the foreground and stop owned services when the session exits
-
-Why this order:
-
-- runner should be ready before orchestrator tries to dispatch work through the configured runner client
-- orchestrator should be ready before web starts relaying to it
-- manifest publish/registration + activation should happen before the browser opens the stack so the UI reflects real local state immediately
-
-### Readiness checks
-
-Runner readiness:
-
-- process is alive
-- local runner node responds to a lightweight RPC ping
-
-Orchestrator readiness:
-
-- process is alive
-- local orchestrator node responds to RPC ping
-- configured HTTP port is accepting connections
-
-Web readiness:
-
-- process is alive
-- configured local web URL returns any successful HTTP response or redirect
-
-Recommended default timeouts:
-
-- runner ready timeout: 10 seconds
-- orchestrator ready timeout: 15 seconds
-- web ready timeout: 20 seconds
-
-### Default local wiring
-
-Recommended defaults:
-
-- orchestrator API URL: `http://127.0.0.1:4101`
-- web URL: `http://127.0.0.1:4173`
-- storage mode: `:memory`
-- SQLite path when enabled: `.favn/data/orchestrator.sqlite3`
-
-Wiring behavior:
-
-- `mix favn.dev` injects `FAVN_ORCHESTRATOR_BASE_URL` for `favn_web`
-- `mix favn.dev` injects a generated local service token into both orchestrator and web
-- `mix favn.dev` injects a generated local web session secret for `favn_web`
-- secrets persist in `.favn/secrets.json` so stop/start keeps local login wiring stable
-- `favn_web` should run in a production-like local mode for this PR, not a Vite/HMR-oriented dev mode
-
-### Foreground lifecycle
-
-Foreground should remain the default behavior.
-
-Default `mix favn.dev`:
-
-- starts runner, orchestrator, and web, then stays attached in the foreground
-- stops the full owned stack when interrupted or when the terminal session exits normally
-- writes current runtime ownership to `.favn/runtime.json` so another terminal can run `mix favn.reload`, `mix favn.status`, or `mix favn.stop`
-- acquires `.favn/lock` only for short runtime state mutation windows, never for the full foreground wait lifetime
-
-Optional interactive mode:
-
-- not required as a separate first-cut mode if normal `mix favn.dev` is already foreground and explicit
-- if added later, it should still attach only to the orchestrator/control-plane runtime
-
-### Failure reporting
-
-If startup fails:
-
-1. write failure details to `.favn/history/last_failure.json`
-2. print which service failed and where its logs are
-3. stop any services started by the failed invocation
-4. leave logs and SQLite state intact
-5. exit non-zero
-
-### Avoiding orphaned processes
-
-Foundational recommendation:
-
-- launch services under one foreground owner session that records child pids/process groups in `.favn/runtime.json`
-
-Why:
-
-- the foreground session can clean up owned services automatically
-- `mix favn.stop` can still terminate the owned subtree when cleanup did not happen cleanly
-- stale pid detection is simpler
-- local crash reporting is easier to reason about
-
-### Behavior when one process is already running
+### `mix favn.install`
 
 Recommended default:
 
-- if all owned services are already running and healthy with the same config hash, print the stack summary and exit `0`
-- if the stack is partially running, partially dead, or the config hash differs, fail with an actionable message and tell the developer to run `mix favn.stop` first
+- explicit prerequisite/setup command
+- resolves and verifies the project-local runtime inputs needed by local dev and
+  build/package commands
+- writes an install fingerprint under `.favn/install/`
+- does not silently run from other commands
 
-Reason:
+What it installs or resolves:
 
-- no surprise duplicate processes
-- no hidden partial repair logic in the first cut
-- lower review and maintenance risk
+- version-matched internal runtime build inputs for `web`, `orchestrator`, and
+  `runner`
+- project-local JS dependency state required by `favn_web`
+- project-local toolchain/install metadata used to detect stale state later
 
-## 4. Detailed plan for `mix favn.stop`
+What it should not do by default:
 
-Category: foundational
+- it should not produce final deployment bundles
+- it should not start services
+- it should not mutate runtime state outside `.favn/install/` and failure history
 
-### Responsibilities
-
-`mix favn.stop` should:
-
-1. acquire the lifecycle lock
-2. read `.favn/runtime.json`
-3. stop web/orchestrator/runner cleanly even if one of them is already dead
-4. delete active runtime state files
-5. preserve logs, manifest cache, secrets, and SQLite data by default
-
-### Stop order
-
-Recommended order:
-
-1. stop `favn_web`
-2. ask orchestrator to stop admitting new work and cancel any in-flight local runs
-3. stop `favn_runner`
-4. stop `favn_orchestrator`
-
-Why:
-
-- web goes down first so no new browser traffic enters the stack
-- orchestrator gets a chance to record shutdown-driven cancellation intent before runner disappears
-- runner exits before orchestrator fully disappears, reducing local orphaned execution work
-
-### Timeout behavior
-
-Recommended defaults:
-
-- graceful stop timeout per service: 10 seconds
-- orchestrator drain/cancel wait before hard stop: 15 seconds
-
-### Forced kill fallback
-
-If graceful stop times out:
-
-1. send a stronger termination signal to the stored process group
-2. wait a short second timeout
-3. record forced-kill fallback in `.favn/history/last_failure.json`
-
-### Behavior when one process is already dead
-
-Expected behavior:
-
-- continue stopping the rest
-- report the dead service as stale/dead in the console summary
-- clear `.favn/runtime.json` when no active owned services remain
-
-### Idempotency
-
-Product-critical expectation:
-
-- `mix favn.stop` is idempotent
-- running it against an already stopped stack exits `0` and prints `stack not running`
-
-## 5. Detailed plan for `mix favn.reload`
-
-Category: foundational
-
-This is the most important next-PR command.
-
-### Responsibilities
-
-`mix favn.reload` should:
-
-1. acquire the lifecycle lock
-2. confirm the local stack is running
-3. recompile the user project
-4. rebuild and pin the current manifest version
-5. restart the runner so changed project code is loaded cleanly
-6. register the new manifest in runner
-7. publish/register the new manifest in orchestrator through the private API
-8. activate the new manifest in orchestrator for future runs
-9. update `.favn/manifests/latest.json` and `.favn/runtime.json`
-10. leave `favn_web` alone
-
-### When browser refresh is enough
-
-For the next PR, the normal web behavior should be:
-
-- `favn_web` stays running unchanged
-- browser refresh calls web
-- web calls orchestrator
-- orchestrator returns state from the current active manifest and current runs
-
-So for ordinary `favn` development, `mix favn.reload` plus browser refresh should be enough.
-
-### When `mix favn.reload` is required
-
-Use `mix favn.reload` for:
-
-- asset changes
-- pipeline changes
-- schedule changes
-- manifest-affecting DSL changes
-- SQL asset or source changes
-- connection/runtime config changes consumed by the runner
-- changes in `apps/favn`, `apps/favn_core`, or `apps/favn_runner` that affect manifest generation or execution behavior
-
-### What happens to in-flight runs
-
-Recommended default for the first cut:
-
-- `mix favn.reload` should fail if orchestrator reports any in-flight runs
-- it should print the run ids and ask the developer to wait, cancel them explicitly, or stop the stack
-
-Why:
-
-- restarting the runner under active work is surprising and hard to explain cleanly in a first-cut local workflow
-- refusing reload is safer and easier to review than best-effort implicit cancellation in the first PR
-
-Future nice-to-have:
-
-- a later `--force` mode could explicitly cancel and continue, but that should stay out of the next PR
-
-### Orchestrator behavior during reload
+Should it resolve/build local web and orchestrator runtime artifacts ahead of time?
 
 Recommended default:
 
-- do not restart orchestrator during `mix favn.reload`
-- `mix favn.reload` should send the newly built manifest to orchestrator through the private API and then activate it
+- resolve install inputs ahead of time: yes
+- build final target artifacts ahead of time: no
 
-### Manifest publish endpoint
+Why:
 
-Foundational recommendation:
+- it keeps install explicit and reusable
+- it avoids stale hidden deployment builds
+- it keeps `build.*` commands as the place where final artifacts are created
 
-- add a private orchestrator endpoint to register one manifest version without restarting orchestrator
-- recommended shape: `POST /api/orchestrator/v1/manifests`
-- keep `POST /api/orchestrator/v1/manifests/:manifest_version_id/activate` as the separate activation step
+Should it verify JS/node/npm tooling for `favn_web`?
 
-Why this belongs in or alongside the next PR:
+- yes
+- missing Node/npm is one of the main reasons local dev or packaging would fail
+- install is the boring place to fail early with a targeted message
 
-- `mix favn.reload` needs a real no-restart publish path
-- the same behavior is needed in production so orchestrator can accept new manifests without stopping
-- it keeps local dev aligned with the steady-state boundary instead of inventing a dev-only import mechanism
+Auto-trigger behavior:
 
-Use full stop/start instead when:
+- recommended default: no auto-trigger
+- `mix favn.dev` and `mix favn.build.*` should validate install state and fail
+  with `install required` or `install stale; run mix favn.install`
 
-- orchestrator code changed
-- orchestrator config changed
-- local lifecycle/control-path wiring changed
+Offline behavior:
 
-### Local runner control boundary
+- if `.favn/install/install.json` matches the required fingerprint, later
+  commands may proceed offline
+- if install inputs are missing or stale, offline operation should fail fast and
+  explicitly
 
-- manifest re-registration during reload must target the live runner process
-- local control cannot rely on one-off helper VMs that do not affect the running runner instance
-- local orchestrator runner-client wiring should explicitly use configured local runner control (`:runner_client` + `:runner_client_opts`) at startup
-- distributed node identities used for local runner/orchestrator control should be stored as full node names (`name@host`) in runtime state
+Missing-tool behavior:
 
-### Should reload recover a stopped stack?
+- fail early during install with actionable diagnostics
+- record the failure under `.favn/history/`
+- do not leave partially-written runtime state
+
+Stale-artifact behavior:
+
+- compare current inputs against an install fingerprint covering at least:
+  - `favn` package version
+  - runtime source fingerprint for `favn_web` and internal release inputs
+  - relevant lockfiles/tool versions used during install
+- if stale, fail explicit commands and require a fresh install
+- allow `mix favn.install --force` as the boring rebuild path
+
+Alternative:
+
+- auto-run install from `dev` and `build`
+
+Pros:
+
+- fewer manual steps for first-time users
+
+Cons:
+
+- hidden network/toolchain side effects
+- harder-to-explain failures
+- less predictable CI/operator behavior
+
+Recommendation:
+
+- keep install explicit
+
+### `mix favn.reset`
 
 Recommended default:
 
-- no
-- `mix favn.reload` should fail if the stack is not running
-- it should print `stack not running; use mix favn.dev`
+- destructive local cleanup command that removes all Favn-managed project-local
+  state under `.favn/`
 
-Reason:
+Semantics:
 
-- reload should mean reload, not bootstrap
-- hidden auto-start behavior makes failures harder to interpret
+- require the stack to be stopped first
+- if recorded runtime state exists and live Favn-owned processes are still
+  running, fail and tell the user to run `mix favn.stop`
+- if runtime state is stale and no live processes remain, clear the stale state
+  and continue
+- delete the full `.favn/` tree
 
-## 6. Detailed plan for `mix favn.status`
+Should it delete all of `.favn/`?
 
-Category: foundational
+- yes
+- first cut should stay simple and honest
 
-### Responsibilities
+Should there be `--keep-*` modes?
 
-`mix favn.status` should show:
+- recommended default: no
 
-- whether web/orchestrator/runner are expected to be running
-- whether their recorded pids are actually alive
-- URLs / ports where applicable
-- storage mode
-- current active manifest id if available
-- last known manifest id if orchestrator is down but cache exists
-- recent failure info if a service died unexpectedly
+Why:
 
-### Output style
+- `reset` should mean full reset
+- partial cleanup modes create more semantics and testing cost than value in the
+  first cut
 
-Boring operator-friendly text, for example:
+Alternative:
 
-```text
-Favn local dev stack
+- `--keep-logs`, `--keep-install`, `--keep-data`
 
-status: running
-storage: memory
-manifest: mv_01H...
+Pros:
 
-web: running pid=12345 url=http://127.0.0.1:4173 log=.favn/logs/web.log
-orchestrator: running pid=12346 url=http://127.0.0.1:4101 log=.favn/logs/orchestrator.log
-runner: running pid=12347 node=favn_runner_dev@127.0.0.1 log=.favn/logs/runner.log
+- more operator convenience
 
-last failure: none
-```
+Cons:
 
-### Data sources
+- more surprising combinations
+- more edge-case behavior to document and test
 
-Recommended order:
+Recommendation:
 
-1. `.favn/runtime.json`
-2. live pid/process-group checks
-3. local RPC calls for runner/orchestrator details
-4. `.favn/manifests/latest.json` fallback when orchestrator is unavailable
-5. `.favn/history/last_failure.json` for recent failure/restart notes
+- keep the first cut destructive and simple
 
-## 7. Minimal config model
+### `mix favn.logs`
 
-Category: foundational
+Recommended default:
 
-Keep the next-PR config small and local-dev-specific.
+- thin file-tail helper over preserved log files under `.favn/logs/`
 
-### Recommended config namespace
+Supported behavior:
 
-Use one small config entry under `apps/favn`:
+- default: show recent logs for all services
+- service selection: `web`, `orchestrator`, or `runner`
+- `--tail N`
+- `--follow`
+- historical access while the stack is down
 
-```elixir
-config :favn, :dev,
-  storage: :memory,
-  sqlite_path: ".favn/data/orchestrator.sqlite3",
-  orchestrator_api_enabled: true,
-  orchestrator_port: 4101,
-  web_port: 4173,
-  orchestrator_base_url: "http://127.0.0.1:4101",
-  web_base_url: "http://127.0.0.1:4173",
-  service_token: nil,
-  web_session_secret: nil
-```
+Operational shape:
 
-### Meaning
+- read known log paths from runtime/configured layout, not from process stdout
+- when showing all services, print service-prefixed output in stable order
+- when following all services, multiplex the three files with service prefixes
 
-- `storage`: `:memory | :sqlite`
-- `sqlite_path`: only used when storage is `:sqlite`
-- `orchestrator_api_enabled`: kept explicit so dev tooling can fail clearly if someone disables the API
-- `orchestrator_port`: private local orchestrator HTTP port
-- `web_port`: local built-web port
-- `orchestrator_base_url`: injected into `favn_web`
-- `web_base_url`: printed and used for status output
-- `service_token`: optional override; if `nil`, generate and persist in `.favn/secrets.json`
-- `web_session_secret`: optional override; if `nil`, generate and persist in `.favn/secrets.json`
+What it should not become:
 
-### Immediate non-goals for config
+- not a structured observability system
+- not a log indexing/query engine
+- not a replacement for reading the raw files directly
 
-Future roadmap only:
+Alternative:
 
-- Postgres-first config design
-- custom storage adapter config
-- release/distribution config model
-- a large matrix of web/orchestrator/runner deployment modes
+- add structured JSON querying and filtering now
 
-### Internal-only runtime values
+Pros:
 
-Do not put these in the public config model for the next PR:
+- richer operator experience
 
-- local node names
-- local Erlang cookie
-- log file paths
-- process-group ids
+Cons:
 
-These belong in `.favn/runtime.json` or `.favn/secrets.json`, not in user-facing config.
+- not needed to close Phase 9
+- pushes the design toward observability work instead of boring tooling
 
-## 8. `.favn/` state model
+Recommendation:
 
-Category: foundational
+- keep it as a thin helper
 
-### Recommended layout
+### `mix favn.build.web`
+
+Operational meaning:
+
+- build the deployable public web/BFF artifact for the current Favn version
+- does not include user business code
+- expects to talk to a separately deployed orchestrator over the private API
+
+Recommended default:
+
+- consume installed `favn_web` build inputs from `.favn/install/`
+- write a final artifact bundle under `.favn/dist/web/<build_id>/`
+- write build working files under `.favn/build/web/<build_id>/`
+
+### `mix favn.build.orchestrator`
+
+Operational meaning:
+
+- build the deployable private orchestrator artifact for the current Favn version
+- does not include user business code
+- remains storage-neutral at build time; runtime storage config is provided by
+  the operator
+
+Recommended default:
+
+- consume installed orchestrator release inputs from `.favn/install/`
+- write a final artifact bundle under `.favn/dist/orchestrator/<build_id>/`
+- write build working files under `.favn/build/orchestrator/<build_id>/`
+
+### `mix favn.build.runner`
+
+Operational meaning:
+
+- build the project-specific execution artifact that combines the internal runner
+  runtime with the user's business code and one pinned manifest version
+
+Recommended default:
+
+- consume the current user project, installed runner build inputs, selected
+  plugins, and a freshly pinned manifest version
+- write a final artifact bundle under `.favn/dist/runner/<build_id>/`
+- write build working files under `.favn/build/runner/<build_id>/`
+
+### `mix favn.build.single`
+
+Operational meaning:
+
+- assemble one deployable bundle that contains separate web, orchestrator, and
+  runner runtimes plus wiring/config needed to run them together on one node
+- convenience topology only; it must not collapse the architecture conceptually
+
+Recommended default:
+
+- internally build or reuse matching `web`, `orchestrator`, and `runner`
+  artifacts from the same build batch
+- write a final assembled bundle under `.favn/dist/single/<build_id>/`
+- write assembly working files under `.favn/build/single/<build_id>/`
+
+## 6. `.favn/` Artifact And State Layout
+
+Recommended layout:
 
 ```text
 .favn/
 ├── runtime.json
 ├── secrets.json
 ├── lock
+├── install/
+│   ├── install.json
+│   ├── toolchain.json
+│   ├── cache/
+│   │   └── npm/
+│   └── runtimes/
+│       ├── web/
+│       │   ├── source/
+│       │   └── node_modules/
+│       ├── orchestrator/
+│       │   └── source/
+│       └── runner/
+│           └── template/
+├── build/
+│   ├── web/<build_id>/
+│   ├── orchestrator/<build_id>/
+│   ├── runner/<build_id>/
+│   └── single/<build_id>/
+├── dist/
+│   ├── web/<build_id>/
+│   ├── orchestrator/<build_id>/
+│   ├── runner/<build_id>/
+│   └── single/<build_id>/
 ├── logs/
+│   ├── web.log
 │   ├── orchestrator.log
-│   ├── runner.log
-│   └── web.log
+│   └── runner.log
 ├── data/
 │   └── orchestrator.sqlite3
 ├── manifests/
-│   └── latest.json
+│   ├── latest.json
+│   └── cache/
+│       └── <manifest_version_id>.json
 └── history/
-    └── last_failure.json
+    ├── last_failure.json
+    └── failures/
+        └── <timestamp>-<command>.json
 ```
 
-### File roles
+### Directory roles
 
-- `runtime.json`: active stack metadata, config hash, owner-session pid, child pids, process groups, ports, node names, start time, current storage mode
-- `secrets.json`: generated local service token, web session secret, and local RPC cookie
-- `lock`: lifecycle command lock file
-- `logs/*`: combined stdout/stderr logs for each service
-- `data/orchestrator.sqlite3`: SQLite local persistence when enabled
-- `manifests/latest.json`: last built manifest metadata and cache pointer for status/reload reporting
-- `history/last_failure.json`: most recent startup/shutdown/failure detection summary
+- `runtime.json`: current live stack state only
+- `secrets.json`: generated local secrets and local control credentials
+- `lock`: short-lived lifecycle mutation lock
+- `install/`: resolved project-local runtime inputs reused by `dev` and build
+  commands
+- `build/`: reproducible intermediate working directories and per-build metadata
+- `dist/`: operator-facing output bundles
+- `logs/`: preserved service logs
+- `data/`: preserved local SQLite state
+- `manifests/latest.json`: last built manifest metadata for status/reload flows
+- `manifests/cache/`: serialized pinned manifests reused by build/package flows
+- `history/`: recent failure summaries and preserved per-command failure records
 
 ### Ephemeral vs preserved
 
@@ -545,301 +392,595 @@ Ephemeral:
 
 - `runtime.json`
 - `lock`
+- `build/` contents are reproducible scratch data, though preserved until reset
 
-Preserved across stop/start by default:
+Preserved by default:
 
+- `install/`
+- `dist/`
+- `logs/`
+- `data/`
+- `manifests/`
+- `history/`
 - `secrets.json`
-- `logs/*`
-- `data/orchestrator.sqlite3`
-- `manifests/latest.json`
-- `history/last_failure.json`
 
-### What later `mix favn.reset` should delete
+### What `mix favn.reset` deletes
 
-Before-v1 but not next PR:
+- all of `.favn/`
+- including install artifacts, dist outputs, logs, SQLite data, manifest cache,
+  secrets, and failure history
 
-- everything under `.favn/`, including SQLite data, logs, manifest cache, secrets, and failure history
+Alternative:
 
-## 9. Module/file plan
+- keep `dist/` outside `.favn/`
 
-Category: foundational
+Pros:
 
-### `apps/favn` user-facing task entrypoints
+- easier manual discovery for operators
 
-- `apps/favn/lib/mix/tasks/favn.dev.ex`
-- `apps/favn/lib/mix/tasks/favn.stop.ex`
-- `apps/favn/lib/mix/tasks/favn.reload.ex`
-- `apps/favn/lib/mix/tasks/favn.status.ex`
+Cons:
 
-### `apps/favn` boring tooling library
+- breaks the project-local side-effect rule
+- scatters Favn-owned artifacts
 
-- `apps/favn/lib/favn/dev.ex`
-  - thin public helper surface for optional IEx mode: `reload/0`, `status/0`, `stop/0`
-- `apps/favn/lib/favn/dev/config.ex`
-  - resolve config defaults, CLI flags, and generated-secret fallbacks
-- `apps/favn/lib/favn/dev/state.ex`
-  - read/write `.favn/runtime.json`, `.favn/secrets.json`, `.favn/manifests/latest.json`, and failure history
-- `apps/favn/lib/favn/dev/lock.ex`
-  - lifecycle lock handling
-- `apps/favn/lib/favn/dev/process.ex`
-  - foreground owner-session process handling, child process management, signal/timeout handling
-- `apps/favn/lib/favn/dev/rpc.ex`
-  - local-node RPC helpers for runner/orchestrator control without compile-time deps
-- `apps/favn/lib/favn/dev/manifest.ex`
-  - build/pin/cache manifest metadata for startup and reload
-- `apps/favn/lib/favn/dev/status.ex`
-  - live stack inspection and console rendering
-- `apps/favn/lib/favn/dev/reload.ex`
-  - compile/build manifest, runner restart, manifest publish/register, activation flow
-- `apps/favn/lib/favn/dev/orchestrator_client.ex`
-  - private HTTP client for manifest publish/activate and status reads needed by local dev tooling
-- `apps/favn/lib/favn/dev/service/orchestrator.ex`
-  - orchestrator command/env builder
-- `apps/favn/lib/favn/dev/service/runner.ex`
-  - runner command/env builder
-- `apps/favn/lib/favn/dev/service/web.ex`
-  - `favn_web` build/start command/env builder
-- `apps/favn/lib/favn/dev/stack.ex`
-  - high-level coordination for `dev`, `stop`, and shared lifecycle behavior
+Recommendation:
 
-### Minimal runtime-side helpers outside `apps/favn`
+- keep all Favn-managed outputs under `.favn/`
 
-Refactor-enabling, still in scope because they are required to preserve boundaries:
+## 7. Build And Package Contracts
 
-- `apps/favn_orchestrator/lib/favn_orchestrator/runner_client/local_node.ex`
-  - local dev runner-client implementation using a localhost-only control path to a separate runner node
+### Shared build contract
 
-Minimal orchestrator-side API addition required for reload:
+Each `mix favn.build.*` command should:
 
-- `POST /api/orchestrator/v1/manifests`
-  - accepts one canonical manifest payload or manifest-version envelope and persists/registers it
-  - protected by the existing private service-auth boundary
+- require a current successful install fingerprint
+- create a new `build_id`
+- write build metadata under `.favn/build/<target>/<build_id>/build.json`
+- write final artifact metadata under `.favn/dist/<target>/<build_id>/metadata.json`
+- leave the final operator-consumable bundle in `.favn/dist/<target>/<build_id>/`
 
-Optional but not required if raw RPC is sufficient:
+Recommended shared metadata fields:
 
-- thin orchestrator/runner readiness helper functions in their existing facades
+- `schema_version`
+- `target`
+- `build_id`
+- `built_at`
+- `favn_package_version`
+- `install_fingerprint`
+- `elixir_version`
+- `otp_release`
+- `source_fingerprint`
+- `required_env`
+- `compatibility`
 
-### Explicit boundary note
-
-Product-critical:
-
-- `apps/favn` must not call `FavnOrchestrator` or `FavnRunner` directly as compile-time deps
-- any runtime-module references from `apps/favn` should go through local RPC helpers and dynamic module names
-
-## 10. Testing plan
-
-Category: foundational
-
-### Unit tests in `apps/favn/test`
-
-- config resolution tests
-- `.favn` path/state read-write tests
-- lock behavior tests
-- status rendering tests
-- stale runtime-state detection tests
-- SQLite path normalization/default tests
-
-### Integration tests in `apps/favn/test`
-
-- foreground owner-session lifecycle tests using small fixture processes
-- `mix favn.dev` startup sequencing tests with fixture/stub services where direct unit isolation is enough
-- `mix favn.stop` graceful-stop and forced-kill fallback tests
-- `mix favn.reload` refusal when stack is stopped
-- `mix favn.reload` refusal when in-flight runs exist
-- `mix favn.reload` runner-only restart behavior while keeping web and orchestrator pids unchanged
-- `mix favn.reload` manifest publish behavior against the real private orchestrator API
-
-### Runtime integration coverage
-
-Add focused tests around the local dev runner bridge:
-
-- `apps/favn_orchestrator/test/...` for `runner_client/local_node.ex`
-- verify manifest register/submit/cancel calls cross a separate local runner node without compile-time runner deps in orchestrator
-- add API tests for `POST /api/orchestrator/v1/manifests` register behavior and follow-up activation flow
-
-### End-to-end smoke path
-
-At least one serial smoke path should cover:
-
-1. `mix favn.dev`
-2. `mix favn.status`
-3. verify web and orchestrator URLs respond
-4. `mix favn.reload`
-5. verify active manifest changes or is re-registered cleanly
-6. `mix favn.stop`
-7. verify runtime state is cleared while logs/SQLite remain
-
-Lifecycle-specific additions:
-
-- test that `mix favn.dev` does not hold `.favn/lock` across the full foreground lifetime
-- test second-terminal `reload/status/stop` behavior while foreground `dev` is running
-- test startup/bootstrap failure cleanup for stale process/state recovery
-
-Recommended location:
-
-- `apps/favn/test/integration/dev_stack_smoke_test.exs`
-
-This can be slower and serial, but it should exist so the next PR proves the real local lifecycle at least once.
-
-## 11. Internal implementation slicing/order
-
-Category: refactor-enabling
-
-Keep the PR as one coherent feature batch, but implement it in small reviewable slices.
-
-### Slice 1: foundation and boundary-safe control path
-
-- `.favn` state model
-- config resolution
-- lifecycle lock
-- foreground owner-session helpers
-- local runner/orchestrator RPC control path
-
-### Slice 2: usable stack lifecycle first
-
-- `mix favn.dev`
-- `mix favn.stop`
-- `mix favn.status`
-- memory mode default
-- SQLite path wiring
-- foreground owner-session cleanup semantics
-
-### Slice 3: manifest-driven reload workflow
-
-- manifest build/pin/cache
-- `mix favn.reload`
-- active-manifest reporting in status
-- browser-refresh-oriented web behavior
-- manifest publish through the private orchestrator API
-
-### Slice 4: optional follow-up polish and smoke coverage
-
-- `Favn.Dev.reload/0`, `status/0`, `stop/0`
-- end-to-end smoke path
-- doc polish
-
-Priority rule:
-
-- if scope gets tight, do not cut `dev/stop/reload/status`
-- cut optional interactive-shell follow-up first, not the foreground core loop
-
-## 12. Required doc updates
-
-Category: foundational
-
-### `README.md`
-
-Update to:
-
-- restate that Phase 8 baseline boundary work now exists
-- state that the immediate next PR is core local dev tooling only
-- add pointers to the new Phase 9 plan/TODO docs
-
-### `docs/REFACTOR.md`
-
-Update to:
-
-- add Phase 9 plan/TODO doc links
-- narrow the immediate Phase 9 slice to core local dev tooling
-- explicitly defer install/reset/logs/build tasks out of the next PR while keeping them in Phase 9 or pre-v1 roadmap
-
-### `docs/FEATURES.md`
-
-Update to:
-
-- add a clear next-PR checklist for the core local dev loop
-- separate later Phase 9 tooling from the next PR
-- keep broader build/install/reset/logs work visible on the roadmap
-
-### Add new docs
-
-Recommended and should land now:
-
-- `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md`
-- `docs/refactor/PHASE_9_TODO.md`
-
-Reason:
-
-- this slice is large enough to need its own planning/source-of-truth docs
-- `docs/FEATURES.md` should stay high-level while `PHASE_9_TODO.md` stays execution-oriented
-
-## 13. Tooling roadmap before v1
-
-| Item | Timing | Category | Notes |
-| --- | --- | --- | --- |
-| `mix favn.dev` | next PR | foundational | foreground local stack startup |
-| `mix favn.stop` | next PR | foundational | clean shutdown and idempotency |
-| `mix favn.reload` | next PR | foundational | daily-driver manifest reload plus runner restart |
-| `POST /api/orchestrator/v1/manifests` | next PR | product-critical | no-restart manifest publish path used by local dev and later production flows |
-| `mix favn.status` | next PR | foundational | boring operator view |
-| optional dedicated interactive shell mode | later Phase 9 if still needed | nice-to-have | likely unnecessary if normal `mix favn.dev` is already foreground |
-| `.favn/` local state model | next PR | foundational | runtime metadata, logs, secrets, SQLite path |
-| SQLite local persistence mode | next PR | foundational | immediate persistent local option |
-| `mix favn.install` | later Phase 9 | refactor-enabling | bootstrap runtime dependencies/setup |
-| `mix favn.reset` | later Phase 9 | refactor-enabling | destructive local cleanup, separate from stop |
-| `mix favn.logs` | later Phase 9 | nice-to-have | log tailing/selection on top of preserved logs |
-| `mix favn.build.web` | before v1 but not next | product-critical | honest split deployment packaging |
-| `mix favn.build.orchestrator` | before v1 but not next | product-critical | honest split deployment packaging |
-| `mix favn.build.runner` | before v1 but not next | product-critical | honest split deployment packaging |
-| `mix favn.build.single` | before v1 but not next | product-critical | first supported single-node assembly |
-| bootstrap/admin setup task | before v1 but not next | product-critical | replace ad hoc env-only bootstrap for real product setup |
-| broader live Postgres verification path | later Phase 9 | refactor-enabling | production-like confidence, not core local loop |
-| durable auth/session hardening | before v1 but not next | product-critical | not part of next PR |
-| richer log/observability UX | future/nice-to-have | nice-to-have | after core lifecycle is stable |
-| Docker/dev-container local mode | future/nice-to-have | future roadmap only | explicitly not required for next PR |
-
-## 14. Open questions with recommended defaults
-
-### 1. How should local orchestrator-to-runner, manifest publish, and second-terminal control work before broader transport packaging?
+### Versioning and compatibility representation
 
 Recommended default:
 
-- use `.favn/runtime.json` plus a localhost-only local control path for lifecycle actions
-- use the private orchestrator API for manifest publish/register + activate
+- write explicit compatibility metadata rather than hiding assumptions in file
+  names
+
+At minimum:
+
+- web artifacts declare orchestrator API compatibility, for example `api_v1`
+- orchestrator artifacts declare supported API/storage/runtime compatibility
+- runner artifacts declare manifest schema version, manifest version id, runner
+  contract version, and included plugin list
+- single artifacts declare the exact `web`, `orchestrator`, and `runner` build
+  ids assembled together
+
+Alternative:
+
+- rely only on package version matching
+
+Pros:
+
+- fewer fields
+
+Cons:
+
+- too implicit for debugging mismatches
+- weaker operator story during upgrades
+
+Recommendation:
+
+- include explicit compatibility metadata files
+
+### `mix favn.build.web`
+
+Consumes:
+
+- `.favn/install/runtimes/web/`
+
+Outputs:
+
+- `.favn/build/web/<build_id>/`
+- `.favn/dist/web/<build_id>/`
+
+Dist contents should include at least:
+
+- deployable web runtime bundle
+- `metadata.json`
+- `README.txt` or equivalent operator notes for required env/config
+
+Required metadata should include at least:
+
+- target `web`
+- build id
+- Favn version
+- supported orchestrator API version
+- required env such as orchestrator base URL, service token, and session secret
+
+### `mix favn.build.orchestrator`
+
+Consumes:
+
+- `.favn/install/runtimes/orchestrator/`
+
+Outputs:
+
+- `.favn/build/orchestrator/<build_id>/`
+- `.favn/dist/orchestrator/<build_id>/`
+
+Dist contents should include at least:
+
+- deployable orchestrator runtime bundle
+- `metadata.json`
+- operator notes for storage and service-auth configuration
+
+Required metadata should include at least:
+
+- target `orchestrator`
+- build id
+- Favn version
+- supported API version
+- supported storage modes and adapter expectations
+- runner contract compatibility version
+
+Recommended default storage stance:
+
+- storage-neutral build artifact
+- runtime config selects memory, SQLite, or Postgres
+- operator recommendation for split deployment: Postgres
+
+### `mix favn.build.runner`
+
+Recommended default:
+
+- one runner build packages one pinned manifest version
+
+Consumes:
+
+- current user project code
+- selected plugins from the current dependency graph/config
+- freshly generated and pinned manifest from `favn_authoring`
+- `.favn/install/runtimes/runner/`
+
+Outputs:
+
+- `.favn/build/runner/<build_id>/`
+- `.favn/dist/runner/<build_id>/`
+
+Dist contents should include at least:
+
+- deployable runner runtime bundle
+- compiled user business code
+- pinned serialized manifest
+- manifest metadata envelope
+- included plugin inventory
+- `metadata.json`
+
+Required metadata should include at least:
+
+- target `runner`
+- build id
+- project/app identity
+- Favn version
+- manifest schema version
+- manifest version id
+- manifest hash
+- runner contract version
+- included plugin identifiers and versions
+
+Runner packaging rule:
+
+- `favn_runner` remains internal and is not part of the user's public authoring
+  dependency surface
+- the runner artifact still includes the internal runner runtime because that is
+  a packaging concern, not a public dependency concern
+- the build task, not the user's dependency list, is responsible for assembling
+  the internal runner runtime around the authored project code
+
+Alternative:
+
+- package runner without a manifest and fetch manifests remotely at runtime
+
+Pros:
+
+- fewer runner rebuilds when manifests change
+
+Cons:
+
+- weaker deployment determinism
+- more complex remote coordination before Phase 9 is even complete
+- easier to blur the line between authored code version and runnable payload
+
+Recommendation:
+
+- keep the first cut pinned to one manifest version per runner build
+
+### `mix favn.build.single`
+
+Recommended default:
+
+- assemble a single deployable bundle containing three explicit runtimes and
+  their wiring, not one merged BEAM system
+
+Consumes:
+
+- matching `web`, `orchestrator`, and `runner` outputs from the same build batch
+  or internally generated equivalents
+
+Outputs:
+
+- `.favn/build/single/<build_id>/`
+- `.favn/dist/single/<build_id>/`
+
+Dist contents should include at least:
+
+- `web/`
+- `orchestrator/`
+- `runner/`
+- `config/assembly.json`
+- `env/web.env`
+- `env/orchestrator.env`
+- `env/runner.env`
+- `bin/start`
+- `bin/stop`
+- `metadata.json`
+
+Config passing model:
+
+- generate one assembly manifest that records service addresses, shared secrets,
+  storage choice, and matching build ids
+- start scripts translate that assembly manifest into per-service env/config at
+  runtime
+
+Recommended default storage mode:
+
+- SQLite
 
 Why:
 
-- separate processes stay intact
-- no new public API surface is needed
-- no compile-time dependency from `apps/favn` to runtime apps
+- memory is not operator-friendly for a packaged single-node bundle
+- Postgres adds an external dependency that fights the point of the single-node
+  convenience mode
 
-### 2. Should `mix favn.reload` cancel in-flight runs automatically?
+Alternative:
+
+- one merged runtime
+
+Pros:
+
+- superficially simpler packaging
+
+Cons:
+
+- collapses the architecture and teaches the wrong mental model
+- makes later split deployment less honest
+
+Recommendation:
+
+- keep three explicit runtimes inside one bundle
+
+### Split deployment contract
+
+Recommended honest operator story:
+
+- `build.web` produces the public web/BFF artifact only
+- `build.orchestrator` produces the private control-plane artifact only
+- `build.runner` produces the project-specific execution artifact only
+- the operator deploys them separately and wires them with explicit URLs,
+  credentials, and runner registration/publish steps
+
+Important honesty rule:
+
+- split deployment is not one command that secretly assumes one node
+- it is three separate artifacts with explicit compatibility metadata
+
+## 8. Ownership By App
+
+### `apps/favn`
+
+Owns:
+
+- public package identity
+- public `Mix.Tasks.Favn.*` entrypoints only
+- public docs/examples for user-facing flows
+- thin delegation to `favn_authoring` and `favn_local`
+
+Should not own:
+
+- `.favn/` filesystem logic
+- install/build/reset/logs implementation details
+- direct compile-time dependencies on runtime product apps
+
+### `apps/favn_local`
+
+Owns:
+
+- `.favn/` artifact/state layout
+- install/reset/logs implementation
+- build/package orchestration and artifact writers
+- local validation and diagnostics behavior
+- recovery/cleanup semantics around project-local state
+
+Recommended implementation ownership:
+
+- `Favn.Dev.Install`
+- `Favn.Dev.Reset`
+- `Favn.Dev.Logs`
+- `Favn.Dev.Build.*`
+- shared `.favn` metadata/diagnostics helpers
+
+### `apps/favn_authoring`
+
+Owns:
+
+- manifest generation, serialization, hashing, and pinning used by build flows
+- plugin resolution from the authored project surface
+- runner-facing manifest/build inputs consumed by `favn_local`
+
+Should not own:
+
+- local runtime state
+- project-local install/build/dist directory policy
+- process lifecycle or log handling
+
+### `apps/favn_core`
+
+Owns only if needed:
+
+- shared structs/types/contracts for manifest or compatibility metadata that are
+  genuinely cross-boundary
+
+Should not absorb:
+
+- packaging workflows
+- project-local tooling orchestration
+
+### Runtime apps
+
+`favn_orchestrator`, `favn_runner`, and `favn_web` should only gain minimal
+export/build hooks or compatibility metadata seams needed to support packaging.
+They should not become owners of public build-task workflow logic.
+
+## 9. User Workflows
+
+### First-time setup
+
+1. add `{:favn, ...}`
+2. configure authored modules normally
+3. run `mix favn.install`
+4. run `mix favn.dev`
+5. use `mix favn.status`, `mix favn.logs`, `mix favn.reload`, and `mix favn.stop`
+   during normal iteration
+
+### Normal local dev
+
+1. `mix favn.install` once per relevant runtime/tooling change
+2. `mix favn.dev`
+3. `mix favn.reload` for manifest/project changes
+4. `mix favn.logs` when needed
+5. `mix favn.stop`
+6. `mix favn.reset` only when a full local wipe is desired
+
+### Build runner
+
+1. run `mix favn.install`
+2. run `mix favn.build.runner`
+3. take the output from `.favn/dist/runner/<build_id>/`
+4. deploy that artifact as the execution runtime for the current project build
+5. publish/activate the included manifest version in the target orchestrator
+
+### Build split deployment
+
+1. run `mix favn.install`
+2. run `mix favn.build.web`
+3. run `mix favn.build.orchestrator`
+4. run `mix favn.build.runner`
+5. deploy web, orchestrator, and runner separately
+6. wire explicit config between them using the produced metadata/env contract
+7. publish and activate the runner artifact's included manifest in orchestrator
+
+### Build single-node deployment
+
+1. run `mix favn.install`
+2. run `mix favn.build.single`
+3. deploy the assembled bundle from `.favn/dist/single/<build_id>/`
+4. start the bundle with the generated single-node scripts
+5. default to SQLite-backed orchestrator storage inside the bundle
+
+## 10. Testing Strategy
+
+### Install and artifact layout
+
+- install layout creation tests
+- install fingerprint and stale-detection tests
+- missing Node/npm diagnostics tests
+- offline reuse tests when install state is current
+
+### Reset and logs
+
+- reset refusal while live stack is still running
+- reset success after stop
+- reset cleanup of full `.favn/`
+- logs access for all services and single-service selection
+- logs historical access when the stack is down
+- follow/tail behavior coverage
+
+### Build contracts
+
+- metadata contract tests for `web`, `orchestrator`, `runner`, and `single`
+- output layout tests for `.favn/build/` and `.favn/dist/`
+- runner build tests that assert inclusion of user code, pinned manifest, and
+  selected plugins
+- single build tests that assert three explicit service bundles are present
+
+### Validation and polish
+
+- stale runtime recovery when all services are dead
+- partial/dead service recovery through `status` plus `stop`
+- startup failure cleanup and failure-history recording
+- explicit SQLite smoke path across install, dev, reload, stop, logs, reset, and
+  single packaging
+- broader opt-in Postgres verification for local and orchestrator packaging paths
+- port conflict and missing prerequisite diagnostics tests
+
+Recommended default:
+
+- keep Postgres verification opt-in through explicit environment-driven test
+  paths
+
+## 11. Docs That Must Be Updated
+
+- `README.md`
+  - add the explicit `mix favn.install` first-time setup step once implemented
+  - document the honest distinction between local dev, split deployment, and
+    single-node packaging
+- `docs/REFACTOR.md`
+  - keep the remaining Phase 9 scope aligned with this plan
+- `docs/FEATURES.md`
+  - keep the high-level roadmap wording aligned with this remaining tooling batch
+- `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md`
+  - this document is the architecture source of truth for the remaining slice
+- `docs/refactor/PHASE_9_TODO.md`
+  - execution checklist derived from this design
+
+## 12. Open Questions With Recommended Defaults
+
+### Should `mix favn.install` be explicit-only or auto-triggered?
+
+Recommended default:
+
+- explicit-only
+
+### Should install produce final web/orchestrator builds ahead of time?
 
 Recommended default:
 
 - no
-- fail fast and ask the user to wait/cancel/stop first
+- resolve install inputs and JS dependencies only
 
-### 3. Should `mix favn.reload` auto-start the stack if it is down?
+### Should `mix favn.reset` offer keep modes in the first cut?
 
 Recommended default:
 
 - no
-- keep bootstrap and reload as separate commands
 
-### 4. Should `mix favn.dev` try to auto-repair partial stacks?
-
-Recommended default:
-
-- no for the first cut
-- print status and require `mix favn.stop` first
-
-### 5. Should a dedicated `mix favn.dev --interactive` land in the next PR?
+### Should `mix favn.logs` stay a thin helper or become structured log tooling?
 
 Recommended default:
 
-- no separate dedicated mode is required in the next PR if normal `mix favn.dev` is already foreground
-- add one later only if we discover a real debugging need beyond the normal foreground loop
+- thin helper only
 
-### 6. Which helper functions should be available in IEx?
+### Should `mix favn.build.runner` package one or many manifest versions?
 
 Recommended default:
 
-- `Favn.Dev.reload()`
-- `Favn.Dev.status()`
-- `Favn.Dev.stop()`
+- one pinned manifest version per build
 
-Boundary warning:
+### What should single-node default storage be?
 
-- do not add helper shortcuts that call across steady-state product boundaries in-process as the normal workflow
-- helpers should remain lifecycle/debug utilities only
+Recommended default:
+
+- SQLite
+
+### Should split deployment artifacts hide the deployment topology?
+
+Recommended default:
+
+- no
+- keep three explicit artifacts and explicit config wiring
+
+### How much diagnostics work belongs in Phase 9?
+
+Recommended default:
+
+- targeted diagnostics only: missing install, missing Node/npm, stale state,
+  startup cleanup, and port conflicts
+- do not expand into a broad doctor framework yet
+
+## 13. Suggested Implementation Slices / PR Order
+
+### Slice 1: install foundation and expanded `.favn/` layout
+
+- add `.favn/install/`, `.favn/build/`, `.favn/dist/`, manifest cache, and
+  failure-history layout expansion
+- implement `mix favn.install`
+- add install fingerprinting and stale detection
+- add targeted prerequisite diagnostics
+
+### Slice 2: reset and logs
+
+- implement `mix favn.reset`
+- implement `mix favn.logs`
+- lock in destructive reset semantics and preserved historical log access
+
+### Slice 3: runner packaging contract first
+
+- implement `mix favn.build.runner`
+- add manifest cache/export contract
+- lock metadata and plugin inclusion contract
+
+### Slice 4: split runtime artifacts
+
+- implement `mix favn.build.web`
+- implement `mix favn.build.orchestrator`
+- lock split deployment metadata and operator docs
+
+### Slice 5: single-node assembly
+
+- implement `mix favn.build.single`
+- lock three-runtime bundle structure and generated config/env contract
+- default single-node storage to SQLite
+
+### Slice 6: validation and polish
+
+- harden startup cleanup, stale-state handling, partial/dead service stop flows,
+  and diagnostics
+- add explicit SQLite and opt-in broader Postgres verification
+- finish docs
+
+Priority rule:
+
+- if scope must be narrowed temporarily, keep `install` and `build.runner`
+  ahead of optional niceties
+- do not cut the topology-preserving `single` semantics even if implementation is
+  minimal
+
+## 14. Acceptance Criteria For Phase 9 Completion
+
+Phase 9 is complete when all of the following are true:
+
+1. users can start from `{:favn, ...}` and run `mix favn.install` followed by
+   `mix favn.dev` without needing to understand internal apps
+2. all Favn-managed install/build/runtime side effects live under `.favn/`
+3. `mix favn.reset` fully removes project-local Favn state after the stack is
+   stopped
+4. `mix favn.logs` provides boring access to current and historical service logs
+5. `mix favn.build.web`, `mix favn.build.orchestrator`, and
+   `mix favn.build.runner` each produce explicit operator-facing artifacts with
+   compatibility metadata
+6. `mix favn.build.runner` packages user code, internal runner runtime, pinned
+   manifest, and selected plugins without making `favn_runner` part of the
+   public dependency surface
+7. `mix favn.build.single` produces one bundle containing explicit web,
+   orchestrator, and runner runtimes, not one collapsed runtime
+8. lifecycle recovery, partial/dead service recovery, startup cleanup, explicit
+   SQLite verification, and broader opt-in Postgres verification all have
+   coverage
+9. missing prerequisite, stale state, and port-conflict failures produce
+   actionable diagnostics
+10. docs describe the local and packaging story honestly without same-BEAM or
+    machine-global assumptions

--- a/docs/refactor/PHASE_9_TODO.md
+++ b/docs/refactor/PHASE_9_TODO.md
@@ -2,146 +2,131 @@
 
 ## Status
 
-Checklist for the next-PR-only core local developer tooling slice described in `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md`.
+Checklist for the remaining developer-tooling and packaging slice described in
+`docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md`.
 
-This list is intentionally detailed and execution-oriented. `docs/FEATURES.md` remains the high-level roadmap.
+Completed baseline work that should not be reopened here:
+
+- [x] `mix favn.dev`
+- [x] `mix favn.dev --sqlite`
+- [x] `mix favn.stop`
+- [x] `mix favn.reload`
+- [x] `mix favn.status`
 
 ## Scope Locks
 
-- [x] Keep this PR focused on `mix favn.dev`, `mix favn.stop`, `mix favn.reload`, `mix favn.status`, and the minimum config/state needed to support them.
-- [x] Do not pull `mix favn.install`, `mix favn.reset`, `mix favn.logs`, or build/packaging flows into this PR.
-- [x] Preserve the `favn_web + favn_orchestrator + favn_runner` process boundary; do not collapse back to a same-BEAM product path.
-- [x] Keep user-facing Mix tasks in `apps/favn`.
-- [x] Do not introduce compile-time deps from `apps/favn` to internal runtime apps.
-- [x] Keep `mix favn.dev` foreground by default; do not optimize the next PR around detached mode.
+- [x] Keep `apps/favn` as the public package and public `mix favn.*` entrypoint owner.
+- [x] Keep `apps/favn_authoring` as authoring/manifest implementation owner.
+- [x] Keep `apps/favn_local` as local lifecycle/tooling and packaging implementation owner.
+- [x] Keep all Favn-managed project-local side effects under `.favn/`.
+- [x] Preserve explicit `web + orchestrator + runner` runtime boundaries.
+- [x] Do not require Docker by default.
+- [x] Do not treat production hardening as part of this Phase 9 slice.
+- [x] Do not reopen already-completed `dev`, `stop`, `reload`, and `status` work.
 
-## `.favn` State And Config Foundations
+## Install Foundation
 
-- [x] Add minimal `:favn, :dev` config resolution for storage mode, SQLite path, local ports, base URLs, and local secrets overrides.
-- [x] Add `.favn/runtime.json` for active stack metadata.
-- [x] Add `.favn/secrets.json` for generated local service token, web session secret, and local RPC cookie.
-- [x] Add `.favn/lock` lifecycle locking.
-- [x] Add `.favn/logs/` log file handling.
-- [x] Add `.favn/manifests/latest.json` manifest cache metadata.
-- [x] Add `.favn/history/last_failure.json` failure tracking.
-- [x] Record enough runtime ownership in `.favn/runtime.json` for a second terminal to run `mix favn.reload`, `mix favn.status`, and `mix favn.stop` against the foreground stack.
+- [ ] Expand `.favn/` layout with `install/`, `build/`, `dist/`, manifest cache, and preserved failure-history directories.
+- [ ] Add install fingerprint metadata under `.favn/install/install.json`.
+- [ ] Add toolchain verification metadata under `.favn/install/toolchain.json`.
+- [ ] Materialize project-local runtime inputs for `web`, `orchestrator`, and `runner` under `.favn/install/runtimes/`.
+- [ ] Keep JS dependency state for `favn_web` under `.favn/install/`.
+- [ ] Implement `mix favn.install` as an explicit setup command.
+- [ ] Make `mix favn.dev` and `mix favn.build.*` fail clearly when install state is missing or stale.
+- [ ] Add a boring reinstall path such as `mix favn.install --force`.
+- [ ] Record install failures under `.favn/history/`.
 
-## Private Manifest Publish API
+## Reset And Logs
 
-- [x] Add `POST /api/orchestrator/v1/manifests` so orchestrator can register a new manifest without restarting.
-- [x] Protect manifest publish with the existing private service-auth boundary.
-- [x] Add contract/API tests for manifest publish and activation flow.
+- [ ] Implement `mix favn.reset`.
+- [ ] Require the stack to be stopped before reset deletes `.favn/`.
+- [ ] Auto-clear only fully stale runtime state during reset when no live owned services remain.
+- [ ] Keep the first cut of reset fully destructive with no `--keep-*` modes.
+- [ ] Implement `mix favn.logs` as a thin file-tail helper.
+- [ ] Support all-services log output.
+- [ ] Support single-service selection for `web`, `orchestrator`, and `runner`.
+- [ ] Support `--tail`.
+- [ ] Support `--follow`.
+- [ ] Preserve historical log access when the stack is down.
 
-## Local Runner/Orchestrator Control Path
+## Build Metadata Foundations
 
-- [x] Add a boundary-safe local control path for separate orchestrator and runner processes.
-- [x] Keep that control path localhost-only and local-dev-scoped.
-- [x] Add an orchestrator-side local runner-client implementation that can talk to a separate runner process without a compile-time runner dependency.
-- [x] Allow the running foreground stack to be addressed from another terminal through project-local runtime state plus the local control path.
+- [ ] Add per-build working directories under `.favn/build/<target>/<build_id>/`.
+- [ ] Add final artifact directories under `.favn/dist/<target>/<build_id>/`.
+- [ ] Write shared `build.json` metadata for each build target.
+- [ ] Write final artifact `metadata.json` for each build target.
+- [ ] Include explicit compatibility metadata instead of relying only on package-version matching.
 
-## `mix favn.dev`
+## `mix favn.build.runner`
 
-- [x] Acquire lifecycle lock before mutating local runtime state.
-- [x] Fail clearly if a partial/stale stack is already present.
-- [x] Build and pin the current manifest on startup.
-- [x] Start runner and verify readiness.
-- [x] Start orchestrator and verify readiness.
-- [x] Register the current manifest in runner.
-- [x] Register and activate the current manifest in orchestrator.
-- [x] Start `favn_web` as a thin built local web process and verify readiness.
-- [x] Wire local orchestrator base URL and service token into `favn_web` automatically.
-- [x] Default to memory storage.
-- [x] Support `--sqlite` as the immediate persistent local mode.
-- [x] Print URLs, pids, storage mode, and log locations on success.
-- [x] Clean up newly started processes when startup fails partway through.
-- [x] Keep the command attached in the foreground and stop the owned stack on interrupt or normal terminal exit.
+- [ ] Build a runner artifact from the current user project plus installed internal runner runtime inputs.
+- [ ] Generate and pin the current manifest through `favn_authoring` during the build.
+- [ ] Package compiled user business code into the runner artifact.
+- [ ] Package the pinned serialized manifest into the runner artifact.
+- [ ] Package selected plugins into the runner artifact as appropriate.
+- [ ] Write runner metadata including manifest schema version, manifest version id, manifest hash, runner contract version, and plugin inventory.
+- [ ] Keep the first cut to one pinned manifest version per runner build.
 
-## `mix favn.stop`
+## `mix favn.build.web`
 
-- [x] Read local runtime state from `.favn/runtime.json`.
-- [x] Stop web cleanly.
-- [x] Ask orchestrator to stop admitting new work and cancel local in-flight runs.
-- [x] Stop runner cleanly.
-- [x] Stop orchestrator cleanly.
-- [x] Add timeout + forced-kill fallback behavior.
-- [x] Preserve logs and SQLite data by default.
-- [x] Remove only active runtime state on success.
-- [x] Make the command idempotent.
+- [ ] Build a deployable web artifact from installed `favn_web` runtime inputs.
+- [ ] Keep the web artifact free of user business code.
+- [ ] Write web metadata including supported orchestrator API compatibility and required environment contract.
 
-## `mix favn.status`
+## `mix favn.build.orchestrator`
 
-- [x] Report whether web/orchestrator/runner are expected to be running.
-- [x] Probe current pid liveness and local readiness.
-- [x] Show URLs / ports where applicable.
-- [x] Show storage mode.
-- [x] Show current active manifest id when available.
-- [x] Fall back to last cached manifest metadata when orchestrator is down.
-- [x] Show recent failure/death info when a service disappeared unexpectedly.
+- [ ] Build a deployable orchestrator artifact from installed internal runtime inputs.
+- [ ] Keep the orchestrator artifact free of user business code.
+- [ ] Keep the build artifact storage-neutral at build time.
+- [ ] Write orchestrator metadata including API compatibility, runner compatibility, and storage expectations.
 
-## `mix favn.reload`
+## `mix favn.build.single`
 
-- [x] Refuse reload when the stack is not running.
-- [x] Recompile the user project.
-- [x] Rebuild and pin the new manifest version.
-- [x] Refuse reload when in-flight runs exist.
-- [x] Restart runner only for the default reload path.
-- [x] Re-register the manifest in runner.
-- [x] Publish/register the manifest in orchestrator through the private API.
-- [x] Activate the new manifest for future runs.
-- [x] Leave `favn_web` alone on default reload.
-- [x] Keep orchestrator running during reload and switch it to the newly registered active manifest.
-- [x] Keep browser refresh as the normal way to observe updated manifest state through `favn_web`.
+- [ ] Assemble one single-node bundle containing separate `web`, `orchestrator`, and `runner` runtimes.
+- [ ] Generate one assembly manifest for config wiring across the three runtimes.
+- [ ] Generate per-service env/config files in the single bundle.
+- [ ] Generate simple start/stop scripts for the single bundle.
+- [ ] Default single-node storage to SQLite.
+- [ ] Keep explicit runtime boundaries visible in the output layout and metadata.
 
-## Optional Interactive Follow-Up
+## Validation And Polish
 
-- [ ] Re-evaluate whether a separate interactive shell mode is needed after the normal foreground workflow lands.
-- [ ] If needed later, attach only to the orchestrator/control-plane runtime.
-- [ ] Add small helper functions for interactive use: `Favn.Dev.reload/0`, `Favn.Dev.status/0`, `Favn.Dev.stop/0`.
-
-## Follow-Up Refactor / Future Features
-
-- [ ] evaluate whether `favn` should later become a thin distribution package over authoring + local tooling ownership (`favn` + `favn_local`)
-- [ ] document and enforce durable local control-plane boundaries between web, orchestrator, and runner in dev mode
-- [ ] add watch mode / auto-reload
-- [ ] add `doctor` / environment validation
-- [ ] add `clean` / reset local state helper
-- [ ] add log-tail helper commands
-- [ ] add restart-single-service helper
-- [ ] improve port conflict diagnostics
-- [ ] define explicit `.favn/` secrets/state policy
+- [ ] Tighten lifecycle recovery when runtime state exists but all owned services are dead.
+- [ ] Tighten partial/dead service handling so `status` reports it clearly and `stop` can clean it up idempotently.
+- [ ] Add stronger startup failure cleanup verification.
+- [ ] Add explicit SQLite follow-up verification for install, dev, logs, reset, and single packaging flows.
+- [ ] Add broader opt-in Postgres verification for local and orchestrator packaging paths.
+- [ ] Add better missing-prerequisite diagnostics for install/build/dev flows.
+- [ ] Add better port-conflict diagnostics for local startup.
+- [ ] Keep diagnostics targeted and boring; do not grow a broad doctor framework in this slice.
 
 ## Testing
 
-- [x] Add config resolution tests.
-- [x] Add `.favn` state read/write tests.
-- [x] Add lifecycle lock tests.
-- [x] Add foreground owner-session lifecycle tests.
-- [x] Add SQLite path/default tests.
-- [x] Add `mix favn.dev` task behavior coverage.
-- [x] Add `mix favn.stop` timeout + forced-kill coverage.
-- [x] Add `mix favn.status` stale-state coverage.
-- [x] Add `mix favn.reload` semantics coverage.
-- [x] Add local runner/orchestrator control-path tests.
-- [x] Add manifest publish API coverage.
-- [x] Add one serial end-to-end local smoke path.
-- [x] Add a lifecycle test that catches lock-scope and live-runner registration regressions.
+- [ ] Add install fingerprint and stale-detection coverage.
+- [ ] Add missing Node/npm diagnostic coverage.
+- [ ] Add offline reuse coverage when install state is current.
+- [ ] Add reset refusal and success coverage.
+- [ ] Add logs all-services, single-service, tail, follow, and historical-access coverage.
+- [ ] Add build metadata contract coverage for `web`, `orchestrator`, `runner`, and `single`.
+- [ ] Add runner artifact coverage for user code, manifest, and plugin inclusion.
+- [ ] Add single artifact coverage for the three-runtime bundle layout.
+- [ ] Add stale-runtime recovery and partial/dead service recovery coverage.
+- [ ] Add explicit SQLite end-to-end coverage for the full Phase 9 tooling loop.
+- [ ] Add broader opt-in Postgres verification coverage.
 
 ## Docs
 
-- [x] Update `README.md` current-focus and doc pointers.
-- [x] Update `docs/REFACTOR.md` Phase 9 wording to distinguish this next PR from later tooling/build work.
-- [x] Update `docs/FEATURES.md` roadmap status for next PR versus later Phase 9 work.
-- [x] Keep this plan doc up to date as implementation lands.
+- [ ] Update `README.md` first-time setup docs when `mix favn.install` lands.
+- [ ] Update `README.md` packaging docs for split vs single deployment.
+- [ ] Keep `docs/REFACTOR.md` Phase 9 wording aligned with the remaining tooling/packageability scope.
+- [ ] Keep `docs/FEATURES.md` roadmap wording aligned with the remaining Phase 9 batch.
+- [ ] Keep `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` current as implementation lands.
+- [ ] Use this TODO file as the execution checklist for the remaining Phase 9 slice.
 
-## Explicitly Deferred Beyond This PR
+## Explicitly Deferred Beyond This Slice
 
-- [ ] `mix favn.install`
-- [ ] `mix favn.reset`
-- [ ] `mix favn.logs`
-- [ ] `mix favn.build.web`
-- [ ] `mix favn.build.orchestrator`
-- [ ] `mix favn.build.runner`
-- [ ] `mix favn.build.single`
-- [ ] broader release/install/distribution polish
-- [ ] durable auth/session hardening
-- [ ] richer local web UX
+- [ ] production hardening and safe-release auth/session work
+- [ ] Docker-first local or packaging workflows
+- [ ] broad environment doctor framework
+- [ ] richer observability or structured log-query tooling
+- [ ] hidden same-BEAM shortcuts for local or packaged runtimes

--- a/docs/refactor/PHASE_9_TODO.md
+++ b/docs/refactor/PHASE_9_TODO.md
@@ -39,13 +39,13 @@ Completed baseline work that should not be reopened here:
 
 ## Storage Configuration Contract
 
-- [ ] Define explicit supported storage modes for Phase 9: `memory`, `sqlite`, and `postgres`.
-- [ ] Keep storage selection as an orchestrator-only concern in local and packaged workflows.
-- [ ] Add public local config documentation under `config :favn, :local` for `storage`, `sqlite_path`, and `postgres` settings.
-- [ ] Preserve `mix favn.dev --sqlite` and add explicit Postgres local-dev invocation support.
-- [ ] Define runtime env contract for packaged orchestrator storage selection (`FAVN_STORAGE`, SQLite path, Postgres connection env).
-- [ ] Define `mix favn.build.single --storage sqlite|postgres` semantics.
-- [ ] Keep web and runner deployment inputs storage-agnostic.
+- [x] Define explicit supported storage modes for Phase 9: `memory`, `sqlite`, and `postgres`.
+- [x] Keep storage selection as an orchestrator-only concern in local and packaged workflows.
+- [x] Add public local config documentation under `config :favn, :local` for `storage`, `sqlite_path`, and `postgres` settings.
+- [x] Preserve `mix favn.dev --sqlite` and add explicit Postgres local-dev invocation support.
+- [x] Define runtime env contract for packaged orchestrator storage selection (`FAVN_STORAGE`, SQLite path, Postgres connection env).
+- [x] Define `mix favn.build.single --storage sqlite|postgres` semantics.
+- [x] Keep web and runner deployment inputs storage-agnostic.
 
 ## Reset And Logs
 

--- a/docs/refactor/PHASE_9_TODO.md
+++ b/docs/refactor/PHASE_9_TODO.md
@@ -26,15 +26,15 @@ Completed baseline work that should not be reopened here:
 
 ## Install Foundation
 
-- [ ] Expand `.favn/` layout with `install/`, `build/`, `dist/`, manifest cache, and preserved failure-history directories.
-- [ ] Add install fingerprint metadata under `.favn/install/install.json`.
-- [ ] Add toolchain verification metadata under `.favn/install/toolchain.json`.
-- [ ] Materialize project-local runtime inputs for `web`, `orchestrator`, and `runner` under `.favn/install/runtimes/`.
+- [x] Expand `.favn/` layout with `install/`, `build/`, `dist/`, manifest cache, and preserved failure-history directories.
+- [x] Add install fingerprint metadata under `.favn/install/install.json`.
+- [x] Add toolchain verification metadata under `.favn/install/toolchain.json`.
+- [x] Materialize project-local runtime inputs for `web`, `orchestrator`, and `runner` under `.favn/install/runtimes/`.
 - [ ] Keep JS dependency state for `favn_web` under `.favn/install/`.
-- [ ] Implement `mix favn.install` as an explicit setup command.
+- [x] Implement `mix favn.install` as an explicit setup command.
 - [ ] Make `mix favn.dev` and `mix favn.build.*` fail clearly when install state is missing or stale.
-- [ ] Add a boring reinstall path such as `mix favn.install --force`.
-- [ ] Record install failures under `.favn/history/`.
+- [x] Add a boring reinstall path such as `mix favn.install --force`.
+- [x] Record install failures under `.favn/history/`.
 
 ## Storage Configuration Contract
 
@@ -48,56 +48,56 @@ Completed baseline work that should not be reopened here:
 
 ## Reset And Logs
 
-- [ ] Implement `mix favn.reset`.
-- [ ] Require the stack to be stopped before reset deletes `.favn/`.
-- [ ] Auto-clear only fully stale runtime state during reset when no live owned services remain.
-- [ ] Keep the first cut of reset fully destructive with no `--keep-*` modes.
-- [ ] Implement `mix favn.logs` as a thin file-tail helper.
-- [ ] Support all-services log output.
-- [ ] Support single-service selection for `web`, `orchestrator`, and `runner`.
-- [ ] Support `--tail`.
-- [ ] Support `--follow`.
-- [ ] Preserve historical log access when the stack is down.
+- [x] Implement `mix favn.reset`.
+- [x] Require the stack to be stopped before reset deletes `.favn/`.
+- [x] Auto-clear only fully stale runtime state during reset when no live owned services remain.
+- [x] Keep the first cut of reset fully destructive with no `--keep-*` modes.
+- [x] Implement `mix favn.logs` as a thin file-tail helper.
+- [x] Support all-services log output.
+- [x] Support single-service selection for `web`, `orchestrator`, and `runner`.
+- [x] Support `--tail`.
+- [x] Support `--follow`.
+- [x] Preserve historical log access when the stack is down.
 
 ## Build Metadata Foundations
 
-- [ ] Add per-build working directories under `.favn/build/<target>/<build_id>/`.
-- [ ] Add final artifact directories under `.favn/dist/<target>/<build_id>/`.
-- [ ] Write shared `build.json` metadata for each build target.
-- [ ] Write final artifact `metadata.json` for each build target.
-- [ ] Include explicit compatibility metadata instead of relying only on package-version matching.
+- [x] Add per-build working directories under `.favn/build/<target>/<build_id>/`.
+- [x] Add final artifact directories under `.favn/dist/<target>/<build_id>/`.
+- [x] Write shared `build.json` metadata for each build target.
+- [x] Write final artifact `metadata.json` for each build target.
+- [x] Include explicit compatibility metadata instead of relying only on package-version matching.
 
 ## `mix favn.build.runner`
 
-- [ ] Build a runner artifact from the current user project plus installed internal runner runtime inputs.
-- [ ] Generate and pin the current manifest through `favn_authoring` during the build.
-- [ ] Package compiled user business code into the runner artifact.
-- [ ] Package the pinned serialized manifest into the runner artifact.
-- [ ] Package selected plugins into the runner artifact as appropriate.
-- [ ] Write runner metadata including manifest schema version, manifest version id, manifest hash, runner contract version, and plugin inventory.
-- [ ] Keep the first cut to one pinned manifest version per runner build.
+- [x] Build a runner artifact from the current user project plus installed internal runner runtime inputs.
+- [x] Generate and pin the current manifest through `favn_authoring` during the build.
+- [x] Package compiled user business code into the runner artifact.
+- [x] Package the pinned serialized manifest into the runner artifact.
+- [x] Package selected plugins into the runner artifact as appropriate.
+- [x] Write runner metadata including manifest schema version, manifest version id, manifest hash, runner contract version, and plugin inventory.
+- [x] Keep the first cut to one pinned manifest version per runner build.
 
 ## `mix favn.build.web`
 
-- [ ] Build a deployable web artifact from installed `favn_web` runtime inputs.
-- [ ] Keep the web artifact free of user business code.
-- [ ] Write web metadata including supported orchestrator API compatibility and required environment contract.
+- [x] Build a deployable web artifact from installed `favn_web` runtime inputs.
+- [x] Keep the web artifact free of user business code.
+- [x] Write web metadata including supported orchestrator API compatibility and required environment contract.
 
 ## `mix favn.build.orchestrator`
 
-- [ ] Build a deployable orchestrator artifact from installed internal runtime inputs.
-- [ ] Keep the orchestrator artifact free of user business code.
-- [ ] Keep the build artifact storage-neutral at build time.
-- [ ] Write orchestrator metadata including API compatibility, runner compatibility, and storage expectations.
+- [x] Build a deployable orchestrator artifact from installed internal runtime inputs.
+- [x] Keep the orchestrator artifact free of user business code.
+- [x] Keep the build artifact storage-neutral at build time.
+- [x] Write orchestrator metadata including API compatibility, runner compatibility, and storage expectations.
 
 ## `mix favn.build.single`
 
-- [ ] Assemble one single-node bundle containing separate `web`, `orchestrator`, and `runner` runtimes.
-- [ ] Generate one assembly manifest for config wiring across the three runtimes.
-- [ ] Generate per-service env/config files in the single bundle.
-- [ ] Generate simple start/stop scripts for the single bundle.
-- [ ] Default single-node storage to SQLite.
-- [ ] Keep explicit runtime boundaries visible in the output layout and metadata.
+- [x] Assemble one single-node bundle containing separate `web`, `orchestrator`, and `runner` runtimes.
+- [x] Generate one assembly manifest for config wiring across the three runtimes.
+- [x] Generate per-service env/config files in the single bundle.
+- [x] Generate simple start/stop scripts for the single bundle.
+- [x] Default single-node storage to SQLite.
+- [x] Keep explicit runtime boundaries visible in the output layout and metadata.
 
 ## Validation And Polish
 
@@ -116,11 +116,11 @@ Completed baseline work that should not be reopened here:
 - [ ] Add install fingerprint and stale-detection coverage.
 - [ ] Add missing Node/npm diagnostic coverage.
 - [ ] Add offline reuse coverage when install state is current.
-- [ ] Add reset refusal and success coverage.
-- [ ] Add logs all-services, single-service, tail, follow, and historical-access coverage.
+- [x] Add reset refusal and success coverage.
+- [x] Add logs all-services, single-service, tail, follow, and historical-access coverage.
 - [ ] Add build metadata contract coverage for `web`, `orchestrator`, `runner`, and `single`.
-- [ ] Add runner artifact coverage for user code, manifest, and plugin inclusion.
-- [ ] Add single artifact coverage for the three-runtime bundle layout.
+- [x] Add runner artifact coverage for user code, manifest, and plugin inclusion.
+- [x] Add single artifact coverage for the three-runtime bundle layout.
 - [ ] Add stale-runtime recovery and partial/dead service recovery coverage.
 - [ ] Add explicit SQLite end-to-end coverage for the full Phase 9 tooling loop.
 - [ ] Add broader opt-in Postgres verification coverage.

--- a/docs/refactor/PHASE_9_TODO.md
+++ b/docs/refactor/PHASE_9_TODO.md
@@ -29,7 +29,8 @@ Completed baseline work that should not be reopened here:
 - [x] Expand `.favn/` layout with `install/`, `build/`, `dist/`, manifest cache, and preserved failure-history directories.
 - [x] Add install fingerprint metadata under `.favn/install/install.json`.
 - [x] Add toolchain verification metadata under `.favn/install/toolchain.json`.
-- [x] Materialize project-local runtime inputs for `web`, `orchestrator`, and `runner` under `.favn/install/runtimes/`.
+- [x] Record project-local runtime input roots for `web`, `orchestrator`, and `runner` in install metadata under `.favn/install/`.
+- [ ] Materialize copied/runtime-resolved inputs under `.favn/install/runtimes/` if we choose to move beyond metadata-only install state.
 - [ ] Keep JS dependency state for `favn_web` under `.favn/install/`.
 - [x] Implement `mix favn.install` as an explicit setup command.
 - [ ] Make `mix favn.dev` and `mix favn.build.*` fail clearly when install state is missing or stale.

--- a/docs/refactor/PHASE_9_TODO.md
+++ b/docs/refactor/PHASE_9_TODO.md
@@ -36,6 +36,16 @@ Completed baseline work that should not be reopened here:
 - [ ] Add a boring reinstall path such as `mix favn.install --force`.
 - [ ] Record install failures under `.favn/history/`.
 
+## Storage Configuration Contract
+
+- [ ] Define explicit supported storage modes for Phase 9: `memory`, `sqlite`, and `postgres`.
+- [ ] Keep storage selection as an orchestrator-only concern in local and packaged workflows.
+- [ ] Add public local config documentation under `config :favn, :local` for `storage`, `sqlite_path`, and `postgres` settings.
+- [ ] Preserve `mix favn.dev --sqlite` and add explicit Postgres local-dev invocation support.
+- [ ] Define runtime env contract for packaged orchestrator storage selection (`FAVN_STORAGE`, SQLite path, Postgres connection env).
+- [ ] Define `mix favn.build.single --storage sqlite|postgres` semantics.
+- [ ] Keep web and runner deployment inputs storage-agnostic.
+
 ## Reset And Logs
 
 - [ ] Implement `mix favn.reset`.
@@ -98,6 +108,7 @@ Completed baseline work that should not be reopened here:
 - [ ] Add broader opt-in Postgres verification for local and orchestrator packaging paths.
 - [ ] Add better missing-prerequisite diagnostics for install/build/dev flows.
 - [ ] Add better port-conflict diagnostics for local startup.
+- [ ] Verify explicit local Postgres configuration and startup path, not just SQLite follow-up behavior.
 - [ ] Keep diagnostics targeted and boring; do not grow a broad doctor framework in this slice.
 
 ## Testing

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -16,12 +16,19 @@ apps/
 │   ├── runtime_facade_test.exs
 │   └── test_helper.exs
 ├── favn_local/test/
+│   ├── dev_build_orchestrator_test.exs
+│   ├── dev_build_runner_test.exs
+│   ├── dev_build_single_test.exs
+│   ├── dev_build_web_test.exs
 │   ├── dev_config_test.exs
+│   ├── dev_install_test.exs
 │   ├── dev_lifecycle_test.exs
 │   ├── dev_lock_test.exs
+│   ├── dev_logs_test.exs
 │   ├── dev_orchestrator_client_test.exs
 │   ├── dev_process_test.exs
 │   ├── dev_reload_test.exs
+│   ├── dev_reset_test.exs
 │   ├── dev_state_test.exs
 │   ├── dev_status_test.exs
 │   ├── dev_stop_test.exs

--- a/mix.exs
+++ b/mix.exs
@@ -4,6 +4,18 @@ defmodule FavnUmbrella.MixProject do
   def project do
     [
       apps_path: "apps",
+      apps: [
+        :favn,
+        :favn_authoring,
+        :favn_core,
+        :favn_duckdb,
+        :favn_local,
+        :favn_orchestrator,
+        :favn_runner,
+        :favn_storage_postgres,
+        :favn_storage_sqlite,
+        :favn_test_support
+      ],
       version: "0.5.0-dev",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
## Summary
- implement the remaining Phase 9 public tooling surface behind `mix favn.*`: `install`, `reset`, `logs`, `build.runner`, `build.web`, `build.orchestrator`, and `build.single`
- add project-local `.favn/` install/build/dist/runtime state management and metadata contracts, including install fingerprints/toolchain capture, failure history, and per-target build/dist metadata
- implement packaging flows in `favn_local` while keeping `apps/favn` as thin public task entrypoints, and document the resulting ownership/usage/config contract (including `apps/favn_local/README.md`)

## Implemented behavior
- `mix favn.install`
  - explicit install setup, tool checks, npm cache setup, install fingerprinting
  - install no-op reporting (`already up to date`)
  - runtime input metadata and source snapshots under `.favn/install/runtimes/*`
- `mix favn.dev` / lifecycle
  - install freshness enforcement before startup
  - storage support for `memory`, `sqlite`, and `postgres`
  - `--sqlite` and `--postgres` flags
  - web build on demand (when `dist/index.html` is missing)
  - readiness via TCP connect checks (no curl dependency)
- `mix favn.reload`
  - runner restart uses correct shortname for `--sname`
- `mix favn.logs`
  - all/single service, tail/follow, historical file-based access
- `mix favn.reset`
  - full `.favn/` destructive reset gated on no live managed services
- build targets
  - `mix favn.build.runner`: user code + pinned manifest + plugin inventory metadata
  - `mix favn.build.web`
  - `mix favn.build.orchestrator`
  - `mix favn.build.single` with sqlite default and postgres override (`--storage sqlite|postgres`), explicit `web/orchestrator/runner` bundle boundaries

## Contract and architecture notes
- preserve public/internal boundaries:
  - `apps/favn`: public Mix task entrypoints only
  - `apps/favn_local`: tooling/package implementation
- runner build root semantics are explicit and honest:
  - rooted in current Mix project
  - mismatched `--root-dir` is rejected with actionable error
- umbrella app list is explicit in root `mix.exs` to avoid accidental app pickup from stray directories

## Testing and validation
- added/expanded tests across public task behavior and `favn_local` internals for install/reset/logs/build/storage/reload edge cases
- full required validation run completed:
  - `mix format`
  - `mix compile --warnings-as-errors`
  - `mix test`
  - `mix credo --strict`
  - `mix dialyzer`
  - `mix xref graph --format stats --label compile-connected`

## Notes
- unrelated local untracked `apps/favn_legacy/` worktree content is intentionally left untouched