### PR TITLE
Harden web sessions and run submission contracts

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
@@ -128,6 +128,9 @@ defmodule FavnOrchestrator.API.Router do
       {:error, :service_unauthorized} ->
         error(conn, 401, "service_unauthorized", "Invalid service credentials")
 
+      {:error, :unauthenticated} ->
+        error(conn, 401, "unauthenticated", "Missing or invalid actor context")
+
       {:error, :active_manifest_not_set} ->
         error(conn, 404, "not_found", "Active manifest is not set")
 
@@ -290,6 +293,9 @@ defmodule FavnOrchestrator.API.Router do
       {:error, :service_unauthorized} ->
         error(conn, 401, "service_unauthorized", "Invalid service credentials")
 
+      {:error, :unauthenticated} ->
+        error(conn, 401, "unauthenticated", "Missing or invalid actor context")
+
       {:error, _reason} ->
         error(conn, 400, "bad_request", "Request failed")
     end
@@ -306,6 +312,9 @@ defmodule FavnOrchestrator.API.Router do
 
       {:error, :service_unauthorized} ->
         error(conn, 401, "service_unauthorized", "Invalid service credentials")
+
+      {:error, :unauthenticated} ->
+        error(conn, 401, "unauthenticated", "Missing or invalid actor context")
 
       {:error, _reason} ->
         error(conn, 400, "bad_request", "Request failed")
@@ -327,6 +336,9 @@ defmodule FavnOrchestrator.API.Router do
       {:error, :service_unauthorized} ->
         error(conn, 401, "service_unauthorized", "Invalid service credentials")
 
+      {:error, :unauthenticated} ->
+        error(conn, 401, "unauthenticated", "Missing or invalid actor context")
+
       {:error, _reason} ->
         error(conn, 400, "bad_request", "Request failed")
     end
@@ -346,6 +358,9 @@ defmodule FavnOrchestrator.API.Router do
 
       {:error, :service_unauthorized} ->
         error(conn, 401, "service_unauthorized", "Invalid service credentials")
+
+      {:error, :unauthenticated} ->
+        error(conn, 401, "unauthenticated", "Missing or invalid actor context")
 
       {:error, _reason} ->
         error(conn, 400, "bad_request", "Request failed")
@@ -393,6 +408,9 @@ defmodule FavnOrchestrator.API.Router do
       {:error, :service_unauthorized} ->
         error(conn, 401, "service_unauthorized", "Invalid service credentials")
 
+      {:error, :unauthenticated} ->
+        error(conn, 401, "unauthenticated", "Missing or invalid actor context")
+
       {:error, _reason} ->
         error(conn, 400, "bad_request", "Request failed")
     end
@@ -421,6 +439,9 @@ defmodule FavnOrchestrator.API.Router do
 
       {:error, :invalid_manifest_selection} ->
         error(conn, 422, "validation_failed", "Invalid manifest selection")
+
+      {:error, :invalid_dependencies} ->
+        error(conn, 422, "validation_failed", "Invalid dependency mode")
 
       {:error, :invalid_asset_target} ->
         error(conn, 422, "validation_failed", "Invalid asset target id")
@@ -942,17 +963,32 @@ defmodule FavnOrchestrator.API.Router do
 
   defp submit_run_from_request(params) do
     with {:ok, target} <- fetch_target(params),
-         {:ok, manifest_version_id} <- select_manifest_version(params) do
+         {:ok, manifest_version_id} <- select_manifest_version(params),
+         {:ok, dependencies} <- fetch_dependencies(params) do
       case target do
         %{type: "asset", id: target_id} ->
-          FavnOrchestrator.submit_asset_run_for_manifest(manifest_version_id, target_id)
+          FavnOrchestrator.submit_asset_run_for_manifest(manifest_version_id, target_id,
+            dependencies: dependencies
+          )
 
         %{type: "pipeline", id: target_id} ->
-          FavnOrchestrator.submit_pipeline_run_for_manifest(manifest_version_id, target_id)
+          FavnOrchestrator.submit_pipeline_run_for_manifest(manifest_version_id, target_id,
+            dependencies: dependencies
+          )
 
         _ ->
           {:error, :invalid_target}
       end
+    end
+  end
+
+  defp fetch_dependencies(params) when is_map(params) do
+    case Map.get(params, "dependencies", "all") do
+      "all" -> {:ok, :all}
+      "none" -> {:ok, :none}
+      :all -> {:ok, :all}
+      :none -> {:ok, :none}
+      _other -> {:error, :invalid_dependencies}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
@@ -964,7 +964,7 @@ defmodule FavnOrchestrator.API.Router do
   defp submit_run_from_request(params) do
     with {:ok, target} <- fetch_target(params),
          {:ok, manifest_version_id} <- select_manifest_version(params),
-         {:ok, dependencies} <- fetch_dependencies(params) do
+         {:ok, dependencies} <- fetch_dependencies(params, target) do
       case target do
         %{type: "asset", id: target_id} ->
           FavnOrchestrator.submit_asset_run_for_manifest(manifest_version_id, target_id,
@@ -972,9 +972,7 @@ defmodule FavnOrchestrator.API.Router do
           )
 
         %{type: "pipeline", id: target_id} ->
-          FavnOrchestrator.submit_pipeline_run_for_manifest(manifest_version_id, target_id,
-            dependencies: dependencies
-          )
+          FavnOrchestrator.submit_pipeline_run_for_manifest(manifest_version_id, target_id)
 
         _ ->
           {:error, :invalid_target}
@@ -982,7 +980,15 @@ defmodule FavnOrchestrator.API.Router do
     end
   end
 
-  defp fetch_dependencies(params) when is_map(params) do
+  defp fetch_dependencies(params, %{type: "pipeline"}) when is_map(params) do
+    if Map.has_key?(params, "dependencies") do
+      {:error, :invalid_dependencies}
+    else
+      {:ok, nil}
+    end
+  end
+
+  defp fetch_dependencies(params, %{type: "asset"}) when is_map(params) do
     case Map.get(params, "dependencies", "all") do
       "all" -> {:ok, :all}
       "none" -> {:ok, :none}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/projector.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/projector.ex
@@ -269,8 +269,11 @@ defmodule FavnOrchestrator.Projector do
   defp pipeline_origin?(%RunState{metadata: metadata}) when is_map(metadata) do
     Map.get(metadata, :replay_submit_kind) == :pipeline or
       is_map(Map.get(metadata, :pipeline_context)) or
-      is_atom(Map.get(metadata, :pipeline_submit_ref)) or
+      present_atom?(Map.get(metadata, :pipeline_submit_ref)) or
       (is_list(Map.get(metadata, :pipeline_target_refs)) and
          Map.get(metadata, :pipeline_target_refs) != [])
   end
+
+  defp present_atom?(value) when is_atom(value) and not is_nil(value), do: true
+  defp present_atom?(_value), do: false
 end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
@@ -209,6 +209,7 @@ defmodule FavnOrchestrator.RunManager do
     retry_backoff_ms = Keyword.get(opts, :retry_backoff_ms, 0)
     timeout_ms = Keyword.get(opts, :timeout_ms, 5_000)
     dependencies = Keyword.get(opts, :dependencies, :all)
+    metadata_with_selection = Map.put(metadata, :asset_dependencies, dependencies)
 
     with :ok <- validate_params(params),
          :ok <- validate_trigger(trigger),
@@ -233,7 +234,7 @@ defmodule FavnOrchestrator.RunManager do
           plan: plan,
           params: params,
           trigger: trigger,
-          metadata: metadata,
+          metadata: metadata_with_selection,
           submit_kind: :manual,
           max_attempts: max_attempts,
           retry_backoff_ms: retry_backoff_ms,
@@ -415,7 +416,10 @@ defmodule FavnOrchestrator.RunManager do
             pipeline_dependencies: rerun_dependencies
           })
         else
-          Map.put(metadata_with_source, :replay_mode, :exact_replay)
+          Map.merge(metadata_with_source, %{
+            replay_mode: :exact_replay,
+            asset_dependencies: rerun_dependencies
+          })
         end
 
       run_state =
@@ -454,12 +458,28 @@ defmodule FavnOrchestrator.RunManager do
       replay_asset_ref = List.first(replay_targets) || source_run.asset_ref
 
       replay_dependencies =
-        normalize_dependencies(Map.get(source_run.metadata, :pipeline_dependencies))
+        normalize_dependencies(metadata_value(source_run.metadata, :pipeline_dependencies))
 
       {replay_asset_ref, replay_targets, replay_dependencies}
     else
-      {source_run.asset_ref, [source_run.asset_ref], :all}
+      replay_dependencies = normalize_asset_dependencies(source_run)
+
+      {source_run.asset_ref, [source_run.asset_ref], replay_dependencies}
     end
+  end
+
+  defp normalize_asset_dependencies(%RunState{} = source_run) do
+    case metadata_value(source_run.metadata, :asset_dependencies) do
+      nil -> normalize_dependencies(plan_dependencies(source_run.plan))
+      value -> normalize_dependencies(value)
+    end
+  end
+
+  defp plan_dependencies(%Favn.Plan{dependencies: dependencies}), do: dependencies
+  defp plan_dependencies(_plan), do: :all
+
+  defp metadata_value(metadata, key) when is_map(metadata) and is_atom(key) do
+    Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
   end
 
   defp pipeline_origin?(%RunState{submit_kind: :pipeline}), do: true
@@ -467,12 +487,16 @@ defmodule FavnOrchestrator.RunManager do
   defp pipeline_origin?(%RunState{metadata: metadata}) when is_map(metadata) do
     Map.get(metadata, :replay_submit_kind) == :pipeline or
       is_map(Map.get(metadata, :pipeline_context)) or
-      is_atom(Map.get(metadata, :pipeline_submit_ref)) or
+      present_atom?(Map.get(metadata, :pipeline_submit_ref)) or
       (is_list(Map.get(metadata, :pipeline_target_refs)) and
          Map.get(metadata, :pipeline_target_refs) != [])
   end
 
+  defp present_atom?(value) when is_atom(value) and not is_nil(value), do: true
+  defp present_atom?(_value), do: false
+
   defp normalize_dependencies(:none), do: :none
+  defp normalize_dependencies("none"), do: :none
   defp normalize_dependencies(_value), do: :all
 
   defp resolve_manifest_version_id(opts) when is_list(opts) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
@@ -209,12 +209,12 @@ defmodule FavnOrchestrator.RunManager do
     retry_backoff_ms = Keyword.get(opts, :retry_backoff_ms, 0)
     timeout_ms = Keyword.get(opts, :timeout_ms, 5_000)
     dependencies = Keyword.get(opts, :dependencies, :all)
-    metadata_with_selection = Map.put(metadata, :asset_dependencies, dependencies)
 
     with :ok <- validate_params(params),
          :ok <- validate_trigger(trigger),
          :ok <- validate_metadata(metadata),
          :ok <- validate_dependencies(dependencies),
+         metadata_with_selection = Map.put(metadata, :asset_dependencies, dependencies),
          :ok <- validate_max_attempts(max_attempts),
          :ok <- validate_retry_backoff_ms(retry_backoff_ms),
          :ok <- validate_timeout_ms(timeout_ms),

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
@@ -208,10 +208,12 @@ defmodule FavnOrchestrator.RunManager do
     max_attempts = Keyword.get(opts, :max_attempts, 1)
     retry_backoff_ms = Keyword.get(opts, :retry_backoff_ms, 0)
     timeout_ms = Keyword.get(opts, :timeout_ms, 5_000)
+    dependencies = Keyword.get(opts, :dependencies, :all)
 
     with :ok <- validate_params(params),
          :ok <- validate_trigger(trigger),
          :ok <- validate_metadata(metadata),
+         :ok <- validate_dependencies(dependencies),
          :ok <- validate_max_attempts(max_attempts),
          :ok <- validate_retry_backoff_ms(retry_backoff_ms),
          :ok <- validate_timeout_ms(timeout_ms),
@@ -220,7 +222,7 @@ defmodule FavnOrchestrator.RunManager do
          {:ok, index} <- Index.build_from_version(version),
          {:ok, _asset} <- Index.fetch_asset(index, asset_ref),
          {:ok, plan} <-
-           Planner.plan(asset_ref, graph_index: index.graph_index, dependencies: :all) do
+           Planner.plan(asset_ref, graph_index: index.graph_index, dependencies: dependencies) do
       run_state =
         RunState.new(
           id: run_id,

--- a/apps/favn_orchestrator/test/api/router_test.exs
+++ b/apps/favn_orchestrator/test/api/router_test.exs
@@ -4,6 +4,7 @@ defmodule FavnOrchestrator.API.RouterTest do
   import Plug.Conn
   import Plug.Test
 
+  alias Favn.Contracts.RunnerResult
   alias Favn.Manifest
   alias Favn.Manifest.Pipeline
   alias Favn.Manifest.Schedule
@@ -18,14 +19,36 @@ defmodule FavnOrchestrator.API.RouterTest do
 
   @opts Router.init([])
 
+  defmodule RunnerClientStub do
+    @behaviour Favn.Contracts.RunnerClient
+
+    @impl true
+    def register_manifest(_version, _opts), do: :ok
+
+    @impl true
+    def submit_work(work, _opts), do: {:ok, "exec_#{work.run_id}"}
+
+    @impl true
+    def await_result(_execution_id, _timeout, _opts) do
+      {:ok, %RunnerResult{status: :ok, asset_results: [], metadata: %{}}}
+    end
+
+    @impl true
+    def cancel_work(_execution_id, _reason, _opts), do: :ok
+  end
+
   setup do
     previous_tokens = Application.get_env(:favn_orchestrator, :api_service_tokens)
+    previous_client = Application.get_env(:favn_orchestrator, :runner_client)
+    previous_client_opts = Application.get_env(:favn_orchestrator, :runner_client_opts)
     previous_username = Application.get_env(:favn_orchestrator, :auth_bootstrap_username)
     previous_password = Application.get_env(:favn_orchestrator, :auth_bootstrap_password)
     previous_display = Application.get_env(:favn_orchestrator, :auth_bootstrap_display_name)
     previous_roles = Application.get_env(:favn_orchestrator, :auth_bootstrap_roles)
 
     Application.put_env(:favn_orchestrator, :api_service_tokens, ["test-service-token"])
+    Application.put_env(:favn_orchestrator, :runner_client, RunnerClientStub)
+    Application.put_env(:favn_orchestrator, :runner_client_opts, [])
     Application.put_env(:favn_orchestrator, :auth_bootstrap_username, "admin")
     Application.put_env(:favn_orchestrator, :auth_bootstrap_password, "admin-password")
     Application.put_env(:favn_orchestrator, :auth_bootstrap_display_name, "Admin User")
@@ -38,6 +61,8 @@ defmodule FavnOrchestrator.API.RouterTest do
 
     on_exit(fn ->
       restore_env(:favn_orchestrator, :api_service_tokens, previous_tokens)
+      restore_env(:favn_orchestrator, :runner_client, previous_client)
+      restore_env(:favn_orchestrator, :runner_client_opts, previous_client_opts)
       restore_env(:favn_orchestrator, :auth_bootstrap_username, previous_username)
       restore_env(:favn_orchestrator, :auth_bootstrap_password, previous_password)
       restore_env(:favn_orchestrator, :auth_bootstrap_display_name, previous_display)
@@ -266,6 +291,63 @@ defmodule FavnOrchestrator.API.RouterTest do
 
     assert response.status == 401
     assert %{"error" => %{"code" => "unauthenticated"}} = Jason.decode!(response.resp_body)
+  end
+
+  test "read endpoints return unauthenticated for invalid forwarded actor sessions" do
+    response =
+      conn(:get, "/api/orchestrator/v1/runs")
+      |> put_req_header("authorization", "Bearer test-service-token")
+      |> put_req_header("x-favn-actor-id", "actor_stale")
+      |> put_req_header("x-favn-session-id", "session_stale")
+      |> Router.call(@opts)
+
+    assert response.status == 401
+    assert %{"error" => %{"code" => "unauthenticated"}} = Jason.decode!(response.resp_body)
+  end
+
+  test "run submission accepts explicit asset dependency mode" do
+    version = dependency_manifest_version("mv_dependency_scope")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password")
+
+    response =
+      conn(:post, "/api/orchestrator/v1/runs", %{
+        target: %{type: "asset", id: "asset:Elixir.MyApp.Assets.Gold:asset"},
+        manifest_selection: %{mode: "version", manifest_version_id: version.manifest_version_id},
+        dependencies: "none"
+      })
+      |> put_req_header("authorization", "Bearer test-service-token")
+      |> put_req_header("x-favn-actor-id", actor.id)
+      |> put_req_header("x-favn-session-id", session.id)
+      |> Router.call(@opts)
+
+    assert response.status == 201
+    assert %{"data" => %{"run" => %{"id" => run_id}}} = Jason.decode!(response.resp_body)
+    assert {:ok, run} = FavnOrchestrator.get_run(run_id)
+    assert run.manifest_version_id == "mv_dependency_scope"
+    assert run.plan.topo_order == [{MyApp.Assets.Gold, :asset}]
+  end
+
+  test "run submission rejects invalid dependency mode" do
+    version = dependency_manifest_version("mv_invalid_dependency_scope")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password")
+
+    response =
+      conn(:post, "/api/orchestrator/v1/runs", %{
+        target: %{type: "asset", id: "asset:Elixir.MyApp.Assets.Gold:asset"},
+        manifest_selection: %{mode: "version", manifest_version_id: version.manifest_version_id},
+        dependencies: "downstream"
+      })
+      |> put_req_header("authorization", "Bearer test-service-token")
+      |> put_req_header("x-favn-actor-id", actor.id)
+      |> put_req_header("x-favn-session-id", session.id)
+      |> Router.call(@opts)
+
+    assert response.status == 422
+    assert %{"error" => %{"code" => "validation_failed"}} = Jason.decode!(response.resp_body)
   end
 
   test "service token can cancel run without actor headers" do
@@ -574,6 +656,27 @@ defmodule FavnOrchestrator.API.RouterTest do
           outputs: [:asset],
           config: %{},
           metadata: %{}
+        }
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
+    version
+  end
+
+  defp dependency_manifest_version(manifest_version_id) do
+    manifest = %Manifest{
+      assets: [
+        %Favn.Manifest.Asset{
+          ref: {MyApp.Assets.Raw, :asset},
+          module: MyApp.Assets.Raw,
+          name: :asset
+        },
+        %Favn.Manifest.Asset{
+          ref: {MyApp.Assets.Gold, :asset},
+          module: MyApp.Assets.Gold,
+          name: :asset,
+          depends_on: [{MyApp.Assets.Raw, :asset}]
         }
       ]
     }

--- a/apps/favn_orchestrator/test/api/router_test.exs
+++ b/apps/favn_orchestrator/test/api/router_test.exs
@@ -350,6 +350,27 @@ defmodule FavnOrchestrator.API.RouterTest do
     assert %{"error" => %{"code" => "validation_failed"}} = Jason.decode!(response.resp_body)
   end
 
+  test "run submission rejects request-level dependency mode for pipeline targets" do
+    version = schedule_manifest_version("mv_pipeline_dependency_rejected")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password")
+
+    response =
+      conn(:post, "/api/orchestrator/v1/runs", %{
+        target: %{type: "pipeline", id: "pipeline:Elixir.MyApp.Pipelines.DailyOrders"},
+        manifest_selection: %{mode: "version", manifest_version_id: version.manifest_version_id},
+        dependencies: "none"
+      })
+      |> put_req_header("authorization", "Bearer test-service-token")
+      |> put_req_header("x-favn-actor-id", actor.id)
+      |> put_req_header("x-favn-session-id", session.id)
+      |> Router.call(@opts)
+
+    assert response.status == 422
+    assert %{"error" => %{"code" => "validation_failed"}} = Jason.decode!(response.resp_body)
+  end
+
   test "service token can cancel run without actor headers" do
     seed_run_events!("run_cancel_service", [1])
 

--- a/apps/favn_orchestrator/test/run_manager_test.exs
+++ b/apps/favn_orchestrator/test/run_manager_test.exs
@@ -571,6 +571,15 @@ defmodule FavnOrchestrator.RunManagerTest do
     assert run.manifest_version_id == "mv_active"
   end
 
+  test "asset run rejects invalid metadata without crashing run manager" do
+    version = manifest_version("mv_invalid_asset_metadata")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest("mv_invalid_asset_metadata")
+
+    assert {:error, :invalid_run_metadata} =
+             FavnOrchestrator.submit_asset_run({MyApp.Assets.Gold, :asset}, metadata: [])
+  end
+
   test "submits multi-target pipeline run in one run plan" do
     version = manifest_version("mv_pipeline_multi")
     assert :ok = FavnOrchestrator.register_manifest(version)

--- a/apps/favn_orchestrator/test/run_manager_test.exs
+++ b/apps/favn_orchestrator/test/run_manager_test.exs
@@ -1083,6 +1083,25 @@ defmodule FavnOrchestrator.RunManagerTest do
     assert rerun.lineage_depth == source_run.lineage_depth + 1
   end
 
+  test "asset rerun preserves original dependency mode" do
+    version = manifest_version("mv_rerun_asset_dependency_scope")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest("mv_rerun_asset_dependency_scope")
+
+    assert {:ok, source_run_id} =
+             FavnOrchestrator.submit_asset_run({MyApp.Assets.Gold, :asset}, dependencies: :none)
+
+    assert {:ok, source_run} = await_terminal_run(source_run_id)
+    assert source_run.plan.dependencies == :none
+    assert source_run.plan.topo_order == [{MyApp.Assets.Gold, :asset}]
+
+    assert {:ok, rerun_id} = FavnOrchestrator.rerun(source_run_id)
+    assert {:ok, rerun} = await_terminal_run(rerun_id)
+
+    assert rerun.plan.dependencies == :none
+    assert rerun.plan.topo_order == [{MyApp.Assets.Gold, :asset}]
+  end
+
   test "pipeline rerun replays original target selection" do
     version = manifest_version("mv_rerun_pipeline_replay")
     assert :ok = FavnOrchestrator.register_manifest(version)

--- a/docs/lib_structure.md
+++ b/docs/lib_structure.md
@@ -275,6 +275,7 @@ Notes:
   - `web/favn_web/src/lib/utils.ts` for shared frontend utility helpers
   - `web/favn_web/src/hooks.server.ts`
   - `web/favn_web/src/lib/server/orchestrator.ts`
+  - `web/favn_web/src/lib/server/session_guard.ts`
   - `web/favn_web/src/lib/server/web_api.ts`
   - `web/favn_web/src/lib/server/session.ts`
   - `web/favn_web/src/routes/login/+page.server.ts`

--- a/web/favn_web/src/lib/server/asset_catalog_views.spec.ts
+++ b/web/favn_web/src/lib/server/asset_catalog_views.spec.ts
@@ -120,6 +120,34 @@ describe('asset catalog view normalizers', () => {
 		expect(catalog.capabilityNotes.map((note) => note.key)).toContain('dependencies');
 	});
 
+	it('prefers asset target manifest metadata when exposed by the backend', () => {
+		const catalog = normalizeAssetCatalogList(
+			{
+				data: {
+					manifest: { manifest_version_id: 'mfv_active', content_hash: 'sha256:active' },
+					targets: {
+						assets: [
+							{
+								target_id: 'asset:Elixir.FavnDemo.Raw.Orders:asset',
+								manifest_version_id: 'mfv_target',
+								content_hash: 'sha256:target'
+							}
+						],
+						pipelines: []
+					}
+				}
+			},
+			{ data: { items: [] } }
+		);
+
+		expect(catalog.assets[0]).toEqual(
+			expect.objectContaining({
+				manifestVersionId: 'mfv_target',
+				manifestContentHash: 'sha256:target'
+			})
+		);
+	});
+
 	it('normalizes robust asset labels and target ids', () => {
 		expect(normalizeAssetRefParts('{Elixir.Foo.Bar, :asset}')).toEqual({
 			ref: 'Elixir.Foo.Bar:asset',

--- a/web/favn_web/src/lib/server/asset_catalog_views.ts
+++ b/web/favn_web/src/lib/server/asset_catalog_views.ts
@@ -182,8 +182,13 @@ function normalizeTargetRecord(target: unknown, index: number): AssetCatalogItem
 		lastRun: null,
 		upstreamCount: asNumber(record.upstream_count) ?? 0,
 		downstreamCount: asNumber(record.downstream_count) ?? 0,
-		manifestVersionId: null,
-		manifestContentHash: null,
+		manifestVersionId: firstString(record, ['manifest_version_id', 'manifestVersionId']),
+		manifestContentHash: firstString(record, [
+			'content_hash',
+			'manifest_content_hash',
+			'manifest_hash',
+			'hash'
+		]),
 		runActions: [],
 		rawTarget: target
 	};
@@ -343,8 +348,8 @@ export function normalizeAssetCatalogList(
 			health: healthFromRun(lastRun),
 			lastRun,
 			runsCount: runs.length,
-			manifestVersionId: versionId,
-			manifestContentHash: contentHash,
+			manifestVersionId: asset.manifestVersionId ?? versionId,
+			manifestContentHash: asset.manifestContentHash ?? contentHash,
 			runActions: runActions(asset)
 		};
 	});

--- a/web/favn_web/src/lib/server/orchestrator.ts
+++ b/web/favn_web/src/lib/server/orchestrator.ts
@@ -103,7 +103,11 @@ export function orchestratorGetRun(session: WebSession, runId: string): Promise<
 
 export function orchestratorSubmitRun(
 	session: WebSession,
-	payload: { target: { type: 'asset' | 'pipeline'; id: string }; manifest_selection?: unknown }
+	payload: {
+		target: { type: 'asset' | 'pipeline'; id: string };
+		manifest_selection?: unknown;
+		dependencies?: 'all' | 'none';
+	}
 ): Promise<Response> {
 	return orchestratorAuthed('/api/orchestrator/v1/runs', session, {
 		method: 'POST',

--- a/web/favn_web/src/lib/server/session_guard.ts
+++ b/web/favn_web/src/lib/server/session_guard.ts
@@ -1,0 +1,37 @@
+import { redirect, type Cookies } from '@sveltejs/kit';
+import { orchestratorGetMe } from './orchestrator';
+import { clearWebSessionCookie, type WebSession } from './session';
+
+type SessionContext = {
+	locals: App.Locals;
+	cookies: Cookies;
+};
+
+export function clearLocalSession(context: SessionContext): void {
+	clearWebSessionCookie(context.cookies);
+	context.locals.session = null;
+}
+
+export async function validateWebSession(context: SessionContext): Promise<WebSession | null> {
+	const session = context.locals.session;
+	if (!session) return null;
+
+	const response = await orchestratorGetMe(session);
+
+	if (response.status === 401) {
+		clearLocalSession(context);
+		return null;
+	}
+
+	return session;
+}
+
+export async function requireProtectedPageSession(context: SessionContext): Promise<WebSession> {
+	const session = await validateWebSession(context);
+
+	if (!session) {
+		throw redirect(303, '/login');
+	}
+
+	return session;
+}

--- a/web/favn_web/src/lib/server/web_api.ts
+++ b/web/favn_web/src/lib/server/web_api.ts
@@ -1,4 +1,5 @@
 import type { RequestEvent } from '@sveltejs/kit';
+import { validateWebSession } from './session_guard';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -13,10 +14,10 @@ export function jsonError(status: number, code: string, message: string): Respon
 	});
 }
 
-export function requireSession(event: RequestEvent): Response | null {
-	if (event.locals.session) {
-		return null;
-	}
+export async function requireSession(event: RequestEvent): Promise<Response | null> {
+	const session = await validateWebSession(event);
+
+	if (session) return null;
 
 	return jsonError(401, 'unauthorized', 'Authentication required');
 }

--- a/web/favn_web/src/routes/api/web/v1/manifests/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/manifests/+server.ts
@@ -3,7 +3,7 @@ import { orchestratorListManifests } from '$lib/server/orchestrator';
 import { relayJson, requireSession } from '$lib/server/web_api';
 
 export const GET: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const upstream = await orchestratorListManifests(event.locals.session!);

--- a/web/favn_web/src/routes/api/web/v1/manifests/[manifest_version_id]/activate/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/manifests/[manifest_version_id]/activate/+server.ts
@@ -3,7 +3,7 @@ import { orchestratorActivateManifest } from '$lib/server/orchestrator';
 import { relayJson, requireSession } from '$lib/server/web_api';
 
 export const POST: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const upstream = await orchestratorActivateManifest(

--- a/web/favn_web/src/routes/api/web/v1/manifests/active/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/manifests/active/+server.ts
@@ -3,7 +3,7 @@ import { orchestratorGetActiveManifest } from '$lib/server/orchestrator';
 import { relayJson, requireSession } from '$lib/server/web_api';
 
 export const GET: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const upstream = await orchestratorGetActiveManifest(event.locals.session!);

--- a/web/favn_web/src/routes/api/web/v1/runs/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/runs/+server.ts
@@ -32,6 +32,10 @@ function parseSubmitPayload(value: Record<string, unknown>): {
 		return null;
 	}
 
+	if (type === 'pipeline' && 'dependencies' in value && dependencies !== undefined) {
+		return null;
+	}
+
 	return {
 		target: { type, id },
 		...('manifest_selection' in value ? { manifest_selection: value.manifest_selection } : {}),
@@ -61,7 +65,7 @@ export const POST: RequestHandler = async (event) => {
 		return jsonError(
 			422,
 			'validation_failed',
-			'Expected target with type "asset"|"pipeline", non-empty id, and optional dependencies "all"|"none"'
+			'Expected target with type "asset"|"pipeline", non-empty id, and optional dependencies "all"|"none" for asset targets only'
 		);
 	}
 

--- a/web/favn_web/src/routes/api/web/v1/runs/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/runs/+server.ts
@@ -5,6 +5,7 @@ import { jsonError, readJsonBody, relayJson, requireSession } from '$lib/server/
 function parseSubmitPayload(value: Record<string, unknown>): {
 	target: { type: 'asset' | 'pipeline'; id: string };
 	manifest_selection?: unknown;
+	dependencies?: 'all' | 'none';
 } | null {
 	const targetValue = value.target;
 
@@ -21,14 +22,25 @@ function parseSubmitPayload(value: Record<string, unknown>): {
 		return null;
 	}
 
+	const dependencies = value.dependencies;
+	if (
+		'dependencies' in value &&
+		dependencies !== undefined &&
+		dependencies !== 'all' &&
+		dependencies !== 'none'
+	) {
+		return null;
+	}
+
 	return {
 		target: { type, id },
-		...('manifest_selection' in value ? { manifest_selection: value.manifest_selection } : {})
+		...('manifest_selection' in value ? { manifest_selection: value.manifest_selection } : {}),
+		...(dependencies === 'all' || dependencies === 'none' ? { dependencies } : {})
 	};
 }
 
 export const GET: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const upstream = await orchestratorListRuns(event.locals.session!);
@@ -36,7 +48,7 @@ export const GET: RequestHandler = async (event) => {
 };
 
 export const POST: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const body = await readJsonBody(event.request);
@@ -49,7 +61,7 @@ export const POST: RequestHandler = async (event) => {
 		return jsonError(
 			422,
 			'validation_failed',
-			'Expected target with type "asset"|"pipeline" and non-empty id'
+			'Expected target with type "asset"|"pipeline", non-empty id, and optional dependencies "all"|"none"'
 		);
 	}
 

--- a/web/favn_web/src/routes/api/web/v1/runs/[run_id]/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/runs/[run_id]/+server.ts
@@ -3,7 +3,7 @@ import { orchestratorGetRun } from '$lib/server/orchestrator';
 import { relayJson, requireSession } from '$lib/server/web_api';
 
 export const GET: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const upstream = await orchestratorGetRun(event.locals.session!, event.params.run_id);

--- a/web/favn_web/src/routes/api/web/v1/runs/[run_id]/cancel/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/runs/[run_id]/cancel/+server.ts
@@ -3,7 +3,7 @@ import { orchestratorCancelRun } from '$lib/server/orchestrator';
 import { relayJson, requireSession } from '$lib/server/web_api';
 
 export const POST: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const upstream = await orchestratorCancelRun(event.locals.session!, event.params.run_id);

--- a/web/favn_web/src/routes/api/web/v1/runs/[run_id]/rerun/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/runs/[run_id]/rerun/+server.ts
@@ -3,7 +3,7 @@ import { orchestratorRerunRun } from '$lib/server/orchestrator';
 import { relayJson, requireSession } from '$lib/server/web_api';
 
 export const POST: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const upstream = await orchestratorRerunRun(event.locals.session!, event.params.run_id);

--- a/web/favn_web/src/routes/api/web/v1/schedules/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/schedules/+server.ts
@@ -3,7 +3,7 @@ import { orchestratorListSchedules } from '$lib/server/orchestrator';
 import { relayJson, requireSession } from '$lib/server/web_api';
 
 export const GET: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const upstream = await orchestratorListSchedules(event.locals.session!);

--- a/web/favn_web/src/routes/api/web/v1/schedules/[schedule_id]/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/schedules/[schedule_id]/+server.ts
@@ -3,7 +3,7 @@ import { orchestratorAuthed } from '$lib/server/orchestrator';
 import { relayJson, requireSession } from '$lib/server/web_api';
 
 export const GET: RequestHandler = async (event) => {
-	const unauthorized = requireSession(event);
+	const unauthorized = await requireSession(event);
 	if (unauthorized) return unauthorized;
 
 	const upstream = await orchestratorAuthed(

--- a/web/favn_web/src/routes/api/web/v1/streams/runs/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/streams/runs/+server.ts
@@ -1,5 +1,6 @@
 import type { RequestHandler } from './$types';
 import { orchestratorAuthed } from '$lib/server/orchestrator';
+import { jsonError, requireSession } from '$lib/server/web_api';
 
 function normalizeLastEventId(value: string | null): string | null {
 	if (!value) return null;
@@ -14,19 +15,20 @@ function normalizeLastEventId(value: string | null): string | null {
 	return trimmed;
 }
 
-export const GET: RequestHandler = async ({ locals, request }) => {
-	if (!locals.session) {
-		return new Response('Unauthorized', { status: 401 });
-	}
+export const GET: RequestHandler = async (event) => {
+	const unauthorized = await requireSession(event);
+	if (unauthorized) return unauthorized;
+
+	const { locals, request } = event;
 
 	const requestedLastEventId = request.headers.get('last-event-id');
 	const lastEventId = normalizeLastEventId(requestedLastEventId);
 
 	if (requestedLastEventId && !lastEventId) {
-		return new Response('Invalid Last-Event-ID', { status: 400 });
+		return jsonError(400, 'validation_failed', 'Invalid Last-Event-ID');
 	}
 
-	const upstream = await orchestratorAuthed('/api/orchestrator/v1/streams/runs', locals.session, {
+	const upstream = await orchestratorAuthed('/api/orchestrator/v1/streams/runs', locals.session!, {
 		method: 'GET',
 		headers: {
 			accept: 'text/event-stream',

--- a/web/favn_web/src/routes/api/web/v1/streams/runs/[run_id]/+server.ts
+++ b/web/favn_web/src/routes/api/web/v1/streams/runs/[run_id]/+server.ts
@@ -1,6 +1,6 @@
 import type { RequestHandler } from './$types';
 import { orchestratorAuthed } from '$lib/server/orchestrator';
-import { jsonError } from '$lib/server/web_api';
+import { jsonError, requireSession } from '$lib/server/web_api';
 
 function normalizeLastEventId(value: string | null): string | null {
 	if (!value) return null;
@@ -15,10 +15,11 @@ function normalizeLastEventId(value: string | null): string | null {
 	return trimmed;
 }
 
-export const GET: RequestHandler = async ({ locals, request, params }) => {
-	if (!locals.session) {
-		return jsonError(401, 'unauthorized', 'Authentication required');
-	}
+export const GET: RequestHandler = async (event) => {
+	const unauthorized = await requireSession(event);
+	if (unauthorized) return unauthorized;
+
+	const { locals, request, params } = event;
 
 	const requestedLastEventId = request.headers.get('last-event-id');
 	const lastEventId = normalizeLastEventId(requestedLastEventId);

--- a/web/favn_web/src/routes/assets/+page.server.ts
+++ b/web/favn_web/src/routes/assets/+page.server.ts
@@ -2,6 +2,7 @@ import { redirect } from '@sveltejs/kit';
 import type { Actions, PageServerLoad } from './$types';
 import { clearWebSessionCookie } from '$lib/server/session';
 import { orchestratorGetActiveManifest, orchestratorListRuns } from '$lib/server/orchestrator';
+import { clearLocalSession, requireProtectedPageSession } from '$lib/server/session_guard';
 import {
 	filterAssetCatalogItems,
 	normalizeAssetCatalogList
@@ -22,17 +23,17 @@ function isNoActiveManifestResponse(response: Response, payload: unknown): boole
 	return body.includes('active_manifest_not_set') || body.includes('not_found');
 }
 
-export const load: PageServerLoad = async ({ locals, cookies, url }) => {
-	if (!locals.session) throw redirect(303, '/login');
+export const load: PageServerLoad = async (event) => {
+	const { locals, cookies, url } = event;
+	const session = await requireProtectedPageSession(event);
 
 	const [activeManifestResponse, runsResponse] = await Promise.all([
-		orchestratorGetActiveManifest(locals.session),
-		orchestratorListRuns(locals.session)
+		orchestratorGetActiveManifest(session),
+		orchestratorListRuns(session)
 	]);
 
 	if (activeManifestResponse.status === 401 || runsResponse.status === 401) {
-		clearWebSessionCookie(cookies);
-		locals.session = null;
+		clearLocalSession({ locals, cookies });
 		throw redirect(303, '/login');
 	}
 

--- a/web/favn_web/src/routes/assets/[asset_ref]/+page.server.ts
+++ b/web/favn_web/src/routes/assets/[asset_ref]/+page.server.ts
@@ -99,14 +99,21 @@ export const actions: Actions = {
 		}
 
 		const detail = await loadDetail(locals, cookies, params.asset_ref);
-		const submittedTargetId = targetId ?? detail.asset.targetId;
-		if (!submittedTargetId) throw error(400, 'Asset target id is not available');
+		const expectedTargetId = detail.asset.targetId;
+		const expectedManifestVersionId = detail.asset.manifestVersionId;
+
+		if (!expectedTargetId) throw error(400, 'Asset target id is not available');
+		if (targetId !== expectedTargetId)
+			throw error(400, 'Submitted asset target does not match detail');
+		if (!manifestVersionId) throw error(400, 'Manifest version id is required');
+		if (!expectedManifestVersionId) throw error(400, 'Asset manifest version id is not available');
+		if (manifestVersionId !== expectedManifestVersionId) {
+			throw error(400, 'Submitted manifest version does not match detail');
+		}
 
 		const response = await orchestratorSubmitRun(locals.session!, {
-			target: { type: 'asset', id: submittedTargetId },
-			manifest_selection: manifestVersionId
-				? { mode: 'version', manifest_version_id: manifestVersionId }
-				: { mode: 'active' },
+			target: { type: 'asset', id: targetId },
+			manifest_selection: { mode: 'version', manifest_version_id: manifestVersionId },
 			dependencies: 'all'
 		});
 

--- a/web/favn_web/src/routes/assets/[asset_ref]/+page.server.ts
+++ b/web/favn_web/src/routes/assets/[asset_ref]/+page.server.ts
@@ -7,6 +7,7 @@ import {
 	orchestratorSubmitRun
 } from '$lib/server/orchestrator';
 import { normalizeAssetCatalogDetail } from '$lib/server/asset_catalog_views';
+import { clearLocalSession, requireProtectedPageSession } from '$lib/server/session_guard';
 
 async function readJsonOr(response: Response, fallback: unknown): Promise<unknown> {
 	try {
@@ -16,21 +17,26 @@ async function readJsonOr(response: Response, fallback: unknown): Promise<unknow
 	}
 }
 
+function nonEmptyFormString(value: FormDataEntryValue | null): string | null {
+	if (typeof value !== 'string') return null;
+	const trimmed = value.trim();
+	return trimmed.length > 0 ? trimmed : null;
+}
+
 async function loadDetail(
 	locals: App.Locals,
 	cookies: import('@sveltejs/kit').Cookies,
 	assetRef: string
 ) {
-	if (!locals.session) throw redirect(303, '/login');
+	const session = await requireProtectedPageSession({ locals, cookies });
 
 	const [activeManifestResponse, runsResponse] = await Promise.all([
-		orchestratorGetActiveManifest(locals.session),
-		orchestratorListRuns(locals.session)
+		orchestratorGetActiveManifest(session),
+		orchestratorListRuns(session)
 	]);
 
 	if (activeManifestResponse.status === 401 || runsResponse.status === 401) {
-		clearWebSessionCookie(cookies);
-		locals.session = null;
+		clearLocalSession({ locals, cookies });
 		throw redirect(303, '/login');
 	}
 
@@ -82,17 +88,30 @@ export const actions: Actions = {
 		locals.session = null;
 		throw redirect(303, '/login');
 	},
-	runWithUpstream: async ({ cookies, locals, params }) => {
+	runWithUpstream: async ({ request, cookies, locals, params }) => {
+		const formData = await request.formData();
+		const scope = nonEmptyFormString(formData.get('scope'));
+		const targetId = nonEmptyFormString(formData.get('target'));
+		const manifestVersionId = nonEmptyFormString(formData.get('manifest_version_id'));
+
+		if (scope !== 'with_dependencies') {
+			throw error(400, 'Expected with_dependencies run scope');
+		}
+
 		const detail = await loadDetail(locals, cookies, params.asset_ref);
-		if (!detail.asset.targetId) throw error(400, 'Asset target id is not available');
+		const submittedTargetId = targetId ?? detail.asset.targetId;
+		if (!submittedTargetId) throw error(400, 'Asset target id is not available');
+
 		const response = await orchestratorSubmitRun(locals.session!, {
-			target: { type: 'asset', id: detail.asset.targetId },
-			manifest_selection: { mode: 'active' }
+			target: { type: 'asset', id: submittedTargetId },
+			manifest_selection: manifestVersionId
+				? { mode: 'version', manifest_version_id: manifestVersionId }
+				: { mode: 'active' },
+			dependencies: 'all'
 		});
 
 		if (response.status === 401) {
-			clearWebSessionCookie(cookies);
-			locals.session = null;
+			clearLocalSession({ locals, cookies });
 			throw redirect(303, '/login');
 		}
 

--- a/web/favn_web/src/routes/runs/+page.server.ts
+++ b/web/favn_web/src/routes/runs/+page.server.ts
@@ -3,6 +3,7 @@ import type { Actions, PageServerLoad } from './$types';
 import { clearWebSessionCookie } from '$lib/server/session';
 import { orchestratorGetActiveManifest, orchestratorListRuns } from '$lib/server/orchestrator';
 import { normalizeRunSummaries } from '$lib/server/run_views';
+import { clearLocalSession, requireProtectedPageSession } from '$lib/server/session_guard';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -31,17 +32,17 @@ async function readJsonOr(response: Response, fallback: unknown): Promise<unknow
 	}
 }
 
-export const load: PageServerLoad = async ({ locals, cookies }) => {
-	if (!locals.session) throw redirect(303, '/login');
+export const load: PageServerLoad = async (event) => {
+	const { locals, cookies } = event;
+	const session = await requireProtectedPageSession(event);
 
 	const [runsResponse, activeManifestResponse] = await Promise.all([
-		orchestratorListRuns(locals.session),
-		orchestratorGetActiveManifest(locals.session)
+		orchestratorListRuns(session),
+		orchestratorGetActiveManifest(session)
 	]);
 
-	if (runsResponse.status === 401) {
-		clearWebSessionCookie(cookies);
-		locals.session = null;
+	if (runsResponse.status === 401 || activeManifestResponse.status === 401) {
+		clearLocalSession({ locals, cookies });
 		throw redirect(303, '/login');
 	}
 

--- a/web/favn_web/src/routes/runs/[run_id]/+page.server.ts
+++ b/web/favn_web/src/routes/runs/[run_id]/+page.server.ts
@@ -3,6 +3,7 @@ import type { Actions, PageServerLoad } from './$types';
 import { clearWebSessionCookie } from '$lib/server/session';
 import { orchestratorGetActiveManifest, orchestratorGetRun } from '$lib/server/orchestrator';
 import { normalizeRunDetail } from '$lib/server/run_views';
+import { clearLocalSession, requireProtectedPageSession } from '$lib/server/session_guard';
 
 type JsonRecord = Record<string, unknown>;
 
@@ -31,17 +32,17 @@ async function readJsonOr(response: Response, fallback: unknown): Promise<unknow
 	}
 }
 
-export const load: PageServerLoad = async ({ locals, cookies, params }) => {
-	if (!locals.session) throw redirect(303, '/login');
+export const load: PageServerLoad = async (event) => {
+	const { locals, cookies, params } = event;
+	const session = await requireProtectedPageSession(event);
 
 	const [runResponse, activeManifestResponse] = await Promise.all([
-		orchestratorGetRun(locals.session, params.run_id),
-		orchestratorGetActiveManifest(locals.session)
+		orchestratorGetRun(session, params.run_id),
+		orchestratorGetActiveManifest(session)
 	]);
 
-	if (runResponse.status === 401) {
-		clearWebSessionCookie(cookies);
-		locals.session = null;
+	if (runResponse.status === 401 || activeManifestResponse.status === 401) {
+		clearLocalSession({ locals, cookies });
 		throw redirect(303, '/login');
 	}
 

--- a/web/favn_web/tests/e2e/auth-session-runs.e2e.ts
+++ b/web/favn_web/tests/e2e/auth-session-runs.e2e.ts
@@ -1,13 +1,47 @@
 import { expect, test, type Page } from '@playwright/test';
+import { createHmac } from 'node:crypto';
 
 const VALID_USERNAME = 'alice';
 const VALID_PASSWORD = 'password123';
 
 const FAVN_WEB_SESSION_COOKIE = 'favn_web_session';
 const BASE_URL = 'http://127.0.0.1:4173';
+const SESSION_SECRET = 'playwright-session-secret';
 
 function encodeSessionCookie(payload: Record<string, unknown>): string {
 	return Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url');
+}
+
+function signedSessionCookie(payload: Record<string, unknown>): string {
+	const encoded = encodeSessionCookie(payload);
+	const signature = createHmac('sha256', SESSION_SECRET).update(encoded).digest('base64url');
+	return `${encoded}.${signature}`;
+}
+
+async function addSessionCookie(page: Page, value: string): Promise<void> {
+	await page.context().addCookies([
+		{
+			name: FAVN_WEB_SESSION_COOKIE,
+			value,
+			domain: '127.0.0.1',
+			path: '/'
+		}
+	]);
+}
+
+async function hasSessionCookie(page: Page): Promise<boolean> {
+	const cookies = await page.context().cookies(BASE_URL);
+	return cookies.some((cookie) => cookie.name === FAVN_WEB_SESSION_COOKIE);
+}
+
+async function setMockActiveManifest(manifestVersionId: string): Promise<void> {
+	const response = await fetch('http://127.0.0.1:4101/__mock/active-manifest', {
+		method: 'POST',
+		headers: { 'content-type': 'application/json' },
+		body: JSON.stringify({ manifest_version_id: manifestVersionId })
+	});
+
+	expect(response.status).toBe(200);
 }
 
 async function loginAsValidUser(page: Page) {
@@ -146,6 +180,7 @@ test.describe('auth/session/runs flow', () => {
 		await page.getByRole('button', { name: 'Run with dependencies' }).click();
 		await expect(page.getByRole('dialog')).toContainText('manifest_v2');
 		await expect(page.getByRole('dialog')).toContainText('With dependencies');
+		await setMockActiveManifest('manifest_v3');
 		await page.getByRole('button', { name: 'Submit run request' }).click();
 		await expect(page).toHaveURL(/\/assets\/Staging\.CustomerOrders%3Aasset$/);
 	});
@@ -171,24 +206,36 @@ test.describe('auth/session/runs flow', () => {
 			issued_at: '1999-12-31T00:00:00.000Z'
 		});
 
-		await page.context().addCookies([
-			{
-				name: FAVN_WEB_SESSION_COOKIE,
-				value: expiredCookie,
-				domain: '127.0.0.1',
-				path: '/'
-			}
-		]);
+		await addSessionCookie(page, expiredCookie);
 
 		await page.goto('/');
 
 		await expect(page).toHaveURL(/\/login$/);
 		await expect
 			.poll(async () => {
-				const cookies = await page.context().cookies('http://127.0.0.1:4173');
-				return cookies.some((cookie) => cookie.name === FAVN_WEB_SESSION_COOKIE);
+				return hasSessionCookie(page);
 			})
 			.toBe(false);
+	});
+
+	test('stale signed session cookie redirects /runs to /login and clears cookie', async ({
+		page
+	}) => {
+		await addSessionCookie(
+			page,
+			signedSessionCookie({
+				session_id: 'sess_stale_signed',
+				actor_id: 'actor_stale_signed',
+				provider: 'password_local',
+				expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+				issued_at: new Date().toISOString()
+			})
+		);
+
+		await page.goto('/runs');
+
+		await expect(page).toHaveURL(/\/login$/);
+		await expect.poll(() => hasSessionCookie(page)).toBe(false);
 	});
 
 	test('web BFF operator API smoke for runs, manifests, and schedules', async ({ page }) => {
@@ -216,14 +263,16 @@ test.describe('auth/session/runs flow', () => {
 
 		const submitRun = await pagePostJson(page, '/api/web/v1/runs', {
 			target: { type: 'asset', id: 'asset.orders' },
-			manifest_selection: { mode: 'active' }
+			manifest_selection: { mode: 'active' },
+			dependencies: 'none'
 		});
 		expect(submitRun.status).toBe(202);
 		expect(submitRun.body).toEqual({
 			data: expect.objectContaining({
 				run_id: 'run_submitted_001',
 				status: 'queued',
-				manifest_selection: { mode: 'active' }
+				manifest_selection: { mode: 'active' },
+				dependencies: 'none'
 			})
 		});
 
@@ -352,5 +401,31 @@ test.describe('auth/session/runs flow', () => {
 				message: 'Authentication required'
 			}
 		});
+	});
+
+	test('stale signed session cookie returns BFF 401 envelope and clears cookie', async ({
+		page
+	}) => {
+		await addSessionCookie(
+			page,
+			signedSessionCookie({
+				session_id: 'sess_stale_bff',
+				actor_id: 'actor_stale_bff',
+				provider: 'password_local',
+				expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+				issued_at: new Date().toISOString()
+			})
+		);
+
+		const response = await page.request.get(`${BASE_URL}/api/web/v1/runs`);
+
+		expect(response.status()).toBe(401);
+		expect(await response.json()).toEqual({
+			error: {
+				code: 'unauthorized',
+				message: 'Authentication required'
+			}
+		});
+		await expect.poll(() => hasSessionCookie(page)).toBe(false);
 	});
 });

--- a/web/favn_web/tests/e2e/auth-session-runs.e2e.ts
+++ b/web/favn_web/tests/e2e/auth-session-runs.e2e.ts
@@ -276,6 +276,20 @@ test.describe('auth/session/runs flow', () => {
 			})
 		});
 
+		const pipelineSubmitWithDependencies = await pagePostJson(page, '/api/web/v1/runs', {
+			target: { type: 'pipeline', id: 'pipeline.reconcile' },
+			manifest_selection: { mode: 'active' },
+			dependencies: 'all'
+		});
+		expect(pipelineSubmitWithDependencies.status).toBe(422);
+		expect(pipelineSubmitWithDependencies.body).toEqual({
+			error: {
+				code: 'validation_failed',
+				message:
+					'Expected target with type "asset"|"pipeline", non-empty id, and optional dependencies "all"|"none" for asset targets only'
+			}
+		});
+
 		const cancelRun = await pagePostJson(page, '/api/web/v1/runs/run_002/cancel');
 		expect(cancelRun.status).toBe(200);
 		expect(cancelRun.body).toEqual({

--- a/web/favn_web/tests/e2e/mock-orchestrator-server.mjs
+++ b/web/favn_web/tests/e2e/mock-orchestrator-server.mjs
@@ -318,6 +318,8 @@ const MANIFESTS = [
 	{ manifest_version_id: 'manifest_v2', status: 'active' }
 ];
 
+let activeManifestVersionId = 'manifest_v2';
+
 const SCHEDULES = [
 	{ schedule_id: 'sched_001', enabled: true, target: { type: 'asset', id: 'asset.orders' } },
 	{
@@ -452,6 +454,7 @@ function handleLogin(request, response) {
 			const sessionId = `sess_${randomUUID()}`;
 			const issuedAt = new Date().toISOString();
 			const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+			activeManifestVersionId = 'manifest_v2';
 
 			sessions.set(sessionId, {
 				actorId,
@@ -492,6 +495,25 @@ function handleRuns(request, response) {
 	});
 }
 
+function handleMe(request, response) {
+	const session = requireAuthenticatedSession(request, response);
+	if (!session) return;
+
+	sendJson(response, 200, {
+		data: {
+			actor: {
+				actor_id: session.actorId,
+				provider: 'password_local'
+			},
+			session: {
+				session_id: session.sessionId,
+				actor_id: session.actorId,
+				provider: 'password_local'
+			}
+		}
+	});
+}
+
 function handleGetRun(request, response, runId) {
 	const session = requireAuthenticatedSession(request, response);
 	if (!session) return;
@@ -519,6 +541,7 @@ function handleSubmitRun(request, response) {
 
 			const target = body.target;
 			const manifestSelection = body.manifest_selection;
+			const dependencies = body.dependencies;
 			if (
 				typeof target !== 'object' ||
 				target === null ||
@@ -532,14 +555,39 @@ function handleSubmitRun(request, response) {
 				return;
 			}
 
+			if (dependencies !== undefined && dependencies !== 'all' && dependencies !== 'none') {
+				sendJson(response, 422, {
+					error: { message: 'Expected dependencies all or none' }
+				});
+				return;
+			}
+
+			const validManifestSelection =
+				typeof manifestSelection === 'object' &&
+				manifestSelection !== null &&
+				!Array.isArray(manifestSelection) &&
+				(manifestSelection.mode === 'active' ||
+					(manifestSelection.mode === 'version' &&
+						typeof manifestSelection.manifest_version_id === 'string'));
+
+			if (!validManifestSelection) {
+				sendJson(response, 422, {
+					error: { message: 'Expected manifest_selection with mode active or version' }
+				});
+				return;
+			}
+
 			if (
-				typeof manifestSelection !== 'object' ||
-				manifestSelection === null ||
-				Array.isArray(manifestSelection) ||
-				manifestSelection.mode !== 'active'
+				target.id === 'asset:Staging.CustomerOrders:asset' &&
+				(dependencies !== 'all' ||
+					manifestSelection.mode !== 'version' ||
+					manifestSelection.manifest_version_id !== 'manifest_v2')
 			) {
 				sendJson(response, 422, {
-					error: { message: 'Expected manifest_selection with mode active' }
+					error: {
+						message:
+							'Expected asset detail run to pin submitted manifest_v2 and include dependencies all'
+					}
 				});
 				return;
 			}
@@ -552,7 +600,8 @@ function handleSubmitRun(request, response) {
 						type: target.type,
 						id: target.id
 					},
-					manifest_selection: manifestSelection
+					manifest_selection: manifestSelection,
+					...(dependencies ? { dependencies } : {})
 				}
 			});
 		})
@@ -599,12 +648,12 @@ function handleGetActiveManifest(request, response) {
 	sendJson(response, 200, {
 		data: {
 			manifest: {
-				manifest_version_id: 'manifest_v2',
+				manifest_version_id: activeManifestVersionId,
 				status: 'active',
-				content_hash: 'sha256:manifest-v2'
+				content_hash: `sha256:${activeManifestVersionId}`
 			},
 			targets: {
-				manifest_version_id: 'manifest_v2',
+				manifest_version_id: activeManifestVersionId,
 				assets: [
 					{ target_id: 'asset:Raw.Crm.Customers:asset', label: 'Raw.Crm.Customers:asset' },
 					{ target_id: 'asset:Raw.Crm.Orders:asset', label: 'Raw.Crm.Orders:asset' },
@@ -618,6 +667,22 @@ function handleGetActiveManifest(request, response) {
 			}
 		}
 	});
+}
+
+function handleSetActiveManifest(request, response) {
+	readJsonBody(request)
+		.then((body) => {
+			if (!body || typeof body.manifest_version_id !== 'string') {
+				sendJson(response, 422, { error: { message: 'Expected manifest_version_id' } });
+				return;
+			}
+
+			activeManifestVersionId = body.manifest_version_id;
+			sendJson(response, 200, { data: { manifest_version_id: activeManifestVersionId } });
+		})
+		.catch(() => {
+			sendJson(response, 500, { error: { message: 'Mock server error' } });
+		});
 }
 
 function handleActivateManifest(request, response, manifestVersionId) {
@@ -683,6 +748,16 @@ const server = createServer((request, response) => {
 
 	if (method === 'POST' && url.pathname === '/api/orchestrator/v1/auth/password/sessions') {
 		handleLogin(request, response);
+		return;
+	}
+
+	if (method === 'POST' && url.pathname === '/__mock/active-manifest') {
+		handleSetActiveManifest(request, response);
+		return;
+	}
+
+	if (method === 'GET' && url.pathname === '/api/orchestrator/v1/me') {
+		handleMe(request, response);
 		return;
 	}
 

--- a/web/favn_web/tests/e2e/mock-orchestrator-server.mjs
+++ b/web/favn_web/tests/e2e/mock-orchestrator-server.mjs
@@ -655,13 +655,26 @@ function handleGetActiveManifest(request, response) {
 			targets: {
 				manifest_version_id: activeManifestVersionId,
 				assets: [
-					{ target_id: 'asset:Raw.Crm.Customers:asset', label: 'Raw.Crm.Customers:asset' },
-					{ target_id: 'asset:Raw.Crm.Orders:asset', label: 'Raw.Crm.Orders:asset' },
+					{
+						target_id: 'asset:Raw.Crm.Customers:asset',
+						label: 'Raw.Crm.Customers:asset',
+						manifest_version_id: 'manifest_v2'
+					},
+					{
+						target_id: 'asset:Raw.Crm.Orders:asset',
+						label: 'Raw.Crm.Orders:asset',
+						manifest_version_id: 'manifest_v2'
+					},
 					{
 						target_id: 'asset:Staging.CustomerOrders:asset',
-						label: 'Staging.CustomerOrders:asset'
+						label: 'Staging.CustomerOrders:asset',
+						manifest_version_id: 'manifest_v2'
 					},
-					{ target_id: 'asset:Mart.CustomerRevenue:asset', label: 'Mart.CustomerRevenue:asset' }
+					{
+						target_id: 'asset:Mart.CustomerRevenue:asset',
+						label: 'Mart.CustomerRevenue:asset',
+						manifest_version_id: 'manifest_v2'
+					}
 				],
 				pipelines: [{ target_id: 'pipeline:DailySalesPipeline', label: 'DailySalesPipeline' }]
 			}


### PR DESCRIPTION
## Summary
- Validate signed web sessions against orchestrator before protected pages and BFF relays, clearing stale cookies and redirecting or returning 401 when the orchestrator rejects the session.
- Make asset detail run submissions explicit with `dependencies: \"all\"` and `manifest_selection: { mode: \"version\", manifest_version_id }` from the rendered form.
- Parse and validate dependency mode in the web BFF and orchestrator run API, preserving default `all` behavior when omitted.

## Verification
- `npm run check` in `web/favn_web`
- `npm run lint` in `web/favn_web`
- `npm test` in `web/favn_web`
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test apps/favn_orchestrator/test/api/router_test.exs`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`

Closes #157
Closes #161