### PR TITLE
fix: use loopback TCP local HTTP client

### DIFF
--- a/apps/favn_local/lib/favn/dev/local_http_client.ex
+++ b/apps/favn_local/lib/favn/dev/local_http_client.ex
@@ -4,7 +4,6 @@ defmodule Favn.Dev.LocalHttpClient do
   @default_connect_timeout_ms 1_000
   @default_timeout_ms 5_000
   @default_http_port 80
-  @loopback_hosts ["127.0.0.1", "::1", "localhost"]
 
   @type method :: :get | :post
   @type header :: {String.t(), String.t()}
@@ -43,17 +42,15 @@ defmodule Favn.Dev.LocalHttpClient do
   defp parse_target(url) do
     case URI.parse(url) do
       %URI{scheme: "http", host: host} = uri when is_binary(host) ->
-        if loopback_host?(host) do
+        with {:ok, connect_host} <- resolve_connect_host(host) do
           {:ok,
            %{
              host: host,
-             connect_host: connect_host(host),
+             connect_host: connect_host,
              host_header: host_header(host, uri.port),
              port: uri.port || @default_http_port,
              request_target: request_target(uri)
            }}
-        else
-          {:error, {:unsupported_url, :non_loopback_host}}
         end
 
       %URI{scheme: "https"} ->
@@ -70,24 +67,51 @@ defmodule Favn.Dev.LocalHttpClient do
     end
   end
 
-  defp loopback_host?(host) when host in @loopback_hosts, do: true
+  defp resolve_connect_host("localhost") do
+    addresses = resolve_localhost_addresses()
 
-  defp loopback_host?(host) do
-    case :inet.parse_address(String.to_charlist(host)) do
-      {:ok, {127, _second, _third, _fourth}} -> true
-      {:ok, {0, 0, 0, 0, 0, 0, 0, 1}} -> true
-      _other -> false
+    cond do
+      addresses == [] ->
+        {:error, {:unsupported_url, :localhost_not_resolved}}
+
+      Enum.all?(addresses, &loopback_address?/1) ->
+        {:ok, hd(addresses)}
+
+      true ->
+        {:error, {:unsupported_url, :non_loopback_host}}
     end
   end
 
-  defp connect_host("localhost"), do: ~c"localhost"
-
-  defp connect_host(host) do
+  defp resolve_connect_host(host) do
     case :inet.parse_address(String.to_charlist(host)) do
-      {:ok, address} -> address
-      _other -> String.to_charlist(host)
+      {:ok, address} ->
+        if loopback_address?(address) do
+          {:ok, address}
+        else
+          {:error, {:unsupported_url, :non_loopback_host}}
+        end
+
+      _other ->
+        {:error, {:unsupported_url, :non_loopback_host}}
     end
   end
+
+  defp resolve_localhost_addresses do
+    ~c"localhost"
+    |> then(fn host -> resolve_addresses(host, :inet) ++ resolve_addresses(host, :inet6) end)
+    |> Enum.uniq()
+  end
+
+  defp resolve_addresses(host, family) do
+    case :inet.getaddrs(host, family) do
+      {:ok, addresses} -> addresses
+      {:error, _reason} -> []
+    end
+  end
+
+  defp loopback_address?({127, _second, _third, _fourth}), do: true
+  defp loopback_address?({0, 0, 0, 0, 0, 0, 0, 1}), do: true
+  defp loopback_address?(_address), do: false
 
   defp host_header(host, nil), do: format_host(host)
   defp host_header(host, @default_http_port), do: format_host(host)
@@ -140,29 +164,27 @@ defmodule Favn.Dev.LocalHttpClient do
   defp request_headers(:get, target, headers, _body) do
     headers
     |> normalize_headers()
-    |> put_header("host", target.host_header)
-    |> put_header("connection", "close")
+    |> force_header("host", target.host_header)
+    |> force_header("connection", "close")
   end
 
   defp request_headers(:post, target, headers, body) do
     headers
     |> normalize_headers()
-    |> put_header("host", target.host_header)
-    |> put_header("connection", "close")
-    |> put_header("content-type", "application/json")
-    |> put_header("content-length", Integer.to_string(byte_size(body)))
+    |> force_header("host", target.host_header)
+    |> force_header("connection", "close")
+    |> force_header("content-type", "application/json")
+    |> force_header("content-length", Integer.to_string(byte_size(body)))
   end
 
   defp normalize_headers(headers) do
     Enum.map(headers, fn {key, value} -> {to_string(key), to_string(value)} end)
   end
 
-  defp put_header(headers, key, value) do
-    if Enum.any?(headers, fn {existing_key, _value} -> String.downcase(existing_key) == key end) do
-      headers
-    else
-      headers ++ [{key, value}]
-    end
+  defp force_header(headers, key, value) do
+    headers
+    |> Enum.reject(fn {existing_key, _value} -> String.downcase(existing_key) == key end)
+    |> Kernel.++([{key, value}])
   end
 
   defp header_lines(headers) do

--- a/apps/favn_local/test/dev_local_http_client_test.exs
+++ b/apps/favn_local/test/dev_local_http_client_test.exs
@@ -20,15 +20,19 @@ defmodule Favn.Dev.LocalHttpClientTest do
     {:ok, base_url, _server} = start_capturing_server(~s({"data":{"created":true}}), 201, self())
 
     assert {:ok, %{"data" => %{"created" => true}}} =
-             LocalHttpClient.request(:post, base_url <> "/runs?dry_run=false", [{"authorization", "Bearer token"}],
+             LocalHttpClient.request(:post, base_url <> "/runs?dry_run=false", override_headers(),
                ~s({"ok":true})
              )
 
     assert_receive {:request, request}
     assert request =~ "POST /runs?dry_run=false HTTP/1.1\r\n"
     assert request =~ "authorization: Bearer token\r\n"
+    assert request =~ "connection: close\r\n"
     assert request =~ "content-type: application/json\r\n"
     assert request =~ "content-length: 11\r\n"
+    refute request =~ "connection: keep-alive\r\n"
+    refute request =~ "content-type: text/plain\r\n"
+    refute request =~ "content-length: 999\r\n"
     assert request =~ "\r\n\r\n{\"ok\":true}"
   end
 
@@ -67,7 +71,7 @@ defmodule Favn.Dev.LocalHttpClientTest do
     server =
       spawn_link(fn ->
         {:ok, socket} = :gen_tcp.accept(listen_socket)
-        {:ok, request} = :gen_tcp.recv(socket, 0, 2_000)
+        {:ok, request} = recv_request(socket)
         if recipient, do: send(recipient, {:request, request})
         :ok = :gen_tcp.send(socket, response(status, body))
         :ok = :gen_tcp.close(socket)
@@ -75,6 +79,61 @@ defmodule Favn.Dev.LocalHttpClientTest do
       end)
 
     {:ok, "http://127.0.0.1:#{port}", server}
+  end
+
+  defp override_headers do
+    [
+      {"authorization", "Bearer token"},
+      {"connection", "keep-alive"},
+      {"content-type", "text/plain"},
+      {"content-length", "999"}
+    ]
+  end
+
+  defp recv_request(socket, buffer \\ "") do
+    case :gen_tcp.recv(socket, 0, 2_000) do
+      {:ok, chunk} ->
+        request = buffer <> chunk
+
+        if complete_request?(request) do
+          {:ok, request}
+        else
+          recv_request(socket, request)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp complete_request?(request) do
+    case :binary.split(request, "\r\n\r\n") do
+      [headers, body] -> byte_size(body) >= content_length(headers)
+      _other -> false
+    end
+  end
+
+  defp content_length(headers) do
+    headers
+    |> String.split("\r\n")
+    |> Enum.find_value(0, fn header ->
+      case String.split(header, ":", parts: 2) do
+        [key, value] -> parse_content_length(key, value)
+        _other -> nil
+      end
+    end)
+  end
+
+  defp parse_content_length(key, value) do
+    if String.downcase(key) == "content-length" do
+      value
+      |> String.trim()
+      |> Integer.parse()
+      |> case do
+        {length, ""} -> length
+        _other -> 0
+      end
+    end
   end
 
   defp response(status, body) do


### PR DESCRIPTION
## Summary
- replace the local tooling HTTP client with a dependency-free loopback-only `:gen_tcp` implementation
- remove the `:inets`/`:httpc` runtime dependency that caused `mix favn.run` to fail when `:http_util` was unavailable
- document the plain HTTP loopback-only local tooling boundary and add focused client coverage

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`

Fixes #140