### PR TITLE
fix: normalize pipeline asset-module shorthand selectors

### DIFF
--- a/apps/favn/test/public_pipeline_parity_test.exs
+++ b/apps/favn/test/public_pipeline_parity_test.exs
@@ -153,6 +153,62 @@ defmodule Favn.PublicPipelineParityTest do
     assert {:error, :not_asset_module} = Favn.resolve_pipeline(module_name)
   end
 
+  test "resolve_pipeline/2 returns invalid_selector for invalid tag/category selector values" do
+    module_name =
+      Module.concat(__MODULE__, "InvalidSelectorValue#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(module_name)} do
+        use Favn.Pipeline
+
+        pipeline :invalid_selector_value do
+          select do
+            tag(%{bad: :value})
+            category([:bad])
+          end
+        end
+      end
+      """,
+      "test/public_pipeline_parity_test.exs"
+    )
+
+    assert {:error, :invalid_selector} = Favn.resolve_pipeline(module_name)
+  end
+
+  test "resolve_pipeline/2 preserves compiler errors for invalid asset module shorthand" do
+    bad_asset_module =
+      Module.concat(__MODULE__, "BadAssetModule#{System.unique_integer([:positive])}")
+
+    pipeline_module =
+      Module.concat(__MODULE__, "BadAssetPipeline#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(bad_asset_module)} do
+        def __favn_assets__, do: :invalid_shape
+      end
+      """,
+      "test/public_pipeline_parity_test.exs"
+    )
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(pipeline_module)} do
+        use Favn.Pipeline
+
+        pipeline :bad_asset_module_selector do
+          asset #{inspect(bad_asset_module)}
+        end
+      end
+      """,
+      "test/public_pipeline_parity_test.exs"
+    )
+
+    assert {:error, {:invalid_asset_module, ^bad_asset_module}} =
+             Favn.resolve_pipeline(pipeline_module)
+  end
+
   test "pipeline DSL rejects invalid selection and clause usage" do
     assert_raise ArgumentError, ~r/cannot mix shorthand selection/, fn ->
       Code.compile_string("""

--- a/apps/favn/test/public_pipeline_parity_test.exs
+++ b/apps/favn/test/public_pipeline_parity_test.exs
@@ -65,6 +65,73 @@ defmodule Favn.PublicPipelineParityTest do
            ]
   end
 
+  test "resolve_pipeline/2 resolves single-asset module shorthand selector" do
+    asset_module = Module.concat(__MODULE__, "SingleAsset#{System.unique_integer([:positive])}")
+
+    pipeline_module =
+      Module.concat(__MODULE__, "SingleAssetPipeline#{System.unique_integer([:positive])}")
+
+    compile_loadable_module!(
+      asset_module,
+      """
+      defmodule #{inspect(asset_module)} do
+        use Favn.Asset
+
+        def asset(_ctx), do: :ok
+      end
+      """
+    )
+
+    compile_loadable_module!(
+      pipeline_module,
+      """
+      defmodule #{inspect(pipeline_module)} do
+        use Favn.Pipeline
+
+        pipeline :single_asset_shorthand do
+          asset #{inspect(asset_module)}
+          deps :none
+        end
+      end
+      """
+    )
+
+    previous_asset_modules = Application.get_env(:favn, :asset_modules)
+    Application.put_env(:favn, :asset_modules, [asset_module, SalesAssets, ReportingAssets])
+
+    on_exit(fn ->
+      if is_nil(previous_asset_modules) do
+        Application.delete_env(:favn, :asset_modules)
+      else
+        Application.put_env(:favn, :asset_modules, previous_asset_modules)
+      end
+    end)
+
+    assert {:ok, resolution} = Favn.resolve_pipeline(pipeline_module)
+    assert resolution.target_refs == [{asset_module, :asset}]
+    assert resolution.pipeline.selectors == [{:asset, {asset_module, :asset}}]
+  end
+
+  test "resolve_pipeline/2 returns not_asset_module for asset module shorthand on multi-asset module" do
+    module_name =
+      Module.concat(__MODULE__, "InvalidAssetShorthand#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(module_name)} do
+        use Favn.Pipeline
+
+        pipeline :invalid_asset_shorthand do
+          asset(#{inspect(SalesAssets)})
+        end
+      end
+      """,
+      "test/public_pipeline_parity_test.exs"
+    )
+
+    assert {:error, :not_asset_module} = Favn.resolve_pipeline(module_name)
+  end
+
   test "resolve_pipeline/2 returns not_asset_module for invalid module selector" do
     module_name = Module.concat(__MODULE__, "InvalidModule#{System.unique_integer([:positive])}")
 

--- a/apps/favn_core/lib/favn/manifest/pipeline_resolver.ex
+++ b/apps/favn_core/lib/favn/manifest/pipeline_resolver.ex
@@ -7,6 +7,7 @@ defmodule Favn.Manifest.PipelineResolver do
   alias Favn.Manifest.Index
   alias Favn.Manifest.Pipeline
   alias Favn.Manifest.Schedule
+  alias Favn.Pipeline.SelectorNormalizer
   alias Favn.Window.Anchor
   alias Favn.Window.Validate
 
@@ -28,33 +29,39 @@ defmodule Favn.Manifest.PipelineResolver do
     params = Keyword.get(opts, :params, %{})
     anchor_window = Keyword.get(opts, :anchor_window)
 
-    with :ok <- validate_opts(opts),
-         :ok <- validate_pipeline(pipeline),
+    with {:ok, selectors} <-
+           SelectorNormalizer.normalize(
+             pipeline.selectors,
+             resolve_asset_module: &resolve_asset_module_from_index(index, &1)
+           ),
+         normalized_pipeline = %Pipeline{pipeline | selectors: selectors},
+         :ok <- validate_opts(opts),
+         :ok <- validate_pipeline(normalized_pipeline),
          :ok <- validate_trigger(trigger),
          :ok <- validate_params(params),
          :ok <- validate_anchor_window(anchor_window),
-         {:ok, schedule} <- resolve_schedule(index, pipeline.schedule),
-         {:ok, target_refs} <- resolve_selectors(index, pipeline.selectors) do
+         {:ok, schedule} <- resolve_schedule(index, normalized_pipeline.schedule),
+         {:ok, target_refs} <- resolve_selectors(index, selectors) do
       {:ok,
        %{
-         pipeline: pipeline,
+         pipeline: normalized_pipeline,
          target_refs: target_refs,
-         dependencies: pipeline.deps,
+         dependencies: normalized_pipeline.deps,
          pipeline_ctx: %{
-           id: pipeline.name,
-           name: pipeline.name,
+           id: normalized_pipeline.name,
+           name: normalized_pipeline.name,
            run_kind: :pipeline,
            resolved_refs: target_refs,
-           deps: pipeline.deps,
-           config: pipeline.config,
-           meta: pipeline.metadata,
+           deps: normalized_pipeline.deps,
+           config: normalized_pipeline.config,
+           meta: normalized_pipeline.metadata,
            trigger: trigger,
            params: params,
            anchor_window: anchor_window,
-           window: pipeline.window,
+           window: normalized_pipeline.window,
            schedule: schedule,
-           source: pipeline.source,
-           outputs: pipeline.outputs
+           source: normalized_pipeline.source,
+           outputs: normalized_pipeline.outputs
          }
        }}
     end
@@ -87,17 +94,7 @@ defmodule Favn.Manifest.PipelineResolver do
 
   defp validate_selectors([]), do: {:error, :empty_pipeline_selection}
 
-  defp validate_selectors(selectors) when is_list(selectors) do
-    if Enum.all?(selectors, &valid_selector?/1), do: :ok, else: {:error, :invalid_selector}
-  end
-
-  defp validate_selectors(_other), do: {:error, :invalid_selector}
-
-  defp valid_selector?({:asset, {module, name}}) when is_atom(module) and is_atom(name), do: true
-  defp valid_selector?({:module, module}) when is_atom(module), do: true
-  defp valid_selector?({:tag, value}) when is_atom(value) or is_binary(value), do: true
-  defp valid_selector?({:category, value}) when is_atom(value) or is_binary(value), do: true
-  defp valid_selector?(_other), do: false
+  defp validate_selectors(selectors) when is_list(selectors), do: :ok
 
   defp validate_outputs(%Pipeline{outputs: outputs}) do
     if Enum.all?(outputs, &is_atom/1), do: :ok, else: {:error, {:invalid_outputs, outputs}}
@@ -190,4 +187,17 @@ defmodule Favn.Manifest.PipelineResolver do
   end
 
   defp tags_from_metadata(_asset), do: []
+
+  defp resolve_asset_module_from_index(%Index{} = index, module) when is_atom(module) do
+    refs =
+      index
+      |> Index.list_assets()
+      |> Enum.filter(&(&1.module == module))
+      |> Enum.map(& &1.ref)
+
+    case refs do
+      [{^module, :asset}] -> {:ok, {module, :asset}}
+      _ -> {:error, :not_asset_module}
+    end
+  end
 end

--- a/apps/favn_core/lib/favn/pipeline/resolver.ex
+++ b/apps/favn_core/lib/favn/pipeline/resolver.ex
@@ -8,6 +8,7 @@ defmodule Favn.Pipeline.Resolver do
 
   alias Favn.Pipeline.Definition
   alias Favn.Pipeline.Resolution
+  alias Favn.Pipeline.SelectorNormalizer
   alias Favn.Triggers.Schedule
   alias Favn.Window.Anchor
 
@@ -30,7 +31,9 @@ defmodule Favn.Pipeline.Resolver do
     schedule_lookup = Keyword.get(opts, :schedule_lookup)
     default_timezone = Schedule.default_timezone()
 
-    with :ok <- validate_definition(definition),
+    with {:ok, selectors} <- SelectorNormalizer.normalize(definition.selectors),
+         normalized_definition = %Definition{definition | selectors: selectors},
+         :ok <- validate_definition(normalized_definition),
          :ok <- validate_params(params),
          :ok <- validate_trigger(trigger),
          :ok <- validate_anchor_window(anchor_window),
@@ -39,7 +42,7 @@ defmodule Favn.Pipeline.Resolver do
          {:ok, schedule} <-
            resolve_schedule(definition.schedule, default_timezone, schedule_lookup),
          {:ok, assets} <- resolve_assets(assets_opt),
-         {:ok, target_refs} <- resolve_selectors(definition, assets) do
+         {:ok, target_refs} <- resolve_selectors(selectors, assets) do
       pipeline_ctx = %{
         id: definition.name,
         name: definition.name,
@@ -59,9 +62,9 @@ defmodule Favn.Pipeline.Resolver do
 
       {:ok,
        %Resolution{
-         pipeline: definition,
+         pipeline: normalized_definition,
          target_refs: target_refs,
-         dependencies: definition.deps,
+         dependencies: normalized_definition.deps,
          pipeline_ctx: pipeline_ctx
        }}
     end
@@ -86,17 +89,7 @@ defmodule Favn.Pipeline.Resolver do
 
   defp validate_selectors([]), do: {:error, :empty_pipeline_selection}
 
-  defp validate_selectors(selectors) when is_list(selectors) do
-    if Enum.all?(selectors, &valid_selector?/1), do: :ok, else: {:error, :invalid_selector}
-  end
-
-  defp validate_selectors(_invalid), do: {:error, :invalid_selector}
-
-  defp valid_selector?({:asset, {module, name}}) when is_atom(module) and is_atom(name), do: true
-  defp valid_selector?({:module, module}) when is_atom(module), do: true
-  defp valid_selector?({:tag, value}) when is_atom(value) or is_binary(value), do: true
-  defp valid_selector?({:category, value}) when is_atom(value) or is_binary(value), do: true
-  defp valid_selector?(_), do: false
+  defp validate_selectors(selectors) when is_list(selectors), do: :ok
 
   defp validate_window(nil), do: :ok
   defp validate_window(value) when is_atom(value), do: :ok
@@ -157,7 +150,7 @@ defmodule Favn.Pipeline.Resolver do
   defp resolve_schedule(value, _default_timezone, _lookup),
     do: {:error, {:invalid_schedule, value}}
 
-  defp resolve_selectors(%Definition{selectors: selectors}, assets) do
+  defp resolve_selectors(selectors, assets) when is_list(selectors) do
     assets_by_ref = Map.new(assets, &{&1.ref, &1})
 
     with {:ok, refs} <- do_resolve_selectors(selectors, assets, assets_by_ref) do

--- a/apps/favn_core/lib/favn/pipeline/selector_normalizer.ex
+++ b/apps/favn_core/lib/favn/pipeline/selector_normalizer.ex
@@ -1,0 +1,67 @@
+defmodule Favn.Pipeline.SelectorNormalizer do
+  @moduledoc false
+
+  alias Favn.Assets.Compiler
+
+  @type selector ::
+          {:asset, module() | Favn.Ref.t()}
+          | {:module, module()}
+          | {:tag, term()}
+          | {:category, term()}
+
+  @type resolve_asset_module :: (module() -> {:ok, Favn.Ref.t()} | {:error, term()})
+
+  @spec normalize([selector()], keyword()) :: {:ok, [selector()]} | {:error, term()}
+  def normalize(selectors, opts \\ [])
+
+  def normalize(selectors, opts) when is_list(selectors) and is_list(opts) do
+    resolve_asset_module = Keyword.get(opts, :resolve_asset_module, &resolve_asset_module/1)
+
+    selectors
+    |> Enum.reduce_while({:ok, []}, fn selector, {:ok, acc} ->
+      case normalize_selector(selector, resolve_asset_module) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  def normalize(_invalid, _opts), do: {:error, :invalid_selector}
+
+  defp normalize_selector({:asset, {module, name} = ref}, _resolve_asset_module)
+       when is_atom(module) and is_atom(name) do
+    {:ok, {:asset, ref}}
+  end
+
+  defp normalize_selector({:asset, module}, resolve_asset_module) when is_atom(module) do
+    with {:ok, {asset_module, name}} <- resolve_asset_module.(module),
+         true <- is_atom(asset_module) and is_atom(name) do
+      {:ok, {:asset, {asset_module, name}}}
+    else
+      _ -> {:error, :not_asset_module}
+    end
+  end
+
+  defp normalize_selector({:module, module}, _resolve_asset_module) when is_atom(module),
+    do: {:ok, {:module, module}}
+
+  defp normalize_selector({:tag, value}, _resolve_asset_module), do: {:ok, {:tag, value}}
+
+  defp normalize_selector({:category, value}, _resolve_asset_module),
+    do: {:ok, {:category, value}}
+
+  defp normalize_selector(_other, _resolve_asset_module), do: {:error, :invalid_selector}
+
+  defp resolve_asset_module(module) when is_atom(module) do
+    with {:ok, assets} <- Compiler.compile_module_assets(module),
+         [%{ref: {^module, :asset}}] <- assets do
+      {:ok, {module, :asset}}
+    else
+      _ -> {:error, :not_asset_module}
+    end
+  end
+end

--- a/apps/favn_core/lib/favn/pipeline/selector_normalizer.ex
+++ b/apps/favn_core/lib/favn/pipeline/selector_normalizer.ex
@@ -38,30 +38,47 @@ defmodule Favn.Pipeline.SelectorNormalizer do
   end
 
   defp normalize_selector({:asset, module}, resolve_asset_module) when is_atom(module) do
-    with {:ok, {asset_module, name}} <- resolve_asset_module.(module),
-         true <- is_atom(asset_module) and is_atom(name) do
-      {:ok, {:asset, {asset_module, name}}}
-    else
-      _ -> {:error, :not_asset_module}
+    case resolve_asset_module.(module) do
+      {:ok, {asset_module, name}} when is_atom(asset_module) and is_atom(name) ->
+        {:ok, {:asset, {asset_module, name}}}
+
+      {:error, :not_asset_module} ->
+        {:error, :not_asset_module}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      _other ->
+        {:error, :not_asset_module}
     end
   end
 
   defp normalize_selector({:module, module}, _resolve_asset_module) when is_atom(module),
     do: {:ok, {:module, module}}
 
-  defp normalize_selector({:tag, value}, _resolve_asset_module), do: {:ok, {:tag, value}}
+  defp normalize_selector({:tag, value}, _resolve_asset_module)
+       when is_atom(value) or is_binary(value),
+       do: {:ok, {:tag, value}}
 
-  defp normalize_selector({:category, value}, _resolve_asset_module),
-    do: {:ok, {:category, value}}
+  defp normalize_selector({:category, value}, _resolve_asset_module)
+       when is_atom(value) or is_binary(value),
+       do: {:ok, {:category, value}}
 
   defp normalize_selector(_other, _resolve_asset_module), do: {:error, :invalid_selector}
 
   defp resolve_asset_module(module) when is_atom(module) do
-    with {:ok, assets} <- Compiler.compile_module_assets(module),
-         [%{ref: {^module, :asset}}] <- assets do
-      {:ok, {module, :asset}}
-    else
-      _ -> {:error, :not_asset_module}
+    case Compiler.compile_module_assets(module) do
+      {:ok, [%{ref: {^module, :asset}}]} ->
+        {:ok, {module, :asset}}
+
+      {:ok, _assets} ->
+        {:error, :not_asset_module}
+
+      {:error, :not_asset_module} ->
+        {:error, :not_asset_module}
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 end

--- a/apps/favn_core/lib/favn/pipeline/selector_normalizer.ex
+++ b/apps/favn_core/lib/favn/pipeline/selector_normalizer.ex
@@ -6,8 +6,8 @@ defmodule Favn.Pipeline.SelectorNormalizer do
   @type selector ::
           {:asset, module() | Favn.Ref.t()}
           | {:module, module()}
-          | {:tag, term()}
-          | {:category, term()}
+          | {:tag, atom() | binary()}
+          | {:category, atom() | binary()}
 
   @type resolve_asset_module :: (module() -> {:ok, Favn.Ref.t()} | {:error, term()})
 

--- a/apps/favn_orchestrator/test/run_manager_test.exs
+++ b/apps/favn_orchestrator/test/run_manager_test.exs
@@ -605,6 +605,23 @@ defmodule FavnOrchestrator.RunManagerTest do
     assert run.target_refs == [{MyApp.Assets.Gold, :asset}]
   end
 
+  test "submits manual pipeline run from persisted descriptor with single-asset module shorthand" do
+    version = manifest_version("mv_pipeline_single_asset_shorthand")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+
+    assert :ok =
+             FavnOrchestrator.activate_manifest("mv_pipeline_single_asset_shorthand")
+
+    assert {:ok, run_id} =
+             FavnOrchestrator.submit_pipeline_run(MyApp.Pipelines.SingleAssetShorthand)
+
+    assert {:ok, run} = await_terminal_run(run_id)
+
+    assert run.status == :ok
+    assert run.submit_kind == :pipeline
+    assert run.target_refs == [{MyApp.Assets.Gold, :asset}]
+  end
+
   test "preserves orchestrator metadata and namespaces runner metadata on success paths" do
     version = manifest_version("mv_metadata_preserve")
     assert :ok = FavnOrchestrator.register_manifest(version)
@@ -1286,6 +1303,14 @@ defmodule FavnOrchestrator.RunManagerTest do
             module: MyApp.Pipelines.Daily,
             name: :daily,
             selectors: [{:asset, {MyApp.Assets.Gold, :asset}}],
+            deps: :all,
+            schedule: nil,
+            metadata: %{}
+          },
+          %Favn.Manifest.Pipeline{
+            module: MyApp.Pipelines.SingleAssetShorthand,
+            name: :single_asset_shorthand,
+            selectors: [{:asset, MyApp.Assets.Gold}],
             deps: :all,
             schedule: nil,
             metadata: %{}

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -121,6 +121,7 @@ Notes:
   - `pipeline/definition.ex`
   - `pipeline/resolver.ex`
   - `pipeline/resolution.ex`
+  - `pipeline/selector_normalizer.ex`
   - `plan.ex`
   - `sql/definition.ex`
   - `sql/source.ex`


### PR DESCRIPTION
## Summary
- Normalize `{:asset, Module}` selectors to canonical refs in both authoring and manifest pipeline resolvers so `asset SomeSingleAssetModule` works consistently.
- Add resolver context-specific module resolution: authoring uses asset compilation while manifest resolution uses manifest index assets without loading user modules at runtime.
- Add regressions for `Favn.resolve_pipeline/2` and orchestrator pipeline submission paths, including negative coverage for multi-asset module shorthand misuse.

## Validation
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`

Closes #101
Closes #102