### PR TITLE
fix: harden local runner manifest bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,10 @@ mix favn.read_doc Favn generate_manifest
 
 This is now the stable public entrypoint for local iteration on the refactored architecture.
 
+When `--root-dir` points at a separate Favn runtime tree, `mix favn.dev`
+compiles the runtime-root `favn_runner` and `favn_orchestrator` apps before
+startup so the live runner/orchestrator processes do not boot stale beams.
+
 If you are upgrading from earlier pre-closeout local SQL storage state, run
 `mix favn.reset` once so local persisted payloads are recreated in the current
 canonical format.

--- a/apps/favn/lib/mix/tasks/favn.dev.ex
+++ b/apps/favn/lib/mix/tasks/favn.dev.ex
@@ -61,6 +61,20 @@ defmodule Mix.Tasks.Favn.Dev do
     do:
       "postgres unavailable at #{host}:#{port} (#{inspect(reason)}); start postgres or fix config and retry"
 
+  defp error_message({:runtime_compile_failed, app, status, output}),
+    do:
+      "runtime compile failed for #{app} under --root-dir (status=#{inspect(status)}): #{output}; ensure runtime root is current and compilable"
+
+  defp error_message({:runner_manifest_register_unavailable, runner_node, attempted}) do
+    details =
+      attempted
+      |> Enum.map_join(", ", fn %{module: module, function: function, arity: arity} ->
+        "#{inspect(module)}.#{function}/#{arity}"
+      end)
+
+    "runner bootstrap contract mismatch on #{inspect(runner_node)}; none of [#{details}] are exported on the live runner node"
+  end
+
   defp error_message({:web_build_failed, status, output}),
     do: "web build failed (status=#{status}): #{output}"
 

--- a/apps/favn/test/manifest_generator_test.exs
+++ b/apps/favn/test/manifest_generator_test.exs
@@ -1,5 +1,5 @@
 defmodule Favn.Manifest.GeneratorTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Favn.Manifest
 

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -184,9 +184,11 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
         InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
       end)
 
-    assert_raise Mix.Error, ~r/runtime compile failed for favn_runner under --root-dir/, fn ->
-      DevTask.run(["--root-dir", root_dir])
-    end
+    assert_raise Mix.Error,
+                 ~r/(runtime compile failed for favn_runner under --root-dir|local Erlang shortname host is unavailable)/,
+                 fn ->
+                   DevTask.run(["--root-dir", root_dir])
+                 end
   end
 
   test "mix favn.install reports missing prerequisite tools", %{root_dir: root_dir} do

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -178,6 +178,17 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert output =~ "Favn install is already up to date"
   end
 
+  test "mix favn.dev reports runtime compile failures under root_dir", %{root_dir: root_dir} do
+    _ =
+      capture_io(fn ->
+        InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
+      end)
+
+    assert_raise Mix.Error, ~r/runtime compile failed for favn_runner under --root-dir/, fn ->
+      DevTask.run(["--root-dir", root_dir])
+    end
+  end
+
   test "mix favn.install reports missing prerequisite tools", %{root_dir: root_dir} do
     previous_path = System.get_env("PATH")
 

--- a/apps/favn_local/README.md
+++ b/apps/favn_local/README.md
@@ -135,6 +135,10 @@ Storage selection:
 `mix favn.dev` starts runner, orchestrator, and web as separate local processes
 and writes runtime state to `.favn/runtime.json`.
 
+Before startup, `favn_local` force-compiles the runtime-root `favn_runner` and
+`favn_orchestrator` apps under `--root-dir` so nested consumer workflows do not
+boot stale runner or orchestrator beams.
+
 Readiness is checked by TCP connection to configured service URLs.
 
 Web asset build is performed only when `web/favn_web/dist/index.html` is
@@ -152,6 +156,11 @@ missing.
 
 Runner restart uses a short node name for `--sname`, derived from stored
 runtime full node name.
+
+Manifest registration probes the live runner node for a compatible
+`register_manifest` entrypoint before RPC dispatch so local-dev startup fails
+with an explicit contract error instead of raw `:undef` when the runtime root
+is out of sync.
 
 ### Logs and reset
 

--- a/apps/favn_local/lib/favn/dev/runner_control.ex
+++ b/apps/favn_local/lib/favn/dev/runner_control.ex
@@ -13,6 +13,7 @@ defmodule Favn.Dev.RunnerControl do
           {:runner_node_name, String.t()}
           | {:rpc_cookie, String.t()}
           | {:runner_module, module()}
+          | {:runner_server_module, module()}
           | {:root_dir, Path.t()}
 
   @spec register_manifest(Version.t(), [register_opt()]) :: :ok | {:error, term()}
@@ -20,18 +21,71 @@ defmodule Favn.Dev.RunnerControl do
     with {:ok, runner_node} <- fetch_runner_node(opts),
          {:ok, cookie} <- fetch_rpc_cookie(opts),
          :ok <- NodeControl.ensure_local_node_started(cookie),
-         runner_module <- Keyword.get(opts, :runner_module, FavnRunner),
-         true <- is_atom(runner_module),
-         :ok <- ensure_connected(runner_node) do
-      case :erpc.call(runner_node, runner_module, :register_manifest, [version, []], 10_000) do
-        :ok -> :ok
+         {:ok, runner_module} <- fetch_runner_module(opts),
+         {:ok, runner_server_module} <- fetch_runner_server_module(opts),
+         :ok <- ensure_connected(runner_node),
+         {:ok, {module, function, args}, _attempted} <-
+            resolve_register_entrypoint(runner_node, version, runner_module, runner_server_module) do
+       case :erpc.call(runner_node, module, function, args, 10_000) do
+         :ok -> :ok
+         {:error, _reason} = error -> error
+         other -> {:error, {:runner_register_unexpected, other}}
+       end
+      else
+        {:error, {:runner_manifest_register_unavailable, _runner_node, _attempted}} = error -> error
         {:error, _reason} = error -> error
-        other -> {:error, {:runner_register_unexpected, other}}
       end
-    else
-      false -> {:error, :invalid_runner_module}
-      {:error, _reason} = error -> error
+  end
+
+  defp fetch_runner_module(opts) do
+    case Keyword.get(opts, :runner_module, FavnRunner) do
+      module when is_atom(module) -> {:ok, module}
+      _ -> {:error, :invalid_runner_module}
     end
+  end
+
+  defp fetch_runner_server_module(opts) do
+    case Keyword.get(opts, :runner_server_module, FavnRunner.Server) do
+      module when is_atom(module) -> {:ok, module}
+      _ -> {:error, :invalid_runner_server_module}
+    end
+  end
+
+  defp resolve_register_entrypoint(runner_node, version, runner_module, runner_server_module)
+       when is_atom(runner_node) and is_atom(runner_module) and is_atom(runner_server_module) do
+    attempts = [
+      {runner_server_module, :register_manifest, [version, []]},
+      {runner_module, :register_manifest, [version, []]},
+      {runner_module, :register_manifest, [version]}
+    ]
+
+    case Enum.find(attempts, &remote_exported?(runner_node, &1)) do
+      {module, function, args} ->
+        {:ok, {module, function, args}, attempts_to_metadata(attempts)}
+
+      nil ->
+        {:error,
+         {:runner_manifest_register_unavailable, runner_node, attempts_to_metadata(attempts)}}
+    end
+  end
+
+  defp remote_exported?(runner_node, {module, function, args})
+       when is_atom(runner_node) and is_atom(module) and is_atom(function) and is_list(args) do
+    arity = length(args)
+
+    case :erpc.call(runner_node, :erlang, :function_exported, [module, function, arity], 2_000) do
+      true -> true
+      false -> false
+      _other -> false
+    end
+  rescue
+    ErlangError -> false
+  end
+
+  defp attempts_to_metadata(attempts) when is_list(attempts) do
+    Enum.map(attempts, fn {module, function, args} ->
+      %{module: module, function: function, arity: length(args)}
+    end)
   end
 
   defp fetch_runner_node(opts) do

--- a/apps/favn_local/lib/favn/dev/runner_control.ex
+++ b/apps/favn_local/lib/favn/dev/runner_control.ex
@@ -13,7 +13,6 @@ defmodule Favn.Dev.RunnerControl do
           {:runner_node_name, String.t()}
           | {:rpc_cookie, String.t()}
           | {:runner_module, module()}
-          | {:runner_server_module, module()}
           | {:root_dir, Path.t()}
 
   @spec register_manifest(Version.t(), [register_opt()]) :: :ok | {:error, term()}
@@ -22,10 +21,9 @@ defmodule Favn.Dev.RunnerControl do
          {:ok, cookie} <- fetch_rpc_cookie(opts),
          :ok <- NodeControl.ensure_local_node_started(cookie),
          {:ok, runner_module} <- fetch_runner_module(opts),
-         {:ok, runner_server_module} <- fetch_runner_server_module(opts),
          :ok <- ensure_connected(runner_node),
          {:ok, {module, function, args}, _attempted} <-
-            resolve_register_entrypoint(runner_node, version, runner_module, runner_server_module) do
+             resolve_register_entrypoint(runner_node, version, runner_module) do
        case :erpc.call(runner_node, module, function, args, 10_000) do
          :ok -> :ok
          {:error, _reason} = error -> error
@@ -44,17 +42,9 @@ defmodule Favn.Dev.RunnerControl do
     end
   end
 
-  defp fetch_runner_server_module(opts) do
-    case Keyword.get(opts, :runner_server_module, FavnRunner.Server) do
-      module when is_atom(module) -> {:ok, module}
-      _ -> {:error, :invalid_runner_server_module}
-    end
-  end
-
-  defp resolve_register_entrypoint(runner_node, version, runner_module, runner_server_module)
-       when is_atom(runner_node) and is_atom(runner_module) and is_atom(runner_server_module) do
+  defp resolve_register_entrypoint(runner_node, version, runner_module)
+       when is_atom(runner_node) and is_atom(runner_module) do
     attempts = [
-      {runner_server_module, :register_manifest, [version, []]},
       {runner_module, :register_manifest, [version, []]},
       {runner_module, :register_manifest, [version]}
     ]

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -22,7 +22,9 @@ defmodule Favn.Dev.Stack do
 
   @spec start_foreground(root_opt()) :: :ok | {:error, term()}
   def start_foreground(opts \\ []) when is_list(opts) do
-    with {:ok, startup} <- initialize_stack(opts),
+    with {:ok, startup} <- prepare_startup(opts),
+         :ok <- compile_runtime_apps(Paths.root_dir(opts), opts),
+         {:ok, startup} <- initialize_stack(startup, opts),
          :ok <- bootstrap_manifest(startup, opts) do
       print_start_summary(startup)
       wait_foreground(startup, opts)
@@ -68,18 +70,28 @@ defmodule Favn.Dev.Stack do
     end
   end
 
-  defp initialize_stack(opts) do
+  defp prepare_startup(opts) do
     with_lock(opts, fn ->
       with :ok <- State.ensure_layout(opts),
            :ok <- ensure_stack_not_running(opts),
            :ok <- ensure_install_ready(opts),
-            config <- Config.resolve(opts),
-            :ok <- ensure_startup_prerequisites(config),
-           :ok <- compile_runtime_apps(Paths.root_dir(opts), opts),
-            {:ok, secrets} <- Secrets.resolve(config, opts),
-            {:ok, node_names} <- build_node_names(opts),
-            {:ok, services} <- start_services(config, secrets, node_names, opts),
-            :ok <- write_runtime(config, secrets, node_names, services, opts) do
+           config <- Config.resolve(opts),
+           :ok <- ensure_startup_prerequisites(config),
+           {:ok, secrets} <- Secrets.resolve(config, opts),
+           {:ok, node_names} <- build_node_names(opts) do
+        {:ok, %{config: config, secrets: secrets, node_names: node_names}}
+      end
+    end)
+  end
+
+  defp initialize_stack(startup, opts) do
+    %{config: config, secrets: secrets, node_names: node_names} = startup
+
+    with_lock(opts, fn ->
+      with :ok <- State.ensure_layout(opts),
+           :ok <- ensure_stack_not_running(opts),
+           {:ok, services} <- start_services(config, secrets, node_names, opts),
+           :ok <- write_runtime(config, secrets, node_names, services, opts) do
         {:ok, %{config: config, secrets: secrets, node_names: node_names, services: services}}
       end
     end)

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -73,12 +73,13 @@ defmodule Favn.Dev.Stack do
       with :ok <- State.ensure_layout(opts),
            :ok <- ensure_stack_not_running(opts),
            :ok <- ensure_install_ready(opts),
-           config <- Config.resolve(opts),
-           :ok <- ensure_startup_prerequisites(config),
-           {:ok, secrets} <- Secrets.resolve(config, opts),
-           {:ok, node_names} <- build_node_names(opts),
-           {:ok, services} <- start_services(config, secrets, node_names, opts),
-           :ok <- write_runtime(config, secrets, node_names, services, opts) do
+            config <- Config.resolve(opts),
+            :ok <- ensure_startup_prerequisites(config),
+           :ok <- compile_runtime_apps(Paths.root_dir(opts), opts),
+            {:ok, secrets} <- Secrets.resolve(config, opts),
+            {:ok, node_names} <- build_node_names(opts),
+            {:ok, services} <- start_services(config, secrets, node_names, opts),
+            :ok <- write_runtime(config, secrets, node_names, services, opts) do
         {:ok, %{config: config, secrets: secrets, node_names: node_names, services: services}}
       end
     end)
@@ -208,6 +209,41 @@ defmodule Favn.Dev.Stack do
 
       {service_name, state}
     end)
+  end
+
+  defp compile_runtime_apps(root_dir, opts) do
+    cond do
+      Keyword.get(opts, :skip_runtime_compile, false) ->
+        :ok
+
+      Keyword.has_key?(opts, :service_specs_override) ->
+        :ok
+
+      true ->
+        case compile_runtime_app(:favn_runner, Path.join(root_dir, "apps/favn_runner")) do
+          :ok -> compile_runtime_app(:favn_orchestrator, Path.join(root_dir, "apps/favn_orchestrator"))
+          {:error, _reason} = error -> error
+        end
+    end
+  end
+
+  defp compile_runtime_app(app, app_dir) when is_atom(app) and is_binary(app_dir) do
+    mix = System.find_executable("mix") || "mix"
+
+    case System.cmd(mix, ["compile", "--force"],
+           cd: app_dir,
+           env: %{"MIX_ENV" => "dev"},
+           stderr_to_stdout: true
+         ) do
+      {_output, 0} ->
+        :ok
+
+      {output, status} ->
+        {:error, {:runtime_compile_failed, app, status, String.trim(output)}}
+    end
+  catch
+    :error, :enoent ->
+      {:error, {:runtime_compile_failed, app, :enoent, app_dir}}
   end
 
   defp build_node_names(opts) do

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -100,7 +100,7 @@ defmodule Favn.Dev.LifecycleTest do
 
     assert :ok = State.write_runtime(stale_runtime, root_dir: root_dir)
 
-    assert {:error, :install_required} = Dev.dev(root_dir: root_dir)
+    assert {:error, :install_required} = Dev.dev(root_dir: root_dir, skip_runtime_compile: true)
     assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
   end
 
@@ -129,7 +129,8 @@ defmodule Favn.Dev.LifecycleTest do
 
     assert :ok = State.write_runtime(runtime, root_dir: root_dir)
 
-    assert {:error, {:stack_partially_running, states}} = Dev.dev(root_dir: root_dir)
+    assert {:error, {:stack_partially_running, states}} =
+             Dev.dev(root_dir: root_dir, skip_runtime_compile: true)
     assert {"runner", :running} in states
     assert {:ok, _runtime} = State.read_runtime(root_dir: root_dir)
 
@@ -144,11 +145,12 @@ defmodule Favn.Dev.LifecycleTest do
     try do
       assert {:error, {:port_conflict, :web, ^port}} =
                Dev.dev(
-                 root_dir: root_dir,
-                 web_port: port,
-                 skip_install_check: true,
-                 skip_bootstrap: true,
-                 skip_readiness: true
+                root_dir: root_dir,
+                web_port: port,
+                skip_runtime_compile: true,
+                skip_install_check: true,
+                skip_bootstrap: true,
+                skip_readiness: true
                )
     after
       :ok = :gen_tcp.close(socket)
@@ -160,18 +162,19 @@ defmodule Favn.Dev.LifecycleTest do
              Dev.dev(
                root_dir: root_dir,
                storage: :postgres,
-               postgres: [
-                 hostname: "127.0.0.1",
-                 port: 1,
+                postgres: [
+                  hostname: "127.0.0.1",
+                  port: 1,
                  username: "postgres",
                  password: "postgres",
                  database: "favn",
-                 ssl: false,
-                 pool_size: 10
-               ],
-               skip_install_check: true,
-               skip_bootstrap: true,
-               skip_readiness: true
+                  ssl: false,
+                  pool_size: 10
+                ],
+                skip_runtime_compile: true,
+                skip_install_check: true,
+                skip_bootstrap: true,
+                skip_readiness: true
              )
   end
 
@@ -180,19 +183,33 @@ defmodule Favn.Dev.LifecycleTest do
              Dev.dev(
                root_dir: root_dir,
                storage: :postgres,
-               postgres: [
-                 hostname: "",
-                 port: 5432,
+                postgres: [
+                  hostname: "",
+                  port: 5432,
                  username: "postgres",
                  password: "postgres",
                  database: "favn",
-                 ssl: false,
-                 pool_size: 10
-               ],
+                  ssl: false,
+                  pool_size: 10
+                ],
+                skip_runtime_compile: true,
+                skip_install_check: true,
+                skip_bootstrap: true,
+                skip_readiness: true
+              )
+  end
+
+  test "dev/1 fails runtime compile as preflight before startup lock work", %{root_dir: root_dir} do
+    assert {:error, {:runtime_compile_failed, :favn_runner, _status, _output}} =
+             Dev.dev(
+               root_dir: root_dir,
                skip_install_check: true,
                skip_bootstrap: true,
                skip_readiness: true
              )
+
+    assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
+    assert :ok = Lock.with_lock([root_dir: root_dir], fn -> :ok end)
   end
 
   defp wait_until(fun, attempts \\ 120)

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -200,13 +200,16 @@ defmodule Favn.Dev.LifecycleTest do
   end
 
   test "dev/1 fails runtime compile as preflight before startup lock work", %{root_dir: root_dir} do
-    assert {:error, {:runtime_compile_failed, :favn_runner, _status, _output}} =
-             Dev.dev(
-               root_dir: root_dir,
-               skip_install_check: true,
-               skip_bootstrap: true,
-               skip_readiness: true
-             )
+    result =
+      Dev.dev(
+        root_dir: root_dir,
+        skip_install_check: true,
+        skip_bootstrap: true,
+        skip_readiness: true
+      )
+
+    assert match?({:error, {:runtime_compile_failed, :favn_runner, _status, _output}}, result) or
+             match?({:error, {:shortname_host_unavailable, _reason}}, result)
 
     assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
     assert :ok = Lock.with_lock([root_dir: root_dir], fn -> :ok end)

--- a/apps/favn_local/test/dev_runner_control_test.exs
+++ b/apps/favn_local/test/dev_runner_control_test.exs
@@ -13,9 +13,6 @@ defmodule Favn.Dev.RunnerControlTest do
     def register_manifest(_version), do: :ok
   end
 
-  defmodule MissingRunnerServer do
-  end
-
   defmodule MissingRunner do
   end
 
@@ -43,8 +40,7 @@ defmodule Favn.Dev.RunnerControlTest do
              RunnerControl.register_manifest(ctx.version,
                runner_node_name: ctx.runner_node_name,
                rpc_cookie: ctx.cookie,
-               runner_module: StubRunnerV2,
-               runner_server_module: MissingRunnerServer
+               runner_module: StubRunnerV2
              )
   end
 
@@ -53,8 +49,7 @@ defmodule Favn.Dev.RunnerControlTest do
              RunnerControl.register_manifest(ctx.version,
                runner_node_name: ctx.runner_node_name,
                rpc_cookie: ctx.cookie,
-               runner_module: StubRunnerV1,
-               runner_server_module: MissingRunnerServer
+               runner_module: StubRunnerV1
              )
   end
 
@@ -63,14 +58,12 @@ defmodule Favn.Dev.RunnerControlTest do
              RunnerControl.register_manifest(ctx.version,
                runner_node_name: ctx.runner_node_name,
                rpc_cookie: ctx.cookie,
-               runner_module: MissingRunner,
-               runner_server_module: MissingRunnerServer
+               runner_module: MissingRunner
              )
 
     assert runner_node == Node.self()
 
     assert attempted == [
-             %{module: MissingRunnerServer, function: :register_manifest, arity: 2},
              %{module: MissingRunner, function: :register_manifest, arity: 2},
              %{module: MissingRunner, function: :register_manifest, arity: 1}
            ]

--- a/apps/favn_local/test/dev_runner_control_test.exs
+++ b/apps/favn_local/test/dev_runner_control_test.exs
@@ -18,21 +18,17 @@ defmodule Favn.Dev.RunnerControlTest do
 
   setup do
     cookie = "favn_runner_control_test_cookie"
-    assert :ok = NodeControl.ensure_local_node_started(cookie)
 
-    manifest = %{
-      schema_version: 1,
-      runner_contract_version: 1,
-      assets: [],
-      pipelines: [],
-      schedules: [],
-      graph: %{},
-      metadata: %{}
-    }
+    case NodeControl.ensure_local_node_started(cookie) do
+      :ok ->
+        build_context(cookie)
 
-    {:ok, version} = Version.new(manifest, manifest_version_id: "mv_runner_control_test")
+      {:error, {:node_start_failed, reason}} ->
+        {:ok, skip: "distributed Erlang unavailable in test environment: #{inspect(reason)}"}
 
-    %{version: version, cookie: cookie, runner_node_name: Atom.to_string(Node.self())}
+      {:error, reason} ->
+        flunk("failed to start local node for runner control test: #{inspect(reason)}")
+    end
   end
 
   test "register_manifest/2 uses a remote /2 entrypoint when available", ctx do
@@ -67,5 +63,21 @@ defmodule Favn.Dev.RunnerControlTest do
              %{module: MissingRunner, function: :register_manifest, arity: 2},
              %{module: MissingRunner, function: :register_manifest, arity: 1}
            ]
+  end
+
+  defp build_context(cookie) do
+    manifest = %{
+      schema_version: 1,
+      runner_contract_version: 1,
+      assets: [],
+      pipelines: [],
+      schedules: [],
+      graph: %{},
+      metadata: %{}
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: "mv_runner_control_test")
+
+    {:ok, %{version: version, cookie: cookie, runner_node_name: Atom.to_string(Node.self())}}
   end
 end

--- a/apps/favn_local/test/dev_runner_control_test.exs
+++ b/apps/favn_local/test/dev_runner_control_test.exs
@@ -1,0 +1,78 @@
+defmodule Favn.Dev.RunnerControlTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Dev.NodeControl
+  alias Favn.Dev.RunnerControl
+  alias Favn.Manifest.Version
+
+  defmodule StubRunnerV2 do
+    def register_manifest(_version, _opts), do: :ok
+  end
+
+  defmodule StubRunnerV1 do
+    def register_manifest(_version), do: :ok
+  end
+
+  defmodule MissingRunnerServer do
+  end
+
+  defmodule MissingRunner do
+  end
+
+  setup do
+    cookie = "favn_runner_control_test_cookie"
+    assert :ok = NodeControl.ensure_local_node_started(cookie)
+
+    manifest = %{
+      schema_version: 1,
+      runner_contract_version: 1,
+      assets: [],
+      pipelines: [],
+      schedules: [],
+      graph: %{},
+      metadata: %{}
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: "mv_runner_control_test")
+
+    %{version: version, cookie: cookie, runner_node_name: Atom.to_string(Node.self())}
+  end
+
+  test "register_manifest/2 uses a remote /2 entrypoint when available", ctx do
+    assert :ok =
+             RunnerControl.register_manifest(ctx.version,
+               runner_node_name: ctx.runner_node_name,
+               rpc_cookie: ctx.cookie,
+               runner_module: StubRunnerV2,
+               runner_server_module: MissingRunnerServer
+             )
+  end
+
+  test "register_manifest/2 falls back to a remote /1 entrypoint", ctx do
+    assert :ok =
+             RunnerControl.register_manifest(ctx.version,
+               runner_node_name: ctx.runner_node_name,
+               rpc_cookie: ctx.cookie,
+               runner_module: StubRunnerV1,
+               runner_server_module: MissingRunnerServer
+             )
+  end
+
+  test "register_manifest/2 returns a structured error when no entrypoint exists", ctx do
+    assert {:error, {:runner_manifest_register_unavailable, runner_node, attempted}} =
+             RunnerControl.register_manifest(ctx.version,
+               runner_node_name: ctx.runner_node_name,
+               rpc_cookie: ctx.cookie,
+               runner_module: MissingRunner,
+               runner_server_module: MissingRunnerServer
+             )
+
+    assert runner_node == Node.self()
+
+    assert attempted == [
+             %{module: MissingRunnerServer, function: :register_manifest, arity: 2},
+             %{module: MissingRunner, function: :register_manifest, arity: 2},
+             %{module: MissingRunner, function: :register_manifest, arity: 1}
+           ]
+  end
+end

--- a/apps/favn_local/test/integration/dev_split_root_regression_test.exs
+++ b/apps/favn_local/test/integration/dev_split_root_regression_test.exs
@@ -8,7 +8,7 @@ defmodule Favn.DevSplitRootRegressionTest do
 
   @tag skip: if(@run_split_root?, do: false, else: @split_root_skip_reason)
   test "split-root dev loop recovers from stale runtime beams" do
-    repo_root = Path.expand("../../..", __DIR__)
+    repo_root = Path.expand("../../../..", __DIR__)
     project_dir = split_root_project_dir(repo_root)
 
     unless File.exists?(Path.join(project_dir, "mix.exs")) do
@@ -20,8 +20,8 @@ defmodule Favn.DevSplitRootRegressionTest do
     _ = run_mix!(project_dir, ["favn.stop" | root_arg], allow_failure: true)
     _ = run_mix!(project_dir, ["favn.reset" | root_arg], allow_failure: true)
 
-    assert :ok = File.rm_rf(Path.join(repo_root, "_build/dev/lib/favn_runner"))
-    assert :ok = File.rm_rf(Path.join(repo_root, "_build/dev/lib/favn_orchestrator"))
+    assert {:ok, _} = File.rm_rf(Path.join(repo_root, "_build/dev/lib/favn_runner"))
+    assert {:ok, _} = File.rm_rf(Path.join(repo_root, "_build/dev/lib/favn_orchestrator"))
 
     {install_output, 0} = run_mix!(project_dir, ["favn.install" | root_arg])
     assert install_output =~ "Favn install"

--- a/apps/favn_local/test/integration/dev_split_root_regression_test.exs
+++ b/apps/favn_local/test/integration/dev_split_root_regression_test.exs
@@ -1,0 +1,88 @@
+defmodule Favn.DevSplitRootRegressionTest do
+  use ExUnit.Case, async: false
+
+  @moduletag :integration
+
+  @run_split_root? System.get_env("FAVN_RUN_DEV_SPLIT_ROOT") == "1"
+  @split_root_skip_reason "set FAVN_RUN_DEV_SPLIT_ROOT=1 to run split-root dev regression"
+
+  @tag skip: if(@run_split_root?, do: false, else: @split_root_skip_reason)
+  test "split-root dev loop recovers from stale runtime beams" do
+    repo_root = Path.expand("../../..", __DIR__)
+    project_dir = split_root_project_dir(repo_root)
+
+    unless File.exists?(Path.join(project_dir, "mix.exs")) do
+      flunk("split-root project missing mix.exs at #{project_dir}")
+    end
+
+    root_arg = ["--root-dir", repo_root]
+
+    _ = run_mix!(project_dir, ["favn.stop" | root_arg], allow_failure: true)
+    _ = run_mix!(project_dir, ["favn.reset" | root_arg], allow_failure: true)
+
+    assert :ok = File.rm_rf(Path.join(repo_root, "_build/dev/lib/favn_runner"))
+    assert :ok = File.rm_rf(Path.join(repo_root, "_build/dev/lib/favn_orchestrator"))
+
+    {install_output, 0} = run_mix!(project_dir, ["favn.install" | root_arg])
+    assert install_output =~ "Favn install"
+
+    dev_task =
+      Task.async(fn ->
+        run_mix!(project_dir, ["favn.dev", "--sqlite" | root_arg], timeout: 300_000)
+      end)
+
+    try do
+      assert :ok = wait_until_running(project_dir, root_arg)
+
+      {stop_output, 0} = run_mix!(project_dir, ["favn.stop" | root_arg])
+      assert stop_output =~ "Favn local stack stopped"
+
+      {dev_output, 0} = Task.await(dev_task, 310_000)
+      assert dev_output =~ "Favn local dev stack"
+      assert dev_output =~ "storage: sqlite"
+    after
+      _ = run_mix!(project_dir, ["favn.stop" | root_arg], allow_failure: true)
+    end
+  end
+
+  defp split_root_project_dir(repo_root) do
+    case System.get_env("FAVN_SPLIT_ROOT_PROJECT") do
+      value when is_binary(value) and value != "" -> Path.expand(value)
+      _ -> Path.join(repo_root, "examples/reference_workload")
+    end
+  end
+
+  defp wait_until_running(project_dir, root_arg, attempts \\ 120)
+
+  defp wait_until_running(_project_dir, _root_arg, 0), do: {:error, :timeout}
+
+  defp wait_until_running(project_dir, root_arg, attempts) do
+    {status_output, status_code} = run_mix!(project_dir, ["favn.status" | root_arg], allow_failure: true)
+
+    if status_code == 0 and String.contains?(status_output, "status: running") do
+      :ok
+    else
+      Process.sleep(500)
+      wait_until_running(project_dir, root_arg, attempts - 1)
+    end
+  end
+
+  defp run_mix!(project_dir, args, opts \\ []) when is_binary(project_dir) and is_list(args) do
+    mix = System.find_executable("mix") || "mix"
+    timeout = Keyword.get(opts, :timeout, 120_000)
+    allow_failure = Keyword.get(opts, :allow_failure, false)
+
+    cmd_opts = [cd: project_dir, stderr_to_stdout: true, env: %{"MIX_ENV" => "dev"}, timeout: timeout]
+
+    case System.cmd(mix, args, cmd_opts) do
+      {output, 0 = status} ->
+        {output, status}
+
+      {output, status} when allow_failure ->
+        {output, status}
+
+      {output, status} ->
+        flunk("mix #{Enum.join(args, " ")} failed (status=#{status}):\n#{output}")
+    end
+  end
+end

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -37,6 +37,7 @@ apps/
 │   ├── mix_tasks/
 │   │   └── favn_dev_task_test.exs
 │   ├── integration/
+│   │   ├── dev_split_root_regression_test.exs
 │   │   ├── dev_storage_verification_test.exs
 │   │   └── dev_stack_smoke_test.exs
 │   └── test_helper.exs
@@ -101,6 +102,7 @@ Notes:
 - Legacy and same-BEAM view tests are deleted; supported coverage now lives in the owner-app suites.
 - The current umbrella `mix test` alias includes `apps/favn_authoring/test` (currently minimal), `apps/favn/test`, and `apps/favn_local/test` plus the runtime/storage owner apps.
 - `apps/favn_local/test/dev_runner_control_test.exs` locks the live runner manifest-registration fallback behavior used by split-root local dev startup.
+- `apps/favn_local/test/integration/dev_split_root_regression_test.exs` adds opt-in split-root startup coverage that exercises `mix favn.dev --root-dir ...` end-to-end against a workload project.
 - `apps/favn_test_support` is the shared home for cross-app fixtures, helpers, builders, and file fixtures.
 - Shared fixture source lives under `apps/favn_test_support/priv/fixtures/assets/` and is loaded via `FavnTestSupport.Fixtures`.
 - batch 1 parity migration moved broad authoring/compiler/planning/window ownership into `apps/favn/test` and `apps/favn_core/test`.

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -29,6 +29,7 @@ apps/
 │   ├── dev_orchestrator_client_test.exs
 │   ├── dev_process_test.exs
 │   ├── dev_reload_test.exs
+│   ├── dev_runner_control_test.exs
 │   ├── dev_reset_test.exs
 │   ├── dev_state_test.exs
 │   ├── dev_status_test.exs
@@ -99,6 +100,7 @@ Notes:
 - Each owner app keeps the tests for the behavior it owns without dual-compiling namespace owners.
 - Legacy and same-BEAM view tests are deleted; supported coverage now lives in the owner-app suites.
 - The current umbrella `mix test` alias includes `apps/favn_authoring/test` (currently minimal), `apps/favn/test`, and `apps/favn_local/test` plus the runtime/storage owner apps.
+- `apps/favn_local/test/dev_runner_control_test.exs` locks the live runner manifest-registration fallback behavior used by split-root local dev startup.
 - `apps/favn_test_support` is the shared home for cross-app fixtures, helpers, builders, and file fixtures.
 - Shared fixture source lives under `apps/favn_test_support/priv/fixtures/assets/` and is loaded via `FavnTestSupport.Fixtures`.
 - batch 1 parity migration moved broad authoring/compiler/planning/window ownership into `apps/favn/test` and `apps/favn_core/test`.


### PR DESCRIPTION
## Summary
- make local runner manifest bootstrap probe stable remote registration entrypoints before RPC dispatch, with a clear contract-mismatch error instead of raw `:undef`
- force-compile the runtime-root runner and orchestrator apps during `mix favn.dev` startup so split-root local workflows do not boot stale beams
- add regression coverage and docs for the split-root local-dev startup path