### PR TITLE
fix local dev shortname host resolution on FQDN hosts

### DIFF
--- a/apps/favn/lib/mix/tasks/favn.dev.ex
+++ b/apps/favn/lib/mix/tasks/favn.dev.ex
@@ -64,6 +64,17 @@ defmodule Mix.Tasks.Favn.Dev do
   defp error_message({:web_build_failed, status, output}),
     do: "web build failed (status=#{status}): #{output}"
 
+  defp error_message({:shortname_host_unavailable, reason}),
+    do:
+      "local Erlang shortname host is unavailable (#{inspect(reason)}); verify local hostname setup and retry"
+
+  defp error_message(:shortname_host_not_available),
+    do: "could not derive local Erlang shortname host; verify local hostname setup and retry"
+
+  defp error_message({:invalid_shortname_host, host}),
+    do:
+      "local host '#{host}' is invalid for Erlang shortnames; use a short hostname or fix local host resolution and retry"
+
   defp error_message({:service_exit, service, status}),
     do:
       "#{service} exited during startup (status=#{status}); inspect .favn/logs/#{service}.log and check for stale state or port conflicts"

--- a/apps/favn_local/lib/favn/dev/node_control.ex
+++ b/apps/favn_local/lib/favn/dev/node_control.ex
@@ -36,12 +36,48 @@ defmodule Favn.Dev.NodeControl do
 
   @spec shortname_to_full(String.t()) :: {:ok, String.t()} | {:error, term()}
   def shortname_to_full(shortname) when is_binary(shortname) and shortname != "" do
-    case :net_adm.localhost() do
-      host when is_list(host) and host != [] ->
-        {:ok, shortname <> "@" <> List.to_string(host)}
-
-      other ->
-        {:error, {:invalid_local_host, other}}
+    with :ok <- ensure_shortname_runtime(),
+         {:ok, host} <- local_short_host() do
+      {:ok, shortname <> "@" <> host}
     end
   end
+
+  defp ensure_shortname_runtime do
+    case Node.alive?() do
+      true ->
+        :ok
+
+      false ->
+        name = "favn_local_host_probe_#{:erlang.unique_integer([:positive])}" |> String.to_atom()
+
+        case Node.start(name, name_domain: :shortnames) do
+          {:ok, _pid} -> :ok
+          {:error, {:already_started, _pid}} -> :ok
+          {:error, reason} -> {:error, {:shortname_host_unavailable, reason}}
+        end
+    end
+  end
+
+  defp local_short_host do
+    case node() do
+      :nonode@nohost ->
+        {:error, :shortname_host_not_available}
+
+      node_name when is_atom(node_name) ->
+        node_name
+        |> Atom.to_string()
+        |> String.split("@", parts: 2)
+        |> parse_short_host()
+    end
+  end
+
+  defp parse_short_host([_name, host]) when is_binary(host) and host != "" do
+    if String.contains?(host, ".") do
+      {:error, {:invalid_shortname_host, host}}
+    else
+      {:ok, host}
+    end
+  end
+
+  defp parse_short_host(_parts), do: {:error, :shortname_host_not_available}
 end

--- a/apps/favn_local/lib/favn/dev/node_control.ex
+++ b/apps/favn_local/lib/favn/dev/node_control.ex
@@ -44,7 +44,7 @@ defmodule Favn.Dev.NodeControl do
   defp local_short_host do
     case node() do
       :nonode@nohost ->
-        {:error, :shortname_host_not_available}
+        short_host_from_localhost()
 
       node_name when is_atom(node_name) ->
         node_name
@@ -53,6 +53,32 @@ defmodule Favn.Dev.NodeControl do
         |> parse_short_host()
     end
   end
+
+  defp short_host_from_localhost do
+    case :net_adm.localhost() do
+      host when is_list(host) and host != [] ->
+        host
+        |> List.to_string()
+        |> String.trim()
+        |> String.downcase()
+        |> String.split(".", parts: 2)
+        |> hd()
+        |> normalize_short_host()
+
+      _other ->
+        {:error, :shortname_host_not_available}
+    end
+  end
+
+  defp normalize_short_host(host) when is_binary(host) and host != "" do
+    if String.contains?(host, ".") do
+      {:error, {:invalid_shortname_host, host}}
+    else
+      {:ok, host}
+    end
+  end
+
+  defp normalize_short_host(_host), do: {:error, :shortname_host_not_available}
 
   defp parse_short_host([_name, host]) when is_binary(host) and host != "" do
     if String.contains?(host, ".") do

--- a/apps/favn_local/lib/favn/dev/node_control.ex
+++ b/apps/favn_local/lib/favn/dev/node_control.ex
@@ -29,32 +29,15 @@ defmodule Favn.Dev.NodeControl do
             :ok
 
           {:error, reason} ->
-            {:error, {:node_start_failed, reason}}
+            {:error, {:shortname_host_unavailable, reason}}
         end
     end
   end
 
   @spec shortname_to_full(String.t()) :: {:ok, String.t()} | {:error, term()}
   def shortname_to_full(shortname) when is_binary(shortname) and shortname != "" do
-    with :ok <- ensure_shortname_runtime(),
-         {:ok, host} <- local_short_host() do
+    with {:ok, host} <- local_short_host() do
       {:ok, shortname <> "@" <> host}
-    end
-  end
-
-  defp ensure_shortname_runtime do
-    case Node.alive?() do
-      true ->
-        :ok
-
-      false ->
-        name = "favn_local_host_probe_#{:erlang.unique_integer([:positive])}" |> String.to_atom()
-
-        case Node.start(name, name_domain: :shortnames) do
-          {:ok, _pid} -> :ok
-          {:error, {:already_started, _pid}} -> :ok
-          {:error, reason} -> {:error, {:shortname_host_unavailable, reason}}
-        end
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -221,7 +221,7 @@ defmodule Favn.Dev.Stack do
     orchestrator_short = "favn_orchestrator_#{suffix}"
     control_short = "favn_local_ctl_#{suffix}"
 
-    with :ok <- NodeControl.ensure_local_node_started(secrets["rpc_cookie"], name: control_short),
+    with :ok <- maybe_start_local_node(secrets, control_short, opts),
          {:ok, runner_full} <- NodeControl.shortname_to_full(runner_short),
          {:ok, orchestrator_full} <- NodeControl.shortname_to_full(orchestrator_short),
          {:ok, control_full} <- NodeControl.shortname_to_full(control_short) do
@@ -234,6 +234,17 @@ defmodule Favn.Dev.Stack do
          control_short: control_short,
          control_full: control_full
        }}
+    end
+  end
+
+  defp maybe_start_local_node(secrets, control_short, opts)
+       when is_map(secrets) and is_binary(control_short) and is_list(opts) do
+    case Keyword.get(opts, :service_specs_override) do
+      list when is_list(list) and list != [] ->
+        :ok
+
+      _ ->
+        NodeControl.ensure_local_node_started(secrets["rpc_cookie"], name: control_short)
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -50,6 +50,9 @@ defmodule Favn.Dev.Stack do
   defp cleanup_required?({:port_check_failed, _service, _port, _reason}), do: false
   defp cleanup_required?({:postgres_misconfigured, _field}), do: false
   defp cleanup_required?({:postgres_unavailable, _host, _port, _reason}), do: false
+  defp cleanup_required?({:shortname_host_unavailable, _reason}), do: false
+  defp cleanup_required?(:shortname_host_not_available), do: false
+  defp cleanup_required?({:invalid_shortname_host, _host}), do: false
   defp cleanup_required?(_reason), do: true
 
   @spec stop(root_opt()) :: :ok | {:error, term()}
@@ -76,7 +79,7 @@ defmodule Favn.Dev.Stack do
            config <- Config.resolve(opts),
            :ok <- ensure_startup_prerequisites(config),
            {:ok, secrets} <- Secrets.resolve(config, opts),
-           {:ok, node_names} <- build_node_names(opts),
+           {:ok, node_names} <- build_node_names(secrets, opts),
            {:ok, services} <- start_services(config, secrets, node_names, opts),
            :ok <- write_runtime(config, secrets, node_names, services, opts) do
         {:ok, %{config: config, secrets: secrets, node_names: node_names, services: services}}
@@ -210,7 +213,7 @@ defmodule Favn.Dev.Stack do
     end)
   end
 
-  defp build_node_names(opts) do
+  defp build_node_names(secrets, opts) when is_map(secrets) do
     root_dir = Paths.root_dir(opts)
     suffix = Integer.to_string(:erlang.phash2(root_dir, 1_000_000))
 
@@ -218,7 +221,8 @@ defmodule Favn.Dev.Stack do
     orchestrator_short = "favn_orchestrator_#{suffix}"
     control_short = "favn_local_ctl_#{suffix}"
 
-    with {:ok, runner_full} <- NodeControl.shortname_to_full(runner_short),
+    with :ok <- NodeControl.ensure_local_node_started(secrets["rpc_cookie"], name: control_short),
+         {:ok, runner_full} <- NodeControl.shortname_to_full(runner_short),
          {:ok, orchestrator_full} <- NodeControl.shortname_to_full(orchestrator_short),
          {:ok, control_full} <- NodeControl.shortname_to_full(control_short) do
       {:ok,

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -195,6 +195,92 @@ defmodule Favn.Dev.LifecycleTest do
              )
   end
 
+  test "dev/1 writes shortname-compatible node names in runtime", %{root_dir: root_dir} do
+    task =
+      Task.async(fn ->
+        Dev.dev(
+          root_dir: root_dir,
+          skip_install_check: true,
+          skip_bootstrap: true,
+          skip_readiness: true,
+          service_specs_override: service_specs(root_dir)
+        )
+      end)
+
+    try do
+      assert :ok =
+               wait_until(fn ->
+                 match?(
+                   {:ok,
+                    %{"node_names" => %{"runner" => _, "orchestrator" => _, "control" => _}}},
+                   State.read_runtime(root_dir: root_dir)
+                 )
+               end)
+
+      assert {:ok, runtime} = State.read_runtime(root_dir: root_dir)
+
+      assert runtime |> get_in(["node_names", "runner"]) |> short_host() |> short_host?()
+      assert runtime |> get_in(["node_names", "orchestrator"]) |> short_host() |> short_host?()
+      assert runtime |> get_in(["node_names", "control"]) |> short_host() |> short_host?()
+
+      assert runtime
+             |> get_in(["services", "runner", "node_name"])
+             |> short_host()
+             |> short_host?()
+
+      assert runtime
+             |> get_in(["services", "orchestrator", "node_name"])
+             |> short_host()
+             |> short_host?()
+
+      assert :ok = Dev.stop(root_dir: root_dir)
+      assert %{stack_status: :stopped} = Dev.status(root_dir: root_dir)
+    after
+      _ = Dev.stop(root_dir: root_dir)
+      _ = Task.await(task, 30_000)
+    end
+  end
+
+  defp service_specs(root_dir) do
+    shell = System.find_executable("bash") || "/bin/bash"
+
+    [
+      %{
+        name: "runner",
+        exec: shell,
+        args: ["-lc", "sleep 60"],
+        cwd: root_dir,
+        log_path: Paths.runner_log_path(root_dir),
+        env: %{}
+      },
+      %{
+        name: "orchestrator",
+        exec: shell,
+        args: ["-lc", "sleep 60"],
+        cwd: root_dir,
+        log_path: Paths.orchestrator_log_path(root_dir),
+        env: %{}
+      },
+      %{
+        name: "web",
+        exec: shell,
+        args: ["-lc", "sleep 60"],
+        cwd: root_dir,
+        log_path: Paths.web_log_path(root_dir),
+        env: %{}
+      }
+    ]
+  end
+
+  defp short_host(node_name) when is_binary(node_name) do
+    case String.split(node_name, "@", parts: 2) do
+      [_name, host] -> host
+      _other -> ""
+    end
+  end
+
+  defp short_host?(host) when is_binary(host), do: host != "" and not String.contains?(host, ".")
+
   defp wait_until(fun, attempts \\ 120)
   defp wait_until(_fun, 0), do: {:error, :timeout}
 

--- a/apps/favn_local/test/dev_node_control_test.exs
+++ b/apps/favn_local/test/dev_node_control_test.exs
@@ -4,9 +4,6 @@ defmodule Favn.Dev.NodeControlTest do
   alias Favn.Dev.NodeControl
 
   test "shortname_to_full/1 uses canonical shortname host" do
-    cookie = "favn_node_control_test_#{System.unique_integer([:positive])}"
-    assert :ok = NodeControl.ensure_local_node_started(cookie)
-
     raw_host = :net_adm.localhost() |> List.to_string()
 
     assert {:ok, full_name} = NodeControl.shortname_to_full("favn_runner_test")

--- a/apps/favn_local/test/dev_node_control_test.exs
+++ b/apps/favn_local/test/dev_node_control_test.exs
@@ -1,0 +1,21 @@
+defmodule Favn.Dev.NodeControlTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Dev.NodeControl
+
+  test "shortname_to_full/1 uses canonical shortname host" do
+    raw_host = :net_adm.localhost() |> List.to_string()
+
+    assert {:ok, full_name} = NodeControl.shortname_to_full("favn_runner_test")
+
+    [name, host] = String.split(full_name, "@", parts: 2)
+
+    assert name == "favn_runner_test"
+    assert host != ""
+    refute String.contains?(host, ".")
+
+    if String.contains?(raw_host, ".") do
+      refute host == raw_host
+    end
+  end
+end

--- a/apps/favn_local/test/dev_node_control_test.exs
+++ b/apps/favn_local/test/dev_node_control_test.exs
@@ -4,6 +4,9 @@ defmodule Favn.Dev.NodeControlTest do
   alias Favn.Dev.NodeControl
 
   test "shortname_to_full/1 uses canonical shortname host" do
+    cookie = "favn_node_control_test_#{System.unique_integer([:positive])}"
+    assert :ok = NodeControl.ensure_local_node_started(cookie)
+
     raw_host = :net_adm.localhost() |> List.to_string()
 
     assert {:ok, full_name} = NodeControl.shortname_to_full("favn_runner_test")

--- a/apps/favn_orchestrator/test/run_manager_test.exs
+++ b/apps/favn_orchestrator/test/run_manager_test.exs
@@ -1,6 +1,8 @@
 defmodule FavnOrchestrator.RunManagerTest do
   use ExUnit.Case, async: false
 
+  @moduletag capture_log: true
+
   alias Favn.Contracts.RunnerResult
   alias Favn.Manifest
   alias Favn.Manifest.Version


### PR DESCRIPTION
## Summary
- derive local shortname node hosts from the active BEAM shortname runtime instead of raw `:net_adm.localhost()`
- start the control node before building node names so runner/orchestrator/control all use canonical shortname-compatible `name@host` values
- add dedicated `mix favn.dev` error messages and a regression test for canonical shortname host derivation

## Validation
- mix format
- mix compile --warnings-as-errors
- mix test
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected

Closes #107