### PR TITLE
fix: support git installs from umbrella repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,12 +76,14 @@ Favn is not published on Hex yet.
 ```elixir
 def deps do
   [
-    {:favn, git: "https://github.com/eirhop/favn.git", branch: "main", sparse: "apps/favn"}
+    {:favn, git: "https://github.com/eirhop/favn.git", branch: "main", subdir: "apps/favn"}
   ]
 end
 ```
 
-`favn` currently lives inside this umbrella repo under `apps/favn`, so the git dependency must use `sparse: "apps/favn"`.
+`favn` currently lives inside this umbrella repo under `apps/favn`, so the git dependency must use `subdir: "apps/favn"`.
+
+For real projects, prefer pinning a tag or commit ref instead of tracking `main` directly.
 
 ### 2. Define an asset
 

--- a/README.md
+++ b/README.md
@@ -76,10 +76,12 @@ Favn is not published on Hex yet.
 ```elixir
 def deps do
   [
-    {:favn, git: "https://github.com/eirhop/favn.git", branch: "main"}
+    {:favn, git: "https://github.com/eirhop/favn.git", branch: "main", sparse: "apps/favn"}
   ]
 end
 ```
+
+`favn` currently lives inside this umbrella repo under `apps/favn`, so the git dependency must use `sparse: "apps/favn"`.
 
 ### 2. Define an asset
 

--- a/apps/favn/mix.exs
+++ b/apps/favn/mix.exs
@@ -31,12 +31,12 @@ defmodule Favn.MixProject do
     ]
   end
 
-  defp internal_dep(app, sparse_path, opts \\ []) do
+  defp internal_dep(app, relative_path, opts \\ []) do
     source =
       if Mix.Project.umbrella?() do
         [in_umbrella: true]
       else
-        [path: sparse_path]
+        [path: relative_path]
       end
 
     {app, Keyword.merge(source, opts)}

--- a/apps/favn/mix.exs
+++ b/apps/favn/mix.exs
@@ -24,10 +24,10 @@ defmodule Favn.MixProject do
 
   defp deps do
     [
-      internal_dep(:favn_authoring, "apps/favn_authoring"),
-      internal_dep(:favn_local, "apps/favn_local"),
-      internal_dep(:favn_orchestrator, "apps/favn_orchestrator", only: :test),
-      internal_dep(:favn_test_support, "apps/favn_test_support", only: :test)
+      internal_dep(:favn_authoring, "../favn_authoring"),
+      internal_dep(:favn_local, "../favn_local"),
+      internal_dep(:favn_orchestrator, "../favn_orchestrator", only: :test),
+      internal_dep(:favn_test_support, "../favn_test_support", only: :test)
     ]
   end
 
@@ -36,17 +36,9 @@ defmodule Favn.MixProject do
       if Mix.Project.umbrella?() do
         [in_umbrella: true]
       else
-        favn_git_dep(sparse_path)
+        [path: sparse_path]
       end
 
     {app, Keyword.merge(source, opts)}
-  end
-
-  defp favn_git_dep(sparse_path) do
-    [
-      git: System.get_env("FAVN_GIT_SOURCE") || "https://github.com/eirhop/favn.git",
-      branch: System.get_env("FAVN_GIT_REF") || "main",
-      sparse: sparse_path
-    ]
   end
 end

--- a/apps/favn/mix.exs
+++ b/apps/favn/mix.exs
@@ -24,10 +24,29 @@ defmodule Favn.MixProject do
 
   defp deps do
     [
-      {:favn_authoring, in_umbrella: true},
-      {:favn_local, in_umbrella: true},
-      {:favn_orchestrator, in_umbrella: true, only: :test},
-      {:favn_test_support, in_umbrella: true, only: :test}
+      internal_dep(:favn_authoring, "apps/favn_authoring"),
+      internal_dep(:favn_local, "apps/favn_local"),
+      internal_dep(:favn_orchestrator, "apps/favn_orchestrator", only: :test),
+      internal_dep(:favn_test_support, "apps/favn_test_support", only: :test)
+    ]
+  end
+
+  defp internal_dep(app, sparse_path, opts \\ []) do
+    source =
+      if Mix.Project.umbrella?() do
+        [in_umbrella: true]
+      else
+        favn_git_dep(sparse_path)
+      end
+
+    {app, Keyword.merge(source, opts)}
+  end
+
+  defp favn_git_dep(sparse_path) do
+    [
+      git: System.get_env("FAVN_GIT_SOURCE") || "https://github.com/eirhop/favn.git",
+      branch: System.get_env("FAVN_GIT_REF") || "main",
+      sparse: sparse_path
     ]
   end
 end

--- a/apps/favn/test/git_dependency_install_test.exs
+++ b/apps/favn/test/git_dependency_install_test.exs
@@ -1,0 +1,99 @@
+defmodule Favn.GitDependencyInstallTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    base_dir =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_git_dependency_install_#{System.unique_integer([:positive])}"
+      )
+
+    snapshot_dir = Path.join(base_dir, "snapshot")
+    consumer_dir = Path.join(base_dir, "consumer")
+
+    on_exit(fn ->
+      File.rm_rf(base_dir)
+    end)
+
+    %{snapshot_dir: snapshot_dir, consumer_dir: consumer_dir}
+  end
+
+  test "fresh consumer can deps.get and compile favn from git umbrella subdir", %{
+    snapshot_dir: snapshot_dir,
+    consumer_dir: consumer_dir
+  } do
+    repo_root = Path.expand("../../..", __DIR__)
+
+    File.mkdir_p!(snapshot_dir)
+
+    assert {:ok, _files} =
+             File.cp_r(Path.join(repo_root, "apps"), Path.join(snapshot_dir, "apps"))
+
+    assert {:ok, _files} =
+             File.cp_r(Path.join(repo_root, "config"), Path.join(snapshot_dir, "config"))
+
+    assert :ok = File.cp(Path.join(repo_root, "mix.lock"), Path.join(snapshot_dir, "mix.lock"))
+
+    assert {_, 0} = System.cmd("git", ["init", "-q"], cd: snapshot_dir)
+    assert {_, 0} = System.cmd("git", ["add", "."], cd: snapshot_dir)
+
+    assert {_, 0} =
+             System.cmd(
+               "git",
+               [
+                 "-c",
+                 "user.name=Test",
+                 "-c",
+                 "user.email=test@example.com",
+                 "commit",
+                 "-q",
+                 "-m",
+                 "snapshot"
+               ],
+               cd: snapshot_dir
+             )
+
+    {ref, 0} = System.cmd("git", ["rev-parse", "HEAD"], cd: snapshot_dir)
+    ref = String.trim(ref)
+
+    assert {_, 0} = System.cmd("mix", ["new", consumer_dir, "--sup"])
+
+    File.write!(
+      Path.join(consumer_dir, "mix.exs"),
+      consumer_mix_exs("file://#{snapshot_dir}", ref)
+    )
+
+    assert {output, 0} = System.cmd("mix", ["deps.get"], cd: consumer_dir, stderr_to_stdout: true)
+    refute output =~ "App favn lists itself as a dependency"
+
+    assert {_, 0} = System.cmd("mix", ["compile"], cd: consumer_dir, stderr_to_stdout: true)
+  end
+
+  defp consumer_mix_exs(repo_url, ref) do
+    """
+    defmodule FavnConsumerInstall.MixProject do
+      use Mix.Project
+
+      def project do
+        [
+          app: :favn_consumer_install,
+          version: \"0.1.0\",
+          elixir: \"~> 1.19\",
+          start_permanent: Mix.env() == :prod,
+          deps: deps()
+        ]
+      end
+
+      def application do
+        [extra_applications: [:logger]]
+      end
+
+      defp deps do
+        [
+          {:favn, git: \"#{repo_url}\", ref: \"#{ref}\", subdir: \"apps/favn\"}
+        ]
+      end
+    end
+    """
+  end
+end

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -339,10 +339,13 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     previous_local = Application.get_env(:favn, :local, :__missing__)
 
     try do
+      web_port = free_port()
+
       Application.put_env(
         :favn,
         :local,
         storage: :postgres,
+        web_port: web_port,
         postgres: [
           hostname: "127.0.0.1",
           port: 1,
@@ -397,5 +400,12 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert output =~ "Favn single build complete"
     assert output =~ "build id:"
     assert output =~ "/.favn/dist/single/"
+  end
+
+  defp free_port do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, {:active, false}, {:reuseaddr, false}])
+    {:ok, port} = :inet.port(socket)
+    :ok = :gen_tcp.close(socket)
+    port
   end
 end

--- a/apps/favn_authoring/mix.exs
+++ b/apps/favn_authoring/mix.exs
@@ -29,12 +29,12 @@ defmodule FavnAuthoring.MixProject do
     ]
   end
 
-  defp internal_dep(app, sparse_path, opts \\ []) do
+  defp internal_dep(app, relative_path, opts \\ []) do
     source =
       if Mix.Project.umbrella?() do
         [in_umbrella: true]
       else
-        [path: sparse_path]
+        [path: relative_path]
       end
 
     {app, Keyword.merge(source, opts)}

--- a/apps/favn_authoring/mix.exs
+++ b/apps/favn_authoring/mix.exs
@@ -24,8 +24,8 @@ defmodule FavnAuthoring.MixProject do
 
   defp deps do
     [
-      internal_dep(:favn_core, "apps/favn_core"),
-      internal_dep(:favn_test_support, "apps/favn_test_support", only: :test)
+      internal_dep(:favn_core, "../favn_core"),
+      internal_dep(:favn_test_support, "../favn_test_support", only: :test)
     ]
   end
 
@@ -34,17 +34,9 @@ defmodule FavnAuthoring.MixProject do
       if Mix.Project.umbrella?() do
         [in_umbrella: true]
       else
-        favn_git_dep(sparse_path)
+        [path: sparse_path]
       end
 
     {app, Keyword.merge(source, opts)}
-  end
-
-  defp favn_git_dep(sparse_path) do
-    [
-      git: System.get_env("FAVN_GIT_SOURCE") || "https://github.com/eirhop/favn.git",
-      branch: System.get_env("FAVN_GIT_REF") || "main",
-      sparse: sparse_path
-    ]
   end
 end

--- a/apps/favn_authoring/mix.exs
+++ b/apps/favn_authoring/mix.exs
@@ -24,8 +24,27 @@ defmodule FavnAuthoring.MixProject do
 
   defp deps do
     [
-      {:favn_core, in_umbrella: true},
-      {:favn_test_support, in_umbrella: true, only: :test}
+      internal_dep(:favn_core, "apps/favn_core"),
+      internal_dep(:favn_test_support, "apps/favn_test_support", only: :test)
+    ]
+  end
+
+  defp internal_dep(app, sparse_path, opts \\ []) do
+    source =
+      if Mix.Project.umbrella?() do
+        [in_umbrella: true]
+      else
+        favn_git_dep(sparse_path)
+      end
+
+    {app, Keyword.merge(source, opts)}
+  end
+
+  defp favn_git_dep(sparse_path) do
+    [
+      git: System.get_env("FAVN_GIT_SOURCE") || "https://github.com/eirhop/favn.git",
+      branch: System.get_env("FAVN_GIT_REF") || "main",
+      sparse: sparse_path
     ]
   end
 end

--- a/apps/favn_core/mix.exs
+++ b/apps/favn_core/mix.exs
@@ -25,7 +25,7 @@ defmodule FavnCore.MixProject do
   defp deps do
     [
       {:jason, "~> 1.4"},
-      internal_dep(:favn_test_support, "apps/favn_test_support", only: :test)
+      internal_dep(:favn_test_support, "../favn_test_support", only: :test)
     ]
   end
 
@@ -34,17 +34,9 @@ defmodule FavnCore.MixProject do
       if Mix.Project.umbrella?() do
         [in_umbrella: true]
       else
-        favn_git_dep(sparse_path)
+        [path: sparse_path]
       end
 
     {app, Keyword.merge(source, opts)}
-  end
-
-  defp favn_git_dep(sparse_path) do
-    [
-      git: System.get_env("FAVN_GIT_SOURCE") || "https://github.com/eirhop/favn.git",
-      branch: System.get_env("FAVN_GIT_REF") || "main",
-      sparse: sparse_path
-    ]
   end
 end

--- a/apps/favn_core/mix.exs
+++ b/apps/favn_core/mix.exs
@@ -29,12 +29,12 @@ defmodule FavnCore.MixProject do
     ]
   end
 
-  defp internal_dep(app, sparse_path, opts) do
+  defp internal_dep(app, relative_path, opts) do
     source =
       if Mix.Project.umbrella?() do
         [in_umbrella: true]
       else
-        [path: sparse_path]
+        [path: relative_path]
       end
 
     {app, Keyword.merge(source, opts)}

--- a/apps/favn_core/mix.exs
+++ b/apps/favn_core/mix.exs
@@ -25,7 +25,26 @@ defmodule FavnCore.MixProject do
   defp deps do
     [
       {:jason, "~> 1.4"},
-      {:favn_test_support, in_umbrella: true, only: :test}
+      internal_dep(:favn_test_support, "apps/favn_test_support", only: :test)
+    ]
+  end
+
+  defp internal_dep(app, sparse_path, opts) do
+    source =
+      if Mix.Project.umbrella?() do
+        [in_umbrella: true]
+      else
+        favn_git_dep(sparse_path)
+      end
+
+    {app, Keyword.merge(source, opts)}
+  end
+
+  defp favn_git_dep(sparse_path) do
+    [
+      git: System.get_env("FAVN_GIT_SOURCE") || "https://github.com/eirhop/favn.git",
+      branch: System.get_env("FAVN_GIT_REF") || "main",
+      sparse: sparse_path
     ]
   end
 end

--- a/apps/favn_local/mix.exs
+++ b/apps/favn_local/mix.exs
@@ -30,12 +30,12 @@ defmodule FavnLocal.MixProject do
     ]
   end
 
-  defp internal_dep(app, sparse_path, opts \\ []) do
+  defp internal_dep(app, relative_path, opts \\ []) do
     source =
       if Mix.Project.umbrella?() do
         [in_umbrella: true]
       else
-        [path: sparse_path]
+        [path: relative_path]
       end
 
     {app, Keyword.merge(source, opts)}

--- a/apps/favn_local/mix.exs
+++ b/apps/favn_local/mix.exs
@@ -24,9 +24,28 @@ defmodule FavnLocal.MixProject do
 
   defp deps do
     [
-      {:favn_authoring, in_umbrella: true},
-      {:favn_core, in_umbrella: true},
-      {:favn_test_support, in_umbrella: true, only: :test}
+      internal_dep(:favn_authoring, "apps/favn_authoring"),
+      internal_dep(:favn_core, "apps/favn_core"),
+      internal_dep(:favn_test_support, "apps/favn_test_support", only: :test)
+    ]
+  end
+
+  defp internal_dep(app, sparse_path, opts \\ []) do
+    source =
+      if Mix.Project.umbrella?() do
+        [in_umbrella: true]
+      else
+        favn_git_dep(sparse_path)
+      end
+
+    {app, Keyword.merge(source, opts)}
+  end
+
+  defp favn_git_dep(sparse_path) do
+    [
+      git: System.get_env("FAVN_GIT_SOURCE") || "https://github.com/eirhop/favn.git",
+      branch: System.get_env("FAVN_GIT_REF") || "main",
+      sparse: sparse_path
     ]
   end
 end

--- a/apps/favn_local/mix.exs
+++ b/apps/favn_local/mix.exs
@@ -24,9 +24,9 @@ defmodule FavnLocal.MixProject do
 
   defp deps do
     [
-      internal_dep(:favn_authoring, "apps/favn_authoring"),
-      internal_dep(:favn_core, "apps/favn_core"),
-      internal_dep(:favn_test_support, "apps/favn_test_support", only: :test)
+      internal_dep(:favn_authoring, "../favn_authoring"),
+      internal_dep(:favn_core, "../favn_core"),
+      internal_dep(:favn_test_support, "../favn_test_support", only: :test)
     ]
   end
 
@@ -35,17 +35,9 @@ defmodule FavnLocal.MixProject do
       if Mix.Project.umbrella?() do
         [in_umbrella: true]
       else
-        favn_git_dep(sparse_path)
+        [path: sparse_path]
       end
 
     {app, Keyword.merge(source, opts)}
-  end
-
-  defp favn_git_dep(sparse_path) do
-    [
-      git: System.get_env("FAVN_GIT_SOURCE") || "https://github.com/eirhop/favn.git",
-      branch: System.get_env("FAVN_GIT_REF") || "main",
-      sparse: sparse_path
-    ]
   end
 end

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -79,11 +79,12 @@ defmodule Favn.Dev.LifecycleTest do
     assert {:error, {:start_failed, "orchestrator", _reason}} =
              Dev.dev(
                root_dir: root_dir,
+               web_port: free_port(),
                service_specs_override: failing_specs,
                skip_install_check: true,
                skip_bootstrap: true,
                skip_readiness: true
-             )
+              )
 
     assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
     assert {:ok, %{"error" => _}} = State.read_last_failure(root_dir: root_dir)
@@ -145,13 +146,13 @@ defmodule Favn.Dev.LifecycleTest do
     try do
       assert {:error, {:port_conflict, :web, ^port}} =
                Dev.dev(
-                root_dir: root_dir,
-                web_port: port,
-                skip_runtime_compile: true,
-                skip_install_check: true,
-                skip_bootstrap: true,
-                skip_readiness: true
-               )
+                 root_dir: root_dir,
+                 web_port: port,
+                 skip_runtime_compile: true,
+                 skip_install_check: true,
+                 skip_bootstrap: true,
+                 skip_readiness: true
+                )
     after
       :ok = :gen_tcp.close(socket)
     end
@@ -161,42 +162,45 @@ defmodule Favn.Dev.LifecycleTest do
     assert {:error, {:postgres_unavailable, "127.0.0.1", 1, _reason}} =
              Dev.dev(
                root_dir: root_dir,
+               web_port: free_port(),
                storage: :postgres,
-                postgres: [
-                  hostname: "127.0.0.1",
-                  port: 1,
+               postgres: [
+                 hostname: "127.0.0.1",
+                 port: 1,
                  username: "postgres",
                  password: "postgres",
                  database: "favn",
-                  ssl: false,
-                  pool_size: 10
-                ],
-                skip_runtime_compile: true,
-                skip_install_check: true,
-                skip_bootstrap: true,
-                skip_readiness: true
-             )
+                 ssl: false,
+                 pool_size: 10
+               ],
+               skip_runtime_compile: true,
+               skip_install_check: true,
+               skip_bootstrap: true,
+               skip_readiness: true
+              )
   end
 
   test "dev/1 returns explicit postgres misconfiguration diagnostics", %{root_dir: root_dir} do
     assert {:error, {:postgres_misconfigured, :hostname}} =
              Dev.dev(
                root_dir: root_dir,
+               web_port: free_port(),
                storage: :postgres,
-                postgres: [
-                  hostname: "",
-                  port: 5432,
+               web_port: free_port(),
+               postgres: [
+                 hostname: "",
+                 port: 5432,
                  username: "postgres",
                  password: "postgres",
                  database: "favn",
-                  ssl: false,
-                  pool_size: 10
-                ],
-                skip_runtime_compile: true,
-                skip_install_check: true,
-                skip_bootstrap: true,
-                skip_readiness: true
-              )
+                 ssl: false,
+                 pool_size: 10
+               ],
+               skip_runtime_compile: true,
+               skip_install_check: true,
+               skip_bootstrap: true,
+               skip_readiness: true
+               )
   end
 
   test "dev/1 fails runtime compile as preflight before startup lock work", %{root_dir: root_dir} do
@@ -311,5 +315,12 @@ defmodule Favn.Dev.LifecycleTest do
       Process.sleep(250)
       wait_until(fun, attempts - 1)
     end
+  end
+
+  defp free_port do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, {:active, false}, {:reuseaddr, false}])
+    {:ok, port} = :inet.port(socket)
+    :ok = :gen_tcp.close(socket)
+    port
   end
 end

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -186,10 +186,9 @@ defmodule Favn.Dev.LifecycleTest do
                root_dir: root_dir,
                web_port: free_port(),
                storage: :postgres,
-               web_port: free_port(),
-               postgres: [
-                 hostname: "",
-                 port: 5432,
+                postgres: [
+                  hostname: "",
+                  port: 5432,
                  username: "postgres",
                  password: "postgres",
                  database: "favn",

--- a/apps/favn_local/test/integration/dev_storage_verification_test.exs
+++ b/apps/favn_local/test/integration/dev_storage_verification_test.exs
@@ -43,6 +43,8 @@ defmodule Favn.Dev.StorageVerificationTest do
   test "sqlite verification across install/dev/status/reload/stop/logs/reset/build.single", %{
     root_dir: root_dir
   } do
+    web_port = free_port()
+
     assert {:ok, :installed} =
              Dev.install(root_dir: root_dir, skip_web_install: true, skip_tool_checks: true)
 
@@ -63,6 +65,7 @@ defmodule Favn.Dev.StorageVerificationTest do
       Task.async(fn ->
         Dev.dev(
           root_dir: root_dir,
+          web_port: web_port,
           storage: :sqlite,
           sqlite_path: ".favn/data/storage_verification.sqlite3",
           skip_tool_checks: true,
@@ -113,10 +116,13 @@ defmodule Favn.Dev.StorageVerificationTest do
         pool_size: String.to_integer(System.get_env("FAVN_DEV_POSTGRES_POOL_SIZE", "10"))
       ]
 
+      web_port = free_port()
+
       task =
         Task.async(fn ->
           Dev.dev(
             root_dir: root_dir,
+            web_port: web_port,
             storage: :postgres,
             postgres: postgres,
             skip_tool_checks: true,
@@ -184,5 +190,12 @@ defmodule Favn.Dev.StorageVerificationTest do
       Process.sleep(100)
       wait_until(fun, attempts - 1)
     end
+  end
+
+  defp free_port do
+    {:ok, socket} = :gen_tcp.listen(0, [:binary, {:active, false}, {:reuseaddr, false}])
+    {:ok, port} = :inet.port(socket)
+    :ok = :gen_tcp.close(socket)
+    port
   end
 end

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -8,6 +8,7 @@ apps/
 │   ├── boundary_defaults_test.exs
 │   ├── dsl_compiler_test.exs
 │   ├── favn_test.exs
+│   ├── git_dependency_install_test.exs
 │   ├── manifest_generator_test.exs
 │   ├── mix_tasks/
 │   │   ├── read_doc_task_test.exs


### PR DESCRIPTION
## Summary
- fix `{:favn, git: ...}` installs for the umbrella layout by documenting the required `sparse: \"apps/favn\"` consumer dependency shape
- make internal `favn` app dependencies resolve correctly both inside the umbrella and when consumed as standalone sparse git dependencies
- harden local lifecycle tests to use free web ports so stray local processes do not cause unrelated failures

## Verification
- mix format
- mix compile --warnings-as-errors
- mix test
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected