### PR TITLE
fix: preserve namespace inheritance during parallel compile

### DIFF
--- a/apps/favn_authoring/lib/favn/namespace.ex
+++ b/apps/favn_authoring/lib/favn/namespace.ex
@@ -136,12 +136,20 @@ defmodule Favn.Namespace do
       Module.open?(module) ->
         Module.get_attribute(module, :favn_namespace_config)
 
-      match?({:module, _}, Code.ensure_loaded(module)) and
+      match?({:module, _}, ensure_namespace_module(module)) and
           function_exported?(module, :__favn_namespace_config__, 0) ->
         module.__favn_namespace_config__()
 
       true ->
         nil
+    end
+  end
+
+  defp ensure_namespace_module(module) when is_atom(module) do
+    if Code.can_await_module_compilation?() do
+      Code.ensure_compiled(module)
+    else
+      Code.ensure_loaded(module)
     end
   end
 

--- a/apps/favn_authoring/lib/favn/namespace.ex
+++ b/apps/favn_authoring/lib/favn/namespace.ex
@@ -145,6 +145,10 @@ defmodule Favn.Namespace do
     end
   end
 
+  # Namespace inheritance is used during DSL compilation, so same-project
+  # ancestor modules may exist but not be compiled yet under parallel compile.
+  # Falling back to ensure_loaded/1 here reintroduces child-first failures for
+  # SQL assets and multi-assets in mix compile/dev packaging paths.
   defp ensure_namespace_module(module) when is_atom(module) do
     if Code.can_await_module_compilation?() do
       Code.ensure_compiled(module)

--- a/apps/favn_core/test/assets/compiler_parity_test.exs
+++ b/apps/favn_core/test/assets/compiler_parity_test.exs
@@ -1,5 +1,5 @@
 defmodule Favn.Assets.CompilerParityTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Favn.Asset
   alias Favn.Assets.Compiler
@@ -166,6 +166,92 @@ defmodule Favn.Assets.CompilerParityTest do
            }
   end
 
+  test "sql asset namespace inheritance is compile-order independent" do
+    root = Module.concat(__MODULE__, "SQLRoot#{System.unique_integer([:positive])}")
+    gold = Module.concat(root, Gold)
+    asset = Module.concat(gold, ExecutiveOverview)
+
+    compile_modules_to_path!([
+      {"sql_asset.ex",
+       """
+       defmodule #{inspect(asset)} do
+         use Favn.Namespace
+         use Favn.SQLAsset
+
+         @materialized :view
+         query do
+           ~SQL\"\"\"
+           select *
+           from executive_overview
+           \"\"\"
+         end
+       end
+       """},
+      {"root.ex",
+       "defmodule #{inspect(root)} do\n  use Favn.Namespace, relation: [connection: :warehouse]\nend"},
+      {"gold.ex",
+       "defmodule #{inspect(gold)} do\n  use Favn.Namespace, relation: [schema: :gold]\nend"}
+    ])
+
+    assert {:ok, [%Asset{relation: relation, relation_inputs: relation_inputs}]} =
+             Compiler.compile_module_assets(asset)
+
+    assert relation == %RelationRef{
+             connection: :warehouse,
+             catalog: nil,
+             schema: "gold",
+             name: "executive_overview"
+           }
+
+    assert [%Favn.Asset.RelationInput{relation_ref: input_relation}] = relation_inputs
+
+    assert input_relation == %RelationRef{
+             connection: :warehouse,
+             catalog: nil,
+             schema: "gold",
+             name: "executive_overview"
+           }
+  end
+
+  test "multi-asset namespace inheritance is compile-order independent" do
+    root = Module.concat(__MODULE__, "MultiRoot#{System.unique_integer([:positive])}")
+    raw = Module.concat(root, Raw)
+    assets = Module.concat(raw, Extracts)
+
+    compile_modules_to_path!([
+      {"multi_asset.ex",
+       """
+       defmodule #{inspect(assets)} do
+         use Favn.Namespace
+         use Favn.MultiAsset
+
+         @relation true
+         asset :orders do
+           rest do
+             path "/orders"
+             data_path "orders"
+           end
+         end
+
+         def asset(_ctx), do: :ok
+       end
+       """},
+      {"root.ex",
+       "defmodule #{inspect(root)} do\n  use Favn.Namespace, relation: [connection: :warehouse]\nend"},
+      {"raw.ex",
+       "defmodule #{inspect(raw)} do\n  use Favn.Namespace, relation: [catalog: :raw, schema: :sales]\nend"}
+    ])
+
+    assert {:ok, [%Asset{relation: relation}]} = Compiler.compile_module_assets(assets)
+
+    assert relation == %RelationRef{
+             connection: :warehouse,
+             catalog: "raw",
+             schema: "sales",
+             name: "orders"
+           }
+  end
+
   test "relation normalization rejects duplicate canonical keys" do
     module_name =
       Module.concat(__MODULE__, "DuplicateCatalog#{System.unique_integer([:positive])}")
@@ -221,5 +307,29 @@ defmodule Favn.Assets.CompilerParityTest do
              Kernel.ParallelCompiler.compile_to_path([file_path], dir, return_diagnostics: true)
 
     assert module in modules
+  end
+
+  defp compile_modules_to_path!(entries) when is_list(entries) do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_core_parallel_modules_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+
+    files =
+      Enum.map(entries, fn {name, source} ->
+        file_path = Path.join(dir, name)
+        File.write!(file_path, source)
+        file_path
+      end)
+
+    Code.prepend_path(dir)
+
+    assert {:ok, _modules, _diagnostics} =
+             Kernel.ParallelCompiler.compile_to_path(files, dir, return_diagnostics: true)
+
+    :ok
   end
 end


### PR DESCRIPTION
## Summary
- make `Favn.Namespace` await same-project ancestor module compilation before reading inherited namespace config
- fix child-first parallel compilation for SQL assets and multi-assets so local tooling and packaging paths keep inherited connection/schema defaults
- add compile-order regression coverage for SQL assets and multi-assets using `Kernel.ParallelCompiler`

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`

Closes #111