### PR TITLE
fix: handle memory local dev storage

### DIFF
--- a/apps/favn_local/lib/favn/dev/runtime_launch.ex
+++ b/apps/favn_local/lib/favn/dev/runtime_launch.ex
@@ -47,13 +47,17 @@ defmodule Favn.Dev.RuntimeLaunch do
       """
       storage = System.get_env("FAVN_DEV_STORAGE", "memory")
 
-      cond do
-        storage == "sqlite" ->
+      case storage do
+        "memory" ->
+          Application.put_env(:favn_orchestrator, :storage_adapter, FavnOrchestrator.Storage.Adapter.Memory)
+          Application.put_env(:favn_orchestrator, :storage_adapter_opts, [])
+
+        "sqlite" ->
           {:ok, _} = Application.ensure_all_started(:favn_storage_sqlite)
           Application.put_env(:favn_orchestrator, :storage_adapter, Favn.Storage.Adapter.SQLite)
           Application.put_env(:favn_orchestrator, :storage_adapter_opts, database: System.get_env("FAVN_DEV_SQLITE_PATH"))
 
-        storage == "postgres" ->
+        "postgres" ->
           {:ok, _} = Application.ensure_all_started(:favn_storage_postgres)
           Application.put_env(:favn_orchestrator, :storage_adapter, Favn.Storage.Adapter.Postgres)
 
@@ -68,6 +72,10 @@ defmodule Favn.Dev.RuntimeLaunch do
             ssl: System.get_env("FAVN_DEV_POSTGRES_SSL", "false") == "true",
             pool_size: String.to_integer(System.get_env("FAVN_DEV_POSTGRES_POOL_SIZE", "10"))
           )
+
+        other ->
+          raise ArgumentError,
+                "unsupported FAVN_DEV_STORAGE=\#{inspect(other)}; expected memory, sqlite, or postgres"
       end
       runner_node = String.to_atom(System.get_env("FAVN_DEV_RUNNER_NODE"))
       Application.put_env(:favn_orchestrator, :runner_client, FavnOrchestrator.RunnerClient.LocalNode)

--- a/apps/favn_local/test/dev_runtime_launch_test.exs
+++ b/apps/favn_local/test/dev_runtime_launch_test.exs
@@ -44,6 +44,32 @@ defmodule Favn.Dev.RuntimeLaunchTest do
     assert "preview" in web.args
   end
 
+  test "orchestrator spec handles memory storage explicitly" do
+    runtime = %{
+      "orchestrator_root" => "/tmp/favn_runtime"
+    }
+
+    config = Config.resolve(storage: :memory)
+
+    node_names = %{
+      runner_full: "favn_runner_test@host",
+      orchestrator_short: "favn_orchestrator_test"
+    }
+
+    secrets = %{
+      "rpc_cookie" => "cookie",
+      "service_token" => "token"
+    }
+
+    orchestrator = RuntimeLaunch.orchestrator_spec(runtime, config, [], node_names, secrets)
+    code = eval_code!(orchestrator)
+
+    assert orchestrator.env["FAVN_DEV_STORAGE"] == "memory"
+    assert code =~ ~s("memory" ->)
+    assert code =~ "FavnOrchestrator.Storage.Adapter.Memory"
+    assert code =~ "unsupported FAVN_DEV_STORAGE"
+  end
+
   test "consumer code path excludes runtime-owned favn apps" do
     build_path =
       Path.join(
@@ -64,5 +90,14 @@ defmodule Favn.Dev.RuntimeLaunchTest do
              Path.join(build_path, "lib/jason/ebin"),
              Path.join(build_path, "lib/my_app/ebin")
            ]
+  end
+
+  defp eval_code!(%{args: args}) do
+    args
+    |> Enum.chunk_every(2, 1, :discard)
+    |> Enum.find_value(fn
+      ["--eval", code] -> code
+      _other -> nil
+    end) || flunk("expected orchestrator args to include --eval code")
   end
 end


### PR DESCRIPTION
## Summary

- Add explicit memory storage handling to the generated local orchestrator startup config.
- Replace the non-exhaustive storage `cond` with an exhaustive `case` and a clear unsupported-storage error.
- Add regression coverage for memory-mode orchestrator launch specs.

Fixes #129.

## Verification

- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`