### PR TITLE
Validate decoded backfill read models

### DIFF
--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -716,29 +716,26 @@ defmodule Favn.Storage.Adapter.Postgres do
          updated_at
        ]) do
     with {:ok, pipeline_module} <- existing_atom(pipeline_module),
-         {:ok, window_kind} <- existing_atom(window_kind),
-         {:ok, status} <- existing_atom(status),
          {:ok, errors} <- decode_payload(errors_payload),
          {:ok, metadata} <- decode_payload(metadata_payload) do
-      {:ok,
-       %CoverageBaseline{
-         baseline_id: baseline_id,
-         pipeline_module: pipeline_module,
-         source_key: source_key,
-         segment_key_hash: segment_key_hash,
-         segment_key_redacted: segment_key_redacted,
-         window_kind: window_kind,
-         timezone: timezone,
-         coverage_start_at: coverage_start_at,
-         coverage_until: coverage_until,
-         created_by_run_id: created_by_run_id,
-         manifest_version_id: manifest_version_id,
-         status: status,
-         errors: errors,
-         metadata: metadata,
-         created_at: created_at,
-         updated_at: updated_at
-       }}
+      CoverageBaseline.new(%{
+        baseline_id: baseline_id,
+        pipeline_module: pipeline_module,
+        source_key: source_key,
+        segment_key_hash: segment_key_hash,
+        segment_key_redacted: segment_key_redacted,
+        window_kind: window_kind,
+        timezone: timezone,
+        coverage_start_at: coverage_start_at,
+        coverage_until: coverage_until,
+        created_by_run_id: created_by_run_id,
+        manifest_version_id: manifest_version_id,
+        status: status,
+        errors: errors,
+        metadata: metadata,
+        created_at: created_at,
+        updated_at: updated_at
+      })
     end
   end
 
@@ -766,35 +763,32 @@ defmodule Favn.Storage.Adapter.Postgres do
          updated_at
        ]) do
     with {:ok, pipeline_module} <- existing_atom(pipeline_module),
-         {:ok, window_kind} <- existing_atom(window_kind),
-         {:ok, status} <- existing_atom(status),
          {:ok, last_error} <- decode_payload(last_error_payload),
          {:ok, errors} <- decode_payload(errors_payload),
          {:ok, metadata} <- decode_payload(metadata_payload) do
-      {:ok,
-       %BackfillWindow{
-         backfill_run_id: backfill_run_id,
-         child_run_id: child_run_id,
-         pipeline_module: pipeline_module,
-         manifest_version_id: manifest_version_id,
-         coverage_baseline_id: coverage_baseline_id,
-         window_kind: window_kind,
-         window_start_at: window_start_at,
-         window_end_at: window_end_at,
-         timezone: timezone,
-         window_key: window_key,
-         status: status,
-         attempt_count: attempt_count,
-         latest_attempt_run_id: latest_attempt_run_id,
-         last_success_run_id: last_success_run_id,
-         last_error: last_error,
-         errors: errors,
-         metadata: metadata,
-         started_at: started_at,
-         finished_at: finished_at,
-         created_at: created_at,
-         updated_at: updated_at
-       }}
+      BackfillWindow.new(%{
+        backfill_run_id: backfill_run_id,
+        child_run_id: child_run_id,
+        pipeline_module: pipeline_module,
+        manifest_version_id: manifest_version_id,
+        coverage_baseline_id: coverage_baseline_id,
+        window_kind: window_kind,
+        window_start_at: window_start_at,
+        window_end_at: window_end_at,
+        timezone: timezone,
+        window_key: window_key,
+        status: status,
+        attempt_count: attempt_count,
+        latest_attempt_run_id: latest_attempt_run_id,
+        last_success_run_id: last_success_run_id,
+        last_error: last_error,
+        errors: errors,
+        metadata: metadata,
+        started_at: started_at,
+        finished_at: finished_at,
+        created_at: created_at,
+        updated_at: updated_at
+      })
     end
   end
 
@@ -821,32 +815,29 @@ defmodule Favn.Storage.Adapter.Postgres do
     with {:ok, asset_ref_module} <- existing_atom(asset_ref_module),
          {:ok, asset_ref_name} <- existing_atom(asset_ref_name),
          {:ok, pipeline_module} <- existing_atom(pipeline_module),
-         {:ok, window_kind} <- existing_atom(window_kind),
-         {:ok, status} <- existing_atom(status),
          {:ok, latest_error} <- decode_payload(latest_error_payload),
          {:ok, errors} <- decode_payload(errors_payload),
          {:ok, metadata} <- decode_payload(metadata_payload) do
-      {:ok,
-       %AssetWindowState{
-         asset_ref_module: asset_ref_module,
-         asset_ref_name: asset_ref_name,
-         pipeline_module: pipeline_module,
-         manifest_version_id: manifest_version_id,
-         window_kind: window_kind,
-         window_start_at: window_start_at,
-         window_end_at: window_end_at,
-         timezone: timezone,
-         window_key: window_key,
-         status: status,
-         latest_run_id: latest_run_id,
-         latest_parent_run_id: latest_parent_run_id,
-         latest_success_run_id: latest_success_run_id,
-         latest_error: latest_error,
-         rows_written: rows_written,
-         errors: errors,
-         metadata: metadata,
-         updated_at: updated_at
-       }}
+      AssetWindowState.new(%{
+        asset_ref_module: asset_ref_module,
+        asset_ref_name: asset_ref_name,
+        pipeline_module: pipeline_module,
+        manifest_version_id: manifest_version_id,
+        window_kind: window_kind,
+        window_start_at: window_start_at,
+        window_end_at: window_end_at,
+        timezone: timezone,
+        window_key: window_key,
+        status: status,
+        latest_run_id: latest_run_id,
+        latest_parent_run_id: latest_parent_run_id,
+        latest_success_run_id: latest_success_run_id,
+        latest_error: latest_error,
+        rows_written: rows_written,
+        errors: errors,
+        metadata: metadata,
+        updated_at: updated_at
+      })
     end
   end
 

--- a/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
+++ b/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
@@ -315,6 +315,247 @@ defmodule FavnStoragePostgres.Integration.AdapterLiveTest do
     end
   end
 
+  test "decodes legacy backfill window kind aliases through constructors", context do
+    case context[:opts] do
+      nil ->
+        :ok
+
+      opts ->
+        unique = System.unique_integer([:positive])
+        now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+        start_at = DateTime.add(now, -86_400, :second)
+        baseline = sample_coverage_baseline("baseline_pg_legacy_#{unique}", :ok, now, start_at)
+
+        window =
+          sample_backfill_window("window_pg_legacy_#{unique}", :running, now, start_at, baseline)
+
+        state =
+          sample_asset_window_state(:orders, "asset_pg_legacy_#{unique}", :running, now, start_at)
+
+        assert :ok = Adapter.put_coverage_baseline(baseline, opts)
+        assert :ok = Adapter.put_backfill_window(window, opts)
+        assert :ok = Adapter.put_asset_window_state(state, opts)
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_pipeline_coverage_baselines SET window_kind = $1 WHERE baseline_id = $2",
+                   [
+                     "daily",
+                     baseline.baseline_id
+                   ]
+                 )
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_backfill_windows SET window_kind = $1 WHERE window_key = $2",
+                   [
+                     "daily",
+                     window.window_key
+                   ]
+                 )
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_asset_window_states SET window_kind = $1 WHERE window_key = $2",
+                   [
+                     "daily",
+                     state.window_key
+                   ]
+                 )
+
+        assert {:ok, ^baseline} = Adapter.get_coverage_baseline(baseline.baseline_id, opts)
+
+        assert {:ok, ^window} =
+                 Adapter.get_backfill_window(
+                   window.backfill_run_id,
+                   window.pipeline_module,
+                   window.window_key,
+                   opts
+                 )
+
+        assert {:ok, ^state} =
+                 Adapter.get_asset_window_state(
+                   state.asset_ref_module,
+                   state.asset_ref_name,
+                   state.window_key,
+                   opts
+                 )
+    end
+  end
+
+  test "rejects invalid persisted backfill read-model statuses", context do
+    case context[:opts] do
+      nil ->
+        :ok
+
+      opts ->
+        unique = System.unique_integer([:positive])
+        now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+        start_at = DateTime.add(now, -86_400, :second)
+
+        baseline =
+          sample_coverage_baseline("baseline_pg_bad_status_#{unique}", :ok, now, start_at)
+
+        window =
+          sample_backfill_window(
+            "window_pg_bad_status_#{unique}",
+            :running,
+            now,
+            start_at,
+            baseline
+          )
+
+        state =
+          sample_asset_window_state(
+            :orders,
+            "asset_pg_bad_status_#{unique}",
+            :running,
+            now,
+            start_at
+          )
+
+        assert :ok = Adapter.put_coverage_baseline(baseline, opts)
+        assert :ok = Adapter.put_backfill_window(window, opts)
+        assert :ok = Adapter.put_asset_window_state(state, opts)
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_pipeline_coverage_baselines SET status = $1 WHERE baseline_id = $2",
+                   [
+                     "bogus",
+                     baseline.baseline_id
+                   ]
+                 )
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_backfill_windows SET status = $1 WHERE window_key = $2",
+                   [
+                     "bogus",
+                     window.window_key
+                   ]
+                 )
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_asset_window_states SET status = $1 WHERE window_key = $2",
+                   [
+                     "bogus",
+                     state.window_key
+                   ]
+                 )
+
+        assert {:error, {:invalid_status, "bogus"}} =
+                 Adapter.get_coverage_baseline(baseline.baseline_id, opts)
+
+        assert {:error, {:invalid_status, "bogus"}} =
+                 Adapter.get_backfill_window(
+                   window.backfill_run_id,
+                   window.pipeline_module,
+                   window.window_key,
+                   opts
+                 )
+
+        assert {:error, {:invalid_status, "bogus"}} =
+                 Adapter.get_asset_window_state(
+                   state.asset_ref_module,
+                   state.asset_ref_name,
+                   state.window_key,
+                   opts
+                 )
+    end
+  end
+
+  test "rejects invalid persisted backfill read-model window kinds", context do
+    case context[:opts] do
+      nil ->
+        :ok
+
+      opts ->
+        unique = System.unique_integer([:positive])
+        now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+        start_at = DateTime.add(now, -86_400, :second)
+        baseline = sample_coverage_baseline("baseline_pg_bad_kind_#{unique}", :ok, now, start_at)
+
+        window =
+          sample_backfill_window(
+            "window_pg_bad_kind_#{unique}",
+            :running,
+            now,
+            start_at,
+            baseline
+          )
+
+        state =
+          sample_asset_window_state(
+            :orders,
+            "asset_pg_bad_kind_#{unique}",
+            :running,
+            now,
+            start_at
+          )
+
+        assert :ok = Adapter.put_coverage_baseline(baseline, opts)
+        assert :ok = Adapter.put_backfill_window(window, opts)
+        assert :ok = Adapter.put_asset_window_state(state, opts)
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_pipeline_coverage_baselines SET window_kind = $1 WHERE baseline_id = $2",
+                   [
+                     "fortnight",
+                     baseline.baseline_id
+                   ]
+                 )
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_backfill_windows SET window_kind = $1 WHERE window_key = $2",
+                   [
+                     "fortnight",
+                     window.window_key
+                   ]
+                 )
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_asset_window_states SET window_kind = $1 WHERE window_key = $2",
+                   [
+                     "fortnight",
+                     state.window_key
+                   ]
+                 )
+
+        assert {:error, {:invalid_window_kind, "fortnight"}} =
+                 Adapter.get_coverage_baseline(baseline.baseline_id, opts)
+
+        assert {:error, {:invalid_window_kind, "fortnight"}} =
+                 Adapter.get_backfill_window(
+                   window.backfill_run_id,
+                   window.pipeline_module,
+                   window.window_key,
+                   opts
+                 )
+
+        assert {:error, {:invalid_window_kind, "fortnight"}} =
+                 Adapter.get_asset_window_state(
+                   state.asset_ref_module,
+                   state.asset_ref_name,
+                   state.window_key,
+                   opts
+                 )
+    end
+  end
+
   test "manual schema readiness can recover after missing migration row", context do
     case context[:opts] do
       nil ->
@@ -329,6 +570,82 @@ defmodule FavnStoragePostgres.Integration.AdapterLiveTest do
         :ok = Migrations.migrate!(Repo)
         assert true == Migrations.schema_ready?(Repo)
     end
+  end
+
+  defp sample_coverage_baseline(baseline_id, status, now, start_at) do
+    {:ok, baseline} =
+      CoverageBaseline.new(%{
+        baseline_id: baseline_id,
+        pipeline_module: MyApp.Pipeline,
+        source_key: "orders",
+        segment_key_hash: "sha256:#{baseline_id}",
+        segment_key_redacted: "tenant-***",
+        window_kind: :daily,
+        timezone: "Etc/UTC",
+        coverage_start_at: start_at,
+        coverage_until: now,
+        created_by_run_id: "run_#{baseline_id}",
+        manifest_version_id: "mv_#{baseline_id}",
+        status: status,
+        errors: [],
+        metadata: %{row_count: 10},
+        created_at: now,
+        updated_at: now
+      })
+
+    baseline
+  end
+
+  defp sample_backfill_window(window_key, status, now, start_at, baseline) do
+    {:ok, window} =
+      BackfillWindow.new(%{
+        backfill_run_id: "backfill_#{window_key}",
+        child_run_id: "child_#{window_key}",
+        pipeline_module: MyApp.Pipeline,
+        manifest_version_id: baseline.manifest_version_id,
+        coverage_baseline_id: baseline.baseline_id,
+        window_kind: :daily,
+        window_start_at: start_at,
+        window_end_at: now,
+        timezone: "Etc/UTC",
+        window_key: window_key,
+        status: status,
+        attempt_count: 1,
+        latest_attempt_run_id: "child_#{window_key}",
+        last_error: %{reason: :retryable},
+        errors: [%{message: "retry"}],
+        metadata: %{partition: "2026-04-27"},
+        started_at: start_at,
+        created_at: start_at,
+        updated_at: now
+      })
+
+    window
+  end
+
+  defp sample_asset_window_state(asset_name, window_key, status, now, start_at) do
+    {:ok, state} =
+      AssetWindowState.new(%{
+        asset_ref_module: MyApp.Asset,
+        asset_ref_name: asset_name,
+        pipeline_module: MyApp.Pipeline,
+        manifest_version_id: "mv_#{window_key}",
+        window_kind: :daily,
+        window_start_at: start_at,
+        window_end_at: now,
+        timezone: "Etc/UTC",
+        window_key: window_key,
+        status: status,
+        latest_run_id: "asset_#{window_key}",
+        latest_parent_run_id: "backfill_#{window_key}",
+        latest_success_run_id: if(status == :ok, do: "asset_#{window_key}", else: nil),
+        rows_written: 10,
+        errors: [],
+        metadata: %{relation: "gold.sales"},
+        updated_at: now
+      })
+
+    state
   end
 
   defp repo_config_from_url(url) do

--- a/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
+++ b/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
@@ -556,6 +556,56 @@ defmodule FavnStoragePostgres.Integration.AdapterLiveTest do
     end
   end
 
+  test "rejects unknown persisted backfill identity atoms", context do
+    case context[:opts] do
+      nil ->
+        :ok
+
+      opts ->
+        unique = System.unique_integer([:positive])
+        now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+        start_at = DateTime.add(now, -86_400, :second)
+
+        baseline =
+          sample_coverage_baseline("baseline_pg_unknown_atom_#{unique}", :ok, now, start_at)
+
+        state =
+          sample_asset_window_state(
+            :orders,
+            "asset_pg_unknown_atom_#{unique}",
+            :running,
+            now,
+            start_at
+          )
+
+        unknown_pipeline = "Elixir.FavnStoragePostgres.UnknownPipeline#{unique}"
+        unknown_asset_name = "unknown_asset_name_#{unique}"
+
+        assert :ok = Adapter.put_coverage_baseline(baseline, opts)
+        assert :ok = Adapter.put_asset_window_state(state, opts)
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_pipeline_coverage_baselines SET pipeline_module = $1 WHERE baseline_id = $2",
+                   [unknown_pipeline, baseline.baseline_id]
+                 )
+
+        assert {:error, {:unknown_atom, ^unknown_pipeline}} =
+                 Adapter.get_coverage_baseline(baseline.baseline_id, opts)
+
+        assert {:ok, _} =
+                 SQL.query(
+                   Repo,
+                   "UPDATE favn_asset_window_states SET asset_ref_name = $1 WHERE window_key = $2",
+                   [unknown_asset_name, state.window_key]
+                 )
+
+        assert {:error, {:unknown_atom, ^unknown_asset_name}} =
+                 Adapter.list_asset_window_states([], opts)
+    end
+  end
+
   test "manual schema readiness can recover after missing migration row", context do
     case context[:opts] do
       nil ->

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -630,27 +630,27 @@ defmodule Favn.Storage.Adapter.SQLite do
          created_at,
          updated_at
        ]) do
-    with {:ok, errors} <- decode_payload(errors_blob),
+    with {:ok, pipeline_module} <- existing_atom(pipeline_module),
+         {:ok, errors} <- decode_payload(errors_blob),
          {:ok, metadata} <- decode_payload(metadata_blob) do
-      {:ok,
-       %CoverageBaseline{
-         baseline_id: baseline_id,
-         pipeline_module: decode_atom(pipeline_module),
-         source_key: source_key,
-         segment_key_hash: segment_key_hash,
-         segment_key_redacted: segment_key_redacted,
-         window_kind: decode_atom(window_kind),
-         timezone: timezone,
-         coverage_start_at: decode_datetime(coverage_start_at),
-         coverage_until: decode_datetime(coverage_until),
-         created_by_run_id: created_by_run_id,
-         manifest_version_id: manifest_version_id,
-         status: decode_atom(status),
-         errors: errors,
-         metadata: metadata,
-         created_at: decode_datetime(created_at),
-         updated_at: decode_datetime(updated_at)
-       }}
+      CoverageBaseline.new(%{
+        baseline_id: baseline_id,
+        pipeline_module: pipeline_module,
+        source_key: source_key,
+        segment_key_hash: segment_key_hash,
+        segment_key_redacted: segment_key_redacted,
+        window_kind: window_kind,
+        timezone: timezone,
+        coverage_start_at: decode_datetime(coverage_start_at),
+        coverage_until: decode_datetime(coverage_until),
+        created_by_run_id: created_by_run_id,
+        manifest_version_id: manifest_version_id,
+        status: status,
+        errors: errors,
+        metadata: metadata,
+        created_at: decode_datetime(created_at),
+        updated_at: decode_datetime(updated_at)
+      })
     end
   end
 
@@ -677,33 +677,33 @@ defmodule Favn.Storage.Adapter.SQLite do
          created_at,
          updated_at
        ]) do
-    with {:ok, last_error} <- decode_payload(last_error_blob),
+    with {:ok, pipeline_module} <- existing_atom(pipeline_module),
+         {:ok, last_error} <- decode_payload(last_error_blob),
          {:ok, errors} <- decode_payload(errors_blob),
          {:ok, metadata} <- decode_payload(metadata_blob) do
-      {:ok,
-       %BackfillWindow{
-         backfill_run_id: backfill_run_id,
-         child_run_id: child_run_id,
-         pipeline_module: decode_atom(pipeline_module),
-         manifest_version_id: manifest_version_id,
-         coverage_baseline_id: coverage_baseline_id,
-         window_kind: decode_atom(window_kind),
-         window_start_at: decode_datetime(window_start_at),
-         window_end_at: decode_datetime(window_end_at),
-         timezone: timezone,
-         window_key: window_key,
-         status: decode_atom(status),
-         attempt_count: attempt_count,
-         latest_attempt_run_id: latest_attempt_run_id,
-         last_success_run_id: last_success_run_id,
-         last_error: last_error,
-         errors: errors,
-         metadata: metadata,
-         started_at: decode_datetime(started_at),
-         finished_at: decode_datetime(finished_at),
-         created_at: decode_datetime(created_at),
-         updated_at: decode_datetime(updated_at)
-       }}
+      BackfillWindow.new(%{
+        backfill_run_id: backfill_run_id,
+        child_run_id: child_run_id,
+        pipeline_module: pipeline_module,
+        manifest_version_id: manifest_version_id,
+        coverage_baseline_id: coverage_baseline_id,
+        window_kind: window_kind,
+        window_start_at: decode_datetime(window_start_at),
+        window_end_at: decode_datetime(window_end_at),
+        timezone: timezone,
+        window_key: window_key,
+        status: status,
+        attempt_count: attempt_count,
+        latest_attempt_run_id: latest_attempt_run_id,
+        last_success_run_id: last_success_run_id,
+        last_error: last_error,
+        errors: errors,
+        metadata: metadata,
+        started_at: decode_datetime(started_at),
+        finished_at: decode_datetime(finished_at),
+        created_at: decode_datetime(created_at),
+        updated_at: decode_datetime(updated_at)
+      })
     end
   end
 
@@ -727,30 +727,32 @@ defmodule Favn.Storage.Adapter.SQLite do
          metadata_blob,
          updated_at
        ]) do
-    with {:ok, latest_error} <- decode_payload(latest_error_blob),
+    with {:ok, asset_ref_module} <- existing_atom(asset_ref_module),
+         {:ok, asset_ref_name} <- existing_atom(asset_ref_name),
+         {:ok, pipeline_module} <- existing_atom(pipeline_module),
+         {:ok, latest_error} <- decode_payload(latest_error_blob),
          {:ok, errors} <- decode_payload(errors_blob),
          {:ok, metadata} <- decode_payload(metadata_blob) do
-      {:ok,
-       %AssetWindowState{
-         asset_ref_module: decode_atom(asset_ref_module),
-         asset_ref_name: decode_atom(asset_ref_name),
-         pipeline_module: decode_atom(pipeline_module),
-         manifest_version_id: manifest_version_id,
-         window_kind: decode_atom(window_kind),
-         window_start_at: decode_datetime(window_start_at),
-         window_end_at: decode_datetime(window_end_at),
-         timezone: timezone,
-         window_key: window_key,
-         status: decode_atom(status),
-         latest_run_id: latest_run_id,
-         latest_parent_run_id: latest_parent_run_id,
-         latest_success_run_id: latest_success_run_id,
-         latest_error: latest_error,
-         rows_written: rows_written,
-         errors: errors,
-         metadata: metadata,
-         updated_at: decode_datetime(updated_at)
-       }}
+      AssetWindowState.new(%{
+        asset_ref_module: asset_ref_module,
+        asset_ref_name: asset_ref_name,
+        pipeline_module: pipeline_module,
+        manifest_version_id: manifest_version_id,
+        window_kind: window_kind,
+        window_start_at: decode_datetime(window_start_at),
+        window_end_at: decode_datetime(window_end_at),
+        timezone: timezone,
+        window_key: window_key,
+        status: status,
+        latest_run_id: latest_run_id,
+        latest_parent_run_id: latest_parent_run_id,
+        latest_success_run_id: latest_success_run_id,
+        latest_error: latest_error,
+        rows_written: rows_written,
+        errors: errors,
+        metadata: metadata,
+        updated_at: decode_datetime(updated_at)
+      })
     end
   end
 
@@ -804,10 +806,10 @@ defmodule Favn.Storage.Adapter.SQLite do
 
   defp encode_atom(value) when is_atom(value), do: Atom.to_string(value)
 
-  defp decode_atom(value) when is_binary(value) do
-    String.to_existing_atom(value)
+  defp existing_atom(value) when is_binary(value) do
+    {:ok, String.to_existing_atom(value)}
   rescue
-    ArgumentError -> {:unknown_atom, value}
+    ArgumentError -> {:error, {:unknown_atom, value}}
   end
 
   defp encode_datetime(nil), do: nil

--- a/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
@@ -571,6 +571,37 @@ defmodule Favn.SQLiteStorageTest do
              )
   end
 
+  test "rejects unknown persisted backfill identity atoms" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    baseline = sample_coverage_baseline("baseline-unknown-atom", :ok, now)
+    state = sample_asset_window_state(:orders, "asset-unknown-atom", :running, now)
+    unknown_pipeline = "Elixir.Favn.SQLiteStorageTest.UnknownPipeline"
+    unknown_asset_name = "unknown_asset_name_#{System.unique_integer([:positive])}"
+
+    assert :ok = OrchestratorStorage.put_coverage_baseline(baseline)
+    assert :ok = OrchestratorStorage.put_asset_window_state(state)
+
+    assert {:ok, _} =
+             SQL.query(
+               Repo,
+               "UPDATE favn_pipeline_coverage_baselines SET pipeline_module = ?1 WHERE baseline_id = ?2",
+               [unknown_pipeline, baseline.baseline_id]
+             )
+
+    assert {:error, {:unknown_atom, ^unknown_pipeline}} =
+             OrchestratorStorage.get_coverage_baseline(baseline.baseline_id)
+
+    assert {:ok, _} =
+             SQL.query(
+               Repo,
+               "UPDATE favn_asset_window_states SET asset_ref_name = ?1 WHERE window_key = ?2",
+               [unknown_asset_name, state.window_key]
+             )
+
+    assert {:error, {:unknown_atom, ^unknown_asset_name}} =
+             OrchestratorStorage.list_asset_window_states()
+  end
+
   defp sample_run(id, status, started_at \\ DateTime.utc_now(), opts \\ []) do
     now = DateTime.truncate(started_at, :second)
 

--- a/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
@@ -423,6 +423,154 @@ defmodule Favn.SQLiteStorageTest do
              )
   end
 
+  test "decodes legacy backfill window kind aliases through constructors" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    baseline = sample_coverage_baseline("baseline-legacy-kind", :ok, now)
+    window = sample_backfill_window("window-legacy-kind", :running, now)
+    state = sample_asset_window_state(:orders, "asset-legacy-kind", :running, now)
+
+    assert :ok = OrchestratorStorage.put_coverage_baseline(baseline)
+    assert :ok = OrchestratorStorage.put_backfill_window(window)
+    assert :ok = OrchestratorStorage.put_asset_window_state(state)
+
+    assert {:ok, _} =
+             SQL.query(Repo, "UPDATE favn_pipeline_coverage_baselines SET window_kind = ?1", [
+               "daily"
+             ])
+
+    assert {:ok, _} =
+             SQL.query(Repo, "UPDATE favn_backfill_windows SET window_kind = ?1", ["daily"])
+
+    assert {:ok, _} =
+             SQL.query(Repo, "UPDATE favn_asset_window_states SET window_kind = ?1", ["daily"])
+
+    assert {:ok, ^baseline} = OrchestratorStorage.get_coverage_baseline(baseline.baseline_id)
+
+    assert {:ok, ^window} =
+             OrchestratorStorage.get_backfill_window(
+               window.backfill_run_id,
+               window.pipeline_module,
+               window.window_key
+             )
+
+    assert {:ok, ^state} =
+             OrchestratorStorage.get_asset_window_state(
+               state.asset_ref_module,
+               state.asset_ref_name,
+               state.window_key
+             )
+  end
+
+  test "rejects invalid persisted backfill read-model statuses" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    baseline = sample_coverage_baseline("baseline-invalid-status", :ok, now)
+    window = sample_backfill_window("window-invalid-status", :running, now)
+    state = sample_asset_window_state(:orders, "asset-invalid-status", :running, now)
+
+    assert :ok = OrchestratorStorage.put_coverage_baseline(baseline)
+    assert :ok = OrchestratorStorage.put_backfill_window(window)
+    assert :ok = OrchestratorStorage.put_asset_window_state(state)
+
+    assert {:ok, _} =
+             SQL.query(
+               Repo,
+               "UPDATE favn_pipeline_coverage_baselines SET status = ?1 WHERE baseline_id = ?2",
+               ["bogus", baseline.baseline_id]
+             )
+
+    assert {:ok, _} =
+             SQL.query(
+               Repo,
+               "UPDATE favn_backfill_windows SET status = ?1 WHERE window_key = ?2",
+               [
+                 "bogus",
+                 window.window_key
+               ]
+             )
+
+    assert {:ok, _} =
+             SQL.query(
+               Repo,
+               "UPDATE favn_asset_window_states SET status = ?1 WHERE window_key = ?2",
+               [
+                 "bogus",
+                 state.window_key
+               ]
+             )
+
+    assert {:error, {:invalid_status, "bogus"}} =
+             OrchestratorStorage.get_coverage_baseline(baseline.baseline_id)
+
+    assert {:error, {:invalid_status, "bogus"}} =
+             OrchestratorStorage.get_backfill_window(
+               window.backfill_run_id,
+               window.pipeline_module,
+               window.window_key
+             )
+
+    assert {:error, {:invalid_status, "bogus"}} =
+             OrchestratorStorage.get_asset_window_state(
+               state.asset_ref_module,
+               state.asset_ref_name,
+               state.window_key
+             )
+  end
+
+  test "rejects invalid persisted backfill read-model window kinds" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    baseline = sample_coverage_baseline("baseline-invalid-kind", :ok, now)
+    window = sample_backfill_window("window-invalid-kind", :running, now)
+    state = sample_asset_window_state(:orders, "asset-invalid-kind", :running, now)
+
+    assert :ok = OrchestratorStorage.put_coverage_baseline(baseline)
+    assert :ok = OrchestratorStorage.put_backfill_window(window)
+    assert :ok = OrchestratorStorage.put_asset_window_state(state)
+
+    assert {:ok, _} =
+             SQL.query(
+               Repo,
+               "UPDATE favn_pipeline_coverage_baselines SET window_kind = ?1 WHERE baseline_id = ?2",
+               ["fortnight", baseline.baseline_id]
+             )
+
+    assert {:ok, _} =
+             SQL.query(
+               Repo,
+               "UPDATE favn_backfill_windows SET window_kind = ?1 WHERE window_key = ?2",
+               [
+                 "fortnight",
+                 window.window_key
+               ]
+             )
+
+    assert {:ok, _} =
+             SQL.query(
+               Repo,
+               "UPDATE favn_asset_window_states SET window_kind = ?1 WHERE window_key = ?2",
+               [
+                 "fortnight",
+                 state.window_key
+               ]
+             )
+
+    assert {:error, {:invalid_window_kind, "fortnight"}} =
+             OrchestratorStorage.get_coverage_baseline(baseline.baseline_id)
+
+    assert {:error, {:invalid_window_kind, "fortnight"}} =
+             OrchestratorStorage.get_backfill_window(
+               window.backfill_run_id,
+               window.pipeline_module,
+               window.window_key
+             )
+
+    assert {:error, {:invalid_window_kind, "fortnight"}} =
+             OrchestratorStorage.get_asset_window_state(
+               state.asset_ref_module,
+               state.asset_ref_name,
+               state.window_key
+             )
+  end
+
   defp sample_run(id, status, started_at \\ DateTime.utc_now(), opts \\ []) do
     now = DateTime.truncate(started_at, :second)
 
@@ -448,76 +596,85 @@ defmodule Favn.SQLiteStorageTest do
   end
 
   defp sample_coverage_baseline(baseline_id, status, now) do
-    %CoverageBaseline{
-      baseline_id: baseline_id,
-      pipeline_module: Favn.SQLiteStorageTest.Pipeline,
-      source_key: "orders-api",
-      segment_key_hash: "sha256:orders",
-      segment_key_redacted: "orders-***",
-      window_kind: :daily,
-      timezone: "Etc/UTC",
-      coverage_start_at: DateTime.add(now, -86_400, :second),
-      coverage_until: now,
-      created_by_run_id: "baseline-run-1",
-      manifest_version_id: "manifest_v1",
-      status: status,
-      errors: [%{reason: :sample_error}],
-      metadata: %{row_count: 12},
-      created_at: now,
-      updated_at: now
-    }
+    {:ok, baseline} =
+      CoverageBaseline.new(%{
+        baseline_id: baseline_id,
+        pipeline_module: Favn.SQLiteStorageTest.Pipeline,
+        source_key: "orders-api",
+        segment_key_hash: "sha256:orders",
+        segment_key_redacted: "orders-***",
+        window_kind: :daily,
+        timezone: "Etc/UTC",
+        coverage_start_at: DateTime.add(now, -86_400, :second),
+        coverage_until: now,
+        created_by_run_id: "baseline-run-1",
+        manifest_version_id: "manifest_v1",
+        status: status,
+        errors: [%{reason: :sample_error}],
+        metadata: %{row_count: 12},
+        created_at: now,
+        updated_at: now
+      })
+
+    baseline
   end
 
   defp sample_backfill_window(window_key, status, window_start_at) do
     window_end_at = DateTime.add(window_start_at, 86_400, :second)
 
-    %BackfillWindow{
-      backfill_run_id: "backfill-run-1",
-      child_run_id: "child-#{window_key}",
-      pipeline_module: Favn.SQLiteStorageTest.Pipeline,
-      manifest_version_id: "manifest_v1",
-      coverage_baseline_id: "baseline-ok",
-      window_kind: :daily,
-      window_start_at: window_start_at,
-      window_end_at: window_end_at,
-      timezone: "Etc/UTC",
-      window_key: window_key,
-      status: status,
-      attempt_count: 2,
-      latest_attempt_run_id: "attempt-#{window_key}",
-      last_success_run_id: if(status == :ok, do: "success-#{window_key}", else: nil),
-      last_error: %{reason: :sample_error},
-      started_at: window_start_at,
-      finished_at: if(status == :running, do: nil, else: window_end_at),
-      created_at: window_start_at,
-      updated_at: window_end_at,
-      errors: [%{attempt: 1, reason: :sample_error}],
-      metadata: %{source: "sqlite-test"}
-    }
+    {:ok, window} =
+      BackfillWindow.new(%{
+        backfill_run_id: "backfill-run-1",
+        child_run_id: "child-#{window_key}",
+        pipeline_module: Favn.SQLiteStorageTest.Pipeline,
+        manifest_version_id: "manifest_v1",
+        coverage_baseline_id: "baseline-ok",
+        window_kind: :daily,
+        window_start_at: window_start_at,
+        window_end_at: window_end_at,
+        timezone: "Etc/UTC",
+        window_key: window_key,
+        status: status,
+        attempt_count: 2,
+        latest_attempt_run_id: "attempt-#{window_key}",
+        last_success_run_id: if(status == :ok, do: "success-#{window_key}", else: nil),
+        last_error: %{reason: :sample_error},
+        started_at: window_start_at,
+        finished_at: if(status == :running, do: nil, else: window_end_at),
+        created_at: window_start_at,
+        updated_at: window_end_at,
+        errors: [%{attempt: 1, reason: :sample_error}],
+        metadata: %{source: "sqlite-test"}
+      })
+
+    window
   end
 
   defp sample_asset_window_state(asset_name, window_key, status, window_start_at) do
     window_end_at = DateTime.add(window_start_at, 86_400, :second)
 
-    %AssetWindowState{
-      asset_ref_module: Favn.SQLiteStorageTest.Asset,
-      asset_ref_name: asset_name,
-      pipeline_module: Favn.SQLiteStorageTest.Pipeline,
-      manifest_version_id: "manifest_v1",
-      window_kind: :daily,
-      window_start_at: window_start_at,
-      window_end_at: window_end_at,
-      timezone: "Etc/UTC",
-      window_key: window_key,
-      status: status,
-      latest_run_id: "asset-run-#{window_key}",
-      latest_parent_run_id: "backfill-run-1",
-      latest_success_run_id: if(status == :ok, do: "asset-success-#{window_key}", else: nil),
-      latest_error: %{reason: :sample_error},
-      rows_written: 42,
-      errors: [%{reason: :sample_error}],
-      metadata: %{partition: window_key},
-      updated_at: window_end_at
-    }
+    {:ok, state} =
+      AssetWindowState.new(%{
+        asset_ref_module: Favn.SQLiteStorageTest.Asset,
+        asset_ref_name: asset_name,
+        pipeline_module: Favn.SQLiteStorageTest.Pipeline,
+        manifest_version_id: "manifest_v1",
+        window_kind: :daily,
+        window_start_at: window_start_at,
+        window_end_at: window_end_at,
+        timezone: "Etc/UTC",
+        window_key: window_key,
+        status: status,
+        latest_run_id: "asset-run-#{window_key}",
+        latest_parent_run_id: "backfill-run-1",
+        latest_success_run_id: if(status == :ok, do: "asset-success-#{window_key}", else: nil),
+        latest_error: %{reason: :sample_error},
+        rows_written: 42,
+        errors: [%{reason: :sample_error}],
+        metadata: %{partition: window_key},
+        updated_at: window_end_at
+      })
+
+    state
   end
 end


### PR DESCRIPTION
## Summary
- Route SQLite and Postgres persisted backfill read-model decodes through `CoverageBaseline`, `BackfillWindow`, and `AssetWindowState` constructors.
- Keep module/asset identity atom decoding explicit while validating persisted `status` and `window_kind` values consistently.
- Add SQL adapter coverage for legacy window kind aliases and invalid persisted statuses/window kinds.

Closes #187

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`
- `mix credo --strict`
- `mix dialyzer`
- `mix xref graph --format stats --label compile-connected`