### PR TITLE
Constrain local dev control ports

### DIFF
--- a/apps/favn/lib/mix/tasks/favn.status.ex
+++ b/apps/favn/lib/mix/tasks/favn.status.ex
@@ -35,7 +35,7 @@ defmodule Mix.Tasks.Favn.Status do
       "orchestrator node: #{format_internal_node(status.internal_control.orchestrator_node)}"
     )
 
-    IO.puts("control node: #{status.internal_control.control_node || "n/a"}")
+    IO.puts("control node: #{format_control_node(status.internal_control.control_node)}")
 
     case status.stack_status do
       :partial -> IO.puts("hint: run mix favn.stop to clean up partial/dead services")
@@ -60,5 +60,12 @@ defmodule Mix.Tasks.Favn.Status do
     port = node.distribution_port || "n/a"
 
     "#{node.status} pid=#{pid} node=#{name} distribution_port=#{port}"
+  end
+
+  defp format_control_node(node) do
+    name = node.node_name || "n/a"
+    port = node.distribution_port || "n/a"
+
+    "node=#{name} distribution_port=#{port}"
   end
 end

--- a/apps/favn/lib/mix/tasks/favn.status.ex
+++ b/apps/favn/lib/mix/tasks/favn.status.ex
@@ -21,9 +21,21 @@ defmodule Mix.Tasks.Favn.Status do
     IO.puts("status: #{status.stack_status}")
     IO.puts("storage: #{status.storage}")
     IO.puts("manifest: #{status.active_manifest_version_id || "none"}")
-    IO.puts("web: #{format_service(status.services.web)}")
-    IO.puts("orchestrator: #{format_service(status.services.orchestrator)}")
-    IO.puts("runner: #{format_service(status.services.runner)}")
+    IO.puts("local URLs:")
+    IO.puts("web: #{format_service(status.services.web)} url=#{status.user_urls.web}")
+
+    IO.puts(
+      "orchestrator API: #{format_service(status.services.orchestrator)} url=#{status.user_urls.orchestrator_api}"
+    )
+
+    IO.puts("internal control plane:")
+    IO.puts("runner node: #{format_internal_node(status.internal_control.runner_node)}")
+
+    IO.puts(
+      "orchestrator node: #{format_internal_node(status.internal_control.orchestrator_node)}"
+    )
+
+    IO.puts("control node: #{status.internal_control.control_node || "n/a"}")
 
     case status.stack_status do
       :partial -> IO.puts("hint: run mix favn.stop to clean up partial/dead services")
@@ -38,5 +50,15 @@ defmodule Mix.Tasks.Favn.Status do
   defp format_service(service) do
     pid = service.pid || "n/a"
     "#{service.status} pid=#{pid}"
+  end
+
+  defp format_internal_node(nil), do: "n/a"
+
+  defp format_internal_node(node) do
+    pid = node.pid || "n/a"
+    name = node.node_name || "n/a"
+    port = node.distribution_port || "n/a"
+
+    "#{node.status} pid=#{pid} node=#{name} distribution_port=#{port}"
   end
 end

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -125,6 +125,11 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
         "orchestrator" => "favn_orchestrator_task@localhost",
         "control" => "favn_local_ctl_task@localhost"
       },
+      "distribution_ports" => %{
+        "runner" => 45_101,
+        "orchestrator" => 45_102,
+        "control" => 45_103
+      },
       "services" => %{
         "web" => %{"pid" => pid},
         "orchestrator" => %{
@@ -160,7 +165,7 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert output =~
              "orchestrator node: running pid=#{pid} node=favn_orchestrator_task@localhost distribution_port=45102"
 
-    assert output =~ "control node: favn_local_ctl_task@localhost"
+    assert output =~ "control node: node=favn_local_ctl_task@localhost distribution_port=45103"
   end
 
   test "mix favn.status reports stale runtime hint", %{root_dir: root_dir} do

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -118,10 +118,25 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     runtime = %{
       "storage" => "memory",
       "active_manifest_version_id" => "mv_task_test",
+      "orchestrator_base_url" => "http://127.0.0.1:4101",
+      "web_base_url" => "http://127.0.0.1:4173",
+      "node_names" => %{
+        "runner" => "favn_runner_task@localhost",
+        "orchestrator" => "favn_orchestrator_task@localhost",
+        "control" => "favn_local_ctl_task@localhost"
+      },
       "services" => %{
         "web" => %{"pid" => pid},
-        "orchestrator" => %{"pid" => pid},
-        "runner" => %{"pid" => pid}
+        "orchestrator" => %{
+          "pid" => pid,
+          "node_name" => "favn_orchestrator_task@localhost",
+          "distribution_port" => 45_102
+        },
+        "runner" => %{
+          "pid" => pid,
+          "node_name" => "favn_runner_task@localhost",
+          "distribution_port" => 45_101
+        }
       }
     }
 
@@ -134,9 +149,18 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
 
     assert output =~ "Favn local dev stack"
     assert output =~ "manifest: mv_task_test"
-    assert output =~ "web:"
-    assert output =~ "orchestrator:"
-    assert output =~ "runner:"
+    assert output =~ "local URLs:"
+    assert output =~ "web: running pid=#{pid} url=http://127.0.0.1:4173"
+    assert output =~ "orchestrator API: running pid=#{pid} url=http://127.0.0.1:4101"
+    assert output =~ "internal control plane:"
+
+    assert output =~
+             "runner node: running pid=#{pid} node=favn_runner_task@localhost distribution_port=45101"
+
+    assert output =~
+             "orchestrator node: running pid=#{pid} node=favn_orchestrator_task@localhost distribution_port=45102"
+
+    assert output =~ "control node: favn_local_ctl_task@localhost"
   end
 
   test "mix favn.status reports stale runtime hint", %{root_dir: root_dir} do
@@ -213,11 +237,25 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
         InstallTask.run(["--root-dir", root_dir, "--skip-web-install"])
       end)
 
-    assert_raise Mix.Error,
-                 ~r/(runtime compile failed for runtime_root under --root-dir|local Erlang shortname host is unavailable)/,
-                 fn ->
-                   DevTask.run(["--root-dir", root_dir])
-                 end
+    previous_local = Application.get_env(:favn, :local, :__missing__)
+
+    try do
+      Application.put_env(:favn, :local,
+        orchestrator_port: free_port(),
+        web_port: free_port()
+      )
+
+      assert_raise Mix.Error,
+                   ~r/(runtime compile failed for runtime_root under --root-dir|local Erlang shortname host is unavailable)/,
+                   fn ->
+                     DevTask.run(["--root-dir", root_dir])
+                   end
+    after
+      case previous_local do
+        :__missing__ -> Application.delete_env(:favn, :local)
+        value -> Application.put_env(:favn, :local, value)
+      end
+    end
   end
 
   test "mix favn.install reports missing prerequisite tools", %{root_dir: root_dir} do
@@ -340,7 +378,7 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     previous_local = Application.get_env(:favn, :local, :__missing__)
 
     try do
-      Application.put_env(:favn, :local, web_port: port)
+      Application.put_env(:favn, :local, orchestrator_port: free_port(), web_port: port)
 
       assert_raise Mix.Error,
                    ~r/port conflict: web cannot bind port #{port}; free the port and retry/,
@@ -372,6 +410,7 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
         :favn,
         :local,
         storage: :postgres,
+        orchestrator_port: free_port(),
         web_port: web_port,
         postgres: [
           hostname: "127.0.0.1",

--- a/apps/favn_local/lib/favn/dev/node_control.ex
+++ b/apps/favn_local/lib/favn/dev/node_control.ex
@@ -37,6 +37,7 @@ defmodule Favn.Dev.NodeControl do
   end
 
   defp configure_loopback_distribution(opts) do
+    System.put_env("ERL_EPMD_ADDRESS", "127.0.0.1")
     Application.put_env(:kernel, :inet_dist_use_interface, {127, 0, 0, 1})
 
     case Keyword.get(opts, :distribution_port) do

--- a/apps/favn_local/lib/favn/dev/node_control.ex
+++ b/apps/favn_local/lib/favn/dev/node_control.ex
@@ -14,6 +14,8 @@ defmodule Favn.Dev.NodeControl do
         :ok
 
       false ->
+        :ok = configure_loopback_distribution(opts)
+
         name =
           opts
           |> Keyword.get(:name, "favn_local_ctl_#{:erlang.unique_integer([:positive])}")
@@ -31,6 +33,19 @@ defmodule Favn.Dev.NodeControl do
           {:error, reason} ->
             {:error, {:shortname_host_unavailable, reason}}
         end
+    end
+  end
+
+  defp configure_loopback_distribution(opts) do
+    Application.put_env(:kernel, :inet_dist_use_interface, {127, 0, 0, 1})
+
+    case Keyword.get(opts, :distribution_port) do
+      port when is_integer(port) and port > 0 ->
+        Application.put_env(:kernel, :inet_dist_listen_min, port)
+        Application.put_env(:kernel, :inet_dist_listen_max, port)
+
+      _missing ->
+        :ok
     end
   end
 

--- a/apps/favn_local/lib/favn/dev/runtime_launch.ex
+++ b/apps/favn_local/lib/favn/dev/runtime_launch.ex
@@ -16,7 +16,7 @@ defmodule Favn.Dev.RuntimeLaunch do
   @loopback_host "127.0.0.1"
   @loopback_ip_flag "{127,0,0,1}"
   @distribution_port_base 45_000
-  @distribution_port_span 6_000
+  @distribution_port_span 20_000
 
   @spec distribution_port(:runner | :orchestrator | :control, keyword()) :: pos_integer()
   def distribution_port(service, opts) when service in [:runner, :orchestrator, :control] do
@@ -306,7 +306,7 @@ defmodule Favn.Dev.RuntimeLaunch do
   end
 
   defp runtime_env do
-    %{"MIX_ENV" => "dev"}
+    %{"MIX_ENV" => "dev", "ERL_EPMD_ADDRESS" => @loopback_host}
   end
 
   defp distributed_erlang_args(service, opts) do

--- a/apps/favn_local/lib/favn/dev/runtime_launch.ex
+++ b/apps/favn_local/lib/favn/dev/runtime_launch.ex
@@ -13,6 +13,23 @@ defmodule Favn.Dev.RuntimeLaunch do
     FAVN_ORCHESTRATOR_BOOTSTRAP_ROLES
   )
 
+  @loopback_host "127.0.0.1"
+  @loopback_ip_flag "{127,0,0,1}"
+  @distribution_port_base 45_000
+  @distribution_port_span 6_000
+
+  @spec distribution_port(:runner | :orchestrator | :control, keyword()) :: pos_integer()
+  def distribution_port(service, opts) when service in [:runner, :orchestrator, :control] do
+    root_dir = Paths.root_dir(opts)
+    base = @distribution_port_base + :erlang.phash2(root_dir, @distribution_port_span)
+
+    case service do
+      :runner -> base
+      :orchestrator -> base + 1
+      :control -> base + 2
+    end
+  end
+
   @spec runner_spec(map(), keyword(), map(), map()) :: map()
   def runner_spec(runtime, opts, node_names, secrets)
       when is_map(runtime) and is_list(opts) and is_map(node_names) and is_map(secrets) do
@@ -33,12 +50,14 @@ defmodule Favn.Dev.RuntimeLaunch do
       """
       |> String.trim()
 
-    base_args = [
-      "--sname",
-      node_names.runner_short,
-      "--cookie",
-      secrets["rpc_cookie"]
-    ]
+    base_args =
+      distributed_erlang_args(:runner, opts) ++
+        [
+          "--sname",
+          node_names.runner_short,
+          "--cookie",
+          secrets["rpc_cookie"]
+        ]
 
     consumer_ebin_paths = ConsumerCodePath.ebin_paths(opts)
 
@@ -72,11 +91,18 @@ defmodule Favn.Dev.RuntimeLaunch do
       """
       storage = System.fetch_env!("FAVN_DEV_STORAGE")
 
+      api_bind_ip =
+        System.fetch_env!("FAVN_ORCHESTRATOR_API_BIND_IP")
+        |> String.split(".", parts: 4)
+        |> Enum.map(&String.to_integer/1)
+        |> List.to_tuple()
+
       Application.put_env(
         :favn_orchestrator,
         :api_server,
         enabled: System.get_env("FAVN_ORCHESTRATOR_API_ENABLED", "0") == "1",
-        port: String.to_integer(System.fetch_env!("FAVN_ORCHESTRATOR_API_PORT"))
+        port: String.to_integer(System.fetch_env!("FAVN_ORCHESTRATOR_API_PORT")),
+        bind_ip: api_bind_ip
       )
 
       Application.put_env(
@@ -137,19 +163,21 @@ defmodule Favn.Dev.RuntimeLaunch do
     %{
       name: "orchestrator",
       exec: elixir,
-      args: [
-        "--sname",
-        node_names.orchestrator_short,
-        "--cookie",
-        secrets["rpc_cookie"],
-        "-S",
-        "mix",
-        "run",
-        "--no-compile",
-        "--no-start",
-        "--eval",
-        code
-      ],
+      args:
+        distributed_erlang_args(:orchestrator, opts) ++
+          [
+            "--sname",
+            node_names.orchestrator_short,
+            "--cookie",
+            secrets["rpc_cookie"],
+            "-S",
+            "mix",
+            "run",
+            "--no-compile",
+            "--no-start",
+            "--eval",
+            code
+          ],
       cwd: runtime["orchestrator_root"],
       log_path: Paths.orchestrator_log_path(Paths.root_dir(opts)),
       env:
@@ -169,6 +197,7 @@ defmodule Favn.Dev.RuntimeLaunch do
           "FAVN_ORCHESTRATOR_API_ENABLED" =>
             if(config.orchestrator_api_enabled, do: "1", else: "0"),
           "FAVN_ORCHESTRATOR_API_PORT" => Integer.to_string(config.orchestrator_port),
+          "FAVN_ORCHESTRATOR_API_BIND_IP" => @loopback_host,
           "FAVN_ORCHESTRATOR_API_SERVICE_TOKENS" => secrets["service_token"],
           "FAVN_ORCHESTRATOR_BOOTSTRAP_USERNAME" => secrets["local_operator_username"],
           "FAVN_ORCHESTRATOR_BOOTSTRAP_PASSWORD" => secrets["local_operator_password"],
@@ -188,7 +217,7 @@ defmodule Favn.Dev.RuntimeLaunch do
     %{
       name: "web",
       exec: node,
-      args: [vite, "preview", "--host", "127.0.0.1", "--port", Integer.to_string(config.web_port)],
+      args: [vite, "preview", "--host", @loopback_host, "--port", Integer.to_string(config.web_port)],
       cwd: runtime["web_root"],
       log_path: Paths.web_log_path(Paths.root_dir(opts)),
       env: %{
@@ -278,6 +307,16 @@ defmodule Favn.Dev.RuntimeLaunch do
 
   defp runtime_env do
     %{"MIX_ENV" => "dev"}
+  end
+
+  defp distributed_erlang_args(service, opts) do
+    port = distribution_port(service, opts)
+
+    [
+      "--erl",
+      "-kernel inet_dist_use_interface #{@loopback_ip_flag} " <>
+        "-kernel inet_dist_listen_min #{port} -kernel inet_dist_listen_max #{port}"
+    ]
   end
 
   defp path_separator do

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -193,7 +193,12 @@ defmodule Favn.Dev.Stack do
 
   defp ensure_port_available(service, port)
        when is_atom(service) and is_integer(port) and port > 0 do
-    case :gen_tcp.listen(port, [:binary, {:active, false}, {:reuseaddr, false}]) do
+    case :gen_tcp.listen(port, [
+           :binary,
+           {:active, false},
+           {:reuseaddr, false},
+           {:ip, {127, 0, 0, 1}}
+         ]) do
       {:ok, socket} ->
         :ok = :gen_tcp.close(socket)
         :ok
@@ -344,7 +349,10 @@ defmodule Favn.Dev.Stack do
         :ok
 
       _ ->
-        NodeControl.ensure_local_node_started(secrets["rpc_cookie"], name: control_short)
+        NodeControl.ensure_local_node_started(secrets["rpc_cookie"],
+          name: control_short,
+          distribution_port: RuntimeLaunch.distribution_port(:control, opts)
+        )
     end
   end
 
@@ -461,8 +469,16 @@ defmodule Favn.Dev.Stack do
 
           service =
             case name do
-              "runner" -> Map.put(service, "node_name", node_names.runner_full)
-              "orchestrator" -> Map.put(service, "node_name", node_names.orchestrator_full)
+              "runner" ->
+                service
+                |> Map.put("node_name", node_names.runner_full)
+                |> Map.put("distribution_port", RuntimeLaunch.distribution_port(:runner, opts))
+
+              "orchestrator" ->
+                service
+                |> Map.put("node_name", node_names.orchestrator_full)
+                |> Map.put("distribution_port", RuntimeLaunch.distribution_port(:orchestrator, opts))
+
               _ -> service
             end
 
@@ -760,13 +776,21 @@ defmodule Favn.Dev.Stack do
     IO.puts("Favn local dev stack")
     IO.puts("storage: #{config.storage}")
     IO.puts("scheduler: #{if(config.scheduler_enabled, do: "enabled", else: "disabled")}")
+    IO.puts("local URLs:")
     IO.puts("web: pid=#{services["web"].pid} url=#{config.web_base_url}")
 
     IO.puts(
-      "orchestrator: pid=#{services["orchestrator"].pid} url=#{config.orchestrator_base_url}"
+      "orchestrator API: pid=#{services["orchestrator"].pid} url=#{config.orchestrator_base_url}"
     )
 
-    IO.puts("runner: pid=#{services["runner"].pid} node=#{node_names.runner_full}")
+    IO.puts("internal control plane:")
+    IO.puts("runner node: pid=#{services["runner"].pid} node=#{node_names.runner_full}")
+
+    IO.puts(
+      "orchestrator node: pid=#{services["orchestrator"].pid} node=#{node_names.orchestrator_full}"
+    )
+
+    IO.puts("control node: node=#{node_names.control_full}")
     IO.puts("logs: web=#{services["web"].log_path}")
     IO.puts("logs: orchestrator=#{services["orchestrator"].log_path}")
     IO.puts("logs: runner=#{services["runner"].log_path}")

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -92,7 +92,7 @@ defmodule Favn.Dev.Stack do
            :ok <- ensure_stack_not_running(opts),
            :ok <- ensure_install_ready(opts),
            config <- Config.resolve(opts),
-           :ok <- ensure_startup_prerequisites(config),
+           :ok <- ensure_startup_prerequisites(config, opts),
            {:ok, runtime} <- resolve_runtime(opts),
            {:ok, secrets} <- Secrets.resolve(config, opts),
            {:ok, node_names} <- build_node_names(secrets, opts) do
@@ -116,7 +116,8 @@ defmodule Favn.Dev.Stack do
            runtime: runtime,
            secrets: secrets,
            node_names: node_names,
-           services: services
+            distribution_ports: distribution_ports(opts),
+            services: services
          }}
       end
     end)
@@ -177,18 +178,27 @@ defmodule Favn.Dev.Stack do
     end
   end
 
-  defp ensure_startup_prerequisites(config) do
-    case ensure_ports_available(config) do
+  defp ensure_startup_prerequisites(config, opts) do
+    case ensure_ports_available(config, opts) do
       :ok -> ensure_storage_ready(config)
       {:error, _reason} = error -> error
     end
   end
 
-  defp ensure_ports_available(config) do
-    case ensure_port_available(:orchestrator, config.orchestrator_port) do
-      :ok -> ensure_port_available(:web, config.web_port)
-      {:error, _reason} = error -> error
-    end
+  defp ensure_ports_available(config, opts) do
+    [
+      {:orchestrator, config.orchestrator_port},
+      {:web, config.web_port},
+      {:runner_distribution, RuntimeLaunch.distribution_port(:runner, opts)},
+      {:orchestrator_distribution, RuntimeLaunch.distribution_port(:orchestrator, opts)},
+      {:control_distribution, RuntimeLaunch.distribution_port(:control, opts)}
+    ]
+    |> Enum.reduce_while(:ok, fn {service, port}, :ok ->
+      case ensure_port_available(service, port) do
+        :ok -> {:cont, :ok}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
   end
 
   defp ensure_port_available(service, port)
@@ -463,6 +473,11 @@ defmodule Favn.Dev.Stack do
         "orchestrator" => node_names.orchestrator_full,
         "control" => node_names.control_full
       },
+      "distribution_ports" => %{
+        "runner" => distribution_ports(opts).runner,
+        "orchestrator" => distribution_ports(opts).orchestrator,
+        "control" => distribution_ports(opts).control
+      },
       "services" =>
         Map.new(services, fn {name, info} ->
           service = %{"pid" => info.pid, "log_path" => info.log_path}
@@ -472,12 +487,12 @@ defmodule Favn.Dev.Stack do
               "runner" ->
                 service
                 |> Map.put("node_name", node_names.runner_full)
-                |> Map.put("distribution_port", RuntimeLaunch.distribution_port(:runner, opts))
+                |> Map.put("distribution_port", distribution_ports(opts).runner)
 
               "orchestrator" ->
                 service
                 |> Map.put("node_name", node_names.orchestrator_full)
-                |> Map.put("distribution_port", RuntimeLaunch.distribution_port(:orchestrator, opts))
+                |> Map.put("distribution_port", distribution_ports(opts).orchestrator)
 
               _ -> service
             end
@@ -772,7 +787,12 @@ defmodule Favn.Dev.Stack do
     end
   end
 
-  defp print_start_summary(%{config: config, node_names: node_names, services: services}) do
+  defp print_start_summary(%{
+         config: config,
+         node_names: node_names,
+         distribution_ports: distribution_ports,
+         services: services
+       }) do
     IO.puts("Favn local dev stack")
     IO.puts("storage: #{config.storage}")
     IO.puts("scheduler: #{if(config.scheduler_enabled, do: "enabled", else: "disabled")}")
@@ -790,7 +810,9 @@ defmodule Favn.Dev.Stack do
       "orchestrator node: pid=#{services["orchestrator"].pid} node=#{node_names.orchestrator_full}"
     )
 
-    IO.puts("control node: node=#{node_names.control_full}")
+    IO.puts(
+      "control node: node=#{node_names.control_full} distribution_port=#{distribution_ports.control}"
+    )
     IO.puts("logs: web=#{services["web"].log_path}")
     IO.puts("logs: orchestrator=#{services["orchestrator"].log_path}")
     IO.puts("logs: runner=#{services["runner"].log_path}")
@@ -798,6 +820,14 @@ defmodule Favn.Dev.Stack do
 
   defp with_lock(opts, fun) when is_function(fun, 0) do
     Lock.with_lock(opts, fun)
+  end
+
+  defp distribution_ports(opts) do
+    %{
+      runner: RuntimeLaunch.distribution_port(:runner, opts),
+      orchestrator: RuntimeLaunch.distribution_port(:orchestrator, opts),
+      control: RuntimeLaunch.distribution_port(:control, opts)
+    }
   end
 
   defp datetime(nil), do: nil

--- a/apps/favn_local/lib/favn/dev/status.ex
+++ b/apps/favn_local/lib/favn/dev/status.ex
@@ -26,6 +26,8 @@ defmodule Favn.Dev.Status do
           storage: config.storage,
           orchestrator_url: config.orchestrator_base_url,
           web_url: config.web_base_url,
+          user_urls: user_urls(config.orchestrator_base_url, config.web_base_url),
+          internal_control: default_internal_control(),
           services: default_service_states(),
           active_manifest_version_id: nil,
           last_failure: normalize_last_failure(State.read_last_failure(opts))
@@ -37,6 +39,8 @@ defmodule Favn.Dev.Status do
           storage: config.storage,
           orchestrator_url: config.orchestrator_base_url,
           web_url: config.web_base_url,
+          user_urls: user_urls(config.orchestrator_base_url, config.web_base_url),
+          internal_control: default_internal_control(),
           services: default_service_states(),
           active_manifest_version_id: nil,
           last_failure: normalize_last_failure(State.read_last_failure(opts)),
@@ -58,6 +62,12 @@ defmodule Favn.Dev.Status do
       storage: runtime["storage"] || config.storage,
       orchestrator_url: runtime["orchestrator_base_url"] || config.orchestrator_base_url,
       web_url: runtime["web_base_url"] || config.web_base_url,
+      user_urls:
+        user_urls(
+          runtime["orchestrator_base_url"] || config.orchestrator_base_url,
+          runtime["web_base_url"] || config.web_base_url
+        ),
+      internal_control: internal_control(runtime, services),
       services: services,
       active_manifest_version_id:
         runtime["active_manifest_version_id"] || manifest_from_cache(opts),
@@ -105,6 +115,31 @@ defmodule Favn.Dev.Status do
 
   defp normalize_last_failure({:ok, failure}), do: failure
   defp normalize_last_failure({:error, _reason}), do: nil
+
+  defp user_urls(orchestrator_url, web_url) do
+    %{web: web_url, orchestrator_api: orchestrator_url}
+  end
+
+  defp internal_control(runtime, services) do
+    %{
+      runner_node: internal_node(runtime, services, "runner"),
+      orchestrator_node: internal_node(runtime, services, "orchestrator"),
+      control_node: get_in(runtime, ["node_names", "control"])
+    }
+  end
+
+  defp internal_node(runtime, services, key) do
+    %{
+      node_name: get_in(runtime, ["services", key, "node_name"]) || get_in(runtime, ["node_names", key]),
+      distribution_port: get_in(runtime, ["services", key, "distribution_port"]),
+      status: Map.fetch!(services, String.to_existing_atom(key)).status,
+      pid: Map.fetch!(services, String.to_existing_atom(key)).pid
+    }
+  end
+
+  defp default_internal_control do
+    %{runner_node: nil, orchestrator_node: nil, control_node: nil}
+  end
 
   defp default_service_states do
     %{

--- a/apps/favn_local/lib/favn/dev/status.ex
+++ b/apps/favn_local/lib/favn/dev/status.ex
@@ -124,21 +124,30 @@ defmodule Favn.Dev.Status do
     %{
       runner_node: internal_node(runtime, services, "runner"),
       orchestrator_node: internal_node(runtime, services, "orchestrator"),
-      control_node: get_in(runtime, ["node_names", "control"])
+      control_node: %{
+        node_name: get_in(runtime, ["node_names", "control"]),
+        distribution_port: get_in(runtime, ["distribution_ports", "control"])
+      }
     }
   end
 
   defp internal_node(runtime, services, key) do
     %{
       node_name: get_in(runtime, ["services", key, "node_name"]) || get_in(runtime, ["node_names", key]),
-      distribution_port: get_in(runtime, ["services", key, "distribution_port"]),
+      distribution_port:
+        get_in(runtime, ["services", key, "distribution_port"]) ||
+          get_in(runtime, ["distribution_ports", key]),
       status: Map.fetch!(services, String.to_existing_atom(key)).status,
       pid: Map.fetch!(services, String.to_existing_atom(key)).pid
     }
   end
 
   defp default_internal_control do
-    %{runner_node: nil, orchestrator_node: nil, control_node: nil}
+    %{
+      runner_node: nil,
+      orchestrator_node: nil,
+      control_node: %{node_name: nil, distribution_port: nil}
+    }
   end
 
   defp default_service_states do

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -78,10 +78,11 @@ defmodule Favn.Dev.LifecycleTest do
     ]
 
     assert {:error, {:start_failed, "orchestrator", _reason}} =
-             Dev.dev(
-               root_dir: root_dir,
-               web_port: free_port(),
-               service_specs_override: failing_specs,
+              Dev.dev(
+                root_dir: root_dir,
+                orchestrator_port: free_port(),
+                web_port: free_port(),
+                service_specs_override: failing_specs,
                skip_install_check: true,
                skip_bootstrap: true,
                skip_readiness: true
@@ -206,10 +207,11 @@ defmodule Favn.Dev.LifecycleTest do
 
     try do
       assert {:error, {:port_conflict, :web, ^port}} =
-               Dev.dev(
-                 root_dir: root_dir,
-                 web_port: port,
-                 skip_runtime_compile: true,
+                Dev.dev(
+                  root_dir: root_dir,
+                  web_port: port,
+                  orchestrator_port: free_port(),
+                  skip_runtime_compile: true,
                  skip_install_check: true,
                  skip_bootstrap: true,
                  skip_readiness: true
@@ -221,10 +223,11 @@ defmodule Favn.Dev.LifecycleTest do
 
   test "dev/1 returns explicit postgres unavailable diagnostics", %{root_dir: root_dir} do
     assert {:error, {:postgres_unavailable, "127.0.0.1", 1, _reason}} =
-             Dev.dev(
-               root_dir: root_dir,
-               web_port: free_port(),
-               storage: :postgres,
+              Dev.dev(
+                root_dir: root_dir,
+                orchestrator_port: free_port(),
+                web_port: free_port(),
+                storage: :postgres,
                postgres: [
                  hostname: "127.0.0.1",
                  port: 1,
@@ -243,10 +246,11 @@ defmodule Favn.Dev.LifecycleTest do
 
   test "dev/1 returns explicit postgres misconfiguration diagnostics", %{root_dir: root_dir} do
     assert {:error, {:postgres_misconfigured, :hostname}} =
-             Dev.dev(
-               root_dir: root_dir,
-               web_port: free_port(),
-               storage: :postgres,
+              Dev.dev(
+                root_dir: root_dir,
+                orchestrator_port: free_port(),
+                web_port: free_port(),
+                storage: :postgres,
                postgres: [
                  hostname: "",
                  port: 5432,
@@ -267,6 +271,8 @@ defmodule Favn.Dev.LifecycleTest do
     result =
       Dev.dev(
         root_dir: root_dir,
+        orchestrator_port: free_port(),
+        web_port: free_port(),
         skip_install_check: true,
         skip_bootstrap: true,
         skip_readiness: true
@@ -284,6 +290,8 @@ defmodule Favn.Dev.LifecycleTest do
       Task.async(fn ->
         Dev.dev(
           root_dir: root_dir,
+          orchestrator_port: free_port(),
+          web_port: free_port(),
           skip_install_check: true,
           skip_bootstrap: true,
           skip_readiness: true,

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -8,6 +8,7 @@ defmodule Favn.Dev.LifecycleTest do
   alias Favn.Dev.NodeControl
   alias Favn.Dev.Paths
   alias Favn.Dev.Process, as: DevProcess
+  alias Favn.Dev.RuntimeLaunch
   alias Favn.Dev.State
 
   @run_real_stack_lifecycle? System.get_env("FAVN_RUN_DEV_LIFECYCLE") == "1" and
@@ -221,9 +222,34 @@ defmodule Favn.Dev.LifecycleTest do
     end
   end
 
+  test "dev/1 preflights deterministic distribution ports", %{root_dir: root_dir} do
+    root_dir = root_with_free_distribution_ports(root_dir)
+    port = RuntimeLaunch.distribution_port(:runner, root_dir: root_dir)
+
+    {:ok, socket} =
+      :gen_tcp.listen(port, [:binary, {:active, false}, {:reuseaddr, false}, {:ip, {127, 0, 0, 1}}])
+
+    try do
+      assert {:error, {:port_conflict, :runner_distribution, ^port}} =
+               Dev.dev(
+                 root_dir: root_dir,
+                 orchestrator_port: free_port(),
+                 web_port: free_port(),
+                 skip_runtime_compile: true,
+                 skip_install_check: true,
+                 skip_bootstrap: true,
+                 skip_readiness: true
+               )
+    after
+      :ok = :gen_tcp.close(socket)
+    end
+  end
+
   test "dev/1 returns explicit postgres unavailable diagnostics", %{root_dir: root_dir} do
+    root_dir = root_with_free_distribution_ports(root_dir)
+
     assert {:error, {:postgres_unavailable, "127.0.0.1", 1, _reason}} =
-              Dev.dev(
+             Dev.dev(
                 root_dir: root_dir,
                 orchestrator_port: free_port(),
                 web_port: free_port(),
@@ -245,8 +271,10 @@ defmodule Favn.Dev.LifecycleTest do
   end
 
   test "dev/1 returns explicit postgres misconfiguration diagnostics", %{root_dir: root_dir} do
+    root_dir = root_with_free_distribution_ports(root_dir)
+
     assert {:error, {:postgres_misconfigured, :hostname}} =
-              Dev.dev(
+             Dev.dev(
                 root_dir: root_dir,
                 orchestrator_port: free_port(),
                 web_port: free_port(),
@@ -413,5 +441,35 @@ defmodule Favn.Dev.LifecycleTest do
     {:ok, port} = :inet.port(socket)
     :ok = :gen_tcp.close(socket)
     port
+  end
+
+  defp root_with_free_distribution_ports(base_root, attempt \\ 0)
+
+  defp root_with_free_distribution_ports(_base_root, 50), do: raise("could not find free distribution ports")
+
+  defp root_with_free_distribution_ports(base_root, attempt) do
+    root_dir = Path.join(base_root, "dist_#{attempt}")
+    ports = [
+      RuntimeLaunch.distribution_port(:runner, root_dir: root_dir),
+      RuntimeLaunch.distribution_port(:orchestrator, root_dir: root_dir),
+      RuntimeLaunch.distribution_port(:control, root_dir: root_dir)
+    ]
+
+    if Enum.all?(ports, &port_free?/1) do
+      root_dir
+    else
+      root_with_free_distribution_ports(base_root, attempt + 1)
+    end
+  end
+
+  defp port_free?(port) do
+    case :gen_tcp.listen(port, [:binary, {:active, false}, {:reuseaddr, false}, {:ip, {127, 0, 0, 1}}]) do
+      {:ok, socket} ->
+        :ok = :gen_tcp.close(socket)
+        true
+
+      {:error, _reason} ->
+        false
+    end
   end
 end

--- a/apps/favn_local/test/dev_runtime_launch_test.exs
+++ b/apps/favn_local/test/dev_runtime_launch_test.exs
@@ -84,6 +84,8 @@ defmodule Favn.Dev.RuntimeLaunchTest do
     assert orchestrator_erl =~ "inet_dist_use_interface {127,0,0,1}"
     assert orchestrator_erl =~ "inet_dist_listen_min #{orchestrator_port}"
     assert orchestrator_erl =~ "inet_dist_listen_max #{orchestrator_port}"
+    assert runner.env["ERL_EPMD_ADDRESS"] == "127.0.0.1"
+    assert orchestrator.env["ERL_EPMD_ADDRESS"] == "127.0.0.1"
     assert orchestrator.env["FAVN_ORCHESTRATOR_API_BIND_IP"] == "127.0.0.1"
     assert code =~ "bind_ip: api_bind_ip"
     assert web.args == [hd(web.args), "preview", "--host", "127.0.0.1", "--port", "4173"]

--- a/apps/favn_local/test/dev_runtime_launch_test.exs
+++ b/apps/favn_local/test/dev_runtime_launch_test.exs
@@ -45,6 +45,50 @@ defmodule Favn.Dev.RuntimeLaunchTest do
     assert "preview" in web.args
   end
 
+  test "runtime specs bind local HTTP and distributed Erlang to loopback" do
+    root_dir = "/tmp/favn_loopback_launch"
+
+    runtime = %{
+      "runner_root" => "/tmp/favn_runtime",
+      "orchestrator_root" => "/tmp/favn_runtime",
+      "web_root" => "/tmp/favn_runtime/web/favn_web"
+    }
+
+    config = Config.resolve(orchestrator_port: 4101, web_port: 4173)
+
+    node_names = %{
+      runner_short: "favn_runner_test",
+      runner_full: "favn_runner_test@host",
+      orchestrator_short: "favn_orchestrator_test"
+    }
+
+    secrets = %{
+      "rpc_cookie" => "cookie",
+      "service_token" => "token",
+      "web_session_secret" => "secret"
+    }
+
+    opts = [root_dir: root_dir]
+    runner = RuntimeLaunch.runner_spec(runtime, opts, node_names, secrets)
+    orchestrator = RuntimeLaunch.orchestrator_spec(runtime, config, opts, node_names, secrets)
+    web = RuntimeLaunch.web_spec(runtime, config, opts, secrets)
+    runner_port = RuntimeLaunch.distribution_port(:runner, opts)
+    orchestrator_port = RuntimeLaunch.distribution_port(:orchestrator, opts)
+    runner_erl = erl_flag!(runner)
+    orchestrator_erl = erl_flag!(orchestrator)
+    code = eval_code!(orchestrator)
+
+    assert runner_erl =~ "inet_dist_use_interface {127,0,0,1}"
+    assert runner_erl =~ "inet_dist_listen_min #{runner_port}"
+    assert runner_erl =~ "inet_dist_listen_max #{runner_port}"
+    assert orchestrator_erl =~ "inet_dist_use_interface {127,0,0,1}"
+    assert orchestrator_erl =~ "inet_dist_listen_min #{orchestrator_port}"
+    assert orchestrator_erl =~ "inet_dist_listen_max #{orchestrator_port}"
+    assert orchestrator.env["FAVN_ORCHESTRATOR_API_BIND_IP"] == "127.0.0.1"
+    assert code =~ "bind_ip: api_bind_ip"
+    assert web.args == [hd(web.args), "preview", "--host", "127.0.0.1", "--port", "4173"]
+  end
+
   test "orchestrator spec carries bootstrap credentials from consumer dotenv and shell env" do
     root_dir = Path.join(System.tmp_dir!(), "favn_orchestrator_env_#{System.unique_integer([:positive])}")
     previous_env = snapshot_system_env(bootstrap_env_keys())
@@ -303,6 +347,15 @@ defmodule Favn.Dev.RuntimeLaunchTest do
       ["--eval", code] -> code
       _other -> nil
     end) || flunk("expected orchestrator args to include --eval code")
+  end
+
+  defp erl_flag!(%{args: args}) do
+    args
+    |> Enum.chunk_every(2, 1, :discard)
+    |> Enum.find_value(fn
+      ["--erl", flags] -> flags
+      _other -> nil
+    end) || flunk("expected args to include --erl flags")
   end
 
   defp before?(text, earlier, later) do

--- a/apps/favn_local/test/dev_status_test.exs
+++ b/apps/favn_local/test/dev_status_test.exs
@@ -30,10 +30,25 @@ defmodule Favn.Dev.StatusTest do
     runtime = %{
       "storage" => "memory",
       "active_manifest_version_id" => "mv_test",
+      "orchestrator_base_url" => "http://127.0.0.1:4101",
+      "web_base_url" => "http://127.0.0.1:4173",
+      "node_names" => %{
+        "runner" => "favn_runner_test@localhost",
+        "orchestrator" => "favn_orchestrator_test@localhost",
+        "control" => "favn_local_ctl_test@localhost"
+      },
       "services" => %{
         "web" => %{"pid" => pid},
-        "orchestrator" => %{"pid" => pid},
-        "runner" => %{"pid" => pid}
+        "orchestrator" => %{
+          "pid" => pid,
+          "node_name" => "favn_orchestrator_test@localhost",
+          "distribution_port" => 45_002
+        },
+        "runner" => %{
+          "pid" => pid,
+          "node_name" => "favn_runner_test@localhost",
+          "distribution_port" => 45_001
+        }
       }
     }
 
@@ -46,6 +61,13 @@ defmodule Favn.Dev.StatusTest do
     assert status.services.web.status == :running
     assert status.services.orchestrator.status == :running
     assert status.services.runner.status == :running
+    assert status.user_urls.web == "http://127.0.0.1:4173"
+    assert status.user_urls.orchestrator_api == "http://127.0.0.1:4101"
+    assert status.internal_control.runner_node.node_name == "favn_runner_test@localhost"
+    assert status.internal_control.runner_node.distribution_port == 45_001
+    assert status.internal_control.orchestrator_node.node_name == "favn_orchestrator_test@localhost"
+    assert status.internal_control.orchestrator_node.distribution_port == 45_002
+    assert status.internal_control.control_node == "favn_local_ctl_test@localhost"
   end
 
   test "inspect_stack/1 reports stale when runtime exists but services are dead", %{

--- a/apps/favn_local/test/dev_status_test.exs
+++ b/apps/favn_local/test/dev_status_test.exs
@@ -37,6 +37,11 @@ defmodule Favn.Dev.StatusTest do
         "orchestrator" => "favn_orchestrator_test@localhost",
         "control" => "favn_local_ctl_test@localhost"
       },
+      "distribution_ports" => %{
+        "runner" => 45_001,
+        "orchestrator" => 45_002,
+        "control" => 45_003
+      },
       "services" => %{
         "web" => %{"pid" => pid},
         "orchestrator" => %{
@@ -67,7 +72,8 @@ defmodule Favn.Dev.StatusTest do
     assert status.internal_control.runner_node.distribution_port == 45_001
     assert status.internal_control.orchestrator_node.node_name == "favn_orchestrator_test@localhost"
     assert status.internal_control.orchestrator_node.distribution_port == 45_002
-    assert status.internal_control.control_node == "favn_local_ctl_test@localhost"
+    assert status.internal_control.control_node.node_name == "favn_local_ctl_test@localhost"
+    assert status.internal_control.control_node.distribution_port == 45_003
   end
 
   test "inspect_stack/1 reports stale when runtime exists but services are dead", %{

--- a/apps/favn_local/test/integration/dev_storage_verification_test.exs
+++ b/apps/favn_local/test/integration/dev_storage_verification_test.exs
@@ -43,6 +43,7 @@ defmodule Favn.Dev.StorageVerificationTest do
   test "sqlite verification across install/dev/status/reload/stop/logs/reset/build.single", %{
     root_dir: root_dir
   } do
+    orchestrator_port = free_port()
     web_port = free_port()
 
     assert {:ok, :installed} =
@@ -70,6 +71,7 @@ defmodule Favn.Dev.StorageVerificationTest do
       Task.async(fn ->
         Dev.dev(
           root_dir: root_dir,
+          orchestrator_port: orchestrator_port,
           web_port: web_port,
           storage: :sqlite,
           sqlite_path: ".favn/data/storage_verification.sqlite3",
@@ -126,12 +128,14 @@ defmodule Favn.Dev.StorageVerificationTest do
         pool_size: String.to_integer(System.get_env("FAVN_DEV_POSTGRES_POOL_SIZE", "10"))
       ]
 
+      orchestrator_port = free_port()
       web_port = free_port()
 
       task =
         Task.async(fn ->
           Dev.dev(
             root_dir: root_dir,
+            orchestrator_port: orchestrator_port,
             web_port: web_port,
             storage: :postgres,
             postgres: postgres,

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/config.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/config.ex
@@ -6,14 +6,55 @@ defmodule FavnOrchestrator.API.Config do
     api_opts = Application.get_env(:favn_orchestrator, :api_server, [])
 
     if Keyword.get(api_opts, :enabled, false) do
-      tokens = Application.get_env(:favn_orchestrator, :api_service_tokens, [])
+      with :ok <- validate_bind_ip(api_opts) do
+        tokens = Application.get_env(:favn_orchestrator, :api_service_tokens, [])
 
-      case Enum.filter(tokens, &(is_binary(&1) and &1 != "")) do
-        [] -> {:error, {:invalid_api_config, :missing_service_tokens}}
-        _ -> :ok
+        case Enum.filter(tokens, &(is_binary(&1) and &1 != "")) do
+          [] -> {:error, {:invalid_api_config, :missing_service_tokens}}
+          _ -> :ok
+        end
       end
     else
       :ok
     end
   end
+
+  @doc false
+  @spec bind_ip(keyword()) :: {:ok, :inet.ip4_address() | nil} | {:error, term()}
+  def bind_ip(api_opts) when is_list(api_opts) do
+    api_opts
+    |> Keyword.get(:bind_ip, Keyword.get(api_opts, :host))
+    |> normalize_bind_ip()
+  end
+
+  defp validate_bind_ip(api_opts) do
+    case bind_ip(api_opts) do
+      {:ok, _bind_ip} -> :ok
+      {:error, reason} -> {:error, {:invalid_api_config, reason}}
+    end
+  end
+
+  defp normalize_bind_ip(nil), do: {:ok, nil}
+
+  defp normalize_bind_ip({a, b, c, d} = ip)
+       when a in 0..255 and b in 0..255 and c in 0..255 and d in 0..255,
+       do: {:ok, ip}
+
+  defp normalize_bind_ip(host) when is_binary(host) do
+    parsed =
+      host
+      |> String.split(".", parts: 4)
+      |> Enum.map(&Integer.parse/1)
+
+    case parsed do
+      [{a, ""}, {b, ""}, {c, ""}, {d, ""}]
+      when a in 0..255 and b in 0..255 and c in 0..255 and d in 0..255 ->
+        {:ok, {a, b, c, d}}
+
+      _other ->
+        {:error, {:invalid_bind_ip, host}}
+    end
+  end
+
+  defp normalize_bind_ip(other), do: {:error, {:invalid_bind_ip, other}}
 end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/application.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/application.ex
@@ -54,12 +54,35 @@ defmodule FavnOrchestrator.Application do
     if Keyword.get(api_opts, :enabled, false) do
       [
         {Plug.Cowboy,
-         scheme: :http,
-         plug: FavnOrchestrator.API.Router,
-         options: [port: Keyword.get(api_opts, :port, 4101)]}
+         scheme: :http, plug: FavnOrchestrator.API.Router, options: api_server_options(api_opts)}
       ]
     else
       []
     end
   end
+
+  defp api_server_options(api_opts) do
+    api_opts
+    |> Keyword.get(:bind_ip, Keyword.get(api_opts, :host))
+    |> normalize_bind_ip()
+    |> case do
+      nil -> [port: Keyword.get(api_opts, :port, 4101)]
+      bind_ip -> [port: Keyword.get(api_opts, :port, 4101), ip: bind_ip]
+    end
+  end
+
+  defp normalize_bind_ip(nil), do: nil
+  defp normalize_bind_ip(ip) when is_tuple(ip) and tuple_size(ip) == 4, do: ip
+
+  defp normalize_bind_ip(host) when is_binary(host) do
+    host
+    |> String.split(".", parts: 4)
+    |> Enum.map(&Integer.parse/1)
+    |> case do
+      [{a, ""}, {b, ""}, {c, ""}, {d, ""}] -> {a, b, c, d}
+      _other -> nil
+    end
+  end
+
+  defp normalize_bind_ip(_other), do: nil
 end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/application.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/application.ex
@@ -62,27 +62,16 @@ defmodule FavnOrchestrator.Application do
   end
 
   defp api_server_options(api_opts) do
-    api_opts
-    |> Keyword.get(:bind_ip, Keyword.get(api_opts, :host))
-    |> normalize_bind_ip()
+    case APIConfig.bind_ip(api_opts) do
+      {:ok, bind_ip} ->
+        bind_ip
+
+      {:error, reason} ->
+        raise ArgumentError, "invalid orchestrator API bind config: #{inspect(reason)}"
+    end
     |> case do
       nil -> [port: Keyword.get(api_opts, :port, 4101)]
       bind_ip -> [port: Keyword.get(api_opts, :port, 4101), ip: bind_ip]
     end
   end
-
-  defp normalize_bind_ip(nil), do: nil
-  defp normalize_bind_ip(ip) when is_tuple(ip) and tuple_size(ip) == 4, do: ip
-
-  defp normalize_bind_ip(host) when is_binary(host) do
-    host
-    |> String.split(".", parts: 4)
-    |> Enum.map(&Integer.parse/1)
-    |> case do
-      [{a, ""}, {b, ""}, {c, ""}, {d, ""}] -> {a, b, c, d}
-      _other -> nil
-    end
-  end
-
-  defp normalize_bind_ip(_other), do: nil
 end

--- a/apps/favn_orchestrator/test/api/config_test.exs
+++ b/apps/favn_orchestrator/test/api/config_test.exs
@@ -33,6 +33,31 @@ defmodule FavnOrchestrator.API.ConfigTest do
     assert :ok = Config.validate()
   end
 
+  test "validate/0 rejects invalid bind_ip when API server enabled" do
+    previous_server = Application.get_env(:favn_orchestrator, :api_server)
+    previous_tokens = Application.get_env(:favn_orchestrator, :api_service_tokens)
+
+    Application.put_env(:favn_orchestrator, :api_server,
+      enabled: true,
+      bind_ip: "not-an-ip"
+    )
+
+    Application.put_env(:favn_orchestrator, :api_service_tokens, ["token"])
+
+    on_exit(fn ->
+      restore_env(:favn_orchestrator, :api_server, previous_server)
+      restore_env(:favn_orchestrator, :api_service_tokens, previous_tokens)
+    end)
+
+    assert {:error, {:invalid_api_config, {:invalid_bind_ip, "not-an-ip"}}} = Config.validate()
+  end
+
+  test "bind_ip/1 accepts IPv4 tuples and strings" do
+    assert {:ok, {127, 0, 0, 1}} = Config.bind_ip(bind_ip: {127, 0, 0, 1})
+    assert {:ok, {127, 0, 0, 1}} = Config.bind_ip(bind_ip: "127.0.0.1")
+    assert {:error, {:invalid_bind_ip, "127.0.0.999"}} = Config.bind_ip(bind_ip: "127.0.0.999")
+  end
+
   defp restore_env(app, key, nil), do: Application.delete_env(app, key)
   defp restore_env(app, key, value), do: Application.put_env(app, key, value)
 end


### PR DESCRIPTION
## Summary
- Bind local dev orchestrator HTTP explicitly to 127.0.0.1 and keep web preview loopback-bound.
- Constrain runner, orchestrator, and control distributed Erlang listeners to loopback with deterministic per-stack ports instead of random external listeners.
- Set ERL_EPMD_ADDRESS=127.0.0.1 for local dev control, runner, and orchestrator startup so Favn-started EPMD is loopback-scoped.
- Update status output to separate user-facing local URLs from internal control-plane node details, including all distribution ports.

## Remaining Internal Listener Behavior
- Distributed Erlang remains the local runner/orchestrator/control path for this PR.
- EPMD is still part of that local distributed Erlang path, but Favn now sets ERL_EPMD_ADDRESS=127.0.0.1 before starting its local control node and passes the same env to runner/orchestrator processes.
- Runner, orchestrator, and control distribution ports are deterministic, loopback-bound, and preflighted for explicit conflict diagnostics.

## Verification
- mix format
- mix test apps/favn_local/test/dev_runtime_launch_test.exs
- mix test apps/favn_local/test/dev_status_test.exs
- mix test apps/favn_local/test/dev_lifecycle_test.exs
- mix test apps/favn_orchestrator/test/api/config_test.exs
- mix test
- mix compile --warnings-as-errors
- mix credo --strict
- mix dialyzer
- mix xref graph --format stats --label compile-connected

Closes #160