### PR TITLE
Harden local relation inspection closeout

### DIFF
--- a/apps/favn_core/lib/favn/contracts/relation_inspection_request.ex
+++ b/apps/favn_core/lib/favn/contracts/relation_inspection_request.ex
@@ -1,6 +1,11 @@
 defmodule Favn.Contracts.RelationInspectionRequest do
   @moduledoc """
   Runner-owned read-only relation inspection request.
+
+  `sample_limit` is a non-negative runner contract value. Browser-facing layers
+  currently clamp requested samples to `1..20`; a runner-level value of `0` is
+  reserved for internal callers that want schema and metadata without sample
+  rows.
   """
 
   alias Favn.RelationRef

--- a/apps/favn_runner/lib/favn_runner/inspection.ex
+++ b/apps/favn_runner/lib/favn_runner/inspection.ex
@@ -6,6 +6,7 @@ defmodule FavnRunner.Inspection do
   alias Favn.Manifest.Asset
   alias Favn.RelationRef
   alias Favn.SQL.Client
+  alias Favn.SQL.Error
   alias Favn.SQL.Result
 
   @include_items [:relation, :columns, :row_count, :sample, :table_metadata]
@@ -14,11 +15,14 @@ defmodule FavnRunner.Inspection do
   @spec inspect_relation(RelationInspectionRequest.t(), Favn.Manifest.Version.t()) ::
           {:ok, RelationInspectionResult.t()} | {:error, term()}
   def inspect_relation(%RelationInspectionRequest{} = request, version) do
-    with {:ok, asset, relation_ref} <- resolve_relation(request, version),
+    include = normalize_include(request.include)
+
+    with {:ok, sample_limit} <- normalize_sample_limit(request.sample_limit, include),
+         {:ok, asset, relation_ref} <- resolve_relation(request, version),
          {:ok, session} <-
            Client.connect(relation_ref.connection, registry_name: @runner_registry) do
       try do
-        {:ok, inspect_with_session(request, asset, relation_ref, session)}
+        {:ok, inspect_with_session(asset, relation_ref, session, include, sample_limit)}
       after
         Client.disconnect(session)
       end
@@ -54,9 +58,7 @@ defmodule FavnRunner.Inspection do
     ArgumentError -> {:error, :invalid_relation}
   end
 
-  defp inspect_with_session(request, asset, relation_ref, session) do
-    include = normalize_include(request.include)
-
+  defp inspect_with_session(asset, relation_ref, session, include, sample_limit) do
     %RelationInspectionResult{
       asset_ref: inspection_asset_ref(asset),
       relation_ref: relation_ref,
@@ -66,7 +68,7 @@ defmodule FavnRunner.Inspection do
     |> maybe_relation(session, relation_ref, include)
     |> maybe_columns(session, relation_ref, include)
     |> maybe_row_count(session, relation_ref, include)
-    |> maybe_sample(session, relation_ref, include, request.sample_limit)
+    |> maybe_sample(session, relation_ref, include, sample_limit)
     |> maybe_table_metadata(session, relation_ref, include)
   end
 
@@ -78,6 +80,17 @@ defmodule FavnRunner.Inspection do
   end
 
   defp normalize_include(_include), do: []
+
+  defp normalize_sample_limit(limit, include) do
+    if :sample in include do
+      case limit do
+        int when is_integer(int) and int >= 0 -> {:ok, min(int, 20)}
+        _invalid -> {:error, :invalid_sample_limit}
+      end
+    else
+      {:ok, 20}
+    end
+  end
 
   defp maybe_relation(result, session, relation_ref, include) do
     if :relation in include,
@@ -129,7 +142,7 @@ defmodule FavnRunner.Inspection do
       {:ok, %Result{} = sample} ->
         %{
           result
-          | sample: %{limit: min(max(limit, 0), 20), columns: sample.columns, rows: sample.rows}
+          | sample: %{limit: limit, columns: sample.columns, rows: sample.rows}
         }
 
       {:error, reason} ->
@@ -151,9 +164,13 @@ defmodule FavnRunner.Inspection do
   end
 
   defp add_warning(%RelationInspectionResult{} = result, code, reason) do
-    warning = %{code: code, message: inspect(reason)}
+    warning = %{code: code, message: warning_message(reason)}
     %{result | warnings: result.warnings ++ [warning]}
   end
+
+  defp warning_message(%Error{message: message}) when is_binary(message), do: message
+  defp warning_message(reason) when is_atom(reason), do: Atom.to_string(reason)
+  defp warning_message(_reason), do: "inspection operation failed"
 
   defp inspection_asset_ref(%Asset{} = asset), do: asset.ref
   defp inspection_asset_ref(_asset), do: nil

--- a/apps/favn_runner/test/execution/sql_asset_test.exs
+++ b/apps/favn_runner/test/execution/sql_asset_test.exs
@@ -188,6 +188,82 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
     assert result.warnings == []
   end
 
+  test "inspection rejects invalid sample limits before opening a SQL session" do
+    ref = {FavnRunner.ExecutionSQLAssetTest.SQLAsset, :asset}
+    version = register_sql_manifest!(ref)
+
+    request = %RelationInspectionRequest{
+      manifest_version_id: version.manifest_version_id,
+      asset_ref: ref,
+      include: [:sample],
+      sample_limit: -1
+    }
+
+    assert {:error, :invalid_sample_limit} =
+             FavnRunner.Inspection.inspect_relation(request, version)
+  end
+
+  test "inspection warnings expose adapter messages without error details or causes" do
+    ref = {FavnRunner.ExecutionSQLAssetTest.SQLAsset, :asset}
+    relation = RelationRef.new!(%{connection: :inspection_fake, name: "orders"})
+
+    :ok =
+      Registry.reload(
+        %{
+          inspection_fake: %Resolved{
+            name: :inspection_fake,
+            adapter: FavnRunner.ExecutionSQLAssetTest.FakeInspectionAdapter,
+            module: __MODULE__,
+            config: %{}
+          }
+        },
+        registry_name: FavnRunner.ConnectionRegistry
+      )
+
+    version = register_inspection_manifest!(ref, relation)
+
+    request = %RelationInspectionRequest{
+      manifest_version_id: version.manifest_version_id,
+      asset_ref: ref,
+      include: [:row_count]
+    }
+
+    assert {:ok, result} = FavnRunner.Inspection.inspect_relation(request, version)
+    assert [%{code: :row_count_failed, message: "safe row count failure"}] = result.warnings
+  end
+
+  defp register_inspection_manifest!(ref, relation) do
+    manifest = %Manifest{
+      schema_version: 1,
+      runner_contract_version: 1,
+      assets: [
+        %Asset{
+          ref: ref,
+          module: elem(ref, 0),
+          name: :asset,
+          type: :sql,
+          execution: %{entrypoint: :asset, arity: 1},
+          relation: relation,
+          materialization: :table,
+          sql_execution: nil
+        }
+      ],
+      pipelines: [],
+      schedules: [],
+      graph: %Graph{nodes: [ref], edges: [], topo_order: [ref]},
+      metadata: %{}
+    }
+
+    {:ok, version} =
+      Version.new(manifest,
+        manifest_version_id:
+          "mv_inspection_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)
+      )
+
+    :ok = FavnRunner.register_manifest(version)
+    version
+  end
+
   defp register_sql_manifest!(ref) do
     relation = RelationRef.new!(%{connection: :duckdb_runtime, name: "manifest_sql_asset"})
 
@@ -343,4 +419,25 @@ defmodule FavnRunner.ExecutionSQLAssetTest.MissingPayloadSQLAsset do
 end
 
 defmodule FavnRunner.ExecutionSQLAssetTest.MissingConnectionSQLAsset do
+end
+
+defmodule FavnRunner.ExecutionSQLAssetTest.FakeInspectionAdapter do
+  alias Favn.Connection.Resolved
+  alias Favn.SQL.Capabilities
+  alias Favn.SQL.Error
+
+  def connect(%Resolved{}, _opts), do: {:ok, :conn}
+  def disconnect(:conn, _opts), do: :ok
+  def capabilities(%Resolved{}, _opts), do: {:ok, %Capabilities{}}
+
+  def row_count(:conn, _ref, _opts) do
+    {:error,
+     %Error{
+       type: :execution_error,
+       message: "safe row count failure",
+       operation: :row_count,
+       details: %{password: "do-not-leak"},
+       cause: %{token: "do-not-leak"}
+     }}
+  end
 end

--- a/docs/ISSUE_172_LOCAL_INSPECTION_PANEL_PLAN.md
+++ b/docs/ISSUE_172_LOCAL_INSPECTION_PANEL_PLAN.md
@@ -24,7 +24,11 @@ The first implementation should answer the dogfooding questions after running a 
 
 This is a local verification feature, not a database IDE.
 
-## Current Baseline
+## Planning Baseline
+
+This section records the baseline at the time the issue plan was written. The
+first curated local inspection slice is now implemented; see the acceptance
+mapping below for current status.
 
 Implemented foundations already present:
 
@@ -40,7 +44,7 @@ Implemented foundations already present:
 - `Favn.SQL.Adapter.DuckDB` already implements relation lookup, schema listing, relation listing, columns, and materialization.
 - `favn_web` already has asset catalog/detail and run detail pages, BFF routes under `/api/web/v1/**`, server-side orchestrator client helpers, normalizers, Storybook stories, and E2E coverage.
 
-Important gaps:
+Important gaps at planning time:
 
 - The private orchestrator run detail DTO currently drops `run.result`, `run.metadata`, `asset_results`, `node_results`, `pipeline`, `pipeline_context`, `params`, and `trigger`.
 - Active manifest target DTOs expose only asset target id and label for assets; they do not expose relation, type, metadata, dependencies, or runtime config declarations.
@@ -449,19 +453,22 @@ For `favn_web` changes, use the web-dev workflow and run the workspace's relevan
 
 ## Acceptance Mapping
 
-- Latest run status is visible: slices 1 and 6.
-- Relation name/catalog/schema/table is visible: slices 1 and 6.
-- Rows written or affected are visible when metadata exists: slices 1 and 6.
-- Schema/columns are visible: slices 2, 3, 4, 5, and 6.
-- Sample rows up to 20 are visible: slices 2, 3, 4, 5, and 6.
-- Freshness or loaded/materialized timestamp is visible when metadata exists: slices 1 and 6.
-- Source config keys are shown with secrets redacted: slices 1 and 6; run-scoped presence requires the V1b runtime summary.
-- Window context is visible: slices 1 and 6.
-- Raw run metadata JSON is visible: slices 1 and 6.
-- Errors and diagnostics are visible without crashing pages: all slices.
-- Upstream/downstream assets are visible from manifest dependencies and run context: slices 1 and 6.
-- DuckLake metadata is visible where safe and available: slice 3.
-- No arbitrary SQL editor is exposed by default: architectural rule across all slices.
+Current status of the first curated local inspection slice:
+
+- Latest run status is visible on asset/run surfaces: implemented by slices 1 and 6.
+- Relation name/catalog/schema/table is visible when the active manifest carries an owned relation: implemented by slices 1 and 6.
+- Rows written or affected are visible when asset metadata includes those fields: implemented by slices 1 and 6.
+- Schema/columns are visible for supported inspected relations: implemented by slices 2, 3, 4, 5, and 6.
+- Sample rows up to 20 are visible for supported inspected relations: implemented by slices 2, 3, 4, 5, and 6.
+- Freshness or loaded/materialized timestamp is visible when metadata includes those fields: implemented by slices 1 and 6.
+- Source config declarations are shown with secret flags and no raw secret values: implemented by slices 1 and 6. Run-scoped present/missing proof remains future V1b work unless existing run diagnostics prove a value is missing.
+- Window context is visible when exposed by the run/manifest payload: implemented by slices 1 and 6.
+- Raw run metadata JSON is visible: implemented by slices 1 and 6.
+- Errors and diagnostics are visible without crashing pages: implemented across the local inspector path.
+- Upstream/downstream assets are visible from manifest dependencies and run context: implemented by slices 1 and 6.
+- DuckDB table metadata is exposed through the safe inspection path where available. Richer DuckLake snapshot/storage metadata remains future work.
+- No arbitrary SQL editor is exposed by default: implemented by the architectural rule across all slices.
+- Tests cover the backend/orchestrator/runner/adapter path and web BFF/UI preview states. Broader live browser-plus-runner DuckDB dogfooding coverage remains future hardening.
 
 ## Non-Goals
 

--- a/docs/ISSUE_172_LOCAL_INSPECTION_PANEL_PLAN.md
+++ b/docs/ISSUE_172_LOCAL_INSPECTION_PANEL_PLAN.md
@@ -107,6 +107,9 @@ Return a stable, JSON-friendly map or struct:
 Rules:
 
 - Default `sample_limit` to 20 and cap it at 20 in every external-facing layer.
+- Browser-facing layers clamp requested samples to `1..20`; the runner contract
+  accepts `0` for internal schema/metadata-only inspection requests that should
+  not fetch sample rows.
 - Support only read-only operations: relation lookup, columns, row count, sample rows, and safe table metadata.
 - Treat missing relation as a normal inspectable state, not a page crash.
 - Normalize dates, decimals, binaries, atoms, and structs to JSON-safe values before exposing them to the web tier.

--- a/docs/structure/favn_duckdb.md
+++ b/docs/structure/favn_duckdb.md
@@ -1,7 +1,9 @@
 # favn_duckdb
 
 Purpose: DuckDB SQL adapter and runner plugin runtime, including in-process and
-separate-process execution modes and DuckDB/DuckLake bootstrap behavior.
+separate-process execution modes, DuckDB/DuckLake bootstrap behavior, and
+adapter-owned safe relation inspection queries for row counts, samples, and table
+metadata.
 
 Code:
 - `apps/favn_duckdb/lib/favn/sql/adapter/duckdb*.ex`
@@ -10,5 +12,6 @@ Code:
 Tests:
 - `apps/favn_duckdb/test/`
 
-Use when changing DuckDB adapter queries/materialization, bootstrap diagnostics,
-runtime placement, worker lifecycle, or DuckDB plugin child specs.
+Use when changing DuckDB adapter queries/materialization, safe inspection query
+generation, bootstrap diagnostics, runtime placement, worker lifecycle, or DuckDB
+plugin child specs.

--- a/docs/structure/favn_sql_runtime.md
+++ b/docs/structure/favn_sql_runtime.md
@@ -1,7 +1,8 @@
 # favn_sql_runtime
 
 Purpose: shared SQL connection validation, SQL client/session runtime, admission
-control, adapter bootstrap hooks, and backend concurrency policy contracts.
+control, adapter bootstrap hooks, backend concurrency policy contracts, and safe
+read-only relation inspection primitives used by local data preview flows.
 
 Code:
 - `apps/favn_sql_runtime/lib/favn/connection/`
@@ -12,5 +13,5 @@ Tests:
 - `apps/favn_sql_runtime/test/`
 
 Use when changing connection runtime config validation, SQL client behavior,
-session lifecycle, transaction behavior, adapter bootstrap, or SQL admission and
-concurrency policy behavior.
+session lifecycle, transaction behavior, adapter bootstrap, read-only relation
+inspection, or SQL admission and concurrency policy behavior.

--- a/web/favn_web/src/lib/components/favn/AssetDetailPage.stories.svelte
+++ b/web/favn_web/src/lib/components/favn/AssetDetailPage.stories.svelte
@@ -26,10 +26,13 @@
 				JSON.stringify({
 					data: {
 						inspection: {
+							status: 'succeeded',
 							row_count: 1,
+							redacted: true,
 							warnings: [{ code: 'metadata_partial', message: 'Some metadata is unavailable' }],
 							columns: [{ name: 'id', data_type: 'INTEGER' }],
-							sample: { limit: 20, columns: ['id'], rows: [{ id: 1 }] }
+							sample: { limit: 20, columns: ['id'], rows: [{ id: 1 }] },
+							metadata: { raw_relation: { schema: 'mart', name: 'customer_revenue' } }
 						}
 					}
 				}),
@@ -46,8 +49,15 @@
 			).toBeInTheDocument();
 			await expect(canvas.getByText('42 / —')).toBeInTheDocument();
 			await userEvent.click(canvas.getByRole('button', { name: 'Load data preview' }));
+			await expect(
+				canvas.getByText('Preview loaded from the local inspection service.')
+			).toBeInTheDocument();
+			await expect(
+				canvas.getByText('Sensitive values were redacted by the inspection service.')
+			).toBeInTheDocument();
 			await expect(canvas.getByText('Some metadata is unavailable')).toBeInTheDocument();
 			await expect(canvas.getByText('INTEGER')).toBeInTheDocument();
+			await expect(canvas.getByText('Raw inspection metadata')).toBeInTheDocument();
 			await expect(canvas.getAllByText('1').length).toBeGreaterThan(0);
 			await userEvent.click(canvas.getByRole('tab', { name: 'Lineage' }));
 			await expect(canvas.getByText('MyApp.Assets.Raw.Customers')).toBeInTheDocument();
@@ -65,6 +75,34 @@
 				assetRef: 'MyApp.Assets.Mart.CustomerRevenue',
 				manifestVersionId: 'mfv_2026_04_27'
 			});
+		} finally {
+			globalThis.fetch = originalFetch;
+		}
+	}}
+/>
+
+<Story
+	name="Inspection failure state"
+	args={{ data: successfulAssetWithRuns, onrun: fn() }}
+	play={async ({ canvasElement, userEvent }) => {
+		const canvas = within(canvasElement);
+		const originalFetch = globalThis.fetch;
+		globalThis.fetch = async () =>
+			new Response(
+				JSON.stringify({
+					error: {
+						code: 'not_found',
+						message: 'No local materialization is available for this asset'
+					}
+				}),
+				{ status: 404, headers: { 'content-type': 'application/json' } }
+			) as unknown as Response;
+
+		try {
+			await userEvent.click(canvas.getByRole('button', { name: 'Load data preview' }));
+			await expect(canvas.getByRole('alert')).toHaveTextContent(
+				'No local materialization is available for this asset'
+			);
 		} finally {
 			globalThis.fetch = originalFetch;
 		}

--- a/web/favn_web/src/lib/components/favn/AssetDetailPage.svelte
+++ b/web/favn_web/src/lib/components/favn/AssetDetailPage.svelte
@@ -48,7 +48,7 @@
 			{}) as Record<string, unknown>
 	);
 	let rawPayload = $derived(asset.raw ?? pageData.raw ?? asset);
-	let rawJson = $derived(JSON.stringify(rawPayload, null, 2));
+	let rawJson = $derived(safeJsonStringify(rawPayload));
 	let runActions = $derived(
 		(pageData.runActions ?? pageData.actions ?? {}) as Record<string, unknown>
 	);
@@ -119,6 +119,18 @@
 	let inspectionErrors = $derived.by(() => {
 		const errors = inspection?.errors;
 		return Array.isArray(errors) ? errors.map(formatDiagnostic) : [];
+	});
+	let inspectionStatus = $derived.by(() => {
+		const status = inspection?.status ?? inspection?.state;
+		if (typeof status === 'string' && status.trim().length > 0) return status.toLowerCase();
+		if (inspectionErrors.length > 0) return 'failed';
+		return inspection ? 'loaded' : 'not loaded';
+	});
+	let inspectionRedactions = $derived.by(() => {
+		const redactions = inspection?.redactions ?? inspection?.redacted_fields ?? inspection?.redactedFields;
+		if (Array.isArray(redactions)) return redactions.map(formatDiagnostic);
+		if (inspection?.redacted === true) return ['Sensitive values were redacted by the inspection service.'];
+		return [];
 	});
 	let notes = $derived.by(() => {
 		const source =
@@ -218,8 +230,29 @@
 	function jsonValue(candidate: unknown): string {
 		if (candidate === null || candidate === undefined || candidate === '') return '—';
 		if (typeof candidate === 'string') return candidate;
+		if (typeof candidate === 'bigint') return candidate.toString();
 		if (typeof candidate === 'number' || typeof candidate === 'boolean') return String(candidate);
-		return JSON.stringify(candidate);
+		return safeJsonStringify(candidate, false);
+	}
+
+	function safeJsonStringify(candidate: unknown, pretty = true): string {
+		const seen = new WeakSet<object>();
+		try {
+			return JSON.stringify(
+				candidate,
+				(_key, value) => {
+					if (typeof value === 'bigint') return value.toString();
+					if (value && typeof value === 'object') {
+						if (seen.has(value)) return '[Circular]';
+						seen.add(value);
+					}
+					return value;
+				},
+				pretty ? 2 : undefined
+			);
+		} catch {
+			return String(candidate);
+		}
 	}
 
 	function formatDiagnostic(candidate: unknown): string {
@@ -247,6 +280,9 @@
 				? (inspectionPayload as InspectionPayload)
 				: null;
 		}
+		if (data && typeof data === 'object' && !Array.isArray(data)) {
+			return data as InspectionPayload;
+		}
 		const direct = record.inspection;
 		if (direct && typeof direct === 'object' && !Array.isArray(direct)) {
 			return direct as InspectionPayload;
@@ -269,7 +305,7 @@
 				),
 				{ headers: { accept: 'application/json' } }
 			);
-			const payload = (await response.json()) as unknown;
+			const payload = (await response.json().catch(() => null)) as unknown;
 			if (!response.ok) {
 				const message =
 					payload && typeof payload === 'object' && 'error' in payload
@@ -664,7 +700,31 @@
 								<span class="text-slate-500">Preview limit</span>
 								<p class="font-medium">20 rows max</p>
 							</div>
+							<div>
+								<span class="text-slate-500">Inspection status</span>
+								<p class="font-medium capitalize">{inspectionStatus}</p>
+							</div>
 						</div>
+
+						{#if inspectionStatus === 'loaded' || inspectionStatus === 'succeeded' || inspectionStatus === 'success'}
+							<p class="rounded-md border border-emerald-200 bg-emerald-50 p-2 text-sm text-emerald-800">
+								Preview loaded from the local inspection service.
+							</p>
+						{:else if inspectionStatus === 'missing' || inspectionStatus === 'not_found'}
+							<p class="rounded-md border border-amber-200 bg-amber-50 p-2 text-sm text-amber-800">
+								No local materialization is available to inspect for this asset yet.
+							</p>
+						{:else if inspectionStatus === 'failed' || inspectionStatus === 'error'}
+							<p class="rounded-md border border-red-200 bg-red-50 p-2 text-sm text-red-700">
+								The local inspection request reported a failure.
+							</p>
+						{/if}
+
+						{#each inspectionRedactions as redaction (redaction)}
+							<p class="rounded-md border border-slate-200 bg-slate-50 p-2 text-sm text-slate-700">
+								{redaction}
+							</p>
+						{/each}
 
 						{#each inspectionWarnings as warning (warning)}
 							<p class="rounded-md border border-amber-200 bg-amber-50 p-2 text-sm text-amber-800">
@@ -725,6 +785,13 @@
 								No sample rows were returned for this preview.
 							</p>
 						{/if}
+
+						<details class="rounded-lg border bg-slate-50 p-3 text-sm">
+							<summary class="cursor-pointer font-medium">Raw inspection metadata</summary>
+							<pre class="mt-3 max-h-64 overflow-auto text-xs whitespace-pre-wrap">{safeJsonStringify(
+									inspection
+								)}</pre>
+						</details>
 					</div>
 				{/if}
 			</Card.Content>

--- a/web/favn_web/src/lib/components/favn/AssetDetailPage.svelte
+++ b/web/favn_web/src/lib/components/favn/AssetDetailPage.svelte
@@ -127,9 +127,11 @@
 		return inspection ? 'loaded' : 'not loaded';
 	});
 	let inspectionRedactions = $derived.by(() => {
-		const redactions = inspection?.redactions ?? inspection?.redacted_fields ?? inspection?.redactedFields;
+		const redactions =
+			inspection?.redactions ?? inspection?.redacted_fields ?? inspection?.redactedFields;
 		if (Array.isArray(redactions)) return redactions.map(formatDiagnostic);
-		if (inspection?.redacted === true) return ['Sensitive values were redacted by the inspection service.'];
+		if (inspection?.redacted === true)
+			return ['Sensitive values were redacted by the inspection service.'];
 		return [];
 	});
 	let notes = $derived.by(() => {
@@ -290,6 +292,18 @@
 		return record;
 	}
 
+	function inspectionErrorMessage(payload: unknown): string {
+		if (payload && typeof payload === 'object' && !Array.isArray(payload)) {
+			const error = (payload as Record<string, unknown>).error;
+			if (error && typeof error === 'object' && !Array.isArray(error)) {
+				const message = (error as Record<string, unknown>).message;
+				if (typeof message === 'string' && message.trim().length > 0) return message;
+			}
+		}
+
+		return 'Inspection request failed';
+	}
+
 	async function loadInspection() {
 		if (!manifestVersionId || !targetId) return;
 
@@ -307,11 +321,7 @@
 			);
 			const payload = (await response.json().catch(() => null)) as unknown;
 			if (!response.ok) {
-				const message =
-					payload && typeof payload === 'object' && 'error' in payload
-						? jsonValue((payload as Record<string, unknown>).error)
-						: 'Inspection request failed';
-				throw new Error(message);
+				throw new Error(inspectionErrorMessage(payload));
 			}
 			inspection = inspectionFromPayload(payload);
 		} catch (error) {
@@ -707,7 +717,9 @@
 						</div>
 
 						{#if inspectionStatus === 'loaded' || inspectionStatus === 'succeeded' || inspectionStatus === 'success'}
-							<p class="rounded-md border border-emerald-200 bg-emerald-50 p-2 text-sm text-emerald-800">
+							<p
+								class="rounded-md border border-emerald-200 bg-emerald-50 p-2 text-sm text-emerald-800"
+							>
 								Preview loaded from the local inspection service.
 							</p>
 						{:else if inspectionStatus === 'missing' || inspectionStatus === 'not_found'}
@@ -788,7 +800,8 @@
 
 						<details class="rounded-lg border bg-slate-50 p-3 text-sm">
 							<summary class="cursor-pointer font-medium">Raw inspection metadata</summary>
-							<pre class="mt-3 max-h-64 overflow-auto text-xs whitespace-pre-wrap">{safeJsonStringify(
+							<pre
+								class="mt-3 max-h-64 overflow-auto text-xs whitespace-pre-wrap">{safeJsonStringify(
 									inspection
 								)}</pre>
 						</details>

--- a/web/favn_web/tests/e2e/auth-session-runs.e2e.ts
+++ b/web/favn_web/tests/e2e/auth-session-runs.e2e.ts
@@ -376,6 +376,18 @@ test.describe('auth/session/runs flow', () => {
 				})
 			}
 		});
+
+		const missingInspection = await pageGetJson(
+			page,
+			'/api/web/v1/manifests/manifest_v2/assets/asset%3AMissing.LocalMaterialization%3Aasset/inspection?limit=20'
+		);
+		expect(missingInspection.status).toBe(404);
+		expect(missingInspection.body).toEqual({
+			error: {
+				code: 'not_found',
+				message: 'No local materialization is available for this asset'
+			}
+		});
 	});
 
 	test('run stream relay smoke includes Last-Event-ID passthrough and validation', async ({

--- a/web/favn_web/tests/e2e/auth-session-runs.e2e.ts
+++ b/web/favn_web/tests/e2e/auth-session-runs.e2e.ts
@@ -175,6 +175,11 @@ test.describe('auth/session/runs flow', () => {
 		await expect(page).toHaveURL(/\/assets\/Staging\.CustomerOrders%3Aasset$/);
 		await expect(page.getByRole('heading', { name: 'CustomerOrders' })).toBeVisible();
 		await expect(page.getByRole('button', { name: 'Asset-only run unavailable' })).toBeDisabled();
+		await page.getByRole('button', { name: 'Load data preview' }).click();
+		await expect(page.getByText('Preview loaded from the local inspection service.')).toBeVisible();
+		await expect(page.getByText('secret columns redacted', { exact: true })).toBeVisible();
+		await expect(page.getByText('[redacted]').first()).toBeVisible();
+		await expect(page.getByText('Raw inspection metadata')).toBeVisible();
 
 		await page.getByRole('tab', { name: 'Runs' }).click();
 		await expect(page.getByText('run_002')).toBeVisible();
@@ -353,6 +358,24 @@ test.describe('auth/session/runs flow', () => {
 				cron: '*/5 * * * *'
 			})
 		});
+
+		const inspection = await pageGetJson(
+			page,
+			'/api/web/v1/manifests/manifest_v2/assets/asset%3AStaging.CustomerOrders%3Aasset/inspection?limit=999&sql=select%201'
+		);
+		expect(inspection.status).toBe(200);
+		expect(inspection.body).toMatchObject({
+			data: {
+				inspection: expect.objectContaining({
+					status: 'succeeded',
+					redacted: true,
+					sample: expect.objectContaining({ limit: 20 }),
+					metadata: expect.objectContaining({
+						query_keys_seen: ['limit']
+					})
+				})
+			}
+		});
 	});
 
 	test('run stream relay smoke includes Last-Event-ID passthrough and validation', async ({
@@ -411,6 +434,17 @@ test.describe('auth/session/runs flow', () => {
 
 		expect(response.status()).toBe(401);
 		expect(await response.json()).toEqual({
+			error: {
+				code: 'unauthorized',
+				message: 'Authentication required'
+			}
+		});
+
+		const inspectionResponse = await page.request.get(
+			`${BASE_URL}/api/web/v1/manifests/manifest_v2/assets/asset%3AStaging.CustomerOrders%3Aasset/inspection`
+		);
+		expect(inspectionResponse.status()).toBe(401);
+		expect(await inspectionResponse.json()).toEqual({
 			error: {
 				code: 'unauthorized',
 				message: 'Authentication required'

--- a/web/favn_web/tests/e2e/mock-orchestrator-server.mjs
+++ b/web/favn_web/tests/e2e/mock-orchestrator-server.mjs
@@ -710,6 +710,59 @@ function handleActivateManifest(request, response, manifestVersionId) {
 	});
 }
 
+function handleAssetInspection(request, response, manifestVersionId, targetId, url) {
+	const session = requireAuthenticatedSession(request, response);
+	if (!session) return;
+
+	const limit = Number.parseInt(url.searchParams.get('limit') ?? '20', 10);
+	const cappedLimit = Number.isFinite(limit) ? Math.min(Math.max(limit, 1), 20) : 20;
+
+	if (manifestVersionId !== 'manifest_v2') {
+		sendJson(response, 404, {
+			error: { code: 'not_found', message: `Manifest ${manifestVersionId} not found` }
+		});
+		return;
+	}
+
+	if (targetId === 'asset:Missing.LocalMaterialization:asset') {
+		sendJson(response, 404, {
+			error: {
+				code: 'not_found',
+				message: 'No local materialization is available for this asset'
+			}
+		});
+		return;
+	}
+
+	sendJson(response, 200, {
+		data: {
+			inspection: {
+				status: 'succeeded',
+				row_count: 2,
+				redacted: true,
+				redactions: ['secret columns redacted'],
+				warnings: [{ code: 'metadata_partial', message: 'Some metadata is unavailable' }],
+				columns: [
+					{ name: 'id', data_type: 'INTEGER' },
+					{ name: 'customer_token', data_type: 'VARCHAR', redacted: true }
+				],
+				sample: {
+					limit: cappedLimit,
+					rows: [
+						{ id: 1, customer_token: '[redacted]' },
+						{ id: 2, customer_token: '[redacted]' }
+					]
+				},
+				metadata: {
+					target_id: targetId,
+					manifest_version_id: manifestVersionId,
+					query_keys_seen: Array.from(url.searchParams.keys())
+				}
+			}
+		}
+	});
+}
+
 function handleListSchedules(request, response) {
 	const session = requireAuthenticatedSession(request, response);
 	if (!session) return;
@@ -822,6 +875,20 @@ const server = createServer((request, response) => {
 	);
 	if (method === 'POST' && activateManifestMatch) {
 		handleActivateManifest(request, response, decodeURIComponent(activateManifestMatch[1]));
+		return;
+	}
+
+	const assetInspectionMatch = url.pathname.match(
+		/^\/api\/orchestrator\/v1\/manifests\/([^/]+)\/assets\/([^/]+)\/inspection$/
+	);
+	if (method === 'GET' && assetInspectionMatch) {
+		handleAssetInspection(
+			request,
+			response,
+			decodeURIComponent(assetInspectionMatch[1]),
+			decodeURIComponent(assetInspectionMatch[2]),
+			url
+		);
 		return;
 	}
 


### PR DESCRIPTION
## Summary
- Harden runner-owned relation inspection sample-limit validation and warning redaction.
- Improve asset detail inspection UI states, raw inspection metadata rendering, and web BFF/E2E coverage.
- Clarify issue 172 acceptance status and structure ownership for SQL runtime/DuckDB inspection paths.

## Verification
- `mix format && mix compile --warnings-as-errors && mix test && mix credo --strict && mix dialyzer && mix xref graph --format stats --label compile-connected`
- `npm run check && npm run build && npx playwright test tests/e2e/auth-session-runs.e2e.ts --reporter=line`

Closes #172