### PR TITLE
fix: harden local dev runtime bootstrap and install flow

### DIFF
--- a/apps/favn_local/lib/favn/dev/consumer_code_path.ex
+++ b/apps/favn_local/lib/favn/dev/consumer_code_path.ex
@@ -1,15 +1,39 @@
 defmodule Favn.Dev.ConsumerCodePath do
   @moduledoc false
 
+  @runtime_owned_apps MapSet.new([
+                        "favn",
+                        "favn_authoring",
+                        "favn_core",
+                        "favn_duckdb",
+                        "favn_local",
+                        "favn_orchestrator",
+                        "favn_runner",
+                        "favn_storage_postgres",
+                        "favn_storage_sqlite",
+                        "favn_test_support"
+                      ])
+
   @spec ebin_paths(keyword()) :: [Path.t()]
-  def ebin_paths(_opts \\ []) do
-    build_path = Mix.Project.build_path() |> Path.expand(File.cwd!())
+  def ebin_paths(opts \\ []) do
+    build_path = Keyword.get_lazy(opts, :build_path, fn -> Mix.Project.build_path() end)
+    build_path = Path.expand(build_path, File.cwd!())
 
     build_path
     |> Path.join("lib/*/ebin")
     |> Path.wildcard()
     |> Enum.filter(&File.dir?/1)
+    |> Enum.reject(&runtime_owned_ebin?/1)
     |> Enum.uniq()
     |> Enum.sort()
+  end
+
+  defp runtime_owned_ebin?(path) when is_binary(path) do
+    app =
+      path
+      |> Path.dirname()
+      |> Path.basename()
+
+    MapSet.member?(@runtime_owned_apps, app)
   end
 end

--- a/apps/favn_local/lib/favn/dev/install.ex
+++ b/apps/favn_local/lib/favn/dev/install.ex
@@ -130,8 +130,11 @@ defmodule Favn.Dev.Install do
         mix_exec = System.find_executable("mix") || "mix"
 
         case System.cmd(mix_exec, ["deps.get"], cd: runtime_root, stderr_to_stdout: true) do
-          {_output, 0} -> :ok
-          {output, status} -> {:error, {:runtime_deps_install_failed, status, String.trim(output)}}
+          {_output, 0} ->
+            :ok
+
+          {output, status} ->
+            {:error, {:runtime_deps_install_failed, status, String.trim(output)}}
         end
       else
         :ok
@@ -148,22 +151,39 @@ defmodule Favn.Dev.Install do
       npm_cache = Paths.install_cache_npm_dir(Paths.root_dir(opts))
       package_lock = Path.join(web_dir, "package-lock.json")
 
-      args =
-        if File.exists?(package_lock) do
-          ["ci", "--silent", "--cache", npm_cache]
-        else
-          ["install", "--silent", "--cache", npm_cache]
-        end
-
       env = %{"npm_config_cache" => npm_cache}
 
-      case System.cmd(npm_exec, args, cd: web_dir, stderr_to_stdout: true, env: env) do
-        {_output, 0} ->
+      install_with_fallback(npm_exec, package_lock, npm_cache, web_dir, env)
+    end
+  end
+
+  defp install_with_fallback(npm_exec, package_lock, npm_cache, web_dir, env) do
+    if File.exists?(package_lock) do
+      case run_npm_install(npm_exec, ["ci", "--cache", npm_cache], web_dir, env) do
+        :ok ->
           :ok
 
-        {output, status} ->
-          {:error, {:web_install_failed, status, String.trim(output)}}
+        {:error, _status, _output} ->
+          case run_npm_install(npm_exec, ["install", "--cache", npm_cache], web_dir, env) do
+            :ok ->
+              :ok
+
+            {:error, status, retry_output} ->
+              {:error, {:web_install_failed, status, String.trim(retry_output)}}
+          end
       end
+    else
+      case run_npm_install(npm_exec, ["install", "--cache", npm_cache], web_dir, env) do
+        :ok -> :ok
+        {:error, status, output} -> {:error, {:web_install_failed, status, String.trim(output)}}
+      end
+    end
+  end
+
+  defp run_npm_install(npm_exec, args, web_dir, env) do
+    case System.cmd(npm_exec, args, cd: web_dir, stderr_to_stdout: true, env: env) do
+      {_output, 0} -> :ok
+      {output, status} -> {:error, status, output}
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/orchestrator_client.ex
+++ b/apps/favn_local/lib/favn/dev/orchestrator_client.ex
@@ -1,11 +1,17 @@
 defmodule Favn.Dev.OrchestratorClient do
   @moduledoc false
 
+  alias Favn.Manifest.Serializer
+
   @spec publish_manifest(String.t(), String.t(), map()) ::
           {:ok, map()} | {:error, term()}
   def publish_manifest(base_url, service_token, payload)
       when is_binary(base_url) and is_binary(service_token) and is_map(payload) do
-    request_post(base_url <> "/api/orchestrator/v1/manifests", service_token, payload)
+    request_post(
+      base_url <> "/api/orchestrator/v1/manifests",
+      service_token,
+      normalize_publish_payload(payload)
+    )
   end
 
   @spec activate_manifest(String.t(), String.t(), String.t()) :: {:ok, map()} | {:error, term()}
@@ -103,6 +109,23 @@ defmodule Favn.Dev.OrchestratorClient do
         else
           _ -> {:error, {:invalid_response, output}}
         end
+    end
+  end
+
+  defp normalize_publish_payload(payload) when is_map(payload) do
+    manifest = Map.get(payload, :manifest) || Map.get(payload, "manifest")
+
+    if manifest do
+      manifest_payload =
+        manifest
+        |> Serializer.encode_manifest!()
+        |> JSON.decode!()
+
+      payload
+      |> Map.put(:manifest, manifest_payload)
+      |> Map.delete("manifest")
+    else
+      payload
     end
   end
 end

--- a/apps/favn_local/lib/favn/dev/runner_control.ex
+++ b/apps/favn_local/lib/favn/dev/runner_control.ex
@@ -9,6 +9,9 @@ defmodule Favn.Dev.RunnerControl do
   alias Favn.Dev.NodeControl
   alias Favn.Manifest.Version
 
+  @register_wait_timeout_ms 10_000
+  @register_poll_interval_ms 100
+
   @type register_opt ::
           {:runner_node_name, String.t()}
           | {:rpc_cookie, String.t()}
@@ -22,17 +25,22 @@ defmodule Favn.Dev.RunnerControl do
          :ok <- NodeControl.ensure_local_node_started(cookie),
          {:ok, runner_module} <- fetch_runner_module(opts),
          :ok <- ensure_connected(runner_node),
-         {:ok, {module, function, args}, _attempted} <-
-             resolve_register_entrypoint(runner_node, version, runner_module) do
-       case :erpc.call(runner_node, module, function, args, 10_000) do
-         :ok -> :ok
-         {:error, _reason} = error -> error
-         other -> {:error, {:runner_register_unexpected, other}}
-       end
-      else
-        {:error, {:runner_manifest_register_unavailable, _runner_node, _attempted}} = error -> error
+         {:ok, result} <-
+           register_with_fallback(
+             runner_node,
+             version,
+             runner_module,
+             @register_wait_timeout_ms
+           ) do
+      case result do
+        :ok -> :ok
         {:error, _reason} = error -> error
+        other -> {:error, {:runner_register_unexpected, other}}
       end
+    else
+      {:error, {:runner_manifest_register_unavailable, _runner_node, _attempted}} = error -> error
+      {:error, _reason} = error -> error
+    end
   end
 
   defp fetch_runner_module(opts) do
@@ -42,34 +50,61 @@ defmodule Favn.Dev.RunnerControl do
     end
   end
 
-  defp resolve_register_entrypoint(runner_node, version, runner_module)
+  defp register_with_fallback(runner_node, version, runner_module, timeout_ms)
+       when is_integer(timeout_ms) and timeout_ms >= 0 do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+
+    do_register_with_fallback(runner_node, version, runner_module, deadline)
+  end
+
+  defp do_register_with_fallback(runner_node, version, runner_module, deadline_ms)
        when is_atom(runner_node) and is_atom(runner_module) do
     attempts = [
       {runner_module, :register_manifest, [version, []]},
       {runner_module, :register_manifest, [version]}
     ]
 
-    case Enum.find(attempts, &remote_exported?(runner_node, &1)) do
-      {module, function, args} ->
-        {:ok, {module, function, args}, attempts_to_metadata(attempts)}
+    case try_register_attempts(runner_node, attempts) do
+      {:ok, result} ->
+        {:ok, result}
 
-      nil ->
-        {:error,
-         {:runner_manifest_register_unavailable, runner_node, attempts_to_metadata(attempts)}}
+      :unavailable ->
+        if System.monotonic_time(:millisecond) >= deadline_ms do
+          {:error,
+           {:runner_manifest_register_unavailable, runner_node, attempts_to_metadata(attempts)}}
+        else
+          Process.sleep(@register_poll_interval_ms)
+          do_register_with_fallback(runner_node, version, runner_module, deadline_ms)
+        end
     end
   end
 
-  defp remote_exported?(runner_node, {module, function, args})
-       when is_atom(runner_node) and is_atom(module) and is_atom(function) and is_list(args) do
-    arity = length(args)
+  defp try_register_attempts(runner_node, attempts) when is_list(attempts) do
+    Enum.reduce_while(attempts, :unavailable, fn attempt, :unavailable ->
+      case invoke_register_attempt(runner_node, attempt) do
+        :unavailable -> {:cont, :unavailable}
+        {:ok, result} -> {:halt, {:ok, result}}
+      end
+    end)
+  end
 
-    case :erpc.call(runner_node, :erlang, :function_exported, [module, function, arity], 2_000) do
-      true -> true
-      false -> false
-      _other -> false
-    end
+  defp invoke_register_attempt(runner_node, {module, function, args})
+       when is_atom(runner_node) and is_atom(module) and is_atom(function) and is_list(args) do
+    {:ok, :erpc.call(runner_node, module, function, args, 10_000)}
   rescue
-    ErlangError -> false
+    error in ErlangError ->
+      if remote_startup_unavailable?(error.original, module, function, length(args)) do
+        :unavailable
+      else
+        reraise error, __STACKTRACE__
+      end
+  catch
+    :exit, reason ->
+      if remote_startup_unavailable?(reason, module, function, length(args)) do
+        :unavailable
+      else
+        :erlang.raise(:exit, reason, __STACKTRACE__)
+      end
   end
 
   defp attempts_to_metadata(attempts) when is_list(attempts) do
@@ -77,6 +112,29 @@ defmodule Favn.Dev.RunnerControl do
       %{module: module, function: function, arity: length(args)}
     end)
   end
+
+  defp remote_startup_unavailable?(reason, module, function, arity) do
+    remote_undef?(reason, module, function, arity) or remote_noproc?(reason) or
+      remote_noconnection?(reason)
+  end
+
+  defp remote_undef?({:exception, :undef, stacktrace}, module, function, arity)
+       when is_list(stacktrace) do
+    Enum.any?(stacktrace, fn
+      {^module, ^function, args, _location} when is_list(args) -> length(args) == arity
+      {^module, ^function, ^arity, _location} -> true
+      _other -> false
+    end)
+  end
+
+  defp remote_undef?(_reason, _module, _function, _arity), do: false
+
+  defp remote_noproc?({:exception, {:noproc, _details}}), do: true
+  defp remote_noproc?({:noproc, _details}), do: true
+  defp remote_noproc?(_reason), do: false
+
+  defp remote_noconnection?({:erpc, :noconnection}), do: true
+  defp remote_noconnection?(_reason), do: false
 
   defp fetch_runner_node(opts) do
     case Keyword.get(opts, :runner_node_name) do

--- a/apps/favn_local/lib/favn/dev/runtime_launch.ex
+++ b/apps/favn_local/lib/favn/dev/runtime_launch.ex
@@ -9,7 +9,7 @@ defmodule Favn.Dev.RuntimeLaunch do
   def runner_spec(runtime, opts, node_names, secrets)
       when is_map(runtime) and is_list(opts) and is_map(node_names) and is_map(secrets) do
     elixir = System.find_executable("elixir") || "elixir"
-    code = "Application.ensure_all_started(:favn_runner); Process.sleep(:infinity)"
+    code = "{:ok, _} = Application.ensure_all_started(:favn_runner); Process.sleep(:infinity)"
 
     base_args = [
       "--sname",
@@ -23,7 +23,9 @@ defmodule Favn.Dev.RuntimeLaunch do
       |> ConsumerCodePath.ebin_paths()
       |> Enum.flat_map(fn path -> ["-pa", path] end)
 
-    args = base_args ++ code_path_args ++ ["-S", "mix", "run", "--no-start", "--eval", code]
+    args =
+      base_args ++
+        code_path_args ++ ["-S", "mix", "run", "--no-compile", "--no-start", "--eval", code]
 
     %{
       name: "runner",
@@ -47,10 +49,12 @@ defmodule Favn.Dev.RuntimeLaunch do
 
       cond do
         storage == "sqlite" ->
+          {:ok, _} = Application.ensure_all_started(:favn_storage_sqlite)
           Application.put_env(:favn_orchestrator, :storage_adapter, Favn.Storage.Adapter.SQLite)
           Application.put_env(:favn_orchestrator, :storage_adapter_opts, database: System.get_env("FAVN_DEV_SQLITE_PATH"))
 
         storage == "postgres" ->
+          {:ok, _} = Application.ensure_all_started(:favn_storage_postgres)
           Application.put_env(:favn_orchestrator, :storage_adapter, Favn.Storage.Adapter.Postgres)
 
           Application.put_env(
@@ -68,7 +72,21 @@ defmodule Favn.Dev.RuntimeLaunch do
       runner_node = String.to_atom(System.get_env("FAVN_DEV_RUNNER_NODE"))
       Application.put_env(:favn_orchestrator, :runner_client, FavnOrchestrator.RunnerClient.LocalNode)
       Application.put_env(:favn_orchestrator, :runner_client_opts, [runner_node: runner_node])
-      Application.ensure_all_started(:favn_orchestrator)
+      Application.put_env(
+        :favn_orchestrator,
+        :api_server,
+        enabled: System.get_env("FAVN_ORCHESTRATOR_API_ENABLED", "0") == "1",
+        port: String.to_integer(System.get_env("FAVN_ORCHESTRATOR_API_PORT", "4101"))
+      )
+
+      Application.put_env(
+        :favn_orchestrator,
+        :api_service_tokens,
+        System.get_env("FAVN_ORCHESTRATOR_API_SERVICE_TOKENS", "")
+        |> String.split(",", trim: true)
+      )
+
+      {:ok, _} = Application.ensure_all_started(:favn_orchestrator)
       Process.sleep(:infinity)
       """
       |> String.trim()
@@ -84,6 +102,7 @@ defmodule Favn.Dev.RuntimeLaunch do
         "-S",
         "mix",
         "run",
+        "--no-compile",
         "--no-start",
         "--eval",
         code
@@ -113,12 +132,13 @@ defmodule Favn.Dev.RuntimeLaunch do
   @spec web_spec(map(), Config.t(), keyword(), map()) :: map()
   def web_spec(runtime, %Config{} = config, opts, secrets)
       when is_map(runtime) and is_list(opts) and is_map(secrets) do
-    npm = System.find_executable("npm") || "npm"
+    node = System.find_executable("node") || "node"
+    vite = Path.join(runtime["web_root"], "node_modules/vite/bin/vite.js")
 
     %{
       name: "web",
-      exec: npm,
-      args: ["run", "preview", "--", "--host", "127.0.0.1", "--port", Integer.to_string(config.web_port)],
+      exec: node,
+      args: [vite, "preview", "--host", "127.0.0.1", "--port", Integer.to_string(config.web_port)],
       cwd: runtime["web_root"],
       log_path: Paths.web_log_path(Paths.root_dir(opts)),
       env: %{

--- a/apps/favn_local/lib/favn/dev/runtime_workspace.ex
+++ b/apps/favn_local/lib/favn/dev/runtime_workspace.ex
@@ -6,6 +6,7 @@ defmodule Favn.Dev.RuntimeWorkspace do
   alias Favn.Dev.State
 
   @schema_version 1
+  @ignored_entries MapSet.new([".favn", "node_modules", "dist", ".svelte-kit", "test-results"])
 
   @spec materialize(RuntimeSource.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def materialize(%{root: source_root, kind: kind}, opts) when is_list(opts) do
@@ -88,7 +89,7 @@ defmodule Favn.Dev.RuntimeWorkspace do
     with :ok <- File.mkdir_p(destination),
          {:ok, entries} <- File.ls(source) do
       Enum.reduce_while(entries, :ok, fn entry, :ok ->
-        if entry == ".favn" do
+        if MapSet.member?(@ignored_entries, entry) do
           {:cont, :ok}
         else
           child_source = Path.join(source, entry)

--- a/apps/favn_local/lib/favn/dev/secrets.ex
+++ b/apps/favn_local/lib/favn/dev/secrets.ex
@@ -18,7 +18,7 @@ defmodule Favn.Dev.Secrets do
       "service_token" => config.service_token || stored["service_token"] || random_secret(24),
       "web_session_secret" =>
         config.web_session_secret || stored["web_session_secret"] || random_secret(32),
-      "rpc_cookie" => stored["rpc_cookie"] || random_secret(24)
+      "rpc_cookie" => normalize_rpc_cookie(stored["rpc_cookie"]) || random_rpc_cookie(24)
     }
 
     case State.write_secrets(secrets, opts) do
@@ -33,4 +33,20 @@ defmodule Favn.Dev.Secrets do
     |> :crypto.strong_rand_bytes()
     |> Base.url_encode64(padding: false)
   end
+
+  defp random_rpc_cookie(size) when is_integer(size) and size > 0 do
+    size
+    |> :crypto.strong_rand_bytes()
+    |> Base.encode16(case: :upper)
+  end
+
+  defp normalize_rpc_cookie(cookie) when is_binary(cookie) and cookie != "" do
+    if String.match?(cookie, ~r/^[A-Za-z0-9_]+$/) do
+      cookie
+    else
+      nil
+    end
+  end
+
+  defp normalize_rpc_cookie(_cookie), do: nil
 end

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -331,6 +331,9 @@ defmodule Favn.Dev.Stack do
       _ ->
         :ok = ensure_web_assets(runtime, opts)
 
+        runner_wait_timeout_ms = Keyword.get(opts, :runner_wait_timeout_ms, 15_000)
+        runner_wait_node_name = Keyword.get(opts, :runner_wait_node_name, node_names.runner_full)
+
         runner_spec = RuntimeLaunch.runner_spec(runtime, opts, node_names, secrets)
 
         orchestrator_spec =
@@ -338,12 +341,18 @@ defmodule Favn.Dev.Stack do
 
         web_spec = RuntimeLaunch.web_spec(runtime, config, opts, secrets)
 
-        with {:ok, services} <- start_service_specs([runner_spec]),
-             :ok <- wait_runner_node_ready(node_names.runner_full, 15_000),
-             {:ok, services} <- start_service_specs([orchestrator_spec], services),
-             {:ok, services} <- start_service_specs([web_spec], services) do
-          {:ok, services}
-        else
+        case start_service_specs([runner_spec]) do
+          {:ok, services} ->
+            with :ok <- wait_runner_node_ready(runner_wait_node_name, runner_wait_timeout_ms),
+                 {:ok, services} <- start_service_specs([orchestrator_spec], services),
+                 {:ok, services} <- start_service_specs([web_spec], services) do
+              {:ok, services}
+            else
+              {:error, _reason} = error ->
+                stop_service_map(services)
+                error
+            end
+
           {:error, _reason} = error ->
             error
         end

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -80,11 +80,11 @@ defmodule Favn.Dev.Stack do
       with :ok <- State.ensure_layout(opts),
            :ok <- ensure_stack_not_running(opts),
            :ok <- ensure_install_ready(opts),
-            config <- Config.resolve(opts),
-            :ok <- ensure_startup_prerequisites(config),
-            {:ok, runtime} <- resolve_runtime(opts),
-            {:ok, secrets} <- Secrets.resolve(config, opts),
-            {:ok, node_names} <- build_node_names(secrets, opts) do
+           config <- Config.resolve(opts),
+           :ok <- ensure_startup_prerequisites(config),
+           {:ok, runtime} <- resolve_runtime(opts),
+           {:ok, secrets} <- Secrets.resolve(config, opts),
+           {:ok, node_names} <- build_node_names(secrets, opts) do
         {:ok, %{config: config, runtime: runtime, secrets: secrets, node_names: node_names}}
       end
     end)
@@ -100,7 +100,13 @@ defmodule Favn.Dev.Stack do
            {:ok, services} <- start_services(runtime, config, secrets, node_names, opts),
            :ok <- write_runtime(config, secrets, node_names, services, opts) do
         {:ok,
-         %{config: config, runtime: runtime, secrets: secrets, node_names: node_names, services: services}}
+         %{
+           config: config,
+           runtime: runtime,
+           secrets: secrets,
+           node_names: node_names,
+           services: services
+         }}
       end
     end)
   end
@@ -273,8 +279,11 @@ defmodule Favn.Dev.Stack do
                env: %{"MIX_ENV" => "dev"},
                stderr_to_stdout: true
              ) do
-          {_output, 0} -> :ok
-          {output, status} -> {:error, {:runtime_compile_failed, :runtime_root, status, String.trim(output)}}
+          {_output, 0} ->
+            :ok
+
+          {output, status} ->
+            {:error, {:runtime_compile_failed, :runtime_root, status, String.trim(output)}}
         end
     end
   end
@@ -315,22 +324,34 @@ defmodule Favn.Dev.Stack do
   end
 
   defp start_services(runtime, config, secrets, node_names, opts) do
-    specs =
-      case Keyword.get(opts, :service_specs_override) do
-        list when is_list(list) and list != [] ->
-          list
+    case Keyword.get(opts, :service_specs_override) do
+      list when is_list(list) and list != [] ->
+        start_service_specs(list)
 
-        _ ->
-          :ok = ensure_web_assets(runtime, opts)
+      _ ->
+        :ok = ensure_web_assets(runtime, opts)
 
-          [
-            RuntimeLaunch.runner_spec(runtime, opts, node_names, secrets),
-            RuntimeLaunch.orchestrator_spec(runtime, config, opts, node_names, secrets),
-            RuntimeLaunch.web_spec(runtime, config, opts, secrets)
-          ]
-      end
+        runner_spec = RuntimeLaunch.runner_spec(runtime, opts, node_names, secrets)
 
-    Enum.reduce_while(specs, {:ok, %{}}, fn spec, {:ok, acc} ->
+        orchestrator_spec =
+          RuntimeLaunch.orchestrator_spec(runtime, config, opts, node_names, secrets)
+
+        web_spec = RuntimeLaunch.web_spec(runtime, config, opts, secrets)
+
+        with {:ok, services} <- start_service_specs([runner_spec]),
+             :ok <- wait_runner_node_ready(node_names.runner_full, 15_000),
+             {:ok, services} <- start_service_specs([orchestrator_spec], services),
+             {:ok, services} <- start_service_specs([web_spec], services) do
+          {:ok, services}
+        else
+          {:error, _reason} = error ->
+            error
+        end
+    end
+  end
+
+  defp start_service_specs(specs, initial \\ %{}) when is_list(specs) and is_map(initial) do
+    Enum.reduce_while(specs, {:ok, initial}, fn spec, {:ok, acc} ->
       case DevProcess.start_service(spec) do
         {:ok, info} ->
           {:cont, {:ok, Map.put(acc, info.name, info)}}
@@ -340,6 +361,29 @@ defmodule Favn.Dev.Stack do
           {:halt, {:error, {:start_failed, spec.name, reason}}}
       end
     end)
+  end
+
+  defp wait_runner_node_ready(runner_full, timeout_ms)
+       when is_binary(runner_full) and is_integer(timeout_ms) and timeout_ms > 0 do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    runner_node = String.to_atom(runner_full)
+
+    do_wait_runner_node_ready(runner_node, deadline)
+  end
+
+  defp do_wait_runner_node_ready(runner_node, deadline_ms) when is_atom(runner_node) do
+    case :net_adm.ping(runner_node) do
+      :pong ->
+        :ok
+
+      :pang ->
+        if System.monotonic_time(:millisecond) >= deadline_ms do
+          {:error, {:runner_node_unreachable, runner_node}}
+        else
+          Process.sleep(100)
+          do_wait_runner_node_ready(runner_node, deadline_ms)
+        end
+    end
   end
 
   defp ensure_web_assets(runtime, opts) do
@@ -416,6 +460,7 @@ defmodule Favn.Dev.Stack do
              runner_node_name: node_names.runner_full,
              rpc_cookie: secrets["rpc_cookie"]
            ),
+         :ok <- wait_http(config.orchestrator_base_url, 15_000),
          :ok <-
            State.write_manifest_latest(
              %{

--- a/apps/favn_local/test/dev_install_test.exs
+++ b/apps/favn_local/test/dev_install_test.exs
@@ -16,6 +16,10 @@ defmodule Favn.Dev.InstallTest do
     File.write!(Path.join(root_dir, "mix.lock"), "lock")
     File.write!(Path.join(root_dir, "web/favn_web/package.json"), "{}")
     File.write!(Path.join(root_dir, "web/favn_web/package-lock.json"), "{}")
+    File.mkdir_p!(Path.join(root_dir, "web/favn_web/node_modules/.bin"))
+    File.mkdir_p!(Path.join(root_dir, "web/favn_web/dist"))
+    File.write!(Path.join(root_dir, "web/favn_web/node_modules/.bin/vite"), "vite")
+    File.write!(Path.join(root_dir, "web/favn_web/dist/index.html"), "built")
 
     File.write!(
       Path.join(root_dir, "apps/favn_runner/mix.exs"),
@@ -55,9 +59,23 @@ defmodule Favn.Dev.InstallTest do
     assert runtime["materialized_root"] == Path.join(root_dir, ".favn/install/runtime_root")
     assert toolchain["schema_version"] == 2
 
-    assert File.exists?(Path.join(root_dir, ".favn/install/runtime_root/apps/favn_runner/mix.exs"))
-    assert File.exists?(Path.join(root_dir, ".favn/install/runtime_root/apps/favn_orchestrator/mix.exs"))
-    assert File.exists?(Path.join(root_dir, ".favn/install/runtime_root/web/favn_web/package.json"))
+    assert File.exists?(
+             Path.join(root_dir, ".favn/install/runtime_root/apps/favn_runner/mix.exs")
+           )
+
+    assert File.exists?(
+             Path.join(root_dir, ".favn/install/runtime_root/apps/favn_orchestrator/mix.exs")
+           )
+
+    assert File.exists?(
+             Path.join(root_dir, ".favn/install/runtime_root/web/favn_web/package.json")
+           )
+
+    refute File.exists?(
+             Path.join(root_dir, ".favn/install/runtime_root/web/favn_web/node_modules")
+           )
+
+    refute File.exists?(Path.join(root_dir, ".favn/install/runtime_root/web/favn_web/dist"))
   end
 
   test "run/1 returns already_installed when fingerprint matches", %{root_dir: root_dir} do
@@ -86,13 +104,15 @@ defmodule Favn.Dev.InstallTest do
 
   test "ensure_ready/1 returns install_stale when fingerprint differs", %{root_dir: root_dir} do
     assert :ok = State.ensure_layout(root_dir: root_dir)
-    assert :ok = State.write_install_runtime(%{"materialized_root" => root_dir}, root_dir: root_dir)
 
     assert :ok =
-              State.write_install(
-                %{"schema_version" => 2, "fingerprint" => %{"consumer_mix_lock_sha256" => "old"}},
-                root_dir: root_dir
-              )
+             State.write_install_runtime(%{"materialized_root" => root_dir}, root_dir: root_dir)
+
+    assert :ok =
+             State.write_install(
+               %{"schema_version" => 2, "fingerprint" => %{"consumer_mix_lock_sha256" => "old"}},
+               root_dir: root_dir
+             )
 
     assert {:error, :install_stale} =
              Install.ensure_ready(root_dir: root_dir, skip_tool_checks: true)

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -5,6 +5,7 @@ defmodule Favn.Dev.LifecycleTest do
 
   alias Favn.Dev
   alias Favn.Dev.Lock
+  alias Favn.Dev.NodeControl
   alias Favn.Dev.Paths
   alias Favn.Dev.Process, as: DevProcess
   alias Favn.Dev.State
@@ -84,10 +85,69 @@ defmodule Favn.Dev.LifecycleTest do
                skip_install_check: true,
                skip_bootstrap: true,
                skip_readiness: true
-              )
+             )
 
     assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
     assert {:ok, %{"error" => _}} = State.read_last_failure(root_dir: root_dir)
+  end
+
+  test "staged runner startup failure stops the already-started runner", %{root_dir: root_dir} do
+    cookie = "favn_staged_cleanup_cookie"
+
+    case NodeControl.ensure_local_node_started(cookie) do
+      :ok ->
+        runtime_root = Path.expand("../../..", __DIR__)
+
+        assert :ok = State.ensure_layout(root_dir: root_dir)
+
+        assert :ok =
+                 State.write_install_runtime(
+                   %{
+                     "schema_version" => 1,
+                     "resolved_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+                     "source_kind" => "test",
+                     "source_root" => runtime_root,
+                     "materialized_root" => runtime_root,
+                     "runner_root" => runtime_root,
+                     "orchestrator_root" => runtime_root,
+                     "web_root" => Path.join(runtime_root, "web/favn_web")
+                   },
+                   root_dir: root_dir
+                 )
+
+        runner_full = expected_runner_full(root_dir)
+
+        try do
+          assert {:error, {:runner_node_unreachable, :missing_runner@nohost}} =
+                   Dev.dev(
+                     root_dir: root_dir,
+                     orchestrator_port: free_port(),
+                     web_port: free_port(),
+                     skip_install_check: true,
+                     skip_runtime_compile: true,
+                     skip_web_build: true,
+                     skip_bootstrap: true,
+                     skip_readiness: true,
+                     runner_wait_node_name: "missing_runner@nohost",
+                     runner_wait_timeout_ms: 100
+                   )
+
+          assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
+          assert {:ok, %{"error" => _}} = State.read_last_failure(root_dir: root_dir)
+
+          assert :ok =
+                   wait_until(fn ->
+                     :net_adm.ping(String.to_atom(runner_full)) == :pang
+                   end)
+        after
+          stop_remote_node(runner_full, root_dir)
+        end
+
+      {:error, reason} ->
+        IO.puts(
+          "Skipping staged runner cleanup test: distributed Erlang unavailable: #{inspect(reason)}"
+        )
+    end
   end
 
   test "dev auto-clears stale runtime before continuing", %{root_dir: root_dir} do
@@ -132,6 +192,7 @@ defmodule Favn.Dev.LifecycleTest do
 
     assert {:error, {:stack_partially_running, states}} =
              Dev.dev(root_dir: root_dir, skip_runtime_compile: true)
+
     assert {"runner", :running} in states
     assert {:ok, _runtime} = State.read_runtime(root_dir: root_dir)
 
@@ -152,7 +213,7 @@ defmodule Favn.Dev.LifecycleTest do
                  skip_install_check: true,
                  skip_bootstrap: true,
                  skip_readiness: true
-                )
+               )
     after
       :ok = :gen_tcp.close(socket)
     end
@@ -177,7 +238,7 @@ defmodule Favn.Dev.LifecycleTest do
                skip_install_check: true,
                skip_bootstrap: true,
                skip_readiness: true
-              )
+             )
   end
 
   test "dev/1 returns explicit postgres misconfiguration diagnostics", %{root_dir: root_dir} do
@@ -186,9 +247,9 @@ defmodule Favn.Dev.LifecycleTest do
                root_dir: root_dir,
                web_port: free_port(),
                storage: :postgres,
-                postgres: [
-                  hostname: "",
-                  port: 5432,
+               postgres: [
+                 hostname: "",
+                 port: 5432,
                  username: "postgres",
                  password: "postgres",
                  database: "favn",
@@ -199,7 +260,7 @@ defmodule Favn.Dev.LifecycleTest do
                skip_install_check: true,
                skip_bootstrap: true,
                skip_readiness: true
-               )
+             )
   end
 
   test "dev/1 fails runtime compile as preflight before startup lock work", %{root_dir: root_dir} do
@@ -303,6 +364,29 @@ defmodule Favn.Dev.LifecycleTest do
   end
 
   defp short_host?(host) when is_binary(host), do: host != "" and not String.contains?(host, ".")
+
+  defp expected_runner_full(root_dir) do
+    suffix = Integer.to_string(:erlang.phash2(root_dir, 1_000_000))
+    runner_short = "favn_runner_#{suffix}"
+    {:ok, runner_full} = NodeControl.shortname_to_full(runner_short)
+    runner_full
+  end
+
+  defp stop_remote_node(runner_full, root_dir) when is_binary(runner_full) do
+    with {:ok, secrets} <- State.read_secrets(root_dir: root_dir),
+         cookie when is_binary(cookie) <- secrets["rpc_cookie"] do
+      runner_node = String.to_atom(runner_full)
+      true = Node.set_cookie(runner_node, String.to_atom(cookie))
+
+      if Node.connect(runner_node) do
+        _ = :erpc.call(runner_node, :init, :stop, [], 2_000)
+      end
+    else
+      _ -> :ok
+    end
+  catch
+    :exit, _reason -> :ok
+  end
 
   defp wait_until(fun, attempts \\ 120)
   defp wait_until(_fun, 0), do: {:error, :timeout}

--- a/apps/favn_local/test/dev_orchestrator_client_test.exs
+++ b/apps/favn_local/test/dev_orchestrator_client_test.exs
@@ -2,6 +2,7 @@ defmodule Favn.Dev.OrchestratorClientTest do
   use ExUnit.Case, async: false
 
   alias Favn.Dev.OrchestratorClient
+  alias Favn.Manifest.Version
 
   setup do
     root_dir =
@@ -37,13 +38,49 @@ defmodule Favn.Dev.OrchestratorClientTest do
              OrchestratorClient.in_flight_runs("http://127.0.0.1:4101", "token")
   end
 
-  defp write_fake_curl(bin_dir, body, status) do
+  test "publish_manifest/3 serializes manifest structs before JSON encoding", %{bin_dir: bin_dir} do
+    args_path = Path.join(bin_dir, "curl_args.txt")
+    write_fake_curl(bin_dir, ~s({"data":{"ok":true}}), 200, args_path)
+
+    manifest = %{
+      schema_version: 1,
+      runner_contract_version: 1,
+      assets: [],
+      pipelines: [],
+      schedules: [],
+      graph: %{},
+      metadata: %{}
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: "mv_orchestrator_client_test")
+
+    assert {:ok, %{"data" => %{"ok" => true}}} =
+             OrchestratorClient.publish_manifest("http://127.0.0.1:4101", "token", %{
+               manifest_version_id: version.manifest_version_id,
+               manifest: version.manifest
+             })
+
+    assert {:ok, args} = File.read(args_path)
+    assert args =~ ~s("manifest_version_id":"mv_orchestrator_client_test")
+    assert args =~ ~s("manifest":{"assets":[])
+    refute args =~ ~s("__struct__")
+  end
+
+  defp write_fake_curl(bin_dir, body, status, args_path \\ nil) do
+    args_line =
+      case args_path do
+        path when is_binary(path) -> "printf '%s\n' \"$*\" > \"#{path}\""
+        _ -> ""
+      end
+
     script =
       [
         "#!/usr/bin/env bash",
+        args_line,
         "printf '%s\\n' '#{body}'",
         "printf '%s\\n' '#{status}'"
       ]
+      |> Enum.reject(&(&1 == ""))
       |> Enum.join("\n")
 
     path = Path.join(bin_dir, "curl")

--- a/apps/favn_local/test/dev_runner_control_test.exs
+++ b/apps/favn_local/test/dev_runner_control_test.exs
@@ -16,6 +16,25 @@ defmodule Favn.Dev.RunnerControlTest do
   defmodule MissingRunner do
   end
 
+  defmodule DelayedRunner do
+    use GenServer
+
+    def start_link(test_pid) when is_pid(test_pid) do
+      GenServer.start_link(__MODULE__, test_pid, name: __MODULE__)
+    end
+
+    def register_manifest(version), do: GenServer.call(__MODULE__, {:register_manifest, version})
+
+    @impl true
+    def init(test_pid), do: {:ok, test_pid}
+
+    @impl true
+    def handle_call({:register_manifest, version}, _from, test_pid) do
+      send(test_pid, {:register_manifest_called, version})
+      {:reply, :ok, test_pid}
+    end
+  end
+
   setup do
     cookie = "favn_runner_control_test_cookie"
 
@@ -69,6 +88,34 @@ defmodule Favn.Dev.RunnerControlTest do
                %{module: MissingRunner, function: :register_manifest, arity: 2},
                %{module: MissingRunner, function: :register_manifest, arity: 1}
              ]
+    end
+  end
+
+  test "register_manifest/2 retries startup-unavailable entrypoints until they become ready",
+       ctx do
+    if maybe_run_distributed?(ctx) do
+      test_pid = self()
+
+      on_exit(fn ->
+        if pid = Process.whereis(DelayedRunner) do
+          GenServer.stop(pid)
+        end
+      end)
+
+      spawn(fn ->
+        Process.sleep(150)
+        {:ok, _pid} = DelayedRunner.start_link(test_pid)
+      end)
+
+      assert :ok =
+               RunnerControl.register_manifest(ctx.version,
+                 runner_node_name: ctx.runner_node_name,
+                 rpc_cookie: ctx.cookie,
+                 runner_module: DelayedRunner
+               )
+
+      assert_receive {:register_manifest_called, %Version{} = version}, 5_000
+      assert version.manifest_version_id == ctx.version.manifest_version_id
     end
   end
 

--- a/apps/favn_local/test/dev_runtime_launch_test.exs
+++ b/apps/favn_local/test/dev_runtime_launch_test.exs
@@ -2,6 +2,7 @@ defmodule Favn.Dev.RuntimeLaunchTest do
   use ExUnit.Case, async: true
 
   alias Favn.Dev.Config
+  alias Favn.Dev.ConsumerCodePath
   alias Favn.Dev.RuntimeLaunch
 
   test "runner, orchestrator, and web specs target installed runtime roots" do
@@ -34,8 +35,34 @@ defmodule Favn.Dev.RuntimeLaunchTest do
     assert runner.cwd == runtime["runner_root"]
     assert orchestrator.cwd == runtime["orchestrator_root"]
     assert web.cwd == runtime["web_root"]
-    assert "-S" in runner.args
+    assert "--no-compile" in runner.args
+    assert "mix" in runner.args
+    assert "--no-compile" in orchestrator.args
     assert "mix" in orchestrator.args
+    assert web.exec == (System.find_executable("node") || "node")
+    assert hd(web.args) == Path.join(runtime["web_root"], "node_modules/vite/bin/vite.js")
     assert "preview" in web.args
+  end
+
+  test "consumer code path excludes runtime-owned favn apps" do
+    build_path =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_consumer_code_path_#{System.unique_integer([:positive])}"
+      )
+
+    on_exit(fn ->
+      File.rm_rf(build_path)
+    end)
+
+    assert :ok = File.mkdir_p(Path.join(build_path, "lib/favn_runner/ebin"))
+    assert :ok = File.mkdir_p(Path.join(build_path, "lib/favn_local/ebin"))
+    assert :ok = File.mkdir_p(Path.join(build_path, "lib/my_app/ebin"))
+    assert :ok = File.mkdir_p(Path.join(build_path, "lib/jason/ebin"))
+
+    assert ConsumerCodePath.ebin_paths(build_path: build_path) == [
+             Path.join(build_path, "lib/jason/ebin"),
+             Path.join(build_path, "lib/my_app/ebin")
+           ]
   end
 end

--- a/apps/favn_local/test/dev_state_test.exs
+++ b/apps/favn_local/test/dev_state_test.exs
@@ -1,6 +1,8 @@
 defmodule Favn.Dev.StateTest do
   use ExUnit.Case, async: true
 
+  alias Favn.Dev.Config
+  alias Favn.Dev.Secrets
   alias Favn.Dev.State
 
   setup do
@@ -59,5 +61,14 @@ defmodule Favn.Dev.StateTest do
     assert {:ok, ^install} = State.read_install(root_dir: root_dir)
     assert {:ok, ^runtime} = State.read_install_runtime(root_dir: root_dir)
     assert {:ok, ^toolchain} = State.read_toolchain(root_dir: root_dir)
+  end
+
+  test "secrets resolve regenerates unsafe rpc cookies", %{root_dir: root_dir} do
+    assert :ok = State.write_secrets(%{"rpc_cookie" => "-bad-cookie"}, root_dir: root_dir)
+
+    assert {:ok, secrets} = Secrets.resolve(Config.resolve(), root_dir: root_dir)
+
+    assert String.match?(secrets["rpc_cookie"], ~r/^[A-Z0-9]+$/)
+    refute secrets["rpc_cookie"] == "-bad-cookie"
   end
 end


### PR DESCRIPTION
## Summary
- harden `favn_local` runtime install and bootstrap for external consumers by filtering runtime-owned ebins, cleaning the materialized web workspace, and making web dependency install more resilient
- fix local dev startup races by improving runner registration retries, using safer RPC cookies, staging service startup, and wiring runtime launch config more explicitly
- add focused regression coverage for install, runtime launch, orchestrator publish, and secrets handling; follow-up architecture work is tracked in #122

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`