### PR TITLE
fix: auto-resolve runtime source root for external consumers

### DIFF
--- a/apps/favn_local/lib/favn/dev/runtime_source.ex
+++ b/apps/favn_local/lib/favn/dev/runtime_source.ex
@@ -31,6 +31,18 @@ defmodule Favn.Dev.RuntimeSource do
     end
   end
 
+  @spec resolve_runtime_root(Path.t()) :: {:ok, Path.t()} | {:error, :not_found}
+  def resolve_runtime_root(path) when is_binary(path) do
+    path
+    |> Path.expand()
+    |> candidate_roots()
+    |> Enum.find(&valid_runtime_root?/1)
+    |> case do
+      nil -> {:error, :not_found}
+      root -> {:ok, root}
+    end
+  end
+
   @spec fingerprint(t()) :: {:ok, map()} | {:error, term()}
   def fingerprint(%{root: root}) when is_binary(root) do
     case valid_runtime_root?(root) do
@@ -68,13 +80,10 @@ defmodule Favn.Dev.RuntimeSource do
   defp dependency_root do
     case Mix.Project.deps_paths()[:favn] do
       nil -> {:error, :not_found}
-      root ->
-        expanded = Path.expand(root)
 
-        if valid_runtime_root?(expanded) do
-          {:ok, %{kind: :dependency_checkout, root: expanded}}
-        else
-          {:error, :not_found}
+      root ->
+        with {:ok, runtime_root} <- resolve_runtime_root(root) do
+          {:ok, %{kind: :dependency_checkout, root: runtime_root}}
         end
     end
   rescue
@@ -84,20 +93,33 @@ defmodule Favn.Dev.RuntimeSource do
   defp source_tree_root do
     root = Path.expand("../../../../../", __DIR__)
 
-    if valid_runtime_root?(root) do
-      {:ok, %{kind: :dependency_checkout, root: root}}
-    else
-      {:error, :not_found}
+    with {:ok, runtime_root} <- resolve_runtime_root(root) do
+      {:ok, %{kind: :dependency_checkout, root: runtime_root}}
     end
   end
 
   defp cwd_root do
     root = Path.expand(File.cwd!())
 
-    if valid_runtime_root?(root) do
-      {:ok, %{kind: :cwd, root: root}}
+    with {:ok, runtime_root} <- resolve_runtime_root(root) do
+      {:ok, %{kind: :cwd, root: runtime_root}}
+    end
+  end
+
+  defp candidate_roots(path) when is_binary(path) do
+    path
+    |> do_candidate_roots([])
+    |> Enum.reverse()
+  end
+
+  defp do_candidate_roots(path, acc) do
+    parent = Path.dirname(path)
+    next_acc = [path | acc]
+
+    if parent == path do
+      next_acc
     else
-      {:error, :not_found}
+      do_candidate_roots(parent, next_acc)
     end
   end
 

--- a/apps/favn_local/test/dev_runtime_source_test.exs
+++ b/apps/favn_local/test/dev_runtime_source_test.exs
@@ -1,0 +1,44 @@
+defmodule Favn.Dev.RuntimeSourceTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Dev.RuntimeSource
+
+  test "resolve_runtime_root/1 walks up to a valid runtime root" do
+    tmp_dir = Path.join(System.tmp_dir!(), "favn_runtime_source_test_#{System.unique_integer([:positive])}")
+
+    on_exit(fn ->
+      File.rm_rf(tmp_dir)
+    end)
+
+    runtime_root = Path.join(tmp_dir, "deps/favn")
+    nested = Path.join(runtime_root, "apps/favn")
+
+    File.mkdir_p!(Path.join(runtime_root, "apps/favn_runner"))
+    File.mkdir_p!(Path.join(runtime_root, "apps/favn_orchestrator"))
+    File.mkdir_p!(Path.join(runtime_root, "web/favn_web"))
+
+    File.write!(Path.join(runtime_root, "apps/favn_runner/mix.exs"), "defmodule Runner.MixProject do end")
+
+    File.write!(
+      Path.join(runtime_root, "apps/favn_orchestrator/mix.exs"),
+      "defmodule Orchestrator.MixProject do end"
+    )
+
+    File.write!(Path.join(runtime_root, "web/favn_web/package.json"), "{}")
+    File.mkdir_p!(nested)
+
+    assert {:ok, ^runtime_root} = RuntimeSource.resolve_runtime_root(nested)
+  end
+
+  test "resolve_runtime_root/1 returns not_found when no runtime root exists" do
+    tmp_dir = Path.join(System.tmp_dir!(), "favn_runtime_source_missing_#{System.unique_integer([:positive])}")
+
+    on_exit(fn ->
+      File.rm_rf(tmp_dir)
+    end)
+
+    File.mkdir_p!(Path.join(tmp_dir, "a/b/c"))
+
+    assert {:error, :not_found} = RuntimeSource.resolve_runtime_root(Path.join(tmp_dir, "a/b/c"))
+  end
+end

--- a/docs/test_structure.md
+++ b/docs/test_structure.md
@@ -30,6 +30,7 @@ apps/
 │   ├── dev_orchestrator_client_test.exs
 │   ├── dev_process_test.exs
 │   ├── dev_reload_test.exs
+│   ├── dev_runtime_source_test.exs
 │   ├── dev_runner_control_test.exs
 │   ├── dev_reset_test.exs
 │   ├── dev_state_test.exs


### PR DESCRIPTION
## Summary
- resolve Favn runtime source by walking up from the `:favn` dependency path until a valid runtime root is found, so `deps/favn/apps/favn` correctly resolves to `deps/favn`
- keep existing runtime source validation semantics while making dependency checkout, source-tree, and cwd discovery share the same root-resolution behavior
- add focused unit coverage for nested dependency-path discovery and missing-root behavior

## Validation
- mix format
- mix compile --warnings-as-errors
- mix test
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected

Fixes #119.