### PR TITLE
docs: audit current features and v1 roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,23 +4,26 @@
 
 Favn is an Elixir library for defining and orchestrating business-oriented data assets.
 This repository is in a v0.5 umbrella refactor.
-During Phase 1, the active v0.4 reference runtime lives in `apps/favn_legacy/lib/favn.ex`.
-The new public app scaffold is `apps/favn/lib/favn.ex` but it is not yet the migrated runtime API source of truth.
-The most important file is `docs/FEATURES.md`. We will use this file to document our progress and roadmap.
+The public package boundary lives in `apps/favn/lib/favn.ex`.
+Authoring implementation lives in `apps/favn_authoring/lib/favn.ex`.
+The most important user-facing docs are `docs/FEATURES.md` and `docs/ROADMAP.md`.
 
 **Important rules**
 - Favn is currently in private development and has no users. Breaking changes is allowed and no need for handling legacy scenarios.
-- Always start by reading `README.md`, `docs/REFACTOR.md`, and `docs/FEATURES.md`. To get context of state of repo.
+- Always start by reading `README.md`, `docs/REFACTOR.md`, `docs/FEATURES.md`, and `docs/ROADMAP.md` to get context on current behavior and planned work.
 - If you know you need to read the whole file use a large limit >2000 so you do not need to do multiple tool calls. 
-- Keep status of roadmap features up to date in `docs/FEATURES.md`. If you need a task list with details, create a separate file for that and link to it from FEATURES.md. 
+- Keep `docs/FEATURES.md` focused on implemented, user-visible behavior only.
+- Keep `docs/ROADMAP.md` focused on planned work only. Do not leave already-implemented items there.
+- When a feature lands, update `docs/FEATURES.md` and remove or downgrade the corresponding roadmap item in `docs/ROADMAP.md`.
+- If you need a detailed task list, create a separate file and link to it from `docs/ROADMAP.md` or the relevant doc.
 - When you start coding, make sure task exist, and when you have created the code always mark task as done.
-- Always keep user documentation up to date in the current source-of-truth location and `README.md`. During Phase 1 this is primarily `apps/favn_legacy/lib/favn.ex`.
+- Always keep user documentation up to date in the current source-of-truth location and `README.md`.
 - when creating new files, please update `docs/lib_structure.md` or `docs/test_structure.md`
 - Before starting a new coding session - always:
     - Identify new coding session through that chat history is empty
     - Make sure main branch is up to date
     - Branch main with name based on feature to be implemented as feature/*.
-    - If user asks explixitly to work on a specific branch then go to that branch, make sure it is up to date and start working. 
+    - If user asks explicitly to work on a specific branch then go to that branch, make sure it is up to date and start working. 
 - After any Elixir code change, run `mix format`, `mix compile --warnings-as-errors`, `mix test`, `mix credo --strict`, `mix dialyzer`, and `mix xref graph --format stats --label compile-connected`. Fix all failures before finishing.
 - In Elixir - always use shared fixtures and test helpers from apps/favn_test_support when available, and keep app-local test support limited to behavior or setup that is genuinely specific to that app.
 - Only web-dev agent should work with favn_web as web-dev has web dev tooling. When needed to do changes on favn_web, offload work to web-dev agent

--- a/README.md
+++ b/README.md
@@ -230,7 +230,8 @@ Storage modes:
 
 ## Documentation
 
-- `docs/FEATURES.md` tracks roadmap and feature status
+- `docs/FEATURES.md` tracks the implemented feature set today
+- `docs/ROADMAP.md` tracks planned next work and later ideas
 - `docs/REFACTOR.md` tracks the `v0.5` architecture and migration plan
 - `docs/lib_structure.md` describes the current library layout
 - `docs/test_structure.md` describes the current test layout

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -1,107 +1,117 @@
-# Favn Roadmap & Feature Status
+# Favn Features
 
-## Current Version
+This file describes the feature set that is implemented in the repository today.
 
-- current release: `v0.4.0`
-- current repo work: `v0.5.0-dev`
+- Only shipped behavior belongs here.
+- Future work belongs in `docs/ROADMAP.md`.
+- Audit scope for this update: `apps/favn`, `apps/favn_authoring`, `apps/favn_core`, `apps/favn_runner`, `apps/favn_duckdb`, `apps/favn_orchestrator`, `apps/favn_storage_sqlite`, `apps/favn_storage_postgres`, `apps/favn_local`, and `web/favn_web`.
 
-## Current Focus
+State labels used below:
 
-Favn `v0.5.0` established the intended manifest-first product architecture and
-the runtime boundaries between:
+- `solid but still private-dev`: implemented and well-covered, but not presented in the repo as release-ready.
+- `prototype`: implemented and usable for development, but still clearly early or intentionally thin.
+- `compatibility-only`: supported mainly to preserve an older/current authoring path, not because it is the preferred future shape.
+- `needs hardening`: implemented, but the code/docs/tests still point to important production-readiness gaps.
+
+## Architecture Status
+
+Favn `v0.5.0` established the intended manifest-first product architecture and the runtime boundaries between:
 
 - `favn` as the public authoring surface and public `mix favn.*` entrypoint owner
-- `favn_authoring` as the internal authoring/manifest implementation owner
-- `favn_local` as the internal local lifecycle/tooling/packaging implementation owner
-- `favn_core` as the shared compiler/manifest/planning/contracts layer
+- `favn_authoring` as the internal authoring and manifest implementation owner
+- `favn_local` as the internal local lifecycle, tooling, and packaging implementation owner
+- `favn_core` as the shared compiler, manifest, planning, and contracts layer
 - `favn_orchestrator` as the control plane and system of record
 - `favn_runner` as the execution runtime
 - `favn_web` as the separate public web edge
 
-The refactor closeout is now complete enough to resume normal feature work.
+The refactor closeout is complete enough that the main remaining work is product hardening and support-boundary clarity, not more architecture migration.
 
-Completed closeout work:
+Implemented closeout outcomes:
 
-- Phase 9 local lifecycle and packaging is complete: `mix favn.install`, `mix favn.dev`, `mix favn.stop`, `mix favn.reload`, `mix favn.status`, `mix favn.logs`, `mix favn.reset`, `mix favn.build.web`, `mix favn.build.orchestrator`, `mix favn.build.runner`, `mix favn.build.single`, and `mix favn.read_doc`
-- Phase 10 app deletion is complete: `apps/favn_legacy` and `apps/favn_view` are removed from the umbrella
-- stable storage adapter entrypoints are restored as `Favn.Storage.Adapter.SQLite` and `Favn.Storage.Adapter.Postgres`
-- SQL adapters now persist canonical inspectable `json-v1` payloads for run snapshots, run events, and scheduler state instead of BEAM term blobs
-- pre-closeout SQL rows persisted as BEAM term blobs are intentionally unsupported; reset/recreate persisted runtime state when upgrading to the closeout adapters
-- scheduler state writes now use explicit optimistic versions rather than permissive blind increments
-- external Postgres repo mode now caches successful schema-readiness validation instead of repeating catalog checks on every adapter call
-- public/package ownership is locked: `apps/favn` stays thin, `apps/favn_authoring` owns authoring internals, and `apps/favn_local` owns local tooling internals
+- The refactor phases are complete, including the local lifecycle and packaging command surface: `mix favn.install`, `mix favn.dev`, `mix favn.stop`, `mix favn.reload`, `mix favn.status`, `mix favn.logs`, `mix favn.reset`, `mix favn.build.web`, `mix favn.build.orchestrator`, `mix favn.build.runner`, `mix favn.build.single`, and `mix favn.read_doc`.
+- Legacy same-BEAM app paths are removed from supported runtime flows: `apps/favn_legacy` and `apps/favn_view` are gone from the umbrella.
+- Stable storage adapter entrypoints are restored as `Favn.Storage.Adapter.SQLite` and `Favn.Storage.Adapter.Postgres`.
+- SQL adapters now persist canonical inspectable `json-v1` payloads for run snapshots, run events, and scheduler state instead of BEAM term blobs.
+- Scheduler state writes now use explicit optimistic versions.
+- External Postgres repo mode now caches successful schema-readiness validation instead of repeating readiness checks on every adapter call.
+- Pre-closeout SQL rows persisted as BEAM term blobs are intentionally unsupported. Existing persisted runtime state must be reset or recreated when upgrading to the closeout adapters.
 
-## Refactor Complete Means
+## Implemented Today
 
-For Favn, "refactor complete" now means:
+### Define assets and data relations
 
-- supported runtime paths no longer depend on `favn_legacy` or same-BEAM `favn_view` shortcuts
-- owner-app boundaries and dependency directions are locked and exercised in the owner apps
-- orchestrator and runner operate on persisted manifest versions and explicit runtime boundaries
-- `favn` remains the public package, while runtime/storage/plugin implementation stays behind owner-app boundaries
-- remaining work before `v1.0` is release hardening, end-to-end confidence, and product polish, not broad architecture migration
+- Single Elixir assets are supported, including docs, metadata, dependencies, windows, and owned relations. State: `solid but still private-dev`. Refs: `Favn.Asset`, `apps/favn_authoring/lib/favn/asset.ex`.
+- Older multi-function asset modules are still supported through `@asset`, although new code is clearly steered toward `Favn.Asset` or `Favn.MultiAsset`. State: `compatibility-only`. Refs: `Favn.Assets`, `apps/favn_authoring/lib/favn/assets.ex`.
+- Generated multi-assets are supported when many assets share one runtime implementation but differ by config, metadata, dependencies, or relation ownership. State: `solid but still private-dev`. Refs: `Favn.MultiAsset`, `apps/favn_authoring/lib/favn/multi_asset.ex`.
+- SQL assets are supported with inline SQL or file-backed SQL, compile-time SQL analysis, tracked relation usage, and table, view, and limited incremental materializations. State: `solid but still private-dev`. Refs: `Favn.SQLAsset`, `Favn.SQL`, `apps/favn_authoring/lib/favn/sql_asset.ex`, `apps/favn_authoring/lib/favn/sql.ex`.
+- External source relations can be declared in the catalog without becoming runnable assets. State: `solid but still private-dev`. Refs: `Favn.Source`, `apps/favn_authoring/lib/favn/source.ex`.
+- Shared relation defaults can be inherited from module structure for connection, catalog, and schema settings. State: `solid but still private-dev`. Refs: `Favn.Namespace`, `apps/favn_authoring/lib/favn/namespace.ex`.
+- Named connection definitions are supported as part of the public authoring contract. State: `solid but still private-dev`. Refs: `Favn.Connection`, `apps/favn_authoring/lib/favn/connection.ex`.
+- Window helpers are implemented for hourly, daily, and monthly asset windows plus run-level anchor and runtime windows. State: `solid but still private-dev`. Refs: `Favn.Window`, `apps/favn_authoring/lib/favn/window.ex`.
 
-## v0.5 Status By Phase
+### Select work and compile manifests
 
-- Phase 0: complete
-- Phase 1: complete
-- Phase 2: complete
-- Phase 3: complete
-- Phase 4: complete
-- Phase 5: complete
-- Phase 6: complete
-- Phase 7: complete
-- Phase 8: complete for refactor scope; safe-release hardening remains separate release work
-- Phase 9: complete
-- Phase 10: complete
+- Pipelines are supported with direct asset targets, multi-target shorthands, additive selectors by asset, module, tag, and category, plus config, metadata, schedules, named window/source, and outputs. State: `solid but still private-dev`. Refs: `Favn.Pipeline`, `apps/favn_authoring/lib/favn/pipeline.ex`, `apps/favn/test/public_pipeline_parity_test.exs`.
+- Reusable named schedules are supported and can be referenced from pipelines. State: `solid but still private-dev`. Refs: `Favn.Triggers.Schedules`, `apps/favn_authoring/lib/favn/triggers/schedules.ex`.
+- Public facade APIs can list assets, fetch a compiled asset or pipeline, resolve a pipeline, generate a manifest, build a manifest artifact, serialize it, hash it, validate compatibility, and pin a manifest version. State: `solid but still private-dev`. Refs: `Favn`, `FavnAuthoring`, `apps/favn/lib/favn.ex`, `apps/favn_authoring/lib/favn.ex`.
+- Canonical manifest generation is implemented from explicit module lists or app config, including assets, pipelines, schedules, and dependency graph data. State: `solid but still private-dev`. Refs: `Favn.Manifest.Generator`, `apps/favn_core/lib/favn/manifest/generator.ex`.
+- Stable manifest serialization, hashing, compatibility validation, and immutable manifest-version envelopes are implemented. State: `solid but still private-dev`. Refs: `Favn.Manifest.Serializer`, `Favn.Manifest.Identity`, `Favn.Manifest.Compatibility`, `Favn.Manifest.Version`, `apps/favn_core/test/manifest/version_test.exs`.
+- Deterministic graph indexing and planning are implemented, including dependency inclusion modes, topological stages, and expansion of backfill ranges across windowed assets. State: `solid but still private-dev`. Refs: `Favn.Assets.GraphIndex`, `Favn.Assets.Planner`, `apps/favn_core/lib/favn/assets/planner.ex`, `apps/favn_core/test/assets/graph_planner_parity_test.exs`.
 
-## Remaining Work Before v1
+### Run pinned work
 
-The remaining work before `v1.0` is no longer refactor migration work.
+- A separate runner boundary is implemented. The runner can register pinned manifest versions, accept asynchronous work, wait for results, cancel work, and run synchronously through the same boundary. State: `solid but still private-dev`. Refs: `FavnRunner`, `FavnRunner.Server`, `apps/favn_runner/lib/favn_runner.ex`, `apps/favn_runner/lib/favn_runner/server.ex`.
+- Elixir assets execute through the runner using manifest-pinned runtime context instead of ad hoc orchestrator-side module discovery. State: `solid but still private-dev`. Refs: `apps/favn_runner/test/favn_runner_test.exs`, `apps/favn_orchestrator/test/orchestrator_runner_integration_test.exs`.
+- Source assets are treated as observe/no-op nodes in execution. State: `solid but still private-dev`. Refs: `apps/favn_runner/test/favn_runner_test.exs`, `Favn.Assets.Planner`.
+- SQL assets execute from manifest-carried SQL payloads, and the runner does not fall back to compiled modules when manifest data is missing. State: `needs hardening`. Refs: `apps/favn_runner/test/execution/sql_asset_test.exs`, `apps/favn_core/lib/favn/manifest/sql_execution.ex`.
+- Runner-side cancellation, timeout handling, and crash reporting are implemented. State: `solid but still private-dev`. Refs: `apps/favn_runner/test/server_test.exs`, `apps/favn_runner/lib/favn_runner/server.ex`.
+- DuckDB is implemented as a runner plugin with both in-process and separate-process execution modes. State: `prototype`. Refs: `FavnDuckdb`, `FavnDuckdb.Runtime`, `apps/favn_duckdb/lib/favn_duckdb.ex`, `apps/favn_duckdb/test/favn_duckdb_test.exs`.
 
-### 1. Safe-release web/orchestrator hardening
+### Orchestrate and operate runs
 
-- durable orchestrator persistence for actors, credentials, sessions, and audit records
-- stronger boring password and session foundations suitable for a real release
-- browser-edge abuse controls and rate limiting
-- service credential hardening, identity binding, and rotation for the web-to-orchestrator boundary
-- durable request idempotency behavior if idempotency is part of the shipped API contract
-- scalable SSE replay/cursor behavior if replay/resume is part of the shipped operator experience
+- Manifest storage is implemented in the orchestrator, including registration, listing, activation, active-manifest lookup, and manifest-scoped run targets. State: `solid but still private-dev`. Refs: `FavnOrchestrator`, `apps/favn_orchestrator/lib/favn_orchestrator.ex`.
+- Asset runs and pipeline runs are submitted as manifest-pinned runs, and reruns stay pinned to the source run's manifest version. State: `solid but still private-dev`. Refs: `FavnOrchestrator`, `apps/favn_orchestrator/test/orchestrator_runner_integration_test.exs`.
+- Run state views, run history, persisted run events, cancellation, and rerun flows are implemented. State: `solid but still private-dev`. Refs: `FavnOrchestrator`, `FavnOrchestrator.Projector`, `apps/favn_orchestrator/lib/favn_orchestrator.ex`.
+- Schedule inspection is implemented from the active manifest, with runtime reload and tick hooks when the scheduler process is running. State: `solid but still private-dev`. Refs: `FavnOrchestrator.reload_scheduler/0`, `FavnOrchestrator.tick_scheduler/0`, `FavnOrchestrator.list_schedule_entries/0`, `apps/favn_orchestrator/lib/favn_orchestrator.ex`.
+- Live run updates are implemented with global and run-scoped SSE endpoints, including replay-after-cursor for run streams. State: `prototype`. Refs: `FavnOrchestrator.API.Router`, `FavnOrchestrator.list_run_stream_events/2`, `apps/favn_orchestrator/test/api/router_test.exs`.
+- A private orchestrator HTTP API is implemented for manifests, runs, schedules, auth, actor management, audit reads, and SSE streams. State: `solid but still private-dev`. Refs: `apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex`, `apps/favn_orchestrator/priv/http_contract/v1/*.schema.json`.
+- Local username/password auth, actor roles (`viewer`, `operator`, `admin`), session introspection and revocation, and audit logging are implemented in the orchestrator. State: `needs hardening`. Refs: `FavnOrchestrator.Auth`, `apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex`, `apps/favn_orchestrator/test/api/router_test.exs`.
 
-### 2. End-to-end runtime confidence
+### Store runtime state
 
-- real end-to-end integration coverage against the live orchestrator boundary
-- packaging verification for supported deployment modes
-- release-oriented verification for local memory, SQLite, and Postgres paths
-- broader confidence around manifest publication, activation, run creation, execution, and event flow across process boundaries
+- In-memory orchestrator storage is implemented and is the default local mode. State: `solid but still private-dev`. Refs: `FavnOrchestrator.Storage.Adapter.Memory`, `apps/favn_orchestrator/lib/favn_orchestrator.ex`.
+- SQLite control-plane persistence is implemented for runs, events, scheduler state, write ordering, optimistic scheduler versions, and canonical `json-v1` payload storage. State: `solid but still private-dev`. Refs: `Favn.Storage.Adapter.SQLite`, `apps/favn_storage_sqlite/test/sqlite_storage_test.exs`.
+- Postgres control-plane persistence is implemented with managed-repo and external-repo modes, cached external readiness validation, and canonical `json-v1` payload storage. State: `solid but still private-dev`. Refs: `Favn.Storage.Adapter.Postgres`, `apps/favn_storage_postgres/test/adapter_test.exs`.
 
-### 3. Stable product and operator experience
+### Develop locally
 
-- stable documented local developer flow
-- stable documented single-node packaging flow
-- stable documented split deployment flow for web, orchestrator, and runner
-- stable documented storage configuration and operator expectations
-- documentation aligned with the actual supported product shape rather than transitional refactor language
+- Public Mix tasks exist for `install`, `dev`, `status`, `logs`, `reload`, `stop`, `reset`, `build.runner`, `build.web`, `build.orchestrator`, and `build.single`. State: `solid but still private-dev`. Refs: `apps/favn/lib/mix/tasks/*.ex`, `apps/favn/test/mix_tasks/public_tasks_test.exs`.
+- Local compiled-document lookup is implemented through `mix favn.read_doc` for modules and public functions. State: `solid but still private-dev`. Refs: `apps/favn/lib/mix/tasks/favn.read_doc.ex`, `apps/favn/test/mix_tasks/read_doc_task_test.exs`.
+- `mix favn.install` fingerprints toolchain and runtime inputs, snapshots web/orchestrator/runner inputs under `.favn/install`, and installs web dependencies. State: `solid but still private-dev`. Refs: `Favn.Dev.Install`, `apps/favn_local/lib/favn/dev/install.ex`, `apps/favn_local/test/dev_install_test.exs`.
+- `mix favn.dev` starts runner, orchestrator, and web as separate local processes, stores runtime state under `.favn/runtime.json`, checks readiness, and bootstraps a manifest into runner and orchestrator. State: `solid but still private-dev`. Refs: `Favn.Dev.Stack`, `apps/favn_local/lib/favn/dev/stack.ex`.
+- Local storage selection is implemented for memory, SQLite, and Postgres. State: `solid but still private-dev`. Refs: `apps/favn_local/README.md`, `apps/favn_local/test/integration/dev_storage_verification_test.exs`.
+- `mix favn.status`, `mix favn.logs`, `mix favn.stop`, and `mix favn.reset` are implemented for stack inspection, log reading, shutdown, and local state cleanup. State: `solid but still private-dev`. Refs: `apps/favn_local/test/dev_logs_test.exs`, `apps/favn_local/test/dev_reset_test.exs`, `apps/favn/test/mix_tasks/public_tasks_test.exs`.
+- Local build flows are implemented for runner, web, orchestrator, and single-node assembly outputs. State: `prototype` overall. `build.runner` is the most complete target, while `build.web`, `build.orchestrator`, and `build.single` are intentionally metadata-oriented or assembly-only outputs. Refs: `apps/favn_local/test/dev_build_runner_test.exs`, `apps/favn_local/test/dev_build_web_test.exs`, `apps/favn_local/test/dev_build_orchestrator_test.exs`, `apps/favn_local/test/dev_build_single_test.exs`.
 
-## v1.0 Goal
+### Use the web prototype
 
-Ship a stable, production-usable Favn on the refactored architecture:
+- A separate SvelteKit web/BFF workspace is implemented under `web/favn_web`. It handles signed cookie sessions, login/logout, protected pages, and server-side relays to the private orchestrator API. State: `needs hardening`. Refs: `web/favn_web/src/hooks.server.ts`, `web/favn_web/src/lib/server/session.ts`, `web/favn_web/src/lib/server/orchestrator.ts`.
+- Web BFF endpoints exist for runs, manifests, schedules, and run-stream relays. State: `prototype`. Refs: `web/favn_web/src/routes/api/web/v1/**`, `web/favn_web/tests/e2e/auth-session-runs.e2e.ts`.
+- End-to-end browser tests cover login, logout, unauthorized redirects, and basic runs, manifests, schedules, and run-stream relay behavior. State: `solid but still private-dev` as test coverage, but it covers a thin prototype rather than a mature product UI. Refs: `web/favn_web/tests/e2e/auth-session-runs.e2e.ts`.
 
-- stable `favn` authoring surface
-- manifest-version-pinned orchestration through separate orchestrator and runner runtimes
-- working and documented local development flow
-- honest and documented single-node and split deployment packaging
-- built-in memory, SQLite, and Postgres storage options
-- release-ready web/orchestrator auth, session, and audit foundations
-- end-to-end verified control-plane and execution flows
+## Current Caveats And Partial Areas
 
-## After v1
+- No major area in this repository is currently documented as fully release-ready. The strongest areas today are authoring, manifest compilation, planning, runner and orchestrator basics, and the local storage loops, but the project still presents itself as private development.
+- The web surface is a working prototype, not a polished product UI. The clearest evidence is the thin BFF route set and the current E2E coverage, not the default scaffold `web/favn_web/README.md`, which is still outdated.
+- The orchestrator HTTP API is private service-to-service infrastructure, not a documented public external API contract.
+- The public `Favn` module intentionally spans both stable authoring helpers and thin runtime delegation helpers. Runtime-facing calls such as `run_pipeline`, `get_run`, and scheduler helpers still depend on the orchestrator and runtime apps being available and return `:runtime_not_available` when they are not. Refs: `apps/favn/lib/favn.ex`, `apps/favn/test/runtime_facade_test.exs`.
+- Auth, session, and audit foundations exist now, but the current implementation is still prototype-grade: the orchestrator auth store is in-memory, browser-edge abuse controls are not present, and service credentials are still a simple static-token model. Refs: `apps/favn_orchestrator/lib/favn_orchestrator/auth/store.ex`, `apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex`, `docs/REFACTOR.md`.
+- SSE support is uneven today. Run-scoped replay is the strongest implemented path, while the global runs stream is still much thinner and not yet a durable or scalable live-update contract. Refs: `apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex`, `apps/favn_orchestrator/test/api/router_test.exs`, `docs/REFACTOR.md`.
+- Packaging is uneven today. `build.runner` produces the strongest operational package contract, while `build.web`, `build.orchestrator`, and `build.single` currently produce metadata-oriented or assembly-only outputs rather than full deployable product artifacts. Refs: `apps/favn_local/test/dev_build_runner_test.exs`, `apps/favn_local/test/dev_build_web_test.exs`, `apps/favn_local/test/dev_build_orchestrator_test.exs`, `apps/favn_local/test/dev_build_single_test.exs`.
+- Persisted runtime state from pre-closeout SQL adapters is not upgrade-compatible. Older SQLite or Postgres rows stored as BEAM term blobs must be reset or recreated once before using the closeout adapters. Refs: `README.md`, `docs/REFACTOR.md`.
+- Postgres support is implemented at the adapter and configuration level, but broader live verification is still opt-in in tests. Refs: `apps/favn_storage_postgres/test/adapter_test.exs`, `apps/favn_storage_postgres/test/integration/adapter_live_test.exs`, `docs/REFACTOR.md`.
 
-- richer web UX and operator workflows
-- more adapters and runner plugins
-- API and polling triggers
-- distributed multi-node execution and resource-aware scheduling
-- deeper observability and operator tooling
-- local watch mode and auto-reload ergonomics
-- broader environment doctor and validation framework
-- richer log querying and service-targeted restart niceties
+## Not In Scope For This File
+
+- Planned next work and later ideas live in `docs/ROADMAP.md`.

--- a/docs/FEATURE_AUDIT_TASKLIST.md
+++ b/docs/FEATURE_AUDIT_TASKLIST.md
@@ -1,0 +1,24 @@
+# Feature Audit Task List
+
+This task list drives the feature audit for `docs/FEATURES.md`.
+
+## Categories And Project Scope
+
+1. Authoring and public API
+   Projects: `apps/favn`, `apps/favn_authoring`
+2. Manifests, planning, runner execution, and DuckDB plugin support
+   Projects: `apps/favn_core`, `apps/favn_runner`, `apps/favn_duckdb`
+3. Orchestration, private API, auth, events, and storage
+   Projects: `apps/favn_orchestrator`, `apps/favn_storage_sqlite`, `apps/favn_storage_postgres`
+4. Local developer workflow and packaging
+   Projects: `apps/favn_local`, public `mix favn.*` tasks in `apps/favn`
+5. Web prototype and BFF behavior
+   Projects: `web/favn_web`
+
+## Audit Questions Per Category
+
+- What is implemented and user-visible today?
+- What is implemented but still clearly partial, prototype-grade, or metadata-only?
+- What appears production-ready versus still needing hardening?
+- What is ambiguous and needs explicit caveats in `docs/FEATURES.md`?
+- What code or tests should be cited as evidence?

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,60 @@
+# Favn Roadmap
+
+This file is only for forward-looking work.
+
+- Implemented capabilities live in `docs/FEATURES.md`.
+- Do not restate shipped behavior here.
+
+Based on the current feature audit, the main path to a stable production `v1` is not broad feature expansion. The highest-value work is to harden the existing surface area, make support boundaries explicit, and turn the current honest-but-partial runtime and packaging story into a dependable production contract.
+
+## Implemented Now
+
+- See `docs/FEATURES.md` for the current feature set and current maturity labels.
+
+## Planned Next
+
+### 1. Lock The Supported `v1` Surface
+
+- Finalize which public APIs are part of the stable `v1` contract and which stay internal or compatibility-only.
+- Clarify the long-term support story for `Favn.Assets`, `Favn.PublicScaffold`, and the runtime delegation helpers currently exposed from `Favn` but marked `@doc false`.
+- Tighten product docs and examples so the recommended authoring and runtime entrypoints are unambiguous.
+
+### 2. Make Deployment Outputs Real
+
+- Turn `build.web`, `build.orchestrator`, and `build.single` from metadata or assembly outputs into genuinely runnable, supportable deployment artifacts, or narrow the official deployment promise before `v1`.
+- Verify both single-node and split-topology deployment paths end to end with realistic runtime flows.
+- Keep `build.runner` aligned with the same production deployment contract.
+
+### 3. Harden Auth, Sessions, Audit, And Service Trust
+
+- Replace the in-memory auth/session/audit store with durable persistence.
+- Replace the current prototype-grade password and session foundations with a more boring production baseline.
+- Add real browser-edge abuse controls for any web-facing release.
+- Harden the web-to-orchestrator service boundary with identity binding, credential rotation, and a review of service-only privileged operations.
+
+### 4. Finish The Live Event And Command Safety Model
+
+- Define and implement the durable idempotency contract for command-style API operations where that behavior is exposed.
+- Strengthen SSE from a thin prototype into a dependable live-update model, especially for the global runs stream and replay/cursor behavior.
+- Add real end-to-end integration coverage against the live orchestrator boundary rather than relying mostly on local mocks or thin route tests.
+
+### 5. Close Storage And Persistence Gaps
+
+- Replace temporary persisted term-blob payloads with the intended stable, inspectable long-term format.
+- Expand Postgres verification so production-oriented persistence has stronger live confidence, not only adapter-shape confidence.
+- Finish remaining storage semantics cleanup that is still tracked as post-legacy or post-extraction follow-up.
+
+### 6. Decide What Must Be Production-Grade At `v1`
+
+- Harden the manifest-pinned SQL execution path enough for the `v1` support promise, especially around runtime payload handling and backend failure behavior.
+- Decide whether DuckDB/plugin execution is part of the core `v1` production promise or remains explicitly experimental beyond `v1`.
+- Make the supported-versus-experimental line explicit in user-facing docs.
+
+## Later / Future Ideas
+
+- A richer operator web experience once the current boundary and auth models are stable.
+- More storage adapters and runner plugins beyond the current built-in set.
+- Additional API-triggered or externally triggered execution flows.
+- Stronger queueing, admission control, distributed execution, and resource-aware scheduling.
+- Deeper observability, diagnostics, and operator tooling.
+- More complete deployment automation for cloud and split-topology environments.

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -6,6 +6,12 @@ App-level technical docs:
 
 - `apps/favn_local/README.md`
 
+Top-level product docs:
+
+- `docs/FEATURES.md` for implemented capabilities
+- `docs/FEATURE_AUDIT_TASKLIST.md` for the current feature audit work breakdown
+- `docs/ROADMAP.md` for planned work
+
 ```text
 apps/
 ├── favn/lib/


### PR DESCRIPTION
## Summary
- replace the old phase/status-style features doc with an implementation-first feature inventory grouped by user-facing capability
- add explicit maturity notes for shipped areas so current support, prototype areas, and hardening gaps are easier to understand
- rewrite the roadmap around real production v1 blockers such as deployment artifacts, auth/session hardening, event safety, and storage cleanup

## Why
The repo already implements a broad feature surface, but the previous docs mixed roadmap progress with current behavior. This change makes it easier for contributors to see what Favn actually supports today and what must improve before claiming a stable production v1.