### PR TITLE
docs: clarify namespace inheritance examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,19 @@ end
 ### 2. Define an asset
 
 ```elixir
-defmodule MyApp.Raw.Sales.Orders do
-  use Favn.Namespace, relation: [connection: :warehouse, catalog: "raw", schema: "sales"]
+defmodule MyApp.Warehouse do
+  use Favn.Namespace, relation: [connection: :warehouse]
+end
+
+defmodule MyApp.Warehouse.Raw do
+  use Favn.Namespace, relation: [catalog: "raw"]
+end
+
+defmodule MyApp.Warehouse.Raw.Sales do
+  use Favn.Namespace, relation: [schema: "sales"]
+end
+
+defmodule MyApp.Warehouse.Raw.Sales.Orders do
   use Favn.Asset
 
   @doc "Load raw orders"
@@ -97,11 +108,24 @@ defmodule MyApp.Raw.Sales.Orders do
 end
 ```
 
+Namespace defaults are inherited from parent modules. Child asset modules only
+need `use Favn.Namespace` when they are adding or overriding shared relation
+defaults. `@relation true` is the normal leaf-module path, while
+`@relation [name: "..."]` is the normal way to override only the relation
+name.
+
 ### 3. Define a downstream SQL asset
 
 ```elixir
-defmodule MyApp.Gold.Sales.OrderSummary do
-  use Favn.Namespace, relation: [connection: :warehouse, catalog: "gold", schema: "sales"]
+defmodule MyApp.Warehouse.Gold do
+  use Favn.Namespace, relation: [catalog: "gold"]
+end
+
+defmodule MyApp.Warehouse.Gold.Sales do
+  use Favn.Namespace, relation: [schema: "sales"]
+end
+
+defmodule MyApp.Warehouse.Gold.Sales.OrderSummary do
   use Favn.SQLAsset
 
   @meta owner: "analytics", category: :sales, tags: [:gold]
@@ -128,7 +152,7 @@ defmodule MyApp.Pipelines.DailySales do
   use Favn.Pipeline
 
   pipeline :daily_sales do
-    asset MyApp.Gold.Sales.OrderSummary
+    asset MyApp.Warehouse.Gold.Sales.OrderSummary
     deps :all
     schedule cron: "0 2 * * *", timezone: "Etc/UTC"
   end
@@ -142,8 +166,8 @@ import Config
 
 config :favn,
   asset_modules: [
-    MyApp.Raw.Sales.Orders,
-    MyApp.Gold.Sales.OrderSummary
+    MyApp.Warehouse.Raw.Sales.Orders,
+    MyApp.Warehouse.Gold.Sales.OrderSummary
   ],
   pipeline_modules: [
     MyApp.Pipelines.DailySales

--- a/apps/favn_authoring/lib/favn/pipeline.ex
+++ b/apps/favn_authoring/lib/favn/pipeline.ex
@@ -51,12 +51,62 @@ defmodule Favn.Pipeline do
 
   ## Full example
 
+      defmodule MyApp.Warehouse do
+        use Favn.Namespace, relation: [connection: :warehouse]
+      end
+
+      defmodule MyApp.Warehouse.Raw do
+        use Favn.Namespace, relation: [catalog: "raw"]
+      end
+
+      defmodule MyApp.Warehouse.Raw.Sales do
+        use Favn.Namespace, relation: [schema: "sales"]
+      end
+
+      defmodule MyApp.Warehouse.Raw.Sales.Orders do
+        use Favn.Asset
+
+        @meta owner: "data-platform", category: :sales, tags: [:raw, :daily]
+        @relation true
+        def asset(_ctx), do: :ok
+      end
+
+      defmodule MyApp.Warehouse.Raw.Sales.OrderLines do
+        use Favn.Asset
+
+        @meta owner: "data-platform", category: :sales, tags: [:raw, :daily]
+        @relation [name: "order_line_items"]
+        def asset(_ctx), do: :ok
+      end
+
+      defmodule MyApp.Warehouse.Gold do
+        use Favn.Namespace, relation: [catalog: "gold"]
+      end
+
+      defmodule MyApp.Warehouse.Gold.Sales do
+        use Favn.Namespace, relation: [schema: "sales"]
+      end
+
+      defmodule MyApp.Warehouse.Gold.Sales.OrderSummary do
+        use Favn.SQLAsset
+
+        @meta owner: "analytics", category: :sales, tags: [:gold, :daily]
+        @materialized :view
+
+        query do
+          ~SQL"""
+          select *
+          from raw.sales.orders
+          """
+        end
+      end
+
       defmodule MyApp.Pipelines.DailySales do
         use Favn.Pipeline
 
         pipeline :daily_sales do
           select do
-            module MyApp.Gold.Sales
+            module MyApp.Warehouse.Gold.Sales
             tag :daily
             category :sales
           end
@@ -70,6 +120,13 @@ defmodule Favn.Pipeline do
           outputs [:warehouse, :metrics]
         end
       end
+
+  Namespace defaults are inherited from parent modules, so leaf asset modules
+  only need `use Favn.Namespace` when they want to add or override shared
+  relation defaults. `@relation true` is the normal path when the module leaf
+  should become the relation name, while `@relation [name: "..."]` is the
+  normal way to override only the relation name. `@meta` stays module-local and
+  is not inherited from namespace modules.
 
   ## Authoring notes
 

--- a/apps/favn_authoring/lib/favn/pipeline.ex
+++ b/apps/favn_authoring/lib/favn/pipeline.ex
@@ -94,10 +94,10 @@ defmodule Favn.Pipeline do
         @materialized :view
 
         query do
-          ~SQL"""
+          ~SQL\"""
           select *
           from raw.sales.orders
-          """
+          \"""
         end
       end
 


### PR DESCRIPTION
## Summary
- update the README quickstart to show inherited `Favn.Namespace` defaults instead of repeating relation config on leaf modules
- expand `Favn.Pipeline` docs with an end-to-end namespace example covering `@relation true`, relation name overrides, and module-local `@meta`
- clarify the recommended namespace authoring pattern that came up in issue #109

Closes #109.