### PR TITLE
Polish run inspector real payload UI

### DIFF
--- a/web/favn_web/.storybook/preview.ts
+++ b/web/favn_web/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from '@storybook/sveltekit';
+import '../src/routes/layout.css';
 
 const preview: Preview = {
 	parameters: {

--- a/web/favn_web/src/lib/components/favn/AppShell.svelte
+++ b/web/favn_web/src/lib/components/favn/AppShell.svelte
@@ -13,13 +13,19 @@
 	}>();
 
 	const navItems = [
-		{ label: 'Runs', href: '/runs', complete: true },
-		{ label: 'Manifests', href: null, complete: false },
-		{ label: 'Schedules', href: null, complete: false },
-		{ label: 'Settings', href: null, complete: false }
+		{ label: 'Runs', href: '/runs' },
+		{ label: 'Manifests', href: null },
+		{ label: 'Settings', href: null }
 	];
 
 	let currentPath = $derived(page.url.pathname);
+	let compactManifestVersionId = $derived(shortId(activeManifestVersionId));
+
+	function shortId(value: string | null | undefined) {
+		if (!value) return 'none';
+		if (value.length <= 18) return value;
+		return `${value.slice(0, 11)}…${value.slice(-4)}`;
+	}
 </script>
 
 <div class="min-h-screen bg-slate-50 text-slate-950">
@@ -34,23 +40,28 @@
 					{@const active =
 						item.href !== null &&
 						(currentPath === item.href || currentPath.startsWith(`${item.href}/`))}
-					<svelte:element
-						this={item.href ? 'a' : 'span'}
-						href={item.href === '/runs' ? resolve('/runs') : undefined}
-						class={[
-							'flex items-center justify-between rounded-md px-3 py-2 text-sm font-medium',
-							active
-								? 'bg-slate-950 text-white'
-								: item.href
-									? 'text-slate-600 hover:bg-slate-100 hover:text-slate-950'
-									: 'cursor-not-allowed text-slate-400'
-						]}
-						aria-current={active ? 'page' : undefined}
-						aria-disabled={item.href ? undefined : 'true'}
-					>
-						<span>{item.label}</span>
-						{#if !item.complete}<span class="text-[10px] opacity-70">soon</span>{/if}
-					</svelte:element>
+					{#if item.href}
+						<a
+							href={resolve(item.href)}
+							class={[
+								'flex items-center justify-between rounded-md px-3 py-2 text-sm font-medium',
+								active
+									? 'bg-slate-950 text-white shadow-sm [&_*]:text-white'
+									: 'text-slate-600 hover:bg-slate-100 hover:text-slate-950'
+							]}
+							aria-current={active ? 'page' : undefined}
+						>
+							<span>{item.label}</span>
+						</a>
+					{:else}
+						<span
+							class="flex cursor-not-allowed items-center justify-between rounded-md px-3 py-2 text-sm font-medium text-slate-400"
+							aria-disabled="true"
+						>
+							<span>{item.label}</span>
+							<span class="text-[10px] text-slate-400">soon</span>
+						</span>
+					{/if}
 				{/each}
 			</nav>
 		</aside>
@@ -60,31 +71,36 @@
 				<div
 					class="flex flex-col gap-3 px-4 py-3 lg:flex-row lg:items-center lg:justify-between lg:px-6"
 				>
-					<div>
+					<div class="min-w-0">
 						<div class="flex items-center gap-2 text-sm font-medium">
 							<span>Favn</span>
 							<span class="h-4 w-px bg-slate-200" aria-hidden="true"></span>
 							<span class="text-slate-500">Local development</span>
 						</div>
-						<nav class="mt-1 text-xs text-slate-500" aria-label="Breadcrumb">
+						<nav class="mt-1 truncate text-xs text-slate-500" aria-label="Breadcrumb">
 							<a href={resolve('/runs')} class="hover:text-slate-950">Runs</a>
 							{#if currentPath !== '/runs'}
 								<span class="mx-1">/</span><span
-									>{currentPath.split('/').filter(Boolean).at(-1)}</span
+									title={currentPath.split('/').filter(Boolean).at(-1)}
+									>{shortId(currentPath.split('/').filter(Boolean).at(-1))}</span
 								>
 							{/if}
 						</nav>
 					</div>
 
-					<div class="flex flex-wrap items-center gap-2 text-xs text-slate-600">
-						<Badge variant="outline">Active manifest: {activeManifestVersionId ?? 'none'}</Badge>
-						<Badge variant="secondary">Storage: local</Badge>
-						<Badge variant="outline">Scheduler: local</Badge>
+					<div class="flex shrink-0 flex-nowrap items-center gap-2 text-xs text-slate-600">
+						<Badge
+							variant="outline"
+							class="max-w-48 truncate"
+							title={activeManifestVersionId ?? 'No active manifest'}
+						>
+							Manifest {compactManifestVersionId}
+						</Badge>
 						<Button
 							href="/api/web/v1/streams/runs"
 							variant="outline"
 							size="sm"
-							title="Open raw runs event stream">Open logs</Button
+							title="Open raw runs event stream">Open event stream</Button
 						>
 						<Button href={currentPath} variant="outline" size="sm" title="Reload this page"
 							>Refresh</Button
@@ -97,7 +113,7 @@
 									class="grid size-6 place-items-center rounded-full bg-slate-950 text-[10px] font-bold text-white"
 									>LO</span
 								>
-								<span>local-operator</span>
+								<span class="hidden xl:inline">local-operator</span>
 							</summary>
 							<div class="absolute right-0 mt-2 w-56 rounded-md border bg-white p-2 shadow-lg">
 								<p class="px-2 py-1 text-xs text-slate-500">Signed in as</p>

--- a/web/favn_web/src/lib/components/favn/ErrorPanel.svelte
+++ b/web/favn_web/src/lib/components/favn/ErrorPanel.svelte
@@ -10,7 +10,7 @@
 </script>
 
 <Alert.Root variant="destructive" class="bg-red-50">
-	<Alert.Title>Run failed in asset {asset}</Alert.Title>
+	<p class="mb-1 font-medium tracking-tight">Run failed in asset {asset}</p>
 	<Alert.Description>{message}</Alert.Description>
 	<div class="mt-3 flex flex-wrap gap-2">
 		<Button size="sm" variant="outline" onclick={() => oninspect?.()}>Inspect failed asset</Button>

--- a/web/favn_web/src/lib/components/favn/OutputRelationsTable.svelte
+++ b/web/favn_web/src/lib/components/favn/OutputRelationsTable.svelte
@@ -7,7 +7,7 @@
 </script>
 
 {#if outputs.length === 0}
-	<p class="text-sm text-slate-500">No materialized outputs reported.</p>
+	<p class="text-sm text-slate-500">No materialized outputs reported by this run.</p>
 {:else}
 	<Table.Root>
 		<Table.Header>

--- a/web/favn_web/src/lib/components/favn/RunDetailPage.stories.svelte
+++ b/web/favn_web/src/lib/components/favn/RunDetailPage.stories.svelte
@@ -2,7 +2,7 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import { expect, within } from 'storybook/test';
 	import RunDetailPage from './RunDetailPage.svelte';
-	import { failedRunDetail } from './story_fixtures';
+	import { failedRunDetail, realPayloadRunDetail } from './story_fixtures';
 
 	const { Story } = defineMeta({
 		title: 'Favn/Run Inspector/Run Detail Page',
@@ -16,9 +16,8 @@
 	args={{ run: failedRunDetail }}
 	play={async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
-		await expect(
-			canvas.getByRole('heading', { name: `Run ${failedRunDetail.id}` })
-		).toBeInTheDocument();
+		await expect(canvas.getByRole('heading', { name: 'Run details' })).toBeInTheDocument();
+		await expect(canvas.getByText('run_01JABCD12')).toBeInTheDocument();
 		await expect(
 			canvas.getByText('Run failed in asset Staging.CustomerOrders')
 		).toBeInTheDocument();
@@ -26,11 +25,23 @@
 />
 
 <Story
-	name="Outputs Tab Interaction"
+	name="Events Tab Interaction"
 	args={{ run: failedRunDetail }}
 	play={async ({ canvasElement, userEvent }) => {
 		const canvas = within(canvasElement);
-		await userEvent.click(canvas.getByRole('button', { name: 'Outputs' }));
-		await expect(canvas.getByText('staging.customer_orders')).toBeInTheDocument();
+		await userEvent.click(canvas.getByRole('button', { name: 'Events' }));
+		await expect(canvas.getByText('asset_failed')).toBeInTheDocument();
+	}}
+/>
+
+<Story
+	name="Real Payload No Outputs"
+	args={{ run: realPayloadRunDetail }}
+	play={async ({ canvasElement }) => {
+		const canvas = within(canvasElement);
+		await expect(canvas.getAllByText(/ReferenceWorkloadComplete/).length).toBeGreaterThan(0);
+		await expect(
+			canvas.getByText('No materialized outputs reported by this run.')
+		).toBeInTheDocument();
 	}}
 />

--- a/web/favn_web/src/lib/components/favn/RunDetailPage.svelte
+++ b/web/favn_web/src/lib/components/favn/RunDetailPage.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
-	import { resolve } from '$app/paths';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
 	import * as Card from '$lib/components/ui/card';
 	import StatusBadge from './StatusBadge.svelte';
-	import RunSummaryCards from './RunSummaryCards.svelte';
 	import ErrorPanel from './ErrorPanel.svelte';
 	import AssetExecutionTable from './AssetExecutionTable.svelte';
 	import OutputRelationsTable from './OutputRelationsTable.svelte';
 	import RunTimeline from './RunTimeline.svelte';
-	import ManifestSummaryCard from './ManifestSummaryCard.svelte';
 	import AssetDetailSheet from './AssetDetailSheet.svelte';
 	import type { AssetExecutionView, RunDetailView } from '$lib/run_view_types';
 
@@ -17,119 +14,139 @@
 	let activeTab = $state('overview');
 	let selectedAsset = $state<AssetExecutionView | null>(null);
 
-	const tabs = ['overview', 'assets', 'timeline', 'outputs', 'manifest', 'raw'];
-	const tabLabels: Record<string, string> = {
-		overview: 'Overview',
-		assets: 'Assets',
-		timeline: 'Timeline',
-		outputs: 'Outputs',
-		manifest: 'Manifest',
-		raw: 'Raw'
-	};
-
 	let rawJson = $derived(JSON.stringify(run.raw, null, 2));
-	let isTerminal = $derived(['succeeded', 'failed', 'cancelled'].includes(run.status));
+	let compactRunId = $derived(shortId(run.id));
+	let compactManifestVersionId = $derived(shortId(run.manifestVersionId));
+	let compactManifestContentHash = $derived(shortHash(run.manifestContentHash));
 	let failedAsset = $derived(
 		run.assets.find((asset: AssetExecutionView) => asset.id === run.failedAssetId) ??
 			run.assets.find((asset: AssetExecutionView) => asset.error) ??
 			null
 	);
-	let stages = $derived.by(() => {
-		const groups: Array<{ stage: string; assets: AssetExecutionView[] }> = [];
-		for (const asset of run.assets) {
-			let group = groups.find((candidate) => candidate.stage === asset.stage);
-			if (!group) {
-				group = { stage: asset.stage, assets: [] };
-				groups.push(group);
-			}
-			group.assets = [...group.assets, asset];
+	let summaryItems = $derived([
+		{ label: 'Status', value: run.status, status: true },
+		{ label: 'Target', value: run.target, title: run.target, wide: true },
+		{ label: 'Submit kind', value: run.submitKind ?? run.trigger },
+		{ label: 'Target type', value: run.targetType },
+		{ label: 'Started', value: run.startedAt ?? '—' },
+		{ label: 'Finished', value: run.finishedAt ?? '—' },
+		{ label: 'Duration', value: run.duration },
+		{ label: 'Assets', value: run.assetCount },
+		{
+			label: 'Manifest version',
+			value: compactManifestVersionId,
+			title: run.manifestVersionId ?? undefined,
+			mono: true
+		},
+		{
+			label: 'Content hash',
+			value: compactManifestContentHash,
+			title: run.manifestContentHash ?? undefined,
+			mono: true
 		}
-		return groups;
-	});
+	]);
+
+	const tabs = ['overview', 'events', 'raw'];
+	const tabLabels: Record<string, string> = {
+		overview: 'Overview',
+		events: 'Events',
+		raw: 'Raw'
+	};
 
 	function copy(text: string | null | undefined) {
 		if (text) navigator.clipboard?.writeText(text);
 	}
 
+	function shortId(value: string | null | undefined) {
+		if (!value) return '—';
+		if (value.length <= 18) return value;
+		return `${value.slice(0, 11)}…${value.slice(-4)}`;
+	}
+
+	function shortHash(value: string | null | undefined) {
+		if (!value) return '—';
+		const [prefix, hash] = value.includes(':') ? value.split(':', 2) : ['', value];
+		const compact = hash.length <= 18 ? hash : `${hash.slice(0, 12)}…${hash.slice(-4)}`;
+		return prefix ? `${prefix}:${compact}` : compact;
+	}
+
 	function tabClass(tab: string) {
 		return activeTab === tab
 			? 'inline-flex h-8 items-center justify-center rounded-md bg-slate-950 px-3 text-xs font-medium text-white shadow'
-			: 'inline-flex h-8 items-center justify-center rounded-md px-3 text-xs font-medium hover:bg-slate-100';
+			: 'inline-flex h-8 items-center justify-center rounded-md px-3 text-xs font-medium text-slate-600 hover:bg-slate-100 hover:text-slate-950';
 	}
 </script>
 
 <section class="space-y-6">
 	<div class="flex flex-col gap-4 xl:flex-row xl:items-start xl:justify-between">
-		<div>
-			<nav class="text-sm text-slate-500" aria-label="Breadcrumb">
-				<a href={resolve('/runs')} class="hover:text-slate-950">Runs</a>
-				<span class="mx-1">/</span><span>{run.id}</span>
-			</nav>
-			<div class="mt-3 flex flex-wrap items-center gap-3">
-				<h1 class="text-3xl font-semibold tracking-tight">Run {run.id}</h1>
+		<div class="min-w-0">
+			<div class="flex flex-wrap items-center gap-3">
+				<h1 class="text-2xl font-semibold tracking-tight">Run details</h1>
 				<StatusBadge status={run.status} />
 			</div>
-			<p class="mt-2 text-sm font-medium text-slate-700">{run.target}</p>
-			<div class="mt-3 flex flex-wrap gap-2 text-xs text-slate-600">
-				<Badge variant="outline">Started {run.startedAt ?? '—'}</Badge>
-				<Badge variant="outline">Duration {run.duration}</Badge>
-				<Badge variant="outline">Triggered {run.trigger}</Badge>
-				<Badge variant="outline">Manifest {run.manifestVersionId ?? '—'}</Badge>
+			<div class="mt-2 flex min-w-0 flex-wrap items-center gap-2 text-sm text-slate-600">
+				<span class="font-mono text-xs" title={run.id}>{compactRunId}</span>
+				<Button size="sm" variant="ghost" class="h-7 px-2" onclick={() => copy(run.id)}>Copy</Button
+				>
 			</div>
+			<p class="mt-2 max-w-3xl truncate text-sm font-medium text-slate-700" title={run.target}>
+				{run.target}
+			</p>
 		</div>
-		<div class="flex flex-wrap gap-2">
-			{#if !isTerminal}
-				<Button variant="destructive" disabled>Cancel</Button>
-			{:else}
-				<Button
-					disabled
-					title="Rerun command wiring will use the same manifest version as this run.">Rerun</Button
-				>
-			{/if}
-			<Button variant="outline" onclick={() => copy(run.id)}>Copy run id</Button>
-			<Button href={`/api/web/v1/streams/runs/${run.id}`} variant="outline">Open logs</Button>
-			<details class="relative">
-				<summary
-					class="inline-flex h-9 cursor-pointer list-none items-center rounded-md border bg-white px-3 text-sm shadow-sm"
-					>More</summary
-				>
-				<div
-					class="absolute right-0 z-10 mt-2 w-56 rounded-md border bg-white p-2 text-sm shadow-lg"
-				>
-					<p class="px-2 py-1 text-xs text-slate-500">Secondary actions</p>
-					<button
-						class="block w-full rounded px-2 py-1 text-left hover:bg-slate-100"
-						onclick={() => copy(rawJson)}>Copy raw JSON</button
-					>
-					<a class="block rounded px-2 py-1 hover:bg-slate-100" href={resolve('/runs')}
-						>Back to runs</a
-					>
-				</div>
-			</details>
+		<div class="flex shrink-0 flex-wrap gap-2 xl:justify-end">
+			<Button size="sm" variant="outline" onclick={() => copy(rawJson)}>Copy raw JSON</Button>
+			<Button size="sm" href={`/api/web/v1/streams/runs/${run.id}`} variant="outline"
+				>Open event stream</Button
+			>
 		</div>
 	</div>
 
-	<div class="grid gap-6 xl:grid-cols-[minmax(0,7fr)_minmax(20rem,3fr)]">
-		<div class="space-y-6">
-			<RunSummaryCards {run} />
+	<div class="flex flex-wrap gap-2 border-b pb-2" aria-label="Run detail tabs">
+		{#each tabs as tab (tab)}
+			<button type="button" class={tabClass(tab)} onclick={() => (activeTab = tab)}>
+				{tabLabels[tab]}
+			</button>
+		{/each}
+	</div>
 
-			{#if run.progressPercent !== null}
-				<Card.Root>
-					<Card.Content class="pt-6">
-						<div class="mb-2 flex justify-between text-sm">
-							<span>Progress</span><span
-								>{run.assetsCompleted} / {run.assetsTotal} assets completed</span
-							>
-						</div>
-						<div class="h-2 rounded-full bg-slate-100">
+	{#if activeTab === 'overview'}
+		<div class="space-y-6">
+			<Card.Root>
+				<Card.Header>
+					<h2 class="text-lg font-semibold tracking-tight">Run summary</h2>
+					<Card.Description>Projected orchestrator state for this run.</Card.Description>
+				</Card.Header>
+				<Card.Content>
+					<dl class="grid grid-cols-1 gap-3 text-sm sm:grid-cols-2 xl:grid-cols-3">
+						{#each summaryItems as item (item.label)}
 							<div
-								class="h-2 rounded-full bg-slate-950"
-								style:width={`${run.progressPercent}%`}
-							></div>
-						</div>
-					</Card.Content>
-				</Card.Root>
-			{/if}
+								class={[
+									'min-w-0 rounded-lg border bg-slate-50/70 p-3',
+									item.wide && 'sm:col-span-2 xl:col-span-3'
+								]}
+							>
+								<dt class="text-xs font-medium tracking-wide text-slate-500 uppercase">
+									{item.label}
+								</dt>
+								<dd
+									class={[
+										'mt-1 min-w-0 text-slate-900',
+										item.mono && 'font-mono text-xs',
+										item.wide ? 'break-words' : 'truncate'
+									]}
+									title={item.title}
+								>
+									{#if item.status}
+										<StatusBadge status={run.status} />
+									{:else}
+										{item.value}
+									{/if}
+								</dd>
+							</div>
+						{/each}
+					</dl>
+				</Card.Content>
+			</Card.Root>
 
 			{#if run.error}
 				<ErrorPanel
@@ -139,123 +156,71 @@
 				/>
 			{/if}
 
-			<div class="flex flex-wrap gap-2 border-b pb-2" role="tablist" aria-label="Run detail tabs">
-				{#each tabs as tab (tab)}
-					<button type="button" class={tabClass(tab)} onclick={() => (activeTab = tab)}
-						>{tabLabels[tab]}</button
-					>
-				{/each}
-			</div>
+			<Card.Root>
+				<Card.Header>
+					<h2 class="text-lg font-semibold tracking-tight">Execution</h2>
+					<Card.Description>Asset-level rows when the orchestrator reported them.</Card.Description>
+				</Card.Header>
+				<Card.Content class="space-y-5">
+					{#if run.assets.length > 0}
+						<div class="text-sm">
+							<AssetExecutionTable
+								assets={run.assets}
+								onselect={(asset) => (selectedAsset = asset)}
+							/>
+						</div>
+					{:else}
+						<div class="rounded-lg border border-dashed bg-slate-50 p-4 text-sm text-slate-600">
+							No asset-level execution rows were reported. Showing run-level events instead.
+						</div>
+						<RunTimeline events={run.timeline} live={run.status === 'running'} />
+					{/if}
 
-			{#if activeTab === 'overview'}
-				<Card.Root>
-					<Card.Header
-						><Card.Title>Execution by stage</Card.Title><Card.Description
-							>Status first, graph later.</Card.Description
-						></Card.Header
-					>
-					<Card.Content class="space-y-3">
-						{#each stages as group (group.stage)}
-							<div class="rounded-lg border p-4">
-								<h3 class="mb-3 text-sm font-semibold">{group.stage}</h3>
-								<div class="space-y-2">
-									{#each group.assets as asset (asset.id)}
-										<button
-											class="flex w-full items-center justify-between gap-3 rounded-md px-2 py-1.5 text-left hover:bg-slate-50"
-											onclick={() => (selectedAsset = asset)}
-										>
-											<span class="truncate">{asset.asset}</span>
-											<StatusBadge status={asset.status} />
-										</button>
-									{/each}
-								</div>
-							</div>
-						{/each}
-					</Card.Content>
-				</Card.Root>
-				<Card.Root>
-					<Card.Header
-						><Card.Title>Output relations</Card.Title><Card.Description
-							>Relations created or attempted by this run.</Card.Description
-						></Card.Header
-					>
-					<Card.Content class="flex flex-wrap gap-2">
-						{#each run.outputs as output (`overview:${output.asset}:${output.relation}`)}
-							<Badge variant={output.failed ? 'destructive' : 'outline'}>{output.relation}</Badge>
-						{/each}
-					</Card.Content>
-				</Card.Root>
-			{:else if activeTab === 'assets'}
-				<Card.Root>
-					<Card.Header
-						><Card.Title>Assets</Card.Title><Card.Description
-							>Click a row to open the asset detail inspector.</Card.Description
-						></Card.Header
-					>
-					<Card.Content>
-						<AssetExecutionTable
-							assets={run.assets}
-							onselect={(asset) => (selectedAsset = asset)}
-						/>
-					</Card.Content>
-				</Card.Root>
-			{:else if activeTab === 'outputs'}
-				<Card.Root
-					><Card.Header
-						><Card.Title>Outputs</Card.Title><Card.Description
-							>Copy a relation or a SELECT statement; data preview comes later.</Card.Description
-						></Card.Header
-					><Card.Content><OutputRelationsTable outputs={run.outputs} /></Card.Content></Card.Root
-				>
-			{:else if activeTab === 'timeline'}
-				<Card.Root
-					><Card.Content class="pt-6"
-						><RunTimeline events={run.timeline} live={run.status === 'running'} /></Card.Content
-					></Card.Root
-				>
-			{:else if activeTab === 'manifest'}
-				<ManifestSummaryCard metadata={run.metadata} />
-			{:else}
-				<Card.Root
-					><Card.Header
-						><Card.Title>Raw</Card.Title><Card.Description
-							>Normalized BFF source payload.</Card.Description
-						></Card.Header
-					><Card.Content
-						><Button size="sm" variant="outline" onclick={() => copy(rawJson)}>Copy JSON</Button>
-						<pre
-							class="mt-3 max-h-[32rem] overflow-auto rounded-md bg-slate-950 p-4 text-xs text-slate-50">{rawJson}</pre></Card.Content
-					></Card.Root
-				>
-			{/if}
+					<div class="space-y-2">
+						<div class="flex items-center justify-between gap-2">
+							<h2 class="text-lg font-semibold">Outputs</h2>
+							{#if run.outputs.length > 0}<Badge variant="outline">{run.outputs.length}</Badge>{/if}
+						</div>
+						{#if run.outputs.length === 0}
+							<p class="rounded-lg border border-dashed bg-slate-50 p-4 text-sm text-slate-600">
+								No materialized outputs reported by this run.
+							</p>
+						{:else}
+							<div class="text-sm"><OutputRelationsTable outputs={run.outputs} /></div>
+						{/if}
+					</div>
+				</Card.Content>
+			</Card.Root>
 		</div>
-
-		<aside class="space-y-4">
-			<Card.Root
-				><Card.Header
-					><Card.Title>Recent events</Card.Title><Card.Description
-						>Run-scoped stream preview.</Card.Description
-					></Card.Header
-				><Card.Content class="space-y-3"
-					>{#each run.timeline.slice(0, 5) as event (event.id)}<div
-							class="rounded-md bg-slate-50 p-3"
-						>
-							<p class="text-sm font-medium">{event.label}</p>
-							<p class="text-xs text-slate-500">{event.timestamp ?? '—'}</p>
-							<p class="text-xs text-slate-600">{event.detail}</p>
-						</div>{/each}</Card.Content
-				></Card.Root
+	{:else if activeTab === 'events'}
+		<Card.Root>
+			<Card.Header>
+				<h2 class="text-lg font-semibold tracking-tight">Events</h2>
+				<Card.Description>Run-level event stream fallback and orchestrator events.</Card.Description
+				>
+			</Card.Header>
+			<Card.Content
+				><RunTimeline events={run.timeline} live={run.status === 'running'} /></Card.Content
 			>
-			<Card.Root
-				><Card.Header><Card.Title>What next?</Card.Title></Card.Header><Card.Content
-					class="space-y-2 text-sm text-slate-600"
-					><p>1. Check the failed asset and error.</p>
-					<p>2. Copy relation or SQL for local debugging.</p>
-					<p>3. Rerun from the same manifest when command support is enabled.</p></Card.Content
-				></Card.Root
-			>
-		</aside>
-	</div>
+		</Card.Root>
+	{:else}
+		<Card.Root>
+			<Card.Header>
+				<h2 class="text-lg font-semibold tracking-tight">Debug</h2>
+				<Card.Description>Raw BFF/orchestrator payload for diagnostics.</Card.Description>
+			</Card.Header>
+			<Card.Content>
+				<div class="mb-3 flex flex-wrap gap-2">
+					<Button size="sm" variant="outline" onclick={() => copy(rawJson)}>Copy JSON</Button>
+					<Button size="sm" variant="outline" href={`/api/web/v1/streams/runs/${run.id}`}>
+						Open event stream
+					</Button>
+				</div>
+				<pre
+					class="max-h-[32rem] overflow-auto rounded-md bg-slate-950 p-4 text-xs text-slate-50">{rawJson}</pre>
+			</Card.Content>
+		</Card.Root>
+	{/if}
 
 	{#if selectedAsset}
 		<AssetDetailSheet

--- a/web/favn_web/src/lib/components/favn/RunsPage.stories.svelte
+++ b/web/favn_web/src/lib/components/favn/RunsPage.stories.svelte
@@ -2,7 +2,7 @@
 	import { defineMeta } from '@storybook/addon-svelte-csf';
 	import { expect, within } from 'storybook/test';
 	import RunsPage from './RunsPage.svelte';
-	import { sampleRuns } from './story_fixtures';
+	import { realPayloadRunSummary, sampleRuns } from './story_fixtures';
 
 	const { Story } = defineMeta({
 		title: 'Favn/Run Inspector/Runs Page',
@@ -13,11 +13,14 @@
 
 <Story
 	name="Populated"
-	args={{ runs: sampleRuns, loadError: null }}
+	args={{ runs: [realPayloadRunSummary, ...sampleRuns], loadError: null }}
 	play={async ({ canvasElement }) => {
 		const canvas = within(canvasElement);
 		await expect(canvas.getByRole('heading', { name: 'Runs' })).toBeInTheDocument();
-		await expect(canvas.getByRole('row', { name: /ImportCustomers/ })).toBeInTheDocument();
+		await expect(
+			canvas.getByRole('row', { name: /ReferenceWorkloadComplete/ })
+		).toBeInTheDocument();
+		await expect(canvas.getByText('3.3s')).toBeInTheDocument();
 	}}
 />
 

--- a/web/favn_web/src/lib/components/favn/RunsPage.svelte
+++ b/web/favn_web/src/lib/components/favn/RunsPage.svelte
@@ -72,7 +72,7 @@
 
 	{#if loadError}
 		<Alert.Root variant="destructive">
-			<Alert.Title>Failed to load runs</Alert.Title>
+			<p class="mb-1 font-medium tracking-tight">Failed to load runs</p>
 			<Alert.Description>{loadError}</Alert.Description>
 		</Alert.Root>
 	{/if}
@@ -80,7 +80,7 @@
 	<Card.Root>
 		<Card.Header>
 			<div class="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
-				<div class="flex flex-wrap gap-2" role="tablist" aria-label="Run status filters">
+				<div class="flex flex-wrap gap-2" aria-label="Run status filters">
 					{#each tabs as tab (tab)}
 						<button
 							type="button"

--- a/web/favn_web/src/lib/components/favn/RunsTable.svelte
+++ b/web/favn_web/src/lib/components/favn/RunsTable.svelte
@@ -6,39 +6,57 @@
 	import type { RunSummaryView } from '$lib/run_view_types';
 
 	let { runs } = $props<{ runs: RunSummaryView[] }>();
+
+	function shortId(value: string | null | undefined) {
+		if (!value) return '—';
+		if (value.length <= 18) return value;
+		return `${value.slice(0, 11)}…${value.slice(-4)}`;
+	}
 </script>
 
-<Table.Root>
+<Table.Root class="table-fixed">
 	<Table.Header>
 		<Table.Row>
-			<Table.Head>Status</Table.Head>
-			<Table.Head>Run</Table.Head>
+			<Table.Head class="w-28">Status</Table.Head>
+			<Table.Head class="w-36">Run</Table.Head>
 			<Table.Head>Target</Table.Head>
-			<Table.Head>Trigger</Table.Head>
-			<Table.Head>Started</Table.Head>
-			<Table.Head>Duration</Table.Head>
-			<Table.Head>Assets</Table.Head>
-			<Table.Head>Manifest</Table.Head>
-			<Table.Head>Actions</Table.Head>
+			<Table.Head class="w-24">Trigger</Table.Head>
+			<Table.Head class="w-24">Started</Table.Head>
+			<Table.Head class="w-28">Duration</Table.Head>
+			<Table.Head class="w-20">Assets</Table.Head>
+			<Table.Head class="w-36">Manifest</Table.Head>
+			<Table.Head class="w-24 text-right">Actions</Table.Head>
 		</Table.Row>
 	</Table.Header>
 	<Table.Body>
 		{#each runs as run (run.id)}
 			<Table.Row>
 				<Table.Cell><StatusBadge status={run.status} /></Table.Cell>
-				<Table.Cell class="font-mono text-xs font-medium text-blue-700"
-					><a href={resolve(`/runs/${run.id}`)}>{run.id}</a></Table.Cell
+				<Table.Cell class="truncate font-mono text-xs font-medium text-blue-700" title={run.id}
+					><a href={resolve(`/runs/${run.id}`)}>{shortId(run.id)}</a></Table.Cell
 				>
-				<Table.Cell>{run.target}</Table.Cell>
+				<Table.Cell class="min-w-0">
+					<div class="flex min-w-0 items-center gap-2">
+						<span
+							class="shrink-0 rounded-md border bg-slate-50 px-1.5 py-0.5 text-[10px] font-medium text-slate-600"
+							>{run.targetType}</span
+						>
+						<span class="truncate" title={run.target}>{run.target}</span>
+					</div>
+				</Table.Cell>
 				<Table.Cell>{run.trigger}</Table.Cell>
 				<Table.Cell>{run.startedAt ?? '—'}</Table.Cell>
 				<Table.Cell>{run.duration}</Table.Cell>
 				<Table.Cell>{run.assetCount}</Table.Cell>
-				<Table.Cell class="font-mono text-xs">{run.manifestVersionId ?? '—'}</Table.Cell>
-				<Table.Cell>
-					<div class="flex items-center gap-2">
+				<Table.Cell
+					class="truncate font-mono text-xs"
+					title={run.manifestVersionId ?? 'No manifest version'}
+					>{shortId(run.manifestVersionId)}</Table.Cell
+				>
+				<Table.Cell class="text-right">
+					<div class="flex items-center justify-end gap-1">
 						<Button href={`/runs/${run.id}`} variant="ghost" size="sm">Inspect</Button>
-						<details class="relative">
+						<details class="relative hidden xl:block">
 							<summary class="cursor-pointer rounded-md border px-2 py-1 text-xs">More</summary>
 							<div
 								class="absolute right-0 z-10 mt-1 w-36 rounded-md border bg-white p-1 text-xs shadow-lg"

--- a/web/favn_web/src/lib/components/favn/story_fixtures.ts
+++ b/web/favn_web/src/lib/components/favn/story_fixtures.ts
@@ -13,7 +13,9 @@ export const failedRunSummary: RunSummaryView = {
 	assetCount: '2/5',
 	assetsCompleted: 2,
 	assetsTotal: 5,
-	manifestVersionId: 'mfv_def456'
+	manifestVersionId: 'mfv_def456',
+	manifestContentHash: 'sha256:def456789abc',
+	submitKind: 'pipeline'
 };
 
 export const runningRunSummary: RunSummaryView = {
@@ -29,7 +31,9 @@ export const runningRunSummary: RunSummaryView = {
 	assetCount: '4/10',
 	assetsCompleted: 4,
 	assetsTotal: 10,
-	manifestVersionId: 'mfv_abc123'
+	manifestVersionId: 'mfv_abc123',
+	manifestContentHash: 'sha256:abc123456789',
+	submitKind: 'pipeline'
 };
 
 export const succeededRunSummary: RunSummaryView = {
@@ -45,7 +49,9 @@ export const succeededRunSummary: RunSummaryView = {
 	assetCount: '8/8',
 	assetsCompleted: 8,
 	assetsTotal: 8,
-	manifestVersionId: 'mfv_abc123'
+	manifestVersionId: 'mfv_abc123',
+	manifestContentHash: 'sha256:abc123456789',
+	submitKind: 'pipeline'
 };
 
 export const sampleRuns: RunSummaryView[] = [
@@ -53,6 +59,24 @@ export const sampleRuns: RunSummaryView[] = [
 	failedRunSummary,
 	runningRunSummary
 ];
+
+export const realPayloadRunSummary: RunSummaryView = {
+	id: 'run_real_001',
+	status: 'succeeded',
+	target: 'Elixir.FavnReferenceWorkload.Warehouse.Ops.ReferenceWorkloadComplete (asset)',
+	targetType: 'pipeline',
+	trigger: 'manual',
+	startedAt: '10:00:00',
+	finishedAt: '10:00:03',
+	durationMs: 3250,
+	duration: '3.3s',
+	assetCount: '—',
+	assetsCompleted: 0,
+	assetsTotal: 0,
+	manifestVersionId: 'mfv_real_123',
+	manifestContentHash: 'sha256:1234567890ab',
+	submitKind: 'pipeline'
+};
 
 export const failedRunDetail: RunDetailView = {
 	...failedRunSummary,
@@ -194,4 +218,49 @@ export const failedRunDetail: RunDetailView = {
 	progressPercent: null,
 	assetCounts: { succeeded: 1, failed: 1, skipped: 1, running: 0, pending: 0 },
 	failedAssetId: 'Staging.CustomerOrders'
+};
+
+export const realPayloadRunDetail: RunDetailView = {
+	...realPayloadRunSummary,
+	raw: {
+		data: {
+			run: {
+				id: 'run_real_001',
+				status: 'ok',
+				submit_kind: 'pipeline',
+				target_refs: ['Elixir.FavnReferenceWorkload.Warehouse.Ops.ReferenceWorkloadComplete:asset'],
+				manifest_version_id: 'mfv_real_123',
+				manifest_content_hash: 'sha256:1234567890abcdef1234567890abcdef',
+				event_seq: 33
+			}
+		}
+	},
+	error: null,
+	assets: [],
+	outputs: [],
+	timeline: [
+		{
+			id: 'submitted',
+			timestamp: '10:00:00',
+			label: 'run_submitted',
+			detail: 'Elixir.FavnReferenceWorkload.Warehouse.Ops.ReferenceWorkloadComplete:asset',
+			assetId: null
+		},
+		{
+			id: 'status',
+			timestamp: '10:00:03',
+			label: 'run_succeeded',
+			detail: 'Latest projected run state · event #33',
+			assetId: null
+		}
+	],
+	metadata: [
+		{ label: 'Run id', value: 'run_real_001' },
+		{ label: 'Submit kind', value: 'pipeline' },
+		{ label: 'Manifest', value: 'mfv_real_123' },
+		{ label: 'Content hash', value: 'sha256:1234567890ab' }
+	],
+	progressPercent: null,
+	assetCounts: { succeeded: 0, failed: 0, skipped: 0, running: 0, pending: 0 },
+	failedAssetId: null
 };

--- a/web/favn_web/src/lib/run_view_types.ts
+++ b/web/favn_web/src/lib/run_view_types.ts
@@ -21,6 +21,8 @@ export type RunSummaryView = {
 	assetsCompleted: number;
 	assetsTotal: number;
 	manifestVersionId: string | null;
+	manifestContentHash: string | null;
+	submitKind: string | null;
 };
 
 export type AssetExecutionView = {

--- a/web/favn_web/src/lib/server/run_views.spec.ts
+++ b/web/favn_web/src/lib/server/run_views.spec.ts
@@ -24,7 +24,8 @@ describe('run view normalizers', () => {
 				status: 'succeeded',
 				target: 'DailySalesPipeline',
 				assetCount: '3/3',
-				manifestVersionId: 'mfv_abc123'
+				manifestVersionId: 'mfv_abc123',
+				manifestContentHash: null
 			})
 		]);
 	});
@@ -59,9 +60,7 @@ describe('run view normalizers', () => {
 			})
 		);
 		expect(detail.assets.map((asset) => asset.status)).toEqual(['succeeded', 'failed']);
-		expect(detail.outputs).toEqual([
-			expect.objectContaining({ relation: 'raw.customers', failed: false })
-		]);
+		expect(detail.outputs).toEqual([]);
 		expect(detail.timeline).toEqual([expect.objectContaining({ label: 'asset_failed' })]);
 	});
 
@@ -79,6 +78,78 @@ describe('run view normalizers', () => {
 
 		expect(detail.status).toBe('succeeded');
 		expect(detail.target).toBe('Raw.Customers');
+	});
+
+	it('normalizes real orchestrator run payloads without inventing outputs', () => {
+		const detail = normalizeRunDetail(
+			{
+				data: {
+					run: {
+						id: 'run_real_001',
+						status: 'ok',
+						started_at: '2026-04-27T10:00:00.000Z',
+						finished_at: '2026-04-27T10:00:03.250Z',
+						manifest_version_id: 'mfv_real_123',
+						manifest_content_hash: 'sha256:1234567890abcdef1234567890abcdef',
+						submit_kind: 'pipeline',
+						target_refs: [
+							'Elixir.FavnReferenceWorkload.Warehouse.Ops.ReferenceWorkloadComplete:asset'
+						],
+						event_seq: 33
+					}
+				}
+			},
+			'run_real_001'
+		);
+
+		expect(detail).toEqual(
+			expect.objectContaining({
+				id: 'run_real_001',
+				status: 'succeeded',
+				target: 'Elixir.FavnReferenceWorkload.Warehouse.Ops.ReferenceWorkloadComplete (asset)',
+				targetType: 'pipeline',
+				durationMs: 3250,
+				duration: '3.3s',
+				manifestVersionId: 'mfv_real_123',
+				manifestContentHash: 'sha256:1234567890ab',
+				submitKind: 'pipeline'
+			})
+		);
+		expect(detail.target).not.toBe('Unknown target');
+		expect(detail.assets).toEqual([]);
+		expect(detail.outputs).toEqual([]);
+		expect(detail.timeline).toEqual([
+			expect.objectContaining({ label: 'run_submitted' }),
+			expect.objectContaining({
+				label: 'run_succeeded',
+				detail: 'Latest projected run state · event #33'
+			})
+		]);
+	});
+
+	it('uses submit kind as a useful list target when list DTOs omit target refs', () => {
+		const summaries = normalizeRunSummaries({
+			data: {
+				items: [
+					{
+						id: 'run_list_real',
+						status: 'ok',
+						submit_kind: 'pipeline',
+						started_at: '2026-04-27T10:00:00.000Z',
+						finished_at: '2026-04-27T10:00:00.499Z'
+					}
+				]
+			}
+		});
+
+		expect(summaries[0]).toEqual(
+			expect.objectContaining({
+				target: 'Pipeline run',
+				targetType: 'pipeline',
+				duration: '499ms'
+			})
+		);
+		expect(summaries[0].target).not.toBe('Unknown target');
 	});
 
 	it('maps domain and UI statuses to inspector statuses', () => {
@@ -111,7 +182,7 @@ describe('run view normalizers', () => {
 		]);
 	});
 
-	it('provides asset/output fallback data when optional lists are missing', () => {
+	it('does not invent asset/output fallback data when optional lists are missing', () => {
 		const detail = normalizeRunDetail(
 			{
 				data: {
@@ -125,11 +196,8 @@ describe('run view normalizers', () => {
 			'run_no_assets'
 		);
 
-		expect(detail.assets).toEqual([
-			expect.objectContaining({ asset: 'Raw.Customers', status: 'succeeded' })
-		]);
-		expect(detail.outputs).toEqual([
-			expect.objectContaining({ relation: 'Raw.Customers', asset: 'Raw.Customers' })
-		]);
+		expect(detail.assets).toEqual([]);
+		expect(detail.outputs).toEqual([]);
+		expect(detail.timeline).toContainEqual(expect.objectContaining({ label: 'run_succeeded' }));
 	});
 });

--- a/web/favn_web/src/lib/server/run_views.ts
+++ b/web/favn_web/src/lib/server/run_views.ts
@@ -31,6 +31,12 @@ function asNumber(value: unknown): number | null {
 	return typeof value === 'number' && Number.isFinite(value) ? value : null;
 }
 
+function asStringArray(value: unknown): string[] {
+	return Array.isArray(value)
+		? value.filter((item): item is string => typeof item === 'string')
+		: [];
+}
+
 function asIntegerish(value: unknown): number | null {
 	if (typeof value === 'number' && Number.isFinite(value)) return value;
 	if (typeof value === 'string' && value.trim() !== '') {
@@ -66,11 +72,45 @@ function normalizeStatus(value: unknown): RunStatus {
 	}
 }
 
-function targetParts(value: unknown): { label: string; type: string } {
-	if (!isRecord(value)) return { label: 'Unknown target', type: 'unknown' };
-	const type = asString(value.type) ?? 'target';
-	const id = asString(value.id) ?? asString(value.name) ?? 'unknown';
-	return { label: id, type };
+function readableRef(value: string): string {
+	const trimmed = value.trim();
+	if (!trimmed) return trimmed;
+	const withoutPrefix = trimmed.replace(/^(asset|pipeline|target|module):/i, '');
+	const [module, suffix] = withoutPrefix.split(':');
+	return suffix ? `${module} (${suffix})` : withoutPrefix;
+}
+
+function targetTypeFromRef(value: string | null): string | null {
+	if (!value) return null;
+	const suffix = value.split(':').at(-1)?.toLowerCase();
+	if (suffix && suffix !== value.toLowerCase()) return suffix;
+	if (/pipeline/i.test(value)) return 'pipeline';
+	if (/asset/i.test(value)) return 'asset';
+	return null;
+}
+
+function targetParts(record: JsonRecord): { label: string; type: string } {
+	const target = isRecord(record.target) ? record.target : null;
+	const targetId = target ? (asString(target.id) ?? asString(target.name)) : null;
+	const submitRef = asString(record.submit_ref);
+	const targetRefs = asStringArray(record.target_refs);
+	const assetRef = asString(record.asset_ref);
+	const pipeline = isRecord(record.pipeline) ? record.pipeline : null;
+	const pipelineRef = pipeline ? (asString(pipeline.module) ?? asString(pipeline.name)) : null;
+	const submitKind = asString(record.submit_kind);
+	const rawLabel = targetId ?? submitRef ?? targetRefs[0] ?? assetRef ?? pipelineRef;
+	const label = rawLabel ? readableRef(rawLabel) : 'Unknown target';
+	const fallbackLabel = submitKind
+		? `${submitKind[0].toUpperCase()}${submitKind.slice(1)} run`
+		: label;
+	const type =
+		(target ? asString(target.type) : null) ??
+		submitKind ??
+		targetTypeFromRef(targetRefs[0] ?? null) ??
+		targetTypeFromRef(assetRef) ??
+		targetTypeFromRef(submitRef) ??
+		(pipelineRef ? 'pipeline' : 'unknown');
+	return { label: rawLabel ? label : fallbackLabel, type };
 }
 
 function firstString(record: JsonRecord, keys: string[]): string | null {
@@ -82,14 +122,32 @@ function firstString(record: JsonRecord, keys: string[]): string | null {
 }
 
 function durationMs(record: JsonRecord): number | null {
-	return asNumber(record.duration_ms) ?? asNumber(record.elapsed_ms) ?? asNumber(record.durationMs);
+	const direct =
+		asNumber(record.duration_ms) ?? asNumber(record.elapsed_ms) ?? asNumber(record.durationMs);
+	if (direct !== null) return direct;
+	const startedAt = firstString(record, ['started_at', 'startedAt']);
+	const finishedAt = firstString(record, ['finished_at', 'finishedAt']);
+	if (!startedAt || !finishedAt) return null;
+	const started = new Date(startedAt).getTime();
+	const finished = new Date(finishedAt).getTime();
+	return Number.isFinite(started) && Number.isFinite(finished) && finished >= started
+		? finished - started
+		: null;
 }
 
 function formatDuration(record: JsonRecord): string {
 	const direct = firstString(record, ['duration', 'duration_ms_label']);
 	if (direct) return direct;
 	const ms = durationMs(record);
-	if (ms === null) return '—';
+	if (ms === null) {
+		const status = normalizeStatus(record.status);
+		const startedAt = firstString(record, ['started_at', 'startedAt']);
+		const started = shortTime(startedAt);
+		if ((status === 'running' || status === 'pending' || status === 'queued') && started) {
+			return `running since ${started}`;
+		}
+		return '—';
+	}
 	if (ms < 1000) return `${ms}ms`;
 	const seconds = ms / 1000;
 	if (seconds < 60) return `${seconds.toFixed(seconds < 10 ? 1 : 0)}s`;
@@ -125,22 +183,30 @@ function listFromPayload(payload: unknown): unknown[] {
 	return [];
 }
 
-function normalizeAssetList(
-	record: JsonRecord,
-	fallbackTarget: string,
-	fallbackStatus: RunStatus
-): AssetExecutionView[] {
+function normalizeAssetList(record: JsonRecord, fallbackStatus: RunStatus): AssetExecutionView[] {
 	const rawAssets = Array.isArray(record.assets)
 		? record.assets
 		: Array.isArray(record.asset_executions)
 			? record.asset_executions
-			: [];
+			: Array.isArray(record.asset_results)
+				? record.asset_results
+				: Array.isArray(record.node_results)
+					? record.node_results
+					: [];
 
 	const assets = rawAssets.map((asset, index) => {
 		const assetRecord = isRecord(asset) ? asset : {};
 		const name =
-			firstString(assetRecord, ['asset', 'asset_id', 'module', 'id', 'name']) ??
-			`${fallbackTarget}#${index + 1}`;
+			firstString(assetRecord, [
+				'asset',
+				'asset_id',
+				'asset_ref',
+				'target_ref',
+				'node_ref',
+				'module',
+				'id',
+				'name'
+			]) ?? `asset_${index + 1}`;
 		const rawAssetOutputs = Array.isArray(assetRecord.outputs) ? assetRecord.outputs : [];
 		const outputs = rawAssetOutputs.map((output, outputIndex) =>
 			normalizeOutputRecord(output, name, outputIndex)
@@ -153,7 +219,7 @@ function normalizeAssetList(
 			status: normalizeStatus(assetRecord.status ?? fallbackStatus),
 			stage: firstString(assetRecord, ['stage_name']) ?? `Stage ${stageNumber ?? index + 1}`,
 			stageNumber,
-			asset: name,
+			asset: readableRef(name),
 			module: firstString(assetRecord, ['module']),
 			type: firstString(assetRecord, ['type', 'asset_type']) ?? 'unknown',
 			startedAt: shortTime(firstString(assetRecord, ['started_at', 'startedAt'])),
@@ -175,61 +241,24 @@ function normalizeAssetList(
 		};
 	});
 
-	if (assets.length > 0) return assets;
-
-	return [
-		{
-			id: fallbackTarget,
-			status: fallbackStatus,
-			stage: 'Stage 1',
-			stageNumber: 1,
-			asset: fallbackTarget,
-			module: null,
-			type: fallbackTarget.startsWith('pipeline:') ? 'pipeline target' : 'asset',
-			startedAt: shortTime(firstString(record, ['started_at', 'startedAt'])),
-			finishedAt: shortTime(firstString(record, ['finished_at', 'finishedAt'])),
-			durationMs: durationMs(record),
-			duration: formatDuration(record),
-			attempt: 1,
-			output: fallbackStatus === 'succeeded' ? fallbackTarget.replace(/^asset:/, '') : null,
-			outputs: [],
-			error:
-				fallbackStatus === 'failed'
-					? 'Run failed before detailed asset errors were available.'
-					: null,
-			sql: null,
-			operation: null,
-			relation: fallbackStatus === 'succeeded' ? fallbackTarget.replace(/^asset:/, '') : null,
-			connection: null,
-			database: null
-		}
-	];
+	return assets;
 }
 
 function normalizeOutputs(record: JsonRecord, assets: AssetExecutionView[]): OutputView[] {
-	const rawOutputs = Array.isArray(record.outputs) ? record.outputs : [];
+	const rawOutputs = Array.isArray(record.outputs)
+		? record.outputs
+		: Array.isArray(record.materializations)
+			? record.materializations
+			: Array.isArray(record.output_metadata)
+				? record.output_metadata
+				: [];
 	const outputs = rawOutputs.map((output, index) =>
 		normalizeOutputRecord(output, assets[0]?.asset ?? 'unknown', index)
 	);
 
 	if (outputs.length > 0) return outputs;
 
-	return assets
-		.filter((asset) => asset.output || asset.outputs.length > 0)
-		.flatMap((asset) => {
-			if (asset.outputs.length > 0) return asset.outputs;
-			return [
-				{
-					relation: asset.output ?? asset.asset,
-					type: 'table',
-					asset: asset.asset,
-					connection: asset.connection ?? 'local',
-					rows: null,
-					updatedAt: asset.startedAt,
-					failed: asset.status === 'failed'
-				}
-			];
-		});
+	return assets.flatMap((asset) => asset.outputs);
 }
 
 function normalizeTimeline(record: JsonRecord, status: RunStatus): TimelineEventView[] {
@@ -247,22 +276,32 @@ function normalizeTimeline(record: JsonRecord, status: RunStatus): TimelineEvent
 
 	if (events.length > 0) return events;
 
-	return [
+	const fallbacks: TimelineEventView[] = [
 		{
 			id: 'submitted',
-			timestamp: shortTime(firstString(record, ['created_at', 'submitted_at'])),
+			timestamp: shortTime(firstString(record, ['created_at', 'submitted_at', 'started_at'])),
 			label: 'run_submitted',
-			detail: 'Run accepted by orchestrator',
+			detail: firstString(record, ['submit_ref']) ?? 'Run accepted by orchestrator',
 			assetId: null
 		},
 		{
 			id: 'status',
-			timestamp: shortTime(firstString(record, ['updated_at', 'started_at'])),
+			timestamp: shortTime(firstString(record, ['updated_at', 'finished_at', 'started_at'])),
 			label: `run_${status}`,
-			detail: 'Latest projected run state',
+			detail:
+				firstString(record, ['terminal_reason', 'error', 'error_message']) ??
+				`Latest projected run state${asIntegerish(record.event_seq) !== null ? ` · event #${asIntegerish(record.event_seq)}` : ''}`,
 			assetId: null
 		}
 	];
+	return fallbacks;
+}
+
+function shortHash(value: string | null): string | null {
+	if (!value) return null;
+	const [prefix, hash] = value.includes(':') ? value.split(':', 2) : ['', value];
+	const short = hash.length > 12 ? hash.slice(0, 12) : hash;
+	return prefix ? `${prefix}:${short}` : short;
 }
 
 function assetCountLabel(record: JsonRecord, assetsCompleted: number, assetsTotal: number): string {
@@ -276,7 +315,7 @@ function assetCountLabel(record: JsonRecord, assetsCompleted: number, assetsTota
 export function normalizeRunSummaries(payload: unknown): RunSummaryView[] {
 	return listFromPayload(payload).map((run, index) => {
 		const record = isRecord(run) ? run : {};
-		const target = targetParts(record.target);
+		const target = targetParts(record);
 		const assetsTotal =
 			asNumber(record.assets_total) ??
 			asNumber(record.asset_total) ??
@@ -299,7 +338,11 @@ export function normalizeRunSummaries(payload: unknown): RunSummaryView[] {
 			assetCount: assetCountLabel(record, assetsCompleted, assetsTotal),
 			assetsCompleted,
 			assetsTotal,
-			manifestVersionId: firstString(record, ['manifest_version_id', 'manifestVersionId'])
+			manifestVersionId: firstString(record, ['manifest_version_id', 'manifestVersionId']) ?? null,
+			manifestContentHash: shortHash(
+				firstString(record, ['manifest_content_hash', 'content_hash', 'manifest_hash'])
+			),
+			submitKind: firstString(record, ['submit_kind'])
 		};
 	});
 }
@@ -307,10 +350,10 @@ export function normalizeRunSummaries(payload: unknown): RunSummaryView[] {
 export function normalizeRunDetail(payload: unknown, requestedRunId: string): RunDetailView {
 	const value = runDetailPayload(payload);
 	const record = isRecord(value) ? value : {};
-	const target = targetParts(record.target);
+	const target = targetParts(record);
 	const status = normalizeStatus(record.status);
 	const id = firstString(record, ['id', 'run_id']) ?? requestedRunId;
-	const assets = normalizeAssetList(record, target.label, status);
+	const assets = normalizeAssetList(record, status);
 	const outputs = normalizeOutputs(record, assets);
 	const firstFailedAsset = assets.find((asset) => asset.status === 'failed' || asset.error);
 	const errorMessage =
@@ -343,6 +386,10 @@ export function normalizeRunDetail(payload: unknown, requestedRunId: string): Ru
 		assetsCompleted,
 		assetsTotal,
 		manifestVersionId: firstString(record, ['manifest_version_id', 'manifestVersionId']),
+		manifestContentHash: shortHash(
+			firstString(record, ['manifest_content_hash', 'content_hash', 'manifest_hash'])
+		),
+		submitKind: firstString(record, ['submit_kind']),
 		raw: payload,
 		error: errorMessage
 			? { asset: firstFailedAsset?.asset ?? target.label, message: errorMessage }
@@ -352,13 +399,17 @@ export function normalizeRunDetail(payload: unknown, requestedRunId: string): Ru
 		timeline: normalizeTimeline(record, status),
 		metadata: [
 			{ label: 'Run id', value: id },
+			{ label: 'Submit kind', value: firstString(record, ['submit_kind']) ?? 'Not available' },
 			{
 				label: 'Manifest',
 				value: firstString(record, ['manifest_version_id', 'manifestVersionId']) ?? 'Not available'
 			},
 			{
 				label: 'Content hash',
-				value: firstString(record, ['content_hash', 'manifest_hash']) ?? 'Not available'
+				value:
+					shortHash(
+						firstString(record, ['manifest_content_hash', 'content_hash', 'manifest_hash'])
+					) ?? 'Not available'
 			},
 			{ label: 'Schema version', value: String(asNumber(record.schema_version) ?? 1) },
 			{ label: 'Runner contract', value: String(asNumber(record.runner_contract_version) ?? 1) },


### PR DESCRIPTION
## Summary
- Improve run inspector normalization for real orchestrator run DTOs, including target fallbacks, status mapping, timestamp durations, manifest hashes, and honest empty outputs.
- Simplify and polish the run detail UI around Overview / Events / Raw, compact long IDs, readable navigation, and clearer labels.
- Load global CSS in Storybook and update run inspector stories/fixtures for real-payload scenarios.

## Validation
- npm run format
- npm run lint
- npm run test:unit -- --run
- npm run build
- Storybook story tests for run inspector and full suite; unrelated existing heading-order a11y warnings remain in LoginPanel/DashboardPage/AssetDetailSheet.
- Playwright inspection of Storybook and local tutorial run inspector.