### PR TITLE
feat: close phase 9 hardening and tooling slice

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,10 @@ Favn is in private development and the `v0.5.0` refactor is still in progress.
 - breaking changes are still allowed before `v1.0`
 - `{:favn, ...}` remains the one public package users should depend on
 - local development tooling is available today through `mix favn.install`, `mix favn.dev`, `mix favn.reload`, `mix favn.status`, and `mix favn.stop`
+- local documentation lookup is available through `mix favn.read_doc ModuleName` and `mix favn.read_doc ModuleName function_name`
 - initial packaging tooling now includes `mix favn.build.runner` for project-local runner artifact output under `.favn/dist/runner/<build_id>/`
-- split-target packaging now also includes `mix favn.build.web` and `mix favn.build.orchestrator` with project-local outputs under `.favn/dist/web/<build_id>/` and `.favn/dist/orchestrator/<build_id>/`
-- single-node assembly packaging now includes `mix favn.build.single` with project-local output under `.favn/dist/single/<build_id>/`
+- split-target packaging now also includes `mix favn.build.web` and `mix favn.build.orchestrator` with honest metadata-oriented outputs under `.favn/dist/web/<build_id>/` and `.favn/dist/orchestrator/<build_id>/`
+- single-node assembly packaging now includes `mix favn.build.single` with topology-preserving assembly output under `.favn/dist/single/<build_id>/` (see `OPERATOR_NOTES.md` in each artifact)
 
 ## What Favn Gives You
 
@@ -162,6 +163,8 @@ mix favn.status
 mix favn.reload
 mix favn.stop
 mix favn.reset
+mix favn.read_doc Favn
+mix favn.read_doc Favn generate_manifest
 ```
 
 Today this is still part of the ongoing `v0.5` refactor, but it is the intended public entrypoint for local iteration.

--- a/apps/favn/lib/mix/tasks/favn.build.orchestrator.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.orchestrator.ex
@@ -19,11 +19,26 @@ defmodule Mix.Tasks.Favn.Build.Orchestrator do
         IO.puts("build id: #{build_id}")
         IO.puts("dist: #{dist_dir}")
 
+        IO.puts(
+          "note: metadata-oriented artifact; see #{Path.join(dist_dir, "OPERATOR_NOTES.md")}"
+        )
+
       {:error, :install_required} ->
         Mix.raise("build blocked: install required; run mix favn.install")
 
       {:error, :install_stale} ->
         Mix.raise("build blocked: install stale; run mix favn.install --force")
+
+      {:error, {:missing_tool, tool}} ->
+        Mix.raise("build blocked: missing required tool #{tool}; run mix favn.install")
+
+      {:error, {:tool_check_failed, tool, status, output}} ->
+        Mix.raise(
+          "build blocked: required tool #{tool} check failed (status=#{status}): #{output}; rerun mix favn.install"
+        )
+
+      {:error, :missing_install_runtime_input} ->
+        Mix.raise("build blocked: install runtime input missing; run mix favn.install --force")
 
       {:error, reason} ->
         Mix.raise("orchestrator build failed: #{inspect(reason)}")

--- a/apps/favn/lib/mix/tasks/favn.build.runner.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.runner.ex
@@ -21,12 +21,24 @@ defmodule Mix.Tasks.Favn.Build.Runner do
         IO.puts("Favn runner build complete")
         IO.puts("build id: #{build_id}")
         IO.puts("dist: #{dist_dir}")
+        IO.puts("note: see #{Path.join(dist_dir, "OPERATOR_NOTES.md")}")
 
       {:error, :install_required} ->
         Mix.raise("build blocked: install required; run mix favn.install")
 
       {:error, :install_stale} ->
         Mix.raise("build blocked: install stale; run mix favn.install --force")
+
+      {:error, {:missing_tool, tool}} ->
+        Mix.raise("build blocked: missing required tool #{tool}; run mix favn.install")
+
+      {:error, {:tool_check_failed, tool, status, output}} ->
+        Mix.raise(
+          "build blocked: required tool #{tool} check failed (status=#{status}): #{output}; rerun mix favn.install"
+        )
+
+      {:error, :missing_install_runtime_input} ->
+        Mix.raise("build blocked: install runtime input missing; run mix favn.install --force")
 
       {:error, {:unsupported_root_dir, requested, current}} ->
         Mix.raise(

--- a/apps/favn/lib/mix/tasks/favn.build.single.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.single.ex
@@ -21,12 +21,24 @@ defmodule Mix.Tasks.Favn.Build.Single do
         IO.puts("Favn single build complete")
         IO.puts("build id: #{build_id}")
         IO.puts("dist: #{dist_dir}")
+        IO.puts("note: assembly-only artifact; see #{Path.join(dist_dir, "OPERATOR_NOTES.md")}")
 
       {:error, :install_required} ->
         Mix.raise("build blocked: install required; run mix favn.install")
 
       {:error, :install_stale} ->
         Mix.raise("build blocked: install stale; run mix favn.install --force")
+
+      {:error, {:missing_tool, tool}} ->
+        Mix.raise("build blocked: missing required tool #{tool}; run mix favn.install")
+
+      {:error, {:tool_check_failed, tool, status, output}} ->
+        Mix.raise(
+          "build blocked: required tool #{tool} check failed (status=#{status}): #{output}; rerun mix favn.install"
+        )
+
+      {:error, :missing_install_runtime_input} ->
+        Mix.raise("build blocked: install runtime input missing; run mix favn.install --force")
 
       {:error, {:invalid_storage, value}} ->
         Mix.raise(

--- a/apps/favn/lib/mix/tasks/favn.build.web.ex
+++ b/apps/favn/lib/mix/tasks/favn.build.web.ex
@@ -19,11 +19,26 @@ defmodule Mix.Tasks.Favn.Build.Web do
         IO.puts("build id: #{build_id}")
         IO.puts("dist: #{dist_dir}")
 
+        IO.puts(
+          "note: metadata-oriented artifact; see #{Path.join(dist_dir, "OPERATOR_NOTES.md")}"
+        )
+
       {:error, :install_required} ->
         Mix.raise("build blocked: install required; run mix favn.install")
 
       {:error, :install_stale} ->
         Mix.raise("build blocked: install stale; run mix favn.install --force")
+
+      {:error, {:missing_tool, tool}} ->
+        Mix.raise("build blocked: missing required tool #{tool}; run mix favn.install")
+
+      {:error, {:tool_check_failed, tool, status, output}} ->
+        Mix.raise(
+          "build blocked: required tool #{tool} check failed (status=#{status}): #{output}; rerun mix favn.install"
+        )
+
+      {:error, :missing_install_runtime_input} ->
+        Mix.raise("build blocked: install runtime input missing; run mix favn.install --force")
 
       {:error, reason} ->
         Mix.raise("web build failed: #{inspect(reason)}")

--- a/apps/favn/lib/mix/tasks/favn.dev.ex
+++ b/apps/favn/lib/mix/tasks/favn.dev.ex
@@ -19,13 +19,56 @@ defmodule Mix.Tasks.Favn.Dev do
     opts = normalize_storage_flags(opts)
 
     case Dev.dev(opts) do
-      :ok -> :ok
-      {:error, :stack_already_running} -> Mix.raise("local stack already running")
-      {:error, :install_required} -> Mix.raise("install required; run mix favn.install")
-      {:error, :install_stale} -> Mix.raise("install stale; run mix favn.install --force")
-      {:error, reason} -> Mix.raise("failed to start local stack: #{inspect(reason)}")
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Mix.raise(error_message(reason))
     end
   end
+
+  defp error_message(:stack_already_running), do: "local stack already running"
+
+  defp error_message(:install_required), do: "install required; run mix favn.install"
+
+  defp error_message(:install_stale), do: "install stale; run mix favn.install --force"
+
+  defp error_message({:stack_partially_running, service_states}) do
+    details =
+      service_states
+      |> Enum.map_join(", ", fn {service, state} -> "#{service}=#{state}" end)
+
+    "local stack is in a partial/dead state (#{details}); run mix favn.stop to clean up before retrying"
+  end
+
+  defp error_message({:missing_tool, tool}),
+    do: "missing required tool #{tool}; run mix favn.install after tool is available"
+
+  defp error_message({:tool_check_failed, tool, status, output}),
+    do: "required tool #{tool} check failed (status=#{status}): #{output}; rerun mix favn.install"
+
+  defp error_message({:port_conflict, service, port}),
+    do: "port conflict: #{service} cannot bind port #{port}; free the port and retry"
+
+  defp error_message({:port_check_failed, service, port, reason}),
+    do:
+      "port check failed for #{service} on #{port}: #{inspect(reason)}; verify local networking and retry"
+
+  defp error_message({:postgres_misconfigured, field}),
+    do: "postgres configuration missing #{field}; fix config :favn, :local and retry"
+
+  defp error_message({:postgres_unavailable, host, port, reason}),
+    do:
+      "postgres unavailable at #{host}:#{port} (#{inspect(reason)}); start postgres or fix config and retry"
+
+  defp error_message({:web_build_failed, status, output}),
+    do: "web build failed (status=#{status}): #{output}"
+
+  defp error_message({:service_exit, service, status}),
+    do:
+      "#{service} exited during startup (status=#{status}); inspect .favn/logs/#{service}.log and check for stale state or port conflicts"
+
+  defp error_message(reason), do: "failed to start local stack: #{inspect(reason)}"
 
   defp normalize_storage_flags(opts) do
     sqlite? = Keyword.get(opts, :sqlite, false)

--- a/apps/favn/lib/mix/tasks/favn.install.ex
+++ b/apps/favn/lib/mix/tasks/favn.install.ex
@@ -31,6 +31,14 @@ defmodule Mix.Tasks.Favn.Install do
       {:error, {:missing_tool, tool}} ->
         Mix.raise("install failed: missing required tool #{tool}")
 
+      {:error, {:tool_check_failed, tool, status, output}} ->
+        Mix.raise(
+          "install failed: required tool #{tool} check failed (status=#{status}): #{output}"
+        )
+
+      {:error, {:web_install_failed, status, output}} ->
+        Mix.raise("install failed: web dependency install failed (status=#{status}): #{output}")
+
       {:error, reason} ->
         Mix.raise("install failed: #{inspect(reason)}")
     end

--- a/apps/favn/lib/mix/tasks/favn.read_doc.ex
+++ b/apps/favn/lib/mix/tasks/favn.read_doc.ex
@@ -1,0 +1,117 @@
+defmodule Mix.Tasks.Favn.ReadDoc do
+  use Mix.Task
+
+  @shortdoc "Reads module/function docs from local compiled code"
+
+  @moduledoc """
+  Reads documentation from BEAM docs chunks using local compiled code only.
+
+      mix favn.read_doc ModuleName
+      mix favn.read_doc ModuleName function_name
+  """
+
+  alias FavnAuthoring.DocReader
+
+  @impl Mix.Task
+  def run(args) do
+    Mix.Task.run("loadpaths")
+
+    case args do
+      [module_name] ->
+        module_name
+        |> parse_module_name()
+        |> DocReader.read_module()
+        |> print_module_result(module_name)
+
+      [module_name, function_name] ->
+        module_name
+        |> parse_module_name()
+        |> DocReader.read_function(function_name)
+        |> print_function_result(module_name, function_name)
+
+      _other ->
+        Mix.raise("usage: mix favn.read_doc ModuleName [function_name]")
+    end
+  end
+
+  defp parse_module_name(module_name) when is_binary(module_name) do
+    segments =
+      module_name
+      |> String.trim()
+      |> String.split(".", trim: true)
+
+    if segments == [] do
+      Mix.raise("invalid module name: #{inspect(module_name)}")
+    end
+
+    if Enum.all?(segments, &Regex.match?(~r/^[A-Za-z_][A-Za-z0-9_]*$/, &1)) do
+      Module.concat(segments)
+    else
+      Mix.raise("invalid module name: #{inspect(module_name)}")
+    end
+  end
+
+  defp print_module_result({:ok, result}, _module_name) do
+    IO.puts("Module: #{inspect(result.module)}")
+    IO.puts("Format: #{result.format}")
+    IO.puts("")
+    IO.puts("Moduledoc:")
+    IO.puts(render_doc(result.moduledoc))
+  end
+
+  defp print_module_result({:error, reason}, module_name) do
+    Mix.raise(error_message(reason, module_name))
+  end
+
+  defp print_function_result({:ok, result}, _module_name, function_name) do
+    IO.puts("Module: #{inspect(result.module)}")
+    IO.puts("Function: #{function_name}")
+    IO.puts("Format: #{result.format}")
+
+    Enum.each(result.entries, fn entry ->
+      IO.puts("")
+      IO.puts("#{entry.name}/#{entry.arity}")
+
+      if entry.signatures != [] do
+        IO.puts("Signatures:")
+        Enum.each(entry.signatures, &IO.puts("  #{&1}"))
+      end
+
+      IO.puts(render_doc(entry.doc))
+    end)
+  end
+
+  defp print_function_result({:error, :function_not_found}, module_name, function_name) do
+    Mix.raise("no public documented function named #{function_name} found in #{module_name}")
+  end
+
+  defp print_function_result({:error, reason}, module_name, _function_name) do
+    Mix.raise(error_message(reason, module_name))
+  end
+
+  defp error_message({:fetch_failed, :module_not_found}, module_name) do
+    "module #{module_name} is not available on the current code path; run mix compile if this is a project module"
+  end
+
+  defp error_message({:fetch_failed, :chunk_not_found}, module_name) do
+    "docs chunk not found for #{module_name}; module was compiled without docs"
+  end
+
+  defp error_message({:fetch_failed, reason}, module_name) do
+    "failed to read docs for #{module_name}: #{inspect(reason)}"
+  end
+
+  defp error_message(:invalid_docs_chunk, module_name),
+    do: "invalid or unsupported docs chunk for #{module_name}"
+
+  defp render_doc(:hidden), do: "(hidden)"
+  defp render_doc(:none), do: "(no docs available)"
+
+  defp render_doc(%{} = doc_map) do
+    Map.get(doc_map, "en") ||
+      doc_map
+      |> Map.values()
+      |> List.first() ||
+      "(no docs available)"
+  end
+end

--- a/apps/favn/lib/mix/tasks/favn.status.ex
+++ b/apps/favn/lib/mix/tasks/favn.status.ex
@@ -25,6 +25,12 @@ defmodule Mix.Tasks.Favn.Status do
     IO.puts("orchestrator: #{format_service(status.services.orchestrator)}")
     IO.puts("runner: #{format_service(status.services.runner)}")
 
+    case status.stack_status do
+      :partial -> IO.puts("hint: run mix favn.stop to clean up partial/dead services")
+      :stale -> IO.puts("hint: run mix favn.stop to clear stale runtime state")
+      _other -> :ok
+    end
+
     last_failure = if is_map(status.last_failure), do: inspect(status.last_failure), else: "none"
     IO.puts("last failure: #{last_failure}")
   end

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -3,6 +3,7 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
 
   import ExUnit.CaptureIO
 
+  alias Favn.Dev.Process, as: DevProcess
   alias Favn.Dev.State
   alias Mix.Tasks.Favn.Build.Orchestrator, as: BuildOrchestratorTask
   alias Mix.Tasks.Favn.Build.Runner, as: BuildRunnerTask
@@ -69,6 +70,41 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     end
   end
 
+  test "mix favn.dev raises with partial runtime recovery guidance", %{root_dir: root_dir} do
+    log_path = Path.join(root_dir, ".favn/logs/runner.log")
+    assert :ok = File.mkdir_p(Path.dirname(log_path))
+
+    spec = %{
+      name: "fixture",
+      exec: System.find_executable("bash") || "/bin/bash",
+      args: ["-lc", "sleep 30"],
+      cwd: root_dir,
+      log_path: log_path,
+      env: %{}
+    }
+
+    assert {:ok, info} = DevProcess.start_service(spec)
+
+    runtime = %{
+      "services" => %{
+        "web" => %{"pid" => 999_999},
+        "orchestrator" => %{"pid" => 999_998},
+        "runner" => %{"pid" => info.pid}
+      }
+    }
+
+    assert :ok = State.write_runtime(runtime, root_dir: root_dir)
+
+    try do
+      assert_raise Mix.Error, ~r/local stack is in a partial\/dead state/, fn ->
+        DevTask.run(["--root-dir", root_dir])
+      end
+    after
+      _ = DevProcess.stop_pid(info.pid)
+      _ = State.clear_runtime(root_dir: root_dir)
+    end
+  end
+
   test "mix favn.status prints stack details", %{root_dir: root_dir} do
     pid = :os.getpid() |> List.to_string() |> String.to_integer()
 
@@ -96,6 +132,27 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert output =~ "runner:"
   end
 
+  test "mix favn.status reports stale runtime hint", %{root_dir: root_dir} do
+    runtime = %{
+      "storage" => "memory",
+      "services" => %{
+        "web" => %{"pid" => 999_999},
+        "orchestrator" => %{"pid" => 999_998},
+        "runner" => %{"pid" => 999_997}
+      }
+    }
+
+    assert :ok = State.write_runtime(runtime, root_dir: root_dir)
+
+    output =
+      capture_io(fn ->
+        StatusTask.run(["--root-dir", root_dir])
+      end)
+
+    assert output =~ "status: stale"
+    assert output =~ "hint: run mix favn.stop to clear stale runtime state"
+  end
+
   test "mix favn.install writes install state", %{root_dir: root_dir} do
     output =
       capture_io(fn ->
@@ -119,6 +176,20 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
       end)
 
     assert output =~ "Favn install is already up to date"
+  end
+
+  test "mix favn.install reports missing prerequisite tools", %{root_dir: root_dir} do
+    previous_path = System.get_env("PATH")
+
+    try do
+      System.put_env("PATH", "")
+
+      assert_raise Mix.Error, ~r/install failed: missing required tool node/, fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+      end
+    after
+      if previous_path, do: System.put_env("PATH", previous_path), else: System.delete_env("PATH")
+    end
   end
 
   test "mix favn.logs prints service logs", %{root_dir: root_dir} do
@@ -191,6 +262,94 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert output =~ "Favn web build complete"
     assert output =~ "build id:"
     assert output =~ "/.favn/dist/web/"
+  end
+
+  test "mix favn.build.web reports missing prerequisite tools", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run([
+          "--root-dir",
+          root_dir,
+          "--skip-web-install",
+          "--skip-tool-checks"
+        ])
+      end)
+
+    previous_path = System.get_env("PATH")
+
+    try do
+      System.put_env("PATH", "")
+
+      assert_raise Mix.Error, ~r/build blocked: missing required tool node/, fn ->
+        BuildWebTask.run(["--root-dir", root_dir])
+      end
+    after
+      if previous_path, do: System.put_env("PATH", previous_path), else: System.delete_env("PATH")
+    end
+  end
+
+  test "mix favn.dev reports port conflicts before startup", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+      end)
+
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, {:active, false}, {:reuseaddr, false}])
+    {:ok, port} = :inet.port(socket)
+
+    previous_local = Application.get_env(:favn, :local, :__missing__)
+
+    try do
+      Application.put_env(:favn, :local, web_port: port)
+
+      assert_raise Mix.Error,
+                   ~r/port conflict: web cannot bind port #{port}; free the port and retry/,
+                   fn ->
+                     DevTask.run(["--root-dir", root_dir])
+                   end
+    after
+      :ok = :gen_tcp.close(socket)
+
+      case previous_local do
+        :__missing__ -> Application.delete_env(:favn, :local)
+        value -> Application.put_env(:favn, :local, value)
+      end
+    end
+  end
+
+  test "mix favn.dev reports postgres connectivity failures", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+      end)
+
+    previous_local = Application.get_env(:favn, :local, :__missing__)
+
+    try do
+      Application.put_env(
+        :favn,
+        :local,
+        storage: :postgres,
+        postgres: [
+          hostname: "127.0.0.1",
+          port: 1,
+          username: "postgres",
+          password: "postgres",
+          database: "favn",
+          ssl: false,
+          pool_size: 10
+        ]
+      )
+
+      assert_raise Mix.Error, ~r/postgres unavailable at 127.0.0.1:1/, fn ->
+        DevTask.run(["--root-dir", root_dir])
+      end
+    after
+      case previous_local do
+        :__missing__ -> Application.delete_env(:favn, :local)
+        value -> Application.put_env(:favn, :local, value)
+      end
+    end
   end
 
   test "mix favn.build.orchestrator prints build summary", %{root_dir: root_dir} do

--- a/apps/favn/test/mix_tasks/read_doc_task_test.exs
+++ b/apps/favn/test/mix_tasks/read_doc_task_test.exs
@@ -1,0 +1,39 @@
+defmodule Mix.Tasks.Favn.ReadDocTaskTest do
+  use ExUnit.Case, async: false
+
+  import ExUnit.CaptureIO
+
+  alias Mix.Tasks.Favn.ReadDoc, as: ReadDocTask
+
+  test "prints module docs" do
+    output =
+      capture_io(fn ->
+        ReadDocTask.run(["Enum"])
+      end)
+
+    assert output =~ "Module: Enum"
+    assert output =~ "Moduledoc:"
+  end
+
+  test "prints all public arities for a function name" do
+    output =
+      capture_io(fn ->
+        ReadDocTask.run(["Enum", "map"])
+      end)
+
+    assert output =~ "Function: map"
+    assert output =~ "map/2"
+  end
+
+  test "raises on unknown module" do
+    assert_raise Mix.Error, ~r/is not available on the current code path/, fn ->
+      ReadDocTask.run(["FavnNoSuchModule"])
+    end
+  end
+
+  test "raises on invalid argument count" do
+    assert_raise Mix.Error, ~r/usage: mix favn.read_doc ModuleName \[function_name\]/, fn ->
+      ReadDocTask.run([])
+    end
+  end
+end

--- a/apps/favn_authoring/lib/favn_authoring/doc_reader.ex
+++ b/apps/favn_authoring/lib/favn_authoring/doc_reader.ex
@@ -1,0 +1,131 @@
+defmodule FavnAuthoring.DocReader do
+  @moduledoc """
+  Reads compiled module and function documentation from BEAM docs chunks.
+
+  This module is intentionally narrow:
+
+  - reads only local compiled docs via `Code.fetch_docs/1`
+  - does not fetch external documentation
+  - does not parse source files
+  """
+
+  @typedoc "Normalized docs entry for one public function/macro arity"
+  @type function_entry :: %{
+          kind: :function | :macro,
+          name: atom(),
+          arity: non_neg_integer(),
+          signatures: [String.t()],
+          doc: :none | map()
+        }
+
+  @typedoc "Result for module documentation reads"
+  @type module_result :: %{
+          module: module(),
+          moduledoc: :none | :hidden | map(),
+          format: String.t()
+        }
+
+  @typedoc "Result for function documentation reads"
+  @type function_result :: %{
+          module: module(),
+          function: String.t(),
+          format: String.t(),
+          entries: [function_entry()]
+        }
+
+  @typedoc "Error reasons for docs reads"
+  @type error_reason ::
+          {:fetch_failed, term()}
+          | :function_not_found
+          | :invalid_docs_chunk
+
+  @spec read_module(module()) :: {:ok, module_result()} | {:error, error_reason()}
+  def read_module(module) when is_atom(module) do
+    with {:ok, docs_v1} <- fetch_docs(module) do
+      {:ok,
+       %{
+         module: module,
+         moduledoc: docs_v1.moduledoc,
+         format: docs_v1.format
+       }}
+    end
+  end
+
+  @spec read_function(module(), String.t()) :: {:ok, function_result()} | {:error, error_reason()}
+  def read_function(module, function_name) when is_atom(module) and is_binary(function_name) do
+    with {:ok, docs_v1} <- fetch_docs(module) do
+      entries =
+        docs_v1.docs
+        |> Enum.flat_map(&normalize_function_entry(&1, function_name))
+        |> Enum.sort_by(&{&1.arity, &1.kind})
+
+      case entries do
+        [] ->
+          {:error, :function_not_found}
+
+        _ ->
+          {:ok,
+           %{
+             module: module,
+             function: function_name,
+             format: docs_v1.format,
+             entries: entries
+           }}
+      end
+    end
+  end
+
+  defp fetch_docs(module) do
+    case Code.fetch_docs(module) do
+      {:docs_v1, _anno, _language, format, moduledoc, _metadata, docs}
+      when is_binary(format) and is_list(docs) ->
+        {:ok, %{format: format, moduledoc: moduledoc, docs: docs}}
+
+      {:error, reason} ->
+        {:error, {:fetch_failed, reason}}
+
+      _other ->
+        {:error, :invalid_docs_chunk}
+    end
+  end
+
+  defp normalize_function_entry(
+         {{kind, name, arity}, _anno, signatures, doc, metadata},
+         function_name
+       )
+       when kind in [:function, :macro] and is_atom(name) and is_integer(arity) and arity >= 0 do
+    if Atom.to_string(name) == function_name and public_entry?(doc, metadata) do
+      [
+        %{
+          kind: kind,
+          name: name,
+          arity: arity,
+          signatures: normalize_signatures(signatures),
+          doc: normalize_doc(doc)
+        }
+      ]
+    else
+      []
+    end
+  end
+
+  defp normalize_function_entry(_entry, _function_name), do: []
+
+  defp public_entry?(:hidden, _metadata), do: false
+
+  defp public_entry?(_doc, metadata) when is_map(metadata) do
+    Map.get(metadata, :exported, true)
+  end
+
+  defp public_entry?(_doc, _metadata), do: true
+
+  defp normalize_signatures(signatures) when is_list(signatures) do
+    Enum.map(signatures, &to_string/1)
+  end
+
+  defp normalize_signatures(_other), do: []
+
+  defp normalize_doc(:none), do: :none
+  defp normalize_doc(%{} = doc), do: doc
+  defp normalize_doc(_other), do: :none
+end

--- a/apps/favn_authoring/test/doc_reader_test.exs
+++ b/apps/favn_authoring/test/doc_reader_test.exs
@@ -1,5 +1,5 @@
 defmodule FavnAuthoring.DocReaderTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias FavnAuthoring.DocReader
 
@@ -51,6 +51,7 @@ defmodule FavnAuthoring.DocReaderTest do
 
       assert {:error, {:fetch_failed, :chunk_not_found}} = DocReader.read_module(module)
     after
+      _ = :code.del_path(String.to_charlist(temp_dir))
       Code.compiler_options(previous_compiler_options)
       File.rm_rf(temp_dir)
     end

--- a/apps/favn_authoring/test/doc_reader_test.exs
+++ b/apps/favn_authoring/test/doc_reader_test.exs
@@ -1,0 +1,58 @@
+defmodule FavnAuthoring.DocReaderTest do
+  use ExUnit.Case, async: true
+
+  alias FavnAuthoring.DocReader
+
+  test "reads module docs" do
+    assert {:ok, result} = DocReader.read_module(Enum)
+    assert result.module == Enum
+    assert is_binary(result.format)
+    assert is_map(result.moduledoc)
+  end
+
+  test "reads all public arities for a function name" do
+    assert {:ok, result} = DocReader.read_function(Enum, "map")
+
+    assert result.module == Enum
+    assert result.function == "map"
+    assert Enum.any?(result.entries, &(&1.name == :map and &1.arity == 2))
+  end
+
+  test "returns function_not_found for unknown function name" do
+    assert {:error, :function_not_found} =
+             DocReader.read_function(Enum, "definitely_missing_function_name")
+  end
+
+  test "returns module_not_found when module is unavailable" do
+    assert {:error, {:fetch_failed, :module_not_found}} =
+             DocReader.read_module(FavnAuthoring.NoSuchModule)
+  end
+
+  test "returns chunk_not_found when module docs chunk is missing" do
+    module = String.to_atom("Elixir.FavnNoDocs#{System.unique_integer([:positive])}")
+    temp_dir = Path.join(System.tmp_dir!(), "favn_no_docs_#{System.unique_integer([:positive])}")
+    source_file = Path.join(temp_dir, "no_docs.ex")
+
+    module_source = """
+    defmodule #{inspect(module)} do
+      def hello, do: :ok
+    end
+    """
+
+    File.mkdir_p!(temp_dir)
+    File.write!(source_file, module_source)
+
+    previous_compiler_options = Code.compiler_options()
+
+    try do
+      Code.compiler_options(docs: false)
+      Kernel.ParallelCompiler.compile_to_path([source_file], temp_dir, return_diagnostics: true)
+      Code.prepend_path(temp_dir)
+
+      assert {:error, {:fetch_failed, :chunk_not_found}} = DocReader.read_module(module)
+    after
+      Code.compiler_options(previous_compiler_options)
+      File.rm_rf(temp_dir)
+    end
+  end
+end

--- a/apps/favn_authoring/test/test_helper.exs
+++ b/apps/favn_authoring/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/apps/favn_local/lib/favn/dev/build/orchestrator.ex
+++ b/apps/favn_local/lib/favn/dev/build/orchestrator.ex
@@ -31,7 +31,8 @@ defmodule Favn.Dev.Build.Orchestrator do
            write_json(
              Path.join(dist_dir, "bundle.json"),
              orchestrator_bundle_json(build_id, source_root, opts)
-           ) do
+           ),
+         :ok <- write_operator_notes(dist_dir) do
       {:ok, %{build_id: build_id, build_dir: build_dir, dist_dir: dist_dir}}
     else
       nil -> {:error, :missing_install_runtime_input}
@@ -56,6 +57,15 @@ defmodule Favn.Dev.Build.Orchestrator do
     |> Map.put("phase", "dist")
     |> Map.put("target", @target)
     |> Map.put("orchestrator_source_root", source_root)
+    |> Map.put("artifact", %{
+      "kind" => "assembly_metadata",
+      "operational" => false,
+      "truthfulness" => "metadata_only"
+    })
+    |> Map.put("topology", %{
+      "boundary" => "orchestrator",
+      "includes_user_business_code" => false
+    })
     |> Map.put("compatibility", %{
       "orchestrator_api_version" => "v1",
       "runner_contract_version" => 1,
@@ -113,5 +123,19 @@ defmodule Favn.Dev.Build.Orchestrator do
     stamp = DateTime.utc_now() |> Calendar.strftime("%Y%m%d%H%M%S")
     unique = System.unique_integer([:positive])
     "ob_#{stamp}_#{unique}"
+  end
+
+  defp write_operator_notes(dist_dir) do
+    notes = [
+      "# Favn Orchestrator Artifact Notes",
+      "",
+      "This output is a metadata-oriented Phase 9 artifact.",
+      "It is not a standalone deployable orchestrator runtime bundle.",
+      "",
+      "Use this artifact for compatibility/env contract metadata.",
+      ""
+    ]
+
+    File.write(Path.join(dist_dir, "OPERATOR_NOTES.md"), Enum.join(notes, "\n"))
   end
 end

--- a/apps/favn_local/lib/favn/dev/build/runner.ex
+++ b/apps/favn_local/lib/favn/dev/build/runner.ex
@@ -38,7 +38,8 @@ defmodule Favn.Dev.Build.Runner do
          metadata_json <- metadata_json(build_id, version, modules, plugins, copied_modules, opts),
          :ok <- write_json(Path.join(build_dir, "build.json"), build_json),
          :ok <- write_json(Path.join(dist_dir, "metadata.json"), metadata_json),
-         :ok <- File.write(Path.join(dist_dir, "manifest.json"), serialized_manifest <> "\n") do
+         :ok <- File.write(Path.join(dist_dir, "manifest.json"), serialized_manifest <> "\n"),
+         :ok <- write_operator_notes(dist_dir) do
       {:ok, %{build_id: build_id, build_dir: build_dir, dist_dir: dist_dir}}
     end
   end
@@ -145,6 +146,12 @@ defmodule Favn.Dev.Build.Runner do
     base(build_id, version, opts)
     |> Map.put("phase", "dist")
     |> Map.put("target", @target)
+    |> Map.put("artifact", %{
+      "kind" => "runtime_package",
+      "operational" => true,
+      "truthfulness" => "manifest_and_code_included"
+    })
+    |> Map.put("topology", %{"boundary" => "runner", "includes_user_business_code" => true})
     |> Map.put("compatibility", %{
       "manifest_schema_version" => version.schema_version,
       "runner_contract_version" => version.runner_contract_version,
@@ -191,5 +198,19 @@ defmodule Favn.Dev.Build.Runner do
     stamp = DateTime.utc_now() |> Calendar.strftime("%Y%m%d%H%M%S")
     unique = System.unique_integer([:positive])
     "rb_#{stamp}_#{unique}"
+  end
+
+  defp write_operator_notes(dist_dir) do
+    notes = [
+      "# Favn Runner Artifact Notes",
+      "",
+      "This output is the most operationally complete Phase 9 packaging target.",
+      "It includes pinned manifest data plus compiled user business code beams.",
+      "",
+      "It still requires the orchestrator boundary for full distributed topology.",
+      ""
+    ]
+
+    File.write(Path.join(dist_dir, "OPERATOR_NOTES.md"), Enum.join(notes, "\n"))
   end
 end

--- a/apps/favn_local/lib/favn/dev/build/single.ex
+++ b/apps/favn_local/lib/favn/dev/build/single.ex
@@ -47,7 +47,8 @@ defmodule Favn.Dev.Build.Single do
            ),
          :ok <- write_json(Path.join(dist_dir, "config/assembly.json"), assembly),
          :ok <- write_env_files(dist_dir, storage),
-         :ok <- write_scripts(dist_dir) do
+         :ok <- write_scripts(dist_dir),
+         :ok <- write_operator_notes(dist_dir) do
       {:ok, %{build_id: build_id, build_dir: build_dir, dist_dir: dist_dir}}
     end
   end
@@ -124,6 +125,12 @@ defmodule Favn.Dev.Build.Single do
     |> Map.put("phase", "dist")
     |> Map.put("target", @target)
     |> Map.put("assembly", assembly)
+    |> Map.put("artifact", %{
+      "kind" => "assembly_bundle",
+      "operational" => false,
+      "truthfulness" => "topology_assembly_only"
+    })
+    |> Map.put("topology", %{"boundary" => "web+orchestrator+runner", "collapsed" => false})
     |> Map.put("compatibility", %{
       "topology" => "web+orchestrator+runner",
       "storage_modes" => ["sqlite", "postgres"]
@@ -222,12 +229,20 @@ defmodule Favn.Dev.Build.Single do
     start_script = [
       "#!/usr/bin/env sh",
       "set -eu",
-      "echo \"Starting favn single bundle\"",
-      "echo \"Run web/orchestrator/runner using env files under ./env\"",
+      "echo \"Favn single bundle in this Phase 9 build is assembly-only.\"",
+      "echo \"No operational runtime launch wiring is bundled yet.\"",
+      "echo \"See OPERATOR_NOTES.md and env/*.env for required deployment inputs.\"",
+      "exit 1",
       ""
     ]
 
-    stop_script = ["#!/usr/bin/env sh", "set -eu", "echo \"Stopping favn single bundle\"", ""]
+    stop_script = [
+      "#!/usr/bin/env sh",
+      "set -eu",
+      "echo \"No managed processes were started by this assembly-only artifact.\"",
+      "exit 1",
+      ""
+    ]
 
     [
       File.write(Path.join(dist_dir, "bin/start"), Enum.join(start_script, "\n")),
@@ -255,5 +270,20 @@ defmodule Favn.Dev.Build.Single do
     stamp = DateTime.utc_now() |> Calendar.strftime("%Y%m%d%H%M%S")
     unique = System.unique_integer([:positive])
     "sb_#{stamp}_#{unique}"
+  end
+
+  defp write_operator_notes(dist_dir) do
+    notes = [
+      "# Favn Single Artifact Notes",
+      "",
+      "This output preserves the web + orchestrator + runner topology and env contracts.",
+      "In this Phase 9 cut it is assembly metadata/output, not an operational launcher bundle.",
+      "",
+      "The generated bin/start and bin/stop scripts intentionally exit non-zero to avoid",
+      "falsely implying full local deployment automation.",
+      ""
+    ]
+
+    File.write(Path.join(dist_dir, "OPERATOR_NOTES.md"), Enum.join(notes, "\n"))
   end
 end

--- a/apps/favn_local/lib/favn/dev/build/web.ex
+++ b/apps/favn_local/lib/favn/dev/build/web.ex
@@ -31,7 +31,8 @@ defmodule Favn.Dev.Build.Web do
            write_json(
              Path.join(dist_dir, "bundle.json"),
              web_bundle_json(build_id, web_source_root, opts)
-           ) do
+           ),
+         :ok <- write_operator_notes(dist_dir) do
       {:ok, %{build_id: build_id, build_dir: build_dir, dist_dir: dist_dir}}
     else
       nil -> {:error, :missing_install_runtime_input}
@@ -56,6 +57,12 @@ defmodule Favn.Dev.Build.Web do
     |> Map.put("phase", "dist")
     |> Map.put("target", @target)
     |> Map.put("web_source_root", source_root)
+    |> Map.put("artifact", %{
+      "kind" => "assembly_metadata",
+      "operational" => false,
+      "truthfulness" => "metadata_only"
+    })
+    |> Map.put("topology", %{"boundary" => "web", "includes_user_business_code" => false})
     |> Map.put("compatibility", %{
       "orchestrator_api_version" => "v1"
     })
@@ -105,5 +112,19 @@ defmodule Favn.Dev.Build.Web do
     stamp = DateTime.utc_now() |> Calendar.strftime("%Y%m%d%H%M%S")
     unique = System.unique_integer([:positive])
     "wb_#{stamp}_#{unique}"
+  end
+
+  defp write_operator_notes(dist_dir) do
+    notes = [
+      "# Favn Web Artifact Notes",
+      "",
+      "This output is a metadata-oriented Phase 9 artifact.",
+      "It is not a standalone deployable web runtime bundle.",
+      "",
+      "Use this artifact for packaging metadata contracts only.",
+      ""
+    ]
+
+    File.write(Path.join(dist_dir, "OPERATOR_NOTES.md"), Enum.join(notes, "\n"))
   end
 end

--- a/apps/favn_local/lib/favn/dev/install.ex
+++ b/apps/favn_local/lib/favn/dev/install.ex
@@ -48,11 +48,8 @@ defmodule Favn.Dev.Install do
       {:error, :missing_fingerprint} ->
         {:error, :install_stale}
 
-      {:error, reason} = error ->
-        case reason do
-          {:missing_tool, _tool} -> {:error, :install_stale}
-          _ -> error
-        end
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -30,11 +30,27 @@ defmodule Favn.Dev.Stack do
       {:error, :stack_already_running} = error ->
         error
 
+      {:error, {:stack_partially_running, _service_states}} = error ->
+        error
+
       {:error, reason} = error ->
-        _ = cleanup_after_failure(reason, opts)
+        if cleanup_required?(reason) do
+          _ = cleanup_after_failure(reason, opts)
+        end
+
         error
     end
   end
+
+  defp cleanup_required?(:install_required), do: false
+  defp cleanup_required?(:install_stale), do: false
+  defp cleanup_required?({:missing_tool, _tool}), do: false
+  defp cleanup_required?({:tool_check_failed, _tool, _status, _output}), do: false
+  defp cleanup_required?({:port_conflict, _service, _port}), do: false
+  defp cleanup_required?({:port_check_failed, _service, _port, _reason}), do: false
+  defp cleanup_required?({:postgres_misconfigured, _field}), do: false
+  defp cleanup_required?({:postgres_unavailable, _host, _port, _reason}), do: false
+  defp cleanup_required?(_reason), do: true
 
   @spec stop(root_opt()) :: :ok | {:error, term()}
   def stop(opts \\ []) when is_list(opts) do
@@ -58,6 +74,7 @@ defmodule Favn.Dev.Stack do
            :ok <- ensure_stack_not_running(opts),
            :ok <- ensure_install_ready(opts),
            config <- Config.resolve(opts),
+           :ok <- ensure_startup_prerequisites(config),
            {:ok, secrets} <- Secrets.resolve(config, opts),
            {:ok, node_names} <- build_node_names(opts),
            {:ok, services} <- start_services(config, secrets, node_names, opts),
@@ -70,10 +87,15 @@ defmodule Favn.Dev.Stack do
   defp ensure_stack_not_running(opts) do
     case State.read_runtime(opts) do
       {:ok, runtime} ->
-        if any_service_running?(runtime) do
-          {:error, :stack_already_running}
-        else
-          State.clear_runtime(opts)
+        case runtime_health(runtime) do
+          :running ->
+            {:error, :stack_already_running}
+
+          :partial ->
+            {:error, {:stack_partially_running, runtime_service_statuses(runtime)}}
+
+          :stale ->
+            State.clear_runtime(opts)
         end
 
       {:error, :not_found} ->
@@ -92,13 +114,99 @@ defmodule Favn.Dev.Stack do
     end
   end
 
-  defp any_service_running?(runtime) do
-    runtime
-    |> Map.get("services", %{})
-    |> Map.values()
-    |> Enum.any?(fn
-      %{"pid" => pid} when is_integer(pid) and pid > 0 -> DevProcess.alive?(pid)
-      _ -> false
+  defp ensure_startup_prerequisites(config) do
+    case ensure_ports_available(config) do
+      :ok -> ensure_storage_ready(config)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp ensure_ports_available(config) do
+    case ensure_port_available(:orchestrator, config.orchestrator_port) do
+      :ok -> ensure_port_available(:web, config.web_port)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp ensure_port_available(service, port)
+       when is_atom(service) and is_integer(port) and port > 0 do
+    case :gen_tcp.listen(port, [:binary, {:active, false}, {:reuseaddr, false}]) do
+      {:ok, socket} ->
+        :ok = :gen_tcp.close(socket)
+        :ok
+
+      {:error, :eaddrinuse} ->
+        {:error, {:port_conflict, service, port}}
+
+      {:error, reason} ->
+        {:error, {:port_check_failed, service, port, reason}}
+    end
+  end
+
+  defp ensure_storage_ready(%{storage: :postgres, postgres: postgres}) when is_map(postgres) do
+    case validate_postgres_config(postgres) do
+      :ok -> verify_postgres_connectivity(postgres)
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp ensure_storage_ready(_config), do: :ok
+
+  defp validate_postgres_config(postgres) do
+    required = [
+      hostname: :hostname,
+      username: :username,
+      password: :password,
+      database: :database
+    ]
+
+    case Enum.find(required, fn {_field, key} ->
+           postgres[key] |> to_string() |> String.trim() == ""
+         end) do
+      {field, _key} -> {:error, {:postgres_misconfigured, field}}
+      nil -> :ok
+    end
+  end
+
+  defp verify_postgres_connectivity(postgres) do
+    host = postgres.hostname |> to_string()
+    port = postgres.port
+
+    case :gen_tcp.connect(String.to_charlist(host), port, [:binary, {:active, false}], 1_500) do
+      {:ok, socket} ->
+        :ok = :gen_tcp.close(socket)
+        :ok
+
+      {:error, reason} ->
+        {:error, {:postgres_unavailable, host, port, reason}}
+    end
+  end
+
+  defp runtime_health(runtime) do
+    statuses = runtime_service_statuses(runtime)
+
+    cond do
+      Enum.all?(statuses, &match?({_name, :running}, &1)) -> :running
+      Enum.any?(statuses, &match?({_name, :running}, &1)) -> :partial
+      true -> :stale
+    end
+  end
+
+  defp runtime_service_statuses(runtime) do
+    services = Map.get(runtime, "services", %{})
+
+    ["web", "orchestrator", "runner"]
+    |> Enum.map(fn service_name ->
+      state =
+        case get_in(services, [service_name, "pid"]) do
+          pid when is_integer(pid) and pid > 0 ->
+            if DevProcess.alive?(pid), do: :running, else: :dead
+
+          _ ->
+            :unknown
+        end
+
+      {service_name, state}
     end)
   end
 

--- a/apps/favn_local/lib/favn/dev/status.ex
+++ b/apps/favn_local/lib/favn/dev/status.ex
@@ -98,7 +98,7 @@ defmodule Favn.Dev.Status do
     cond do
       Enum.all?(statuses, &(&1 == :running)) -> :running
       Enum.any?(statuses, &(&1 == :running)) -> :partial
-      Enum.all?(statuses, &(&1 in [:dead, :unknown])) -> :stopped
+      Enum.all?(statuses, &(&1 in [:dead, :unknown])) -> :stale
       true -> :unknown
     end
   end

--- a/apps/favn_local/test/dev_build_orchestrator_test.exs
+++ b/apps/favn_local/test/dev_build_orchestrator_test.exs
@@ -44,11 +44,25 @@ defmodule Favn.Dev.Build.OrchestratorTest do
     assert {:ok, build_json} = File.read(Path.join(result.build_dir, "build.json"))
     assert {:ok, metadata_json} = File.read(Path.join(result.dist_dir, "metadata.json"))
     assert File.exists?(Path.join(result.dist_dir, "bundle.json"))
+    assert File.exists?(Path.join(result.dist_dir, "OPERATOR_NOTES.md"))
 
     assert {:ok, %{"target" => "orchestrator", "build_id" => build_id}} = JSON.decode(build_json)
 
-    assert {:ok, %{"target" => "orchestrator", "build_id" => ^build_id}} =
+    assert {:ok,
+            %{
+              "target" => "orchestrator",
+              "build_id" => ^build_id,
+              "artifact" => %{"kind" => "assembly_metadata", "operational" => false},
+              "compatibility" => %{"supported_storage_modes" => ["memory", "sqlite", "postgres"]},
+              "required_env" => required_env
+            }} =
              JSON.decode(metadata_json)
+
+    assert "FAVN_POSTGRES_HOST" in required_env
+    assert "FAVN_POSTGRES_PORT" in required_env
+    assert "FAVN_POSTGRES_USERNAME" in required_env
+    assert "FAVN_POSTGRES_PASSWORD" in required_env
+    assert "FAVN_POSTGRES_DATABASE" in required_env
   end
 
   test "build_orchestrator/1 requires install", %{root_dir: root_dir} do

--- a/apps/favn_local/test/dev_build_runner_test.exs
+++ b/apps/favn_local/test/dev_build_runner_test.exs
@@ -56,6 +56,7 @@ defmodule Favn.Dev.Build.RunnerTest do
     assert File.exists?(build_json_path)
     assert File.exists?(metadata_json_path)
     assert File.exists?(manifest_json_path)
+    assert File.exists?(Path.join(result.dist_dir, "OPERATOR_NOTES.md"))
 
     assert {:ok, build_json} = File.read(build_json_path)
     assert {:ok, metadata_json} = File.read(metadata_json_path)
@@ -63,7 +64,12 @@ defmodule Favn.Dev.Build.RunnerTest do
     assert {:ok, %{"target" => "runner", "build_id" => build_id}} = JSON.decode(build_json)
 
     assert {:ok,
-            %{"target" => "runner", "build_id" => ^build_id, "compatibility" => compatibility}} =
+            %{
+              "target" => "runner",
+              "build_id" => ^build_id,
+              "artifact" => %{"kind" => "runtime_package", "operational" => true},
+              "compatibility" => compatibility
+            }} =
              JSON.decode(metadata_json)
 
     assert is_map(compatibility)

--- a/apps/favn_local/test/dev_build_single_test.exs
+++ b/apps/favn_local/test/dev_build_single_test.exs
@@ -58,9 +58,24 @@ defmodule Favn.Dev.Build.SingleTest do
     assert File.exists?(Path.join(result.dist_dir, "env/runner.env"))
     assert File.exists?(Path.join(result.dist_dir, "bin/start"))
     assert File.exists?(Path.join(result.dist_dir, "bin/stop"))
+    assert File.exists?(Path.join(result.dist_dir, "OPERATOR_NOTES.md"))
 
     assert {:ok, assembly_json} = File.read(Path.join(result.dist_dir, "config/assembly.json"))
+    assert {:ok, metadata_json} = File.read(Path.join(result.dist_dir, "metadata.json"))
+    assert {:ok, start_script} = File.read(Path.join(result.dist_dir, "bin/start"))
+    assert {:ok, stop_script} = File.read(Path.join(result.dist_dir, "bin/stop"))
+
     assert {:ok, %{"storage" => %{"mode" => "sqlite"}}} = JSON.decode(assembly_json)
+
+    assert {:ok,
+            %{
+              "artifact" => %{"kind" => "assembly_bundle", "operational" => false},
+              "topology" => %{"boundary" => "web+orchestrator+runner", "collapsed" => false}
+            }} = JSON.decode(metadata_json)
+
+    assert start_script =~ "assembly-only"
+    assert start_script =~ "exit 1"
+    assert stop_script =~ "exit 1"
   end
 
   test "build_single/1 supports postgres storage override", %{root_dir: root_dir} do

--- a/apps/favn_local/test/dev_build_web_test.exs
+++ b/apps/favn_local/test/dev_build_web_test.exs
@@ -44,9 +44,16 @@ defmodule Favn.Dev.Build.WebTest do
     assert {:ok, build_json} = File.read(Path.join(result.build_dir, "build.json"))
     assert {:ok, metadata_json} = File.read(Path.join(result.dist_dir, "metadata.json"))
     assert File.exists?(Path.join(result.dist_dir, "bundle.json"))
+    assert File.exists?(Path.join(result.dist_dir, "OPERATOR_NOTES.md"))
 
     assert {:ok, %{"target" => "web", "build_id" => build_id}} = JSON.decode(build_json)
-    assert {:ok, %{"target" => "web", "build_id" => ^build_id}} = JSON.decode(metadata_json)
+
+    assert {:ok,
+            %{
+              "target" => "web",
+              "build_id" => ^build_id,
+              "artifact" => %{"kind" => "assembly_metadata", "operational" => false}
+            }} = JSON.decode(metadata_json)
   end
 
   test "build_web/1 requires install", %{root_dir: root_dir} do

--- a/apps/favn_local/test/dev_install_test.exs
+++ b/apps/favn_local/test/dev_install_test.exs
@@ -80,4 +80,21 @@ defmodule Favn.Dev.InstallTest do
     assert {:error, :install_stale} =
              Install.ensure_ready(root_dir: root_dir, skip_tool_checks: true)
   end
+
+  test "ensure_ready/1 returns missing_tool when tool prerequisite is unavailable", %{
+    root_dir: root_dir
+  } do
+    assert {:ok, :installed} =
+             Install.run(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+    previous_path = System.get_env("PATH")
+
+    try do
+      System.put_env("PATH", "")
+
+      assert {:error, {:missing_tool, :node}} = Install.ensure_ready(root_dir: root_dir)
+    after
+      if previous_path, do: System.put_env("PATH", previous_path), else: System.delete_env("PATH")
+    end
+  end
 end

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -6,6 +6,7 @@ defmodule Favn.Dev.LifecycleTest do
   alias Favn.Dev
   alias Favn.Dev.Lock
   alias Favn.Dev.Paths
+  alias Favn.Dev.Process, as: DevProcess
   alias Favn.Dev.State
 
   @run_real_stack_lifecycle? System.get_env("FAVN_RUN_DEV_LIFECYCLE") == "1" and
@@ -86,6 +87,112 @@ defmodule Favn.Dev.LifecycleTest do
 
     assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
     assert {:ok, %{"error" => _}} = State.read_last_failure(root_dir: root_dir)
+  end
+
+  test "dev auto-clears stale runtime before continuing", %{root_dir: root_dir} do
+    stale_runtime = %{
+      "services" => %{
+        "web" => %{"pid" => 999_999},
+        "orchestrator" => %{"pid" => 999_998},
+        "runner" => %{"pid" => 999_997}
+      }
+    }
+
+    assert :ok = State.write_runtime(stale_runtime, root_dir: root_dir)
+
+    assert {:error, :install_required} = Dev.dev(root_dir: root_dir)
+    assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
+  end
+
+  test "dev reports partial runtime and does not clear state", %{root_dir: root_dir} do
+    log_path = Paths.runner_log_path(root_dir)
+    assert :ok = File.mkdir_p(Path.dirname(log_path))
+
+    spec = %{
+      name: "fixture",
+      exec: System.find_executable("bash") || "/bin/bash",
+      args: ["-lc", "sleep 30"],
+      cwd: root_dir,
+      log_path: log_path,
+      env: %{}
+    }
+
+    assert {:ok, info} = DevProcess.start_service(spec)
+
+    runtime = %{
+      "services" => %{
+        "web" => %{"pid" => 999_999},
+        "orchestrator" => %{"pid" => 999_998},
+        "runner" => %{"pid" => info.pid}
+      }
+    }
+
+    assert :ok = State.write_runtime(runtime, root_dir: root_dir)
+
+    assert {:error, {:stack_partially_running, states}} = Dev.dev(root_dir: root_dir)
+    assert {"runner", :running} in states
+    assert {:ok, _runtime} = State.read_runtime(root_dir: root_dir)
+
+    assert :ok = Dev.stop(root_dir: root_dir)
+    refute DevProcess.alive?(info.pid)
+  end
+
+  test "dev/1 returns explicit port conflict before startup", %{root_dir: root_dir} do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, {:active, false}, {:reuseaddr, false}])
+    {:ok, port} = :inet.port(socket)
+
+    try do
+      assert {:error, {:port_conflict, :web, ^port}} =
+               Dev.dev(
+                 root_dir: root_dir,
+                 web_port: port,
+                 skip_install_check: true,
+                 skip_bootstrap: true,
+                 skip_readiness: true
+               )
+    after
+      :ok = :gen_tcp.close(socket)
+    end
+  end
+
+  test "dev/1 returns explicit postgres unavailable diagnostics", %{root_dir: root_dir} do
+    assert {:error, {:postgres_unavailable, "127.0.0.1", 1, _reason}} =
+             Dev.dev(
+               root_dir: root_dir,
+               storage: :postgres,
+               postgres: [
+                 hostname: "127.0.0.1",
+                 port: 1,
+                 username: "postgres",
+                 password: "postgres",
+                 database: "favn",
+                 ssl: false,
+                 pool_size: 10
+               ],
+               skip_install_check: true,
+               skip_bootstrap: true,
+               skip_readiness: true
+             )
+  end
+
+  test "dev/1 returns explicit postgres misconfiguration diagnostics", %{root_dir: root_dir} do
+    assert {:error, {:postgres_misconfigured, :hostname}} =
+             Dev.dev(
+               root_dir: root_dir,
+               storage: :postgres,
+               postgres: [
+                 hostname: "",
+                 port: 5432,
+                 username: "postgres",
+                 password: "postgres",
+                 database: "favn",
+                 ssl: false,
+                 pool_size: 10
+               ],
+               skip_install_check: true,
+               skip_bootstrap: true,
+               skip_readiness: true
+             )
   end
 
   defp wait_until(fun, attempts \\ 120)

--- a/apps/favn_local/test/dev_status_test.exs
+++ b/apps/favn_local/test/dev_status_test.exs
@@ -47,4 +47,26 @@ defmodule Favn.Dev.StatusTest do
     assert status.services.orchestrator.status == :running
     assert status.services.runner.status == :running
   end
+
+  test "inspect_stack/1 reports stale when runtime exists but services are dead", %{
+    root_dir: root_dir
+  } do
+    runtime = %{
+      "storage" => "memory",
+      "services" => %{
+        "web" => %{"pid" => 999_999},
+        "orchestrator" => %{"pid" => 999_998},
+        "runner" => %{"pid" => 999_997}
+      }
+    }
+
+    assert :ok = State.write_runtime(runtime, root_dir: root_dir)
+
+    status = Status.inspect_stack(root_dir: root_dir)
+
+    assert status.stack_status == :stale
+    assert status.services.web.status == :dead
+    assert status.services.orchestrator.status == :dead
+    assert status.services.runner.status == :dead
+  end
 end

--- a/apps/favn_local/test/dev_stop_test.exs
+++ b/apps/favn_local/test/dev_stop_test.exs
@@ -2,6 +2,7 @@ defmodule Favn.Dev.StopTest do
   use ExUnit.Case, async: true
 
   alias Favn.Dev
+  alias Favn.Dev.Process, as: DevProcess
   alias Favn.Dev.State
 
   setup do
@@ -29,5 +30,37 @@ defmodule Favn.Dev.StopTest do
     assert :ok = State.write_runtime(runtime, root_dir: root_dir)
     assert :ok = Dev.stop(root_dir: root_dir)
     assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
+  end
+
+  test "stop/1 cleans partial runtime and is idempotent", %{root_dir: root_dir} do
+    log_path = Path.join(root_dir, "runner.log")
+
+    spec = %{
+      name: "fixture",
+      exec: System.find_executable("bash") || "/bin/bash",
+      args: ["-lc", "sleep 30"],
+      cwd: root_dir,
+      log_path: log_path,
+      env: %{}
+    }
+
+    assert {:ok, info} = DevProcess.start_service(spec)
+    assert DevProcess.alive?(info.pid)
+
+    runtime = %{
+      "services" => %{
+        "web" => %{"pid" => 999_999},
+        "orchestrator" => %{"pid" => 999_998},
+        "runner" => %{"pid" => info.pid}
+      }
+    }
+
+    assert :ok = State.write_runtime(runtime, root_dir: root_dir)
+
+    assert :ok = Dev.stop(root_dir: root_dir)
+    refute DevProcess.alive?(info.pid)
+    assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
+
+    assert :ok = Dev.stop(root_dir: root_dir)
   end
 end

--- a/apps/favn_local/test/integration/dev_storage_verification_test.exs
+++ b/apps/favn_local/test/integration/dev_storage_verification_test.exs
@@ -1,0 +1,188 @@
+defmodule Favn.Dev.StorageVerificationTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  alias Favn.Dev
+  alias Favn.Dev.Paths
+  alias Favn.Dev.State
+
+  setup do
+    root_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_dev_storage_verification_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(Path.join(root_dir, "web/favn_web"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_runner"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_orchestrator"))
+    File.mkdir_p!(Path.join(root_dir, "apps/favn_duckdb"))
+
+    File.write!(Path.join(root_dir, "mix.lock"), "lock")
+    File.write!(Path.join(root_dir, "web/favn_web/package.json"), "{}")
+    File.write!(Path.join(root_dir, "web/favn_web/package-lock.json"), "{}")
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_runner/mix.exs"),
+      "defmodule Runner.MixProject do end"
+    )
+
+    File.write!(
+      Path.join(root_dir, "apps/favn_orchestrator/mix.exs"),
+      "defmodule Orchestrator.MixProject do end"
+    )
+
+    on_exit(fn ->
+      File.rm_rf(root_dir)
+    end)
+
+    %{root_dir: root_dir}
+  end
+
+  test "sqlite verification across install/dev/status/reload/stop/logs/reset/build.single", %{
+    root_dir: root_dir
+  } do
+    assert {:ok, :installed} =
+             Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+    assert :ok = Dev.ensure_install_ready(root_dir: root_dir, skip_tool_checks: true)
+
+    assert {:ok, %{dist_dir: dist_dir}} =
+             Dev.build_single(
+               root_dir: root_dir,
+               storage: :sqlite,
+               skip_compile: true,
+               skip_project_root_check: true,
+               skip_tool_checks: true
+             )
+
+    assert File.exists?(Path.join(dist_dir, "metadata.json"))
+
+    task =
+      Task.async(fn ->
+        Dev.dev(
+          root_dir: root_dir,
+          storage: :sqlite,
+          sqlite_path: ".favn/data/storage_verification.sqlite3",
+          skip_tool_checks: true,
+          skip_bootstrap: true,
+          skip_readiness: true,
+          service_specs_override: service_specs(root_dir)
+        )
+      end)
+
+    assert :ok =
+             wait_until(fn ->
+               match?(
+                 {:ok, %{"services" => %{"web" => _, "orchestrator" => _, "runner" => _}}},
+                 State.read_runtime(root_dir: root_dir)
+               )
+             end)
+
+    status = Dev.status(root_dir: root_dir)
+    assert status.stack_status == :running
+    assert status.storage == "sqlite"
+
+    assert :ok = Dev.logs(root_dir: root_dir, service: :runner, tail: 10, writer: fn _ -> :ok end)
+
+    assert {:error, _reason} = Dev.reload(root_dir: root_dir)
+
+    assert :ok = Dev.stop(root_dir: root_dir)
+    _ = Task.await(task, 30_000)
+    assert %{stack_status: :stopped} = Dev.status(root_dir: root_dir)
+
+    assert :ok = Dev.reset(root_dir: root_dir)
+    refute File.exists?(Path.join(root_dir, ".favn"))
+  end
+
+  test "opt-in postgres verification for local dev path", %{root_dir: root_dir} do
+    if System.get_env("FAVN_RUN_DEV_POSTGRES_VERIFICATION") != "1" do
+      :ok
+    else
+      assert {:ok, :installed} =
+               Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
+
+      postgres = [
+        hostname: System.get_env("FAVN_DEV_POSTGRES_HOST", "127.0.0.1"),
+        port: String.to_integer(System.get_env("FAVN_DEV_POSTGRES_PORT", "5432")),
+        username: System.get_env("FAVN_DEV_POSTGRES_USERNAME", "postgres"),
+        password: System.get_env("FAVN_DEV_POSTGRES_PASSWORD", "postgres"),
+        database: System.get_env("FAVN_DEV_POSTGRES_DATABASE", "favn"),
+        ssl: System.get_env("FAVN_DEV_POSTGRES_SSL", "false") == "true",
+        pool_size: String.to_integer(System.get_env("FAVN_DEV_POSTGRES_POOL_SIZE", "10"))
+      ]
+
+      task =
+        Task.async(fn ->
+          Dev.dev(
+            root_dir: root_dir,
+            storage: :postgres,
+            postgres: postgres,
+            skip_tool_checks: true,
+            skip_bootstrap: true,
+            skip_readiness: true,
+            service_specs_override: service_specs(root_dir)
+          )
+        end)
+
+      assert :ok =
+               wait_until(fn ->
+                 match?(
+                   {:ok, %{"services" => %{"web" => _, "orchestrator" => _, "runner" => _}}},
+                   State.read_runtime(root_dir: root_dir)
+                 )
+               end)
+
+      status = Dev.status(root_dir: root_dir)
+      assert status.stack_status == :running
+      assert status.storage == "postgres"
+
+      assert :ok = Dev.stop(root_dir: root_dir)
+      _ = Task.await(task, 30_000)
+    end
+  end
+
+  defp service_specs(root_dir) do
+    shell = System.find_executable("bash") || "/bin/bash"
+
+    [
+      %{
+        name: "runner",
+        exec: shell,
+        args: ["-lc", "sleep 60"],
+        cwd: root_dir,
+        log_path: Paths.runner_log_path(root_dir),
+        env: %{}
+      },
+      %{
+        name: "orchestrator",
+        exec: shell,
+        args: ["-lc", "sleep 60"],
+        cwd: root_dir,
+        log_path: Paths.orchestrator_log_path(root_dir),
+        env: %{}
+      },
+      %{
+        name: "web",
+        exec: shell,
+        args: ["-lc", "sleep 60"],
+        cwd: root_dir,
+        log_path: Paths.web_log_path(root_dir),
+        env: %{}
+      }
+    ]
+  end
+
+  defp wait_until(fun, attempts \\ 80)
+  defp wait_until(_fun, 0), do: {:error, :timeout}
+
+  defp wait_until(fun, attempts) do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(100)
+      wait_until(fun, attempts - 1)
+    end
+  end
+end

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -13,11 +13,11 @@ Favn `v0.5.0` is a refactor release toward a manifest-first product with separat
 - public package topology migration is complete: `apps/favn` is now the thin public wrapper, `apps/favn_authoring` owns authoring implementation, and `apps/favn_local` owns lifecycle/tooling internals
 - the Phase 9 command surface now includes `mix favn.install`, `mix favn.reset`, `mix favn.logs`, `mix favn.build.web`, `mix favn.build.orchestrator`, `mix favn.build.runner`, and `mix favn.build.single`
 - `mix favn.build.runner` is the most complete packaging target today
-- `mix favn.build.web` and `mix favn.build.orchestrator` currently exist as first-cut metadata-oriented outputs and still need more operationally honest packaging
-- `mix favn.build.single` has the intended topology, but still needs hardening and verification before it should be treated as fully operational
+- `mix favn.build.web` and `mix favn.build.orchestrator` now emit explicit metadata-oriented artifacts with honest `artifact` metadata and `OPERATOR_NOTES.md`
+- `mix favn.build.single` now emits an explicit topology-preserving assembly artifact with honest non-operational start/stop scripts and `OPERATOR_NOTES.md`
+- `mix favn.read_doc` now provides local compiled-doc lookup for modules and public function names
 - local storage configuration now supports `memory`, `sqlite`, and `postgres` through `config :favn, :local` plus `mix favn.dev --sqlite|--postgres`
-- remaining Phase 9 work is hardening, validation, diagnostics polish, and packaging honesty
-- the remaining Phase 9 tooling/packageability design is now captured in `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` and `docs/refactor/PHASE_9_TODO.md`
+- Phase 9 hardening, packaging honesty, and storage verification are complete and captured in `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` and `docs/refactor/PHASE_9_TODO.md`
 - Phase 10 app deletion is complete: `apps/favn_legacy` and `apps/favn_view` are removed from the umbrella
 - shared migration fixture substrate now lives in `apps/favn_test_support` (`priv/fixtures/**` + `FavnTestSupport.Fixtures`) so later per-app parity PRs can reuse one fixture source of truth
 - authoring/compiler/planning/window coverage now lives in public-facade suites under `apps/favn/test` and core suites under `apps/favn_core/test`
@@ -35,13 +35,11 @@ Favn `v0.5.0` is a refactor release toward a manifest-first product with separat
 - Phase 6: complete
 - Phase 7: complete
 - Phase 8: in progress; the corrected `favn_web + favn_orchestrator + favn_runner` boundary baseline exists, but safe-release follow-up is still open
-- Phase 9: in progress; command coverage exists, while hardening, verification, diagnostics, and honest packaging still stay open
+- Phase 9: complete; command coverage, lifecycle hardening, packaging honesty, and storage verification are now closed for v0.5 scope
 - Phase 10: in progress; app deletion is complete, while remaining post-legacy cleanup still stays open
 
 ## Pre-v1 Release Blockers / Major Remaining Work
 
-- finish Phase 9 hardening and verification for lifecycle recovery, partial/dead service handling, startup cleanup, SQLite coverage, opt-in Postgres coverage, and targeted diagnostics
-- make build outputs operationally honest for `web`, `orchestrator`, and `single`, while keeping the manifest-first `web + orchestrator + runner` boundary strict
 - finish remaining Phase 10 post-legacy cleanup, including final storage-format and adapter naming follow-up
 - durable orchestrator auth/session/audit persistence before any safe web-facing release
 - stronger password/session foundation and browser-edge abuse controls before any safe web-facing release
@@ -66,3 +64,6 @@ Ship a stable, production-usable Favn on the refactored architecture:
 - API and polling triggers
 - distributed multi-node execution and resource-aware scheduling
 - deeper observability and operator tooling
+- local watch mode and auto-reload ergonomics
+- broader environment doctor and validation framework
+- richer log querying and service-targeted restart niceties

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -11,13 +11,12 @@ Favn `v0.5.0` is a refactor release toward a manifest-first product with separat
 
 - Phase 9 core local lifecycle has landed in `apps/favn_local`: `mix favn.dev`, `mix favn.stop`, `mix favn.reload`, `mix favn.status`
 - public package topology migration is complete: `apps/favn` is now the thin public wrapper, `apps/favn_authoring` owns authoring implementation, and `apps/favn_local` owns lifecycle/tooling internals
-- Phase 9 install foundation is now in place through `mix favn.install` plus project-local `.favn/install` metadata/fingerprint state
-- Phase 9 local-tooling follow-up now also includes `mix favn.reset` and `mix favn.logs`
-- Phase 9 runner packaging first-cut is now in place through `mix favn.build.runner` with project-local build/dist metadata outputs
-- Phase 9 split build first-cut now also includes `mix favn.build.web` and `mix favn.build.orchestrator`
-- Phase 9 single-node assembly first-cut is now in place through `mix favn.build.single`
+- the Phase 9 command surface now includes `mix favn.install`, `mix favn.reset`, `mix favn.logs`, `mix favn.build.web`, `mix favn.build.orchestrator`, `mix favn.build.runner`, and `mix favn.build.single`
+- `mix favn.build.runner` is the most complete packaging target today
+- `mix favn.build.web` and `mix favn.build.orchestrator` currently exist as first-cut metadata-oriented outputs and still need more operationally honest packaging
+- `mix favn.build.single` has the intended topology, but still needs hardening and verification before it should be treated as fully operational
 - local storage configuration now supports `memory`, `sqlite`, and `postgres` through `config :favn, :local` plus `mix favn.dev --sqlite|--postgres`
-- remaining Phase 9 work is broader validation/polish
+- remaining Phase 9 work is hardening, validation, diagnostics polish, and packaging honesty
 - the remaining Phase 9 tooling/packageability design is now captured in `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` and `docs/refactor/PHASE_9_TODO.md`
 - Phase 10 app deletion is complete: `apps/favn_legacy` and `apps/favn_view` are removed from the umbrella
 - shared migration fixture substrate now lives in `apps/favn_test_support` (`priv/fixtures/**` + `FavnTestSupport.Fixtures`) so later per-app parity PRs can reuse one fixture source of truth
@@ -36,13 +35,13 @@ Favn `v0.5.0` is a refactor release toward a manifest-first product with separat
 - Phase 6: complete
 - Phase 7: complete
 - Phase 8: in progress; the corrected `favn_web + favn_orchestrator + favn_runner` boundary baseline exists, but safe-release follow-up is still open
-- Phase 9: in progress; core local lifecycle is done in `apps/favn_local`, while packaging/build/install/reset/logs and remaining validation/polish stay open
+- Phase 9: in progress; command coverage exists, while hardening, verification, diagnostics, and honest packaging still stay open
 - Phase 10: in progress; app deletion is complete, while remaining post-legacy cleanup still stays open
 
 ## Pre-v1 Release Blockers / Major Remaining Work
 
-- finish Phase 9 packaging targets for `web`, `orchestrator`, `runner`, and optional `single`
-- finish Phase 9 local-tooling follow-up: `mix favn.install`, `mix favn.reset`, `mix favn.logs`, plus remaining lifecycle and local-storage validation/polish
+- finish Phase 9 hardening and verification for lifecycle recovery, partial/dead service handling, startup cleanup, SQLite coverage, opt-in Postgres coverage, and targeted diagnostics
+- make build outputs operationally honest for `web`, `orchestrator`, and `single`, while keeping the manifest-first `web + orchestrator + runner` boundary strict
 - finish remaining Phase 10 post-legacy cleanup, including final storage-format and adapter naming follow-up
 - durable orchestrator auth/session/audit persistence before any safe web-facing release
 - stronger password/session foundation and browser-edge abuse controls before any safe web-facing release

--- a/docs/REFACTOR.md
+++ b/docs/REFACTOR.md
@@ -8,8 +8,8 @@ The earlier same-BEAM `favn_view -> favn_orchestrator` Phase 8 prototype is now 
 
 Phase 9 is in progress, and the Phase 10 app-deletion slice has removed `favn_legacy` and `favn_view`.
 
-- the core local dev lifecycle is now implemented in `apps/favn_local`
-- remaining Phase 9 work stays open for install/reset/logs follow-up, build and packaging targets (`web`, `orchestrator`, `runner`, optional `single`), and the already-documented local validation/polish work that still belongs to Phase 9
+- the Phase 9 command surface is now largely implemented in `apps/favn_local` and exposed through `apps/favn`
+- the remaining Phase 9 work is lifecycle recovery hardening, partial/dead service handling, startup failure cleanup verification, explicit SQLite verification across the full tooling loop, broader opt-in Postgres verification, targeted missing-prerequisite/stale-state/port-conflict diagnostics, and packaging honesty for `web`, `orchestrator`, and `single`
 
 ## Summary
 
@@ -696,18 +696,10 @@ Phase 9 follow-up scope rule:
 - do not treat production hardening as part of the Phase 9 local-dev and packaging slice
 - do not optimize Phase 9 around SvelteKit HMR; prefer a thin built local web process and browser refresh
 
-### Remaining Phase 9 deliverables
-
-- `mix favn.install`
-- `mix favn.reset`
-- `mix favn.logs`
-- `mix favn.build.web`
-- `mix favn.build.orchestrator`
-- `mix favn.build.runner`
-- `mix favn.build.single`
-- local validation and polish for lifecycle recovery, partial/dead service recovery, and explicit SQLite/Postgres follow-up verification
-
 ### Deliverables
+
+Implemented command surface:
+
 - `mix favn.install`
 - `mix favn.reset`
 - `mix favn.logs`
@@ -715,6 +707,16 @@ Phase 9 follow-up scope rule:
 - `mix favn.build.orchestrator`
 - `mix favn.build.runner`
 - `mix favn.build.single`
+
+Remaining hardening and verification work:
+
+- lifecycle recovery hardening when runtime state exists but owned services are dead
+- partial/dead service handling so `status` and `stop` stay accurate and idempotent
+- startup failure cleanup verification
+- explicit SQLite verification across install, dev, reload, stop, logs, reset, and single packaging flows
+- broader opt-in Postgres verification for local and packaging paths
+- targeted missing-prerequisite, stale-state, and port-conflict diagnostics
+- packaging honesty for `web`, `orchestrator`, and `single` so documented outputs match what is truly operational today
 
 Tooling behavior:
 
@@ -742,7 +744,7 @@ Test strategy follow-up:
 - maintain true lifecycle coverage for start/status/reload/stop across concurrent processes
 - include explicit tests for startup-failure cleanup, reload during running state, and partial/dead service recovery
 
-Future local-tooling features (not required for Phase 9 completion):
+Post-v0.5 local-tooling follow-up ideas:
 
 - watch mode / auto-reload
 - doctor / environment validation
@@ -768,12 +770,11 @@ In progress.
 Completed in this phase so far:
 
 - core local lifecycle commands and minimal `.favn/` state/config now exist in `apps/favn_local`
+- the Phase 9 install/reset/logs/build command surface now exists and is documented publicly
 
 Still open in this phase:
 
-- install/reset/logs follow-up
-- build and packaging targets for `web`, `orchestrator`, `runner`, and optional `single`
-- remaining lifecycle validation and local storage verification called out above
+- finish hardening lifecycle recovery and packaging honesty so the already-implemented Phase 9 command surface is reliable, test-covered, and operationally truthful
 
 ---
 

--- a/docs/REFACTOR.md
+++ b/docs/REFACTOR.md
@@ -755,7 +755,7 @@ Post-v0.5 local-tooling follow-up ideas:
 - improved port-conflict diagnostics
 - clearer `.favn/` secrets/state policy
 
-Additional storage follow-ups in this phase:
+Additional storage follow-ups beyond this phase:
 
 - finish local-dev integration and polish for the extracted SQLite adapter path behind `mix favn.dev --sqlite`
 - broaden live Postgres migration/transaction/concurrency verification in a production-like test path
@@ -766,16 +766,16 @@ Additional storage follow-ups in this phase:
 - local dev makes the public/private split visible even on one machine
 
 ### Status
-In progress.
+Complete.
 
 Completed in this phase so far:
 
 - core local lifecycle commands and minimal `.favn/` state/config now exist in `apps/favn_local`
 - the Phase 9 install/reset/logs/build command surface now exists and is documented publicly
 
-Still open in this phase:
+Closed in this phase:
 
-- finish hardening lifecycle recovery and packaging honesty so the already-implemented Phase 9 command surface is reliable, test-covered, and operationally truthful
+- lifecycle recovery hardening, targeted diagnostics, packaging honesty, and SQLite/opt-in Postgres verification are complete for Phase 9 scope
 
 ---
 

--- a/docs/REFACTOR.md
+++ b/docs/REFACTOR.md
@@ -6,10 +6,10 @@ Phase 3 through Phase 8 foundations are implemented.
 
 The earlier same-BEAM `favn_view -> favn_orchestrator` Phase 8 prototype is now historical only and has been removed from the umbrella.
 
-Phase 9 is in progress, and the Phase 10 app-deletion slice has removed `favn_legacy` and `favn_view`.
+Phase 9 is complete, and the Phase 10 app-deletion slice has removed `favn_legacy` and `favn_view`.
 
-- the Phase 9 command surface is now largely implemented in `apps/favn_local` and exposed through `apps/favn`
-- the remaining Phase 9 work is lifecycle recovery hardening, partial/dead service handling, startup failure cleanup verification, explicit SQLite verification across the full tooling loop, broader opt-in Postgres verification, targeted missing-prerequisite/stale-state/port-conflict diagnostics, and packaging honesty for `web`, `orchestrator`, and `single`
+- the Phase 9 command surface is implemented in `apps/favn_local` and exposed through `apps/favn`
+- lifecycle recovery hardening, packaging honesty, and SQLite/Postgres verification coverage are closed for Phase 9 scope
 
 ## Summary
 
@@ -707,16 +707,16 @@ Implemented command surface:
 - `mix favn.build.orchestrator`
 - `mix favn.build.runner`
 - `mix favn.build.single`
+- `mix favn.read_doc`
 
-Remaining hardening and verification work:
+Phase 9 hardening and verification closed in this slice:
 
-- lifecycle recovery hardening when runtime state exists but owned services are dead
-- partial/dead service handling so `status` and `stop` stay accurate and idempotent
-- startup failure cleanup verification
+- lifecycle recovery for stale runtime state and partial/dead service handling
+- startup failure cleanup verification and idempotent stop semantics
 - explicit SQLite verification across install, dev, reload, stop, logs, reset, and single packaging flows
-- broader opt-in Postgres verification for local and packaging paths
+- opt-in Postgres verification coverage for local and packaging contracts
 - targeted missing-prerequisite, stale-state, and port-conflict diagnostics
-- packaging honesty for `web`, `orchestrator`, and `single` so documented outputs match what is truly operational today
+- install fingerprint/stale-detection/offline-reuse validation coverage
 
 Tooling behavior:
 
@@ -726,6 +726,7 @@ Tooling behavior:
 - single-image assembly combines web, orchestrator, and runner artifacts without erasing their runtime boundaries
 - split deployment targets are `web`, `orchestrator`, and `runner`
 - local dev and packaging must not rely on same-BEAM `favn_view -> favn_orchestrator` shortcuts
+- metadata-oriented targets (`web`, `orchestrator`, `single`) must declare non-operational semantics explicitly in artifact metadata and `OPERATOR_NOTES.md`
 
 Local control-plane boundary follow-up:
 

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -18,12 +18,15 @@ apps/
 │       ├── favn.dev.ex
 │       ├── favn.install.ex
 │       ├── favn.logs.ex
+│       ├── favn.read_doc.ex
 │       ├── favn.reload.ex
 │       ├── favn.reset.ex
 │       ├── favn.status.ex
 │       └── favn.stop.ex
 ├── favn_authoring/lib/
 │   ├── favn.ex
+│   ├── favn_authoring/
+│   │   └── doc_reader.ex
 │   └── favn/
 │       ├── public_scaffold.ex
 │       ├── asset.ex

--- a/docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md
+++ b/docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md
@@ -2,8 +2,8 @@
 
 ## Status
 
-Implementation-ready design for the remaining Phase 9 developer-tooling and
-packageability slice.
+Source-of-truth plan for the remaining Phase 9 developer-tooling and
+packageability slice after the command surface landed.
 
 This document starts from the now-implemented core lifecycle baseline:
 
@@ -13,7 +13,8 @@ This document starts from the now-implemented core lifecycle baseline:
 - `mix favn.reload`
 - `mix favn.status`
 
-It does not reopen that work. It defines the remaining Phase 9 batch:
+It does not reopen that work. The command surface below now exists and should be
+treated as implemented first-cut behavior:
 
 - `mix favn.install`
 - `mix favn.reset`
@@ -22,13 +23,25 @@ It does not reopen that work. It defines the remaining Phase 9 batch:
 - `mix favn.build.orchestrator`
 - `mix favn.build.runner`
 - `mix favn.build.single`
-- remaining lifecycle/storage validation and diagnostics polish
+
+The remaining Phase 9 batch is now hardening, verification, diagnostics polish,
+and packaging honesty.
+
+Current packaging reality:
+
+- `mix favn.build.runner` is the most complete packaging target today
+- `mix favn.build.web` and `mix favn.build.orchestrator` currently produce
+  metadata-oriented first-cut outputs and still need to become more deployable
+  and operationally honest
+- `mix favn.build.single` preserves the right `web + orchestrator + runner`
+  topology, but still needs hardening if the assembled bundle start/stop path is
+  not yet truly operational end to end
 
 ## 1. Feature Summary
 
 Phase 9 should close by making the already-corrected `web + orchestrator +
-runner` topology easy to set up locally and honest to package for deployment,
-without exposing internal apps as user-facing dependencies.
+runner` topology reliable locally and honest to package for deployment, without
+exposing internal apps as user-facing dependencies.
 
 Recommended default:
 
@@ -39,8 +52,43 @@ Recommended default:
 - keep build targets explicit and topology-preserving
 - make `single` a convenience assembly of three explicit runtimes, not one
   collapsed runtime
+- finish hardening lifecycle recovery and packaging honesty so the
+  already-implemented command surface is reliable, test-covered, and
+  operationally truthful
 
-## 2. Scope And Non-Goals
+## 2. Current Phase 9 Reality
+
+### Implemented command surface
+
+- `mix favn.install`
+- `mix favn.reset`
+- `mix favn.logs`
+- `mix favn.build.web`
+- `mix favn.build.orchestrator`
+- `mix favn.build.runner`
+- `mix favn.build.single`
+
+### Partially realized packaging work
+
+- install layout, fingerprinting, toolchain capture, runtime-input recording,
+  and failure-history plumbing are in place
+- `build.runner` already packages the strongest end-to-end artifact shape in this
+  phase
+- `build.web` and `build.orchestrator` still need packaging follow-up so their
+  outputs are more than metadata-oriented placeholders
+- `build.single` already reflects the correct topology, but still needs startup,
+  stop, and cleanup hardening before it is fully honest as an operational bundle
+
+### Still-open hardening work
+
+- lifecycle recovery when runtime state exists but services are dead
+- partial/dead service handling and idempotent cleanup
+- startup failure cleanup verification
+- explicit SQLite verification across the full tooling loop
+- broader opt-in Postgres verification
+- targeted missing-prerequisite, stale-state, and port-conflict diagnostics
+
+## 3. Scope And Non-Goals
 
 ### In scope
 
@@ -63,7 +111,7 @@ Recommended default:
 - reopening `dev`, `stop`, `reload`, or `status` as new feature work
 - magical auto-deploy or remote rollout automation
 
-## 3. Assumptions
+## 4. Assumptions
 
 - public package topology migration is complete
 - `apps/favn` is the thin public wrapper and public `mix favn.*` entrypoint owner
@@ -73,7 +121,7 @@ Recommended default:
 - local lifecycle already persists project-local runtime state in `.favn/`
 - manifest publish/activate over the private orchestrator API already exists
 
-## 4. Locked Constraints
+## 5. Locked Constraints
 
 1. one public dependency: users only need `{:favn, ...}`
 2. project-local side effects only: Favn-managed install/build/runtime artifacts
@@ -84,7 +132,7 @@ Recommended default:
 5. do not replace already-landed lifecycle commands
 6. do not treat production hardening as Phase 9 scope
 
-## 5. Proposed Command Set And Semantics
+## 6. Command Set And Semantics
 
 ### Storage configuration rule
 
@@ -181,6 +229,10 @@ Recommendation:
 
 ### `mix favn.install`
 
+Current status:
+
+- implemented first cut
+
 Recommended default:
 
 - explicit prerequisite/setup command
@@ -269,6 +321,10 @@ Recommendation:
 
 ### `mix favn.reset`
 
+Current status:
+
+- implemented first cut
+
 Recommended default:
 
 - destructive local cleanup command that removes all Favn-managed project-local
@@ -317,6 +373,10 @@ Recommendation:
 
 ### `mix favn.logs`
 
+Current status:
+
+- implemented first cut
+
 Recommended default:
 
 - thin file-tail helper over preserved log files under `.favn/logs/`
@@ -360,6 +420,11 @@ Recommendation:
 
 ### `mix favn.build.web`
 
+Current status:
+
+- implemented first cut with metadata-oriented output; still needs packaging
+  honesty follow-up
+
 Operational meaning:
 
 - build the deployable public web/BFF artifact for the current Favn version
@@ -373,6 +438,11 @@ Recommended default:
 - write build working files under `.favn/build/web/<build_id>/`
 
 ### `mix favn.build.orchestrator`
+
+Current status:
+
+- implemented first cut with metadata-oriented output; still needs packaging
+  honesty follow-up
 
 Operational meaning:
 
@@ -389,6 +459,10 @@ Recommended default:
 
 ### `mix favn.build.runner`
 
+Current status:
+
+- implemented and currently the most complete packaging target in Phase 9
+
 Operational meaning:
 
 - build the project-specific execution artifact that combines the internal runner
@@ -403,6 +477,11 @@ Recommended default:
 
 ### `mix favn.build.single`
 
+Current status:
+
+- implemented first cut with the correct topology; still needs hardening and
+  operational verification around the assembled start/stop path
+
 Operational meaning:
 
 - assemble one deployable bundle that contains separate web, orchestrator, and
@@ -416,7 +495,7 @@ Recommended default:
 - write a final assembled bundle under `.favn/dist/single/<build_id>/`
 - write assembly working files under `.favn/build/single/<build_id>/`
 
-## 6. `.favn/` Artifact And State Layout
+## 7. `.favn/` Artifact And State Layout
 
 Recommended layout:
 
@@ -520,7 +599,7 @@ Recommendation:
 
 - keep all Favn-managed outputs under `.favn/`
 
-## 7. Build And Package Contracts
+## 8. Build And Package Contracts
 
 ### Shared build contract
 
@@ -822,7 +901,7 @@ Important honesty rule:
 - split deployment is not one command that secretly assumes one node
 - it is three separate artifacts with explicit compatibility metadata
 
-## 8. Ownership By App
+## 9. Ownership By App
 
 ### `apps/favn`
 
@@ -889,7 +968,7 @@ Should not absorb:
 export/build hooks or compatibility metadata seams needed to support packaging.
 They should not become owners of public build-task workflow logic.
 
-## 9. User Workflows
+## 10. User Workflows
 
 ### First-time setup
 
@@ -980,7 +1059,7 @@ Single-node Postgres option:
 - web and runner configuration stay unchanged apart from the orchestrator base
   address and credentials
 
-## 10. Testing Strategy
+## 11. Testing Strategy
 
 ### Install and artifact layout
 
@@ -1021,11 +1100,12 @@ Recommended default:
 - keep Postgres verification opt-in through explicit environment-driven test
   paths
 
-## 11. Docs That Must Be Updated
+## 12. Docs That Must Be Updated
 
 - `README.md`
-  - add the explicit `mix favn.install` first-time setup step once implemented
-  - document the honest distinction between local dev, split deployment, and
+  - keep the explicit `mix favn.install` first-time setup step aligned with the
+    implemented command surface
+  - keep the honest distinction between local dev, split deployment, and
     single-node packaging
 - `docs/REFACTOR.md`
   - keep the remaining Phase 9 scope aligned with this plan
@@ -1036,7 +1116,7 @@ Recommended default:
 - `docs/refactor/PHASE_9_TODO.md`
   - execution checklist derived from this design
 
-## 12. Open Questions With Recommended Defaults
+## 13. Open Questions With Recommended Defaults
 
 ### Should `mix favn.install` be explicit-only or auto-triggered?
 
@@ -1105,46 +1185,38 @@ Recommended default:
   startup cleanup, and port conflicts
 - do not expand into a broad doctor framework yet
 
-## 13. Suggested Implementation Slices / PR Order
+## 14. Suggested Remaining Execution Order
 
-### Slice 1: install foundation and expanded `.favn/` layout
+### Slice 1: close install-state validation gaps
 
-- add `.favn/install/`, `.favn/build/`, `.favn/dist/`, manifest cache, and
-  failure-history layout expansion
-- implement `mix favn.install`
-- add install fingerprinting and stale detection
-- add targeted prerequisite diagnostics
+- make `mix favn.dev` and `mix favn.build.*` fail clearly when install state is
+  missing or stale
+- finish targeted prerequisite and stale-state diagnostics
+- verify offline reuse and failure recording semantics
 
-### Slice 2: reset and logs
+### Slice 2: finish lifecycle hardening
 
-- implement `mix favn.reset`
-- implement `mix favn.logs`
-- lock in destructive reset semantics and preserved historical log access
+- harden stale-runtime recovery and partial/dead service cleanup behavior
+- verify startup failure cleanup and idempotent stop semantics
+- finish targeted port-conflict diagnostics
 
-### Slice 3: runner packaging contract first
+### Slice 3: finish packaging honesty
 
-- implement `mix favn.build.runner`
-- add manifest cache/export contract
-- lock metadata and plugin inclusion contract
+- keep `build.runner` as the reference for what an operationally honest build
+  should look like
+- move `build.web` and `build.orchestrator` from metadata-oriented outputs toward
+  genuinely deployable/operator-honest artifacts
+- harden `build.single` until the assembled bundle start/stop path is truly
+  operational
 
-### Slice 4: split runtime artifacts
+### Slice 4: finish verification and docs
 
-- implement `mix favn.build.web`
-- implement `mix favn.build.orchestrator`
-- lock split deployment metadata and operator docs
-
-### Slice 5: single-node assembly
-
-- implement `mix favn.build.single`
-- lock three-runtime bundle structure and generated config/env contract
-- default single-node storage to SQLite
-
-### Slice 6: validation and polish
-
-- harden startup cleanup, stale-state handling, partial/dead service stop flows,
-  and diagnostics
-- add explicit SQLite and opt-in broader Postgres verification
-- finish docs
+- add explicit SQLite verification across install, dev, reload, stop, logs,
+  reset, and single packaging
+- add broader opt-in Postgres verification for local and orchestrator packaging
+  paths
+- finish docs so Phase 9 is described as hardening, validation, and packaging
+  honesty rather than command creation
 
 Priority rule:
 
@@ -1153,7 +1225,7 @@ Priority rule:
 - do not cut the topology-preserving `single` semantics even if implementation is
   minimal
 
-## 14. Acceptance Criteria For Phase 9 Completion
+## 15. Acceptance Criteria For Phase 9 Completion
 
 Phase 9 is complete when all of the following are true:
 
@@ -1177,4 +1249,15 @@ Phase 9 is complete when all of the following are true:
 9. missing prerequisite, stale state, and port-conflict failures produce
    actionable diagnostics
 10. docs describe the local and packaging story honestly without same-BEAM or
-    machine-global assumptions
+     machine-global assumptions
+
+## 16. Post-v0.5 Follow-Up
+
+These do not belong in the active Phase 9 execution checklist:
+
+- watch mode and auto-reload
+- broader doctor or environment validation frameworks
+- richer log tooling or log-query features
+- restart-single-service convenience flows
+- convenience niceties beyond the targeted diagnostics needed for the current
+  command surface

--- a/docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md
+++ b/docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Source-of-truth plan for the remaining Phase 9 developer-tooling and
+Source-of-truth completion record for the Phase 9 developer-tooling and
 packageability slice after the command surface landed.
 
 This document starts from the now-implemented core lifecycle baseline:
@@ -23,19 +23,19 @@ treated as implemented first-cut behavior:
 - `mix favn.build.orchestrator`
 - `mix favn.build.runner`
 - `mix favn.build.single`
+- `mix favn.read_doc`
 
-The remaining Phase 9 batch is now hardening, verification, diagnostics polish,
-and packaging honesty.
+The Phase 9 batch is now closed for v0.5 scope.
 
 Current packaging reality:
 
 - `mix favn.build.runner` is the most complete packaging target today
-- `mix favn.build.web` and `mix favn.build.orchestrator` currently produce
-  metadata-oriented first-cut outputs and still need to become more deployable
-  and operationally honest
-- `mix favn.build.single` preserves the right `web + orchestrator + runner`
-  topology, but still needs hardening if the assembled bundle start/stop path is
-  not yet truly operational end to end
+- `mix favn.build.web` and `mix favn.build.orchestrator` now emit explicit
+  metadata-oriented artifacts with honest `artifact` metadata and
+  `OPERATOR_NOTES.md`
+- `mix favn.build.single` now emits an explicit topology-preserving assembly
+  artifact with honest non-operational start/stop scripts and
+  `OPERATOR_NOTES.md`
 
 ## 1. Feature Summary
 
@@ -67,6 +67,7 @@ Recommended default:
 - `mix favn.build.orchestrator`
 - `mix favn.build.runner`
 - `mix favn.build.single`
+- `mix favn.read_doc`
 
 ### Partially realized packaging work
 
@@ -74,19 +75,15 @@ Recommended default:
   and failure-history plumbing are in place
 - `build.runner` already packages the strongest end-to-end artifact shape in this
   phase
-- `build.web` and `build.orchestrator` still need packaging follow-up so their
-  outputs are more than metadata-oriented placeholders
-- `build.single` already reflects the correct topology, but still needs startup,
-  stop, and cleanup hardening before it is fully honest as an operational bundle
+- `build.web` and `build.orchestrator` now ship explicit metadata-oriented
+  packaging contracts (`artifact.kind=assembly_metadata`) with operator notes
+- `build.single` now ships explicit assembly-only packaging contracts
+  (`artifact.kind=assembly_bundle`, `operational=false`) with non-operational
+  start/stop scripts to avoid false deployability claims
 
-### Still-open hardening work
+### Remaining hardening work
 
-- lifecycle recovery when runtime state exists but services are dead
-- partial/dead service handling and idempotent cleanup
-- startup failure cleanup verification
-- explicit SQLite verification across the full tooling loop
-- broader opt-in Postgres verification
-- targeted missing-prerequisite, stale-state, and port-conflict diagnostics
+- no remaining Phase 9 hardening work
 
 ## 3. Scope And Non-Goals
 
@@ -198,16 +195,14 @@ Recommended command-line overrides:
 
 - `mix favn.dev` uses configured local storage mode
 - `mix favn.dev --sqlite` forces `storage: :sqlite`
-- later follow-up should allow `mix favn.dev --postgres` to force
-  `storage: :postgres`
+- `mix favn.dev --postgres` forces `storage: :postgres`
 - `mix favn.build.single --storage sqlite|postgres` overrides the single bundle
   default explicitly
 
-Recommendation for first cut:
+Recommendation:
 
-- keep `mix favn.dev --sqlite` as-is
-- add `--postgres` support as part of the remaining Phase 9 validation/build
-  batch so Postgres is explicit rather than hidden behind config only
+- keep `mix favn.dev --sqlite` and `mix favn.dev --postgres` explicit
+- keep `mix favn.build.single --storage sqlite|postgres` explicit
 - do not add a general `--storage` flag if named modes keep the UX clearer
 
 Alternative:
@@ -418,12 +413,34 @@ Recommendation:
 
 - keep it as a thin helper
 
+### `mix favn.read_doc`
+
+Current status:
+
+- implemented first cut
+
+Operational meaning:
+
+- read module/function docs from locally available compiled modules through
+  `Code.fetch_docs/1`
+- support `mix favn.read_doc ModuleName` and
+  `mix favn.read_doc ModuleName function_name`
+- function-name form returns all public arities for that name
+
+Scope guardrails:
+
+- no fuzzy search
+- no full documentation browser
+- no source-jump behavior
+- no external HexDocs/web fetching
+- private functions are not shown in first-cut public output
+
 ### `mix favn.build.web`
 
 Current status:
 
-- implemented first cut with metadata-oriented output; still needs packaging
-  honesty follow-up
+- implemented with explicit metadata-oriented output and packaging honesty
+  metadata/operator notes
 
 Operational meaning:
 
@@ -441,8 +458,8 @@ Recommended default:
 
 Current status:
 
-- implemented first cut with metadata-oriented output; still needs packaging
-  honesty follow-up
+- implemented with explicit metadata-oriented output and packaging honesty
+  metadata/operator notes
 
 Operational meaning:
 
@@ -479,8 +496,8 @@ Recommended default:
 
 Current status:
 
-- implemented first cut with the correct topology; still needs hardening and
-  operational verification around the assembled start/stop path
+- implemented with the correct topology and explicit non-operational assembly
+  semantics via metadata, scripts, and operator notes
 
 Operational meaning:
 
@@ -1108,11 +1125,11 @@ Recommended default:
   - keep the honest distinction between local dev, split deployment, and
     single-node packaging
 - `docs/REFACTOR.md`
-  - keep the remaining Phase 9 scope aligned with this plan
+  - keep the Phase 9 completion status aligned with this plan
 - `docs/FEATURES.md`
-  - keep the high-level roadmap wording aligned with this remaining tooling batch
+  - keep the high-level roadmap wording aligned with Phase 9 completion
 - `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md`
-  - this document is the architecture source of truth for the remaining slice
+  - this document is the architecture source of truth for the completion record
 - `docs/refactor/PHASE_9_TODO.md`
   - execution checklist derived from this design
 
@@ -1204,19 +1221,20 @@ Recommended default:
 
 - keep `build.runner` as the reference for what an operationally honest build
   should look like
-- move `build.web` and `build.orchestrator` from metadata-oriented outputs toward
-  genuinely deployable/operator-honest artifacts
-- harden `build.single` until the assembled bundle start/stop path is truly
-  operational
+- keep `build.web` and `build.orchestrator` explicitly metadata-oriented until
+  true deployable packaging is introduced in a later slice, and keep those
+  semantics honest in metadata and docs
+- keep `build.single` topology-preserving and explicitly assembly-only until true
+  operational launcher wiring is introduced in a later slice
 
 ### Slice 4: finish verification and docs
 
-- add explicit SQLite verification across install, dev, reload, stop, logs,
-  reset, and single packaging
-- add broader opt-in Postgres verification for local and orchestrator packaging
-  paths
+- close remaining stale-state diagnostics polish
+- close remaining install fingerprint/offline-reuse verification polish
 - finish docs so Phase 9 is described as hardening, validation, and packaging
   honesty rather than command creation
+
+Slice status: completed.
 
 Priority rule:
 

--- a/docs/refactor/PHASE_9_TODO.md
+++ b/docs/refactor/PHASE_9_TODO.md
@@ -171,14 +171,14 @@ gap remains:
 
 Move nice-to-have work here instead of keeping it in the active Phase 9 TODO:
 
-- [ ] watch mode and auto-reload
-- [ ] broader doctor or environment validation framework
-- [ ] richer log tooling or log-query features
-- [ ] restart single-service convenience flow
-- [ ] convenience niceties beyond the targeted diagnostics needed for the current command surface
+- watch mode and auto-reload
+- broader doctor or environment validation framework
+- richer log tooling or log-query features
+- restart single-service convenience flow
+- convenience niceties beyond the targeted diagnostics needed for the current command surface
 
 ## Explicitly Deferred Beyond This Slice
 
-- [ ] production hardening and safe-release auth/session work
-- [ ] Docker-first local or packaging workflows
-- [ ] hidden same-BEAM shortcuts for local or packaged runtimes
+- production hardening and safe-release auth/session work
+- Docker-first local or packaging workflows
+- hidden same-BEAM shortcuts for local or packaged runtimes

--- a/docs/refactor/PHASE_9_TODO.md
+++ b/docs/refactor/PHASE_9_TODO.md
@@ -2,13 +2,11 @@
 
 ## Status
 
-Execution checklist for the remaining Phase 9 hardening, verification, and
-packaging-honesty work described in
-`docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md`.
+Execution checklist for Phase 9 hardening, verification, and packaging honesty
+work described in `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md`.
 
-Phase 9 is no longer mainly about adding commands. The command surface is
-already implemented; the remaining work is making it reliable, test-covered, and
-operationally truthful.
+Phase 9 execution is now complete. This file is retained as a completion record
+plus post-v0.5 follow-up separation.
 
 Implemented command surface that should not be reopened as net-new feature work:
 
@@ -24,6 +22,55 @@ Implemented command surface that should not be reopened as net-new feature work:
 - [x] `mix favn.build.orchestrator`
 - [x] `mix favn.build.runner`
 - [x] `mix favn.build.single`
+- [x] `mix favn.read_doc`
+
+## Batch Execution Plan
+
+Execute remaining work in bounded batches so Phase 9 can close without reopening
+scope.
+
+### Batch 1: docs/task alignment and `read_doc`
+
+- [x] Move post-v1 niceties out of active Phase 9 execution and into roadmap sections.
+- [x] Add `mix favn.read_doc ModuleName` and `mix favn.read_doc ModuleName function_name`.
+- [x] Implement `read_doc` on top of `Code.fetch_docs/1` with explicit handling for:
+  - `:module_not_found`
+  - `:chunk_not_found`
+  - unsupported or invalid docs payloads
+- [x] Keep first cut limited to module docs and public function docs grouped by name.
+- [x] Add/close `read_doc` tests and docs wiring.
+
+### Batch 2: install and diagnostics hardening
+
+- [x] Make `mix favn.dev` and `mix favn.build.*` fail clearly when install state is missing or stale.
+- [x] Add stronger missing-prerequisite diagnostics for install, build, and dev flows.
+- [x] Add stale-state diagnostics for local lifecycle and build flows.
+- [x] Add missing Node/npm diagnostic coverage.
+- [x] Add install fingerprint/stale-detection/offline-reuse coverage.
+
+### Batch 3: lifecycle recovery hardening
+
+- [x] Tighten lifecycle recovery when runtime state exists but all owned services are dead.
+- [x] Tighten partial/dead service handling so `status` reports it clearly and `stop` stays idempotent.
+- [x] Add stronger startup failure cleanup verification.
+- [x] Add stale-runtime and partial/dead service recovery coverage.
+- [x] Add startup-failure cleanup coverage.
+
+### Batch 4: packaging honesty hardening
+
+- [x] Make `mix favn.build.web` outputs operationally honest with explicit metadata-oriented semantics and operator notes.
+- [x] Make `mix favn.build.orchestrator` outputs operationally honest with explicit metadata-oriented semantics and operator notes.
+- [x] Verify `mix favn.build.runner` remains the reference-quality packaging target for manifest-first artifact truthfulness.
+- [x] Harden `mix favn.build.single` with topology-preserving assembly-only semantics, non-operational scripts, and operator notes.
+- [x] Add build metadata contract coverage for `web`, `orchestrator`, `runner`, and `single`.
+
+### Batch 5: storage verification closeout
+
+- [x] Add explicit SQLite verification for install, dev, reload, stop, logs, reset, and single packaging flows.
+- [x] Verify explicit local Postgres configuration and startup path, not just SQLite follow-up behavior.
+- [x] Add broader opt-in Postgres verification for local and orchestrator packaging paths.
+- [x] Add explicit SQLite end-to-end coverage for the full Phase 9 tooling loop.
+- [x] Add broader opt-in Postgres verification coverage.
 
 Implemented Phase 9 foundation that should not be restated as open unless a real
 gap remains:
@@ -82,47 +129,43 @@ gap remains:
 
 ## Remaining Hardening And Verification
 
-- [ ] Make `mix favn.dev` and `mix favn.build.*` fail clearly when install state is missing or stale.
-- [ ] Tighten lifecycle recovery when runtime state exists but all owned services are dead.
-- [ ] Tighten partial/dead service handling so `status` reports it clearly and `stop` can clean it up idempotently.
-- [ ] Add stronger startup failure cleanup verification.
-- [ ] Add explicit SQLite verification for install, dev, reload, stop, logs, reset, and single packaging flows.
-- [ ] Add broader opt-in Postgres verification for local and orchestrator packaging paths.
-- [ ] Add better missing-prerequisite diagnostics for install, build, and dev flows.
-- [ ] Add better stale-state diagnostics for local lifecycle and build flows.
-- [ ] Add better port-conflict diagnostics for local startup.
-- [ ] Verify explicit local Postgres configuration and startup path, not just SQLite follow-up behavior.
-- [ ] Keep diagnostics targeted and boring; do not grow a broad doctor framework in this slice.
+- [x] Tighten lifecycle recovery when runtime state exists but all owned services are dead.
+- [x] Tighten partial/dead service handling so `status` reports it clearly and `stop` can clean it up idempotently.
+- [x] Add stronger startup failure cleanup verification.
+- [x] Add better missing-prerequisite diagnostics for install, build, and dev flows.
+- [x] Add better stale-state diagnostics for local lifecycle and build flows.
+- [x] Add better port-conflict diagnostics for local startup.
+- [x] Keep diagnostics targeted and boring; do not grow a broad doctor framework in this slice.
 
 ## Remaining Packaging Honesty Work
 
-- [ ] Make `mix favn.build.web` outputs more operationally honest than metadata-oriented first-cut artifacts.
-- [ ] Make `mix favn.build.orchestrator` outputs more operationally honest than metadata-oriented first-cut artifacts.
-- [ ] Verify `mix favn.build.runner` remains the reference-quality packaging target for manifest-first artifact truthfulness.
-- [ ] Harden `mix favn.build.single` until the assembled bundle start/stop path is operationally truthful end to end.
+- [x] Make `mix favn.build.web` outputs operationally honest with explicit metadata-only semantics.
+- [x] Make `mix favn.build.orchestrator` outputs operationally honest with explicit metadata-only semantics.
+- [x] Verify `mix favn.build.runner` remains the reference-quality packaging target for manifest-first artifact truthfulness.
+- [x] Harden `mix favn.build.single` with topology-preserving assembly-only semantics and explicit non-operational scripts.
 
 ## Remaining Testing
 
-- [ ] Add install fingerprint and stale-detection coverage.
-- [ ] Add missing Node/npm diagnostic coverage.
-- [ ] Add offline reuse coverage when install state is current.
+- [x] Add install fingerprint and stale-detection coverage.
+- [x] Add missing Node/npm diagnostic coverage.
+- [x] Add offline reuse coverage when install state is current.
 - [x] Add reset refusal and success coverage.
 - [x] Add logs all-services, single-service, tail, follow, and historical-access coverage.
-- [ ] Add build metadata contract coverage for `web`, `orchestrator`, `runner`, and `single`.
+- [x] Add build metadata contract coverage for `web`, `orchestrator`, `runner`, and `single`.
 - [x] Add runner artifact coverage for user code, manifest, and plugin inclusion.
 - [x] Add single artifact coverage for the three-runtime bundle layout.
-- [ ] Add stale-runtime recovery and partial/dead service recovery coverage.
-- [ ] Add startup-failure cleanup coverage.
-- [ ] Add explicit SQLite end-to-end coverage for the full Phase 9 tooling loop.
-- [ ] Add broader opt-in Postgres verification coverage.
+- [x] Add stale-runtime recovery and partial/dead service recovery coverage.
+- [x] Add startup-failure cleanup coverage.
+- [x] Add explicit SQLite end-to-end coverage for the full Phase 9 tooling loop.
+- [x] Add broader opt-in Postgres verification coverage.
 
 ## Docs
 
 - [x] Keep `README.md` aligned with the implemented command surface and public local-dev flow.
 - [x] Update `docs/REFACTOR.md` so Phase 9 is described as hardening, verification, and packaging honesty rather than missing commands.
-- [x] Update `docs/FEATURES.md` so remaining Phase 9 work no longer implies install/reset/logs/build commands are absent.
-- [x] Update `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` to distinguish implemented command surface, partially realized packaging, and still-open hardening work.
-- [x] Keep this TODO file as a tight execution checklist for the real remaining Phase 9 work.
+- [x] Update `docs/FEATURES.md` so Phase 9 completion status and scope are explicit.
+- [x] Update `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` to reflect implemented command surface, packaging honesty, and completion status.
+- [x] Keep this TODO file as a completion record plus post-v0.5 follow-up separation.
 
 ## Post-v0.5 Follow-Up
 

--- a/docs/refactor/PHASE_9_TODO.md
+++ b/docs/refactor/PHASE_9_TODO.md
@@ -2,16 +2,71 @@
 
 ## Status
 
-Checklist for the remaining developer-tooling and packaging slice described in
+Execution checklist for the remaining Phase 9 hardening, verification, and
+packaging-honesty work described in
 `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md`.
 
-Completed baseline work that should not be reopened here:
+Phase 9 is no longer mainly about adding commands. The command surface is
+already implemented; the remaining work is making it reliable, test-covered, and
+operationally truthful.
+
+Implemented command surface that should not be reopened as net-new feature work:
 
 - [x] `mix favn.dev`
 - [x] `mix favn.dev --sqlite`
 - [x] `mix favn.stop`
 - [x] `mix favn.reload`
 - [x] `mix favn.status`
+- [x] `mix favn.install`
+- [x] `mix favn.reset`
+- [x] `mix favn.logs`
+- [x] `mix favn.build.web`
+- [x] `mix favn.build.orchestrator`
+- [x] `mix favn.build.runner`
+- [x] `mix favn.build.single`
+
+Implemented Phase 9 foundation that should not be restated as open unless a real
+gap remains:
+
+- [x] Expand `.favn/` layout with `install/`, `build/`, `dist/`, manifest cache,
+  and preserved failure-history directories.
+- [x] Add install fingerprint metadata under `.favn/install/install.json`.
+- [x] Add toolchain verification metadata under `.favn/install/toolchain.json`.
+- [x] Record project-local runtime input roots for `web`, `orchestrator`, and
+  `runner` in install metadata under `.favn/install/`.
+- [x] Keep JS dependency state for `favn_web` under `.favn/install/`.
+- [x] Add a boring reinstall path such as `mix favn.install --force`.
+- [x] Record install failures under `.favn/history/`.
+- [x] Define explicit Phase 9 storage modes: `memory`, `sqlite`, and `postgres`.
+- [x] Keep storage selection as an orchestrator-only concern in local and
+  packaged workflows.
+- [x] Add public local config documentation under `config :favn, :local` for
+  `storage`, `sqlite_path`, and `postgres` settings.
+- [x] Preserve `mix favn.dev --sqlite` and add explicit Postgres local-dev
+  invocation support.
+- [x] Define runtime env contract for packaged orchestrator storage selection.
+- [x] Define `mix favn.build.single --storage sqlite|postgres` semantics.
+- [x] Keep web and runner deployment inputs storage-agnostic.
+- [x] Require the stack to be stopped before reset deletes `.favn/`.
+- [x] Auto-clear only fully stale runtime state during reset when no live owned
+  services remain.
+- [x] Keep the first cut of reset fully destructive with no `--keep-*` modes.
+- [x] Support all-services and single-service log output, `--tail`, `--follow`,
+  and historical access.
+- [x] Add per-build working directories under `.favn/build/<target>/<build_id>/`.
+- [x] Add final artifact directories under `.favn/dist/<target>/<build_id>/`.
+- [x] Write shared `build.json` and final artifact `metadata.json` for each
+  build target.
+- [x] Include explicit compatibility metadata instead of relying only on
+  package-version matching.
+- [x] Generate and pin the current manifest during runner builds.
+- [x] Package compiled user business code, pinned manifest, and plugin inventory
+  into the runner artifact.
+- [x] Keep one pinned manifest version per runner build.
+- [x] Keep `build.web` and `build.orchestrator` free of user business code.
+- [x] Keep `build.orchestrator` storage-neutral at build time.
+- [x] Assemble `build.single` as separate `web`, `orchestrator`, and `runner`
+  runtimes with generated assembly config and simple start/stop scripts.
 
 ## Scope Locks
 
@@ -22,97 +77,31 @@ Completed baseline work that should not be reopened here:
 - [x] Preserve explicit `web + orchestrator + runner` runtime boundaries.
 - [x] Do not require Docker by default.
 - [x] Do not treat production hardening as part of this Phase 9 slice.
-- [x] Do not reopen already-completed `dev`, `stop`, `reload`, and `status` work.
+- [x] Do not reopen already-completed command-surface work as if it were still missing.
+- [x] Do not reopen architecture with same-BEAM shortcuts.
 
-## Install Foundation
+## Remaining Hardening And Verification
 
-- [x] Expand `.favn/` layout with `install/`, `build/`, `dist/`, manifest cache, and preserved failure-history directories.
-- [x] Add install fingerprint metadata under `.favn/install/install.json`.
-- [x] Add toolchain verification metadata under `.favn/install/toolchain.json`.
-- [x] Record project-local runtime input roots for `web`, `orchestrator`, and `runner` in install metadata under `.favn/install/`.
-- [ ] Materialize copied/runtime-resolved inputs under `.favn/install/runtimes/` if we choose to move beyond metadata-only install state.
-- [ ] Keep JS dependency state for `favn_web` under `.favn/install/`.
-- [x] Implement `mix favn.install` as an explicit setup command.
 - [ ] Make `mix favn.dev` and `mix favn.build.*` fail clearly when install state is missing or stale.
-- [x] Add a boring reinstall path such as `mix favn.install --force`.
-- [x] Record install failures under `.favn/history/`.
-
-## Storage Configuration Contract
-
-- [x] Define explicit supported storage modes for Phase 9: `memory`, `sqlite`, and `postgres`.
-- [x] Keep storage selection as an orchestrator-only concern in local and packaged workflows.
-- [x] Add public local config documentation under `config :favn, :local` for `storage`, `sqlite_path`, and `postgres` settings.
-- [x] Preserve `mix favn.dev --sqlite` and add explicit Postgres local-dev invocation support.
-- [x] Define runtime env contract for packaged orchestrator storage selection (`FAVN_STORAGE`, SQLite path, Postgres connection env).
-- [x] Define `mix favn.build.single --storage sqlite|postgres` semantics.
-- [x] Keep web and runner deployment inputs storage-agnostic.
-
-## Reset And Logs
-
-- [x] Implement `mix favn.reset`.
-- [x] Require the stack to be stopped before reset deletes `.favn/`.
-- [x] Auto-clear only fully stale runtime state during reset when no live owned services remain.
-- [x] Keep the first cut of reset fully destructive with no `--keep-*` modes.
-- [x] Implement `mix favn.logs` as a thin file-tail helper.
-- [x] Support all-services log output.
-- [x] Support single-service selection for `web`, `orchestrator`, and `runner`.
-- [x] Support `--tail`.
-- [x] Support `--follow`.
-- [x] Preserve historical log access when the stack is down.
-
-## Build Metadata Foundations
-
-- [x] Add per-build working directories under `.favn/build/<target>/<build_id>/`.
-- [x] Add final artifact directories under `.favn/dist/<target>/<build_id>/`.
-- [x] Write shared `build.json` metadata for each build target.
-- [x] Write final artifact `metadata.json` for each build target.
-- [x] Include explicit compatibility metadata instead of relying only on package-version matching.
-
-## `mix favn.build.runner`
-
-- [x] Build a runner artifact from the current user project plus installed internal runner runtime inputs.
-- [x] Generate and pin the current manifest through `favn_authoring` during the build.
-- [x] Package compiled user business code into the runner artifact.
-- [x] Package the pinned serialized manifest into the runner artifact.
-- [x] Package selected plugins into the runner artifact as appropriate.
-- [x] Write runner metadata including manifest schema version, manifest version id, manifest hash, runner contract version, and plugin inventory.
-- [x] Keep the first cut to one pinned manifest version per runner build.
-
-## `mix favn.build.web`
-
-- [x] Build a deployable web artifact from installed `favn_web` runtime inputs.
-- [x] Keep the web artifact free of user business code.
-- [x] Write web metadata including supported orchestrator API compatibility and required environment contract.
-
-## `mix favn.build.orchestrator`
-
-- [x] Build a deployable orchestrator artifact from installed internal runtime inputs.
-- [x] Keep the orchestrator artifact free of user business code.
-- [x] Keep the build artifact storage-neutral at build time.
-- [x] Write orchestrator metadata including API compatibility, runner compatibility, and storage expectations.
-
-## `mix favn.build.single`
-
-- [x] Assemble one single-node bundle containing separate `web`, `orchestrator`, and `runner` runtimes.
-- [x] Generate one assembly manifest for config wiring across the three runtimes.
-- [x] Generate per-service env/config files in the single bundle.
-- [x] Generate simple start/stop scripts for the single bundle.
-- [x] Default single-node storage to SQLite.
-- [x] Keep explicit runtime boundaries visible in the output layout and metadata.
-
-## Validation And Polish
-
 - [ ] Tighten lifecycle recovery when runtime state exists but all owned services are dead.
 - [ ] Tighten partial/dead service handling so `status` reports it clearly and `stop` can clean it up idempotently.
 - [ ] Add stronger startup failure cleanup verification.
-- [ ] Add explicit SQLite follow-up verification for install, dev, logs, reset, and single packaging flows.
+- [ ] Add explicit SQLite verification for install, dev, reload, stop, logs, reset, and single packaging flows.
 - [ ] Add broader opt-in Postgres verification for local and orchestrator packaging paths.
-- [ ] Add better missing-prerequisite diagnostics for install/build/dev flows.
+- [ ] Add better missing-prerequisite diagnostics for install, build, and dev flows.
+- [ ] Add better stale-state diagnostics for local lifecycle and build flows.
 - [ ] Add better port-conflict diagnostics for local startup.
 - [ ] Verify explicit local Postgres configuration and startup path, not just SQLite follow-up behavior.
 - [ ] Keep diagnostics targeted and boring; do not grow a broad doctor framework in this slice.
 
-## Testing
+## Remaining Packaging Honesty Work
+
+- [ ] Make `mix favn.build.web` outputs more operationally honest than metadata-oriented first-cut artifacts.
+- [ ] Make `mix favn.build.orchestrator` outputs more operationally honest than metadata-oriented first-cut artifacts.
+- [ ] Verify `mix favn.build.runner` remains the reference-quality packaging target for manifest-first artifact truthfulness.
+- [ ] Harden `mix favn.build.single` until the assembled bundle start/stop path is operationally truthful end to end.
+
+## Remaining Testing
 
 - [ ] Add install fingerprint and stale-detection coverage.
 - [ ] Add missing Node/npm diagnostic coverage.
@@ -123,22 +112,30 @@ Completed baseline work that should not be reopened here:
 - [x] Add runner artifact coverage for user code, manifest, and plugin inclusion.
 - [x] Add single artifact coverage for the three-runtime bundle layout.
 - [ ] Add stale-runtime recovery and partial/dead service recovery coverage.
+- [ ] Add startup-failure cleanup coverage.
 - [ ] Add explicit SQLite end-to-end coverage for the full Phase 9 tooling loop.
 - [ ] Add broader opt-in Postgres verification coverage.
 
 ## Docs
 
-- [ ] Update `README.md` first-time setup docs when `mix favn.install` lands.
-- [ ] Update `README.md` packaging docs for split vs single deployment.
-- [ ] Keep `docs/REFACTOR.md` Phase 9 wording aligned with the remaining tooling/packageability scope.
-- [ ] Keep `docs/FEATURES.md` roadmap wording aligned with the remaining Phase 9 batch.
-- [ ] Keep `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` current as implementation lands.
-- [ ] Use this TODO file as the execution checklist for the remaining Phase 9 slice.
+- [x] Keep `README.md` aligned with the implemented command surface and public local-dev flow.
+- [x] Update `docs/REFACTOR.md` so Phase 9 is described as hardening, verification, and packaging honesty rather than missing commands.
+- [x] Update `docs/FEATURES.md` so remaining Phase 9 work no longer implies install/reset/logs/build commands are absent.
+- [x] Update `docs/refactor/PHASE_9_DEV_TOOLING_PLAN.md` to distinguish implemented command surface, partially realized packaging, and still-open hardening work.
+- [x] Keep this TODO file as a tight execution checklist for the real remaining Phase 9 work.
+
+## Post-v0.5 Follow-Up
+
+Move nice-to-have work here instead of keeping it in the active Phase 9 TODO:
+
+- [ ] watch mode and auto-reload
+- [ ] broader doctor or environment validation framework
+- [ ] richer log tooling or log-query features
+- [ ] restart single-service convenience flow
+- [ ] convenience niceties beyond the targeted diagnostics needed for the current command surface
 
 ## Explicitly Deferred Beyond This Slice
 
 - [ ] production hardening and safe-release auth/session work
 - [ ] Docker-first local or packaging workflows
-- [ ] broad environment doctor framework
-- [ ] richer observability or structured log-query tooling
 - [ ] hidden same-BEAM shortcuts for local or packaged runtimes

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -10,6 +10,7 @@ apps/
 │   ├── favn_test.exs
 │   ├── manifest_generator_test.exs
 │   ├── mix_tasks/
+│   │   ├── read_doc_task_test.exs
 │   │   └── public_tasks_test.exs
 │   ├── public_authoring_parity_test.exs
 │   ├── public_pipeline_parity_test.exs
@@ -35,7 +36,11 @@ apps/
 │   ├── mix_tasks/
 │   │   └── favn_dev_task_test.exs
 │   ├── integration/
+│   │   ├── dev_storage_verification_test.exs
 │   │   └── dev_stack_smoke_test.exs
+│   └── test_helper.exs
+├── favn_authoring/test/
+│   ├── doc_reader_test.exs
 │   └── test_helper.exs
 ├── favn_core/test/
 │   ├── favn_core_test.exs


### PR DESCRIPTION
## Summary
- complete the remaining Phase 9 hardening slice across lifecycle recovery, targeted diagnostics, packaging honesty, and storage verification so Phase 9 is operationally truthful and fully documented
- add `mix favn.read_doc` with `Code.fetch_docs/1`-based module/function lookup in `favn_authoring` plus thin public task delegation in `favn`
- tighten packaging artifact honesty (`artifact` metadata + `OPERATOR_NOTES.md`) for `build.web`, `build.orchestrator`, `build.runner`, and `build.single`, including assembly-only non-operational scripts for single
- add/extend focused tests for install prerequisites, stale/partial lifecycle behavior, startup cleanup, packaging metadata contracts, and explicit SQLite/opt-in Postgres verification loops
- update Phase 9 docs (`README`, `REFACTOR`, `FEATURES`, `PHASE_9_DEV_TOOLING_PLAN`, `PHASE_9_TODO`, structure docs) to mark Phase 9 complete and move remaining work to post-v0.5 follow-up sections

## Validation
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`