### PR TITLE
Refine favn_local failure handling

### DIFF
--- a/apps/favn_local/lib/favn/dev/build/single.ex
+++ b/apps/favn_local/lib/favn/dev/build/single.ex
@@ -55,7 +55,8 @@ defmodule Favn.Dev.Build.Single do
 
   defp storage_mode(opts) do
     case Keyword.get(opts, :storage, :sqlite) do
-      value when is_binary(value) -> String.to_atom(value)
+      "sqlite" -> :sqlite
+      "postgres" -> :postgres
       value -> value
     end
   end

--- a/apps/favn_local/lib/favn/dev/build/single.ex
+++ b/apps/favn_local/lib/favn/dev/build/single.ex
@@ -17,13 +17,13 @@ defmodule Favn.Dev.Build.Single do
 
   @spec run(root_opt()) :: {:ok, map()} | {:error, term()}
   def run(opts \\ []) when is_list(opts) do
-    with :ok <- Install.ensure_ready(opts),
+    with storage <- storage_mode(opts),
+         :ok <- validate_storage(storage),
+         :ok <- Install.ensure_ready(opts),
          :ok <- State.ensure_layout(opts),
          {:ok, web} <- Web.run(opts),
          {:ok, orchestrator} <- Orchestrator.run(opts),
          {:ok, runner} <- Runner.run(opts),
-         storage <- storage_mode(opts),
-         :ok <- validate_storage(storage),
          {build_id, root_dir} <- {build_id(), Paths.root_dir(opts)},
          build_dir <- Paths.build_single_dir(root_dir, build_id),
          dist_dir <- Paths.dist_single_dir(root_dir, build_id),

--- a/apps/favn_local/lib/favn/dev/stack.ex
+++ b/apps/favn_local/lib/favn/dev/stack.ex
@@ -116,8 +116,8 @@ defmodule Favn.Dev.Stack do
            runtime: runtime,
            secrets: secrets,
            node_names: node_names,
-            distribution_ports: distribution_ports(opts),
-            services: services
+           distribution_ports: distribution_ports(opts),
+           services: services
          }}
       end
     end)
@@ -372,32 +372,34 @@ defmodule Favn.Dev.Stack do
         start_service_specs(list)
 
       _ ->
-        :ok = ensure_web_assets(runtime, opts)
+        with :ok <- ensure_web_assets(runtime, opts) do
+          runner_wait_timeout_ms = Keyword.get(opts, :runner_wait_timeout_ms, 15_000)
 
-        runner_wait_timeout_ms = Keyword.get(opts, :runner_wait_timeout_ms, 15_000)
-        runner_wait_node_name = Keyword.get(opts, :runner_wait_node_name, node_names.runner_full)
+          runner_wait_node_name =
+            Keyword.get(opts, :runner_wait_node_name, node_names.runner_full)
 
-        runner_spec = RuntimeLaunch.runner_spec(runtime, opts, node_names, secrets)
+          runner_spec = RuntimeLaunch.runner_spec(runtime, opts, node_names, secrets)
 
-        orchestrator_spec =
-          RuntimeLaunch.orchestrator_spec(runtime, config, opts, node_names, secrets)
+          orchestrator_spec =
+            RuntimeLaunch.orchestrator_spec(runtime, config, opts, node_names, secrets)
 
-        web_spec = RuntimeLaunch.web_spec(runtime, config, opts, secrets)
+          web_spec = RuntimeLaunch.web_spec(runtime, config, opts, secrets)
 
-        case start_service_specs([runner_spec]) do
-          {:ok, services} ->
-            with :ok <- wait_runner_node_ready(runner_wait_node_name, runner_wait_timeout_ms),
-                 {:ok, services} <- start_service_specs([orchestrator_spec], services),
-                 {:ok, services} <- start_service_specs([web_spec], services) do
-              {:ok, services}
-            else
-              {:error, _reason} = error ->
-                stop_service_map(services)
-                error
-            end
+          case start_service_specs([runner_spec]) do
+            {:ok, services} ->
+              with :ok <- wait_runner_node_ready(runner_wait_node_name, runner_wait_timeout_ms),
+                   {:ok, services} <- start_service_specs([orchestrator_spec], services),
+                   {:ok, services} <- start_service_specs([web_spec], services) do
+                {:ok, services}
+              else
+                {:error, _reason} = error ->
+                  stop_service_map(services)
+                  error
+              end
 
-          {:error, _reason} = error ->
-            error
+            {:error, _reason} = error ->
+              error
+          end
         end
     end
   end
@@ -494,7 +496,8 @@ defmodule Favn.Dev.Stack do
                 |> Map.put("node_name", node_names.orchestrator_full)
                 |> Map.put("distribution_port", distribution_ports(opts).orchestrator)
 
-              _ -> service
+              _ ->
+                service
             end
 
           {name, service}
@@ -524,7 +527,7 @@ defmodule Favn.Dev.Stack do
              runner_node_name: node_names.runner_full,
              rpc_cookie: secrets["rpc_cookie"]
            ),
-          :ok <- wait_orchestrator_health(config.orchestrator_base_url, 15_000),
+         :ok <- wait_orchestrator_health(config.orchestrator_base_url, 15_000),
          :ok <-
            State.write_manifest_latest(
              %{
@@ -538,18 +541,18 @@ defmodule Favn.Dev.Stack do
              opts
            ),
          {:ok, _published} <-
-            OrchestratorClient.publish_manifest(
-              config.orchestrator_base_url,
-              secrets["service_token"],
-              %{
-                manifest_version_id: version.manifest_version_id,
-                content_hash: version.content_hash,
-                schema_version: version.schema_version,
-                runner_contract_version: version.runner_contract_version,
-                serialization_format: version.serialization_format,
-                manifest: version.manifest
-              }
-            ),
+           OrchestratorClient.publish_manifest(
+             config.orchestrator_base_url,
+             secrets["service_token"],
+             %{
+               manifest_version_id: version.manifest_version_id,
+               content_hash: version.content_hash,
+               schema_version: version.schema_version,
+               runner_contract_version: version.runner_contract_version,
+               serialization_format: version.serialization_format,
+               manifest: version.manifest
+             }
+           ),
          {:ok, _activated} <-
            OrchestratorClient.activate_manifest(
              config.orchestrator_base_url,
@@ -695,7 +698,12 @@ defmodule Favn.Dev.Stack do
     |> maybe_put_log_paths(startup, runtime)
   end
 
-  defp maybe_put_failure_details(payload, %{operation: operation, method: method, url: url, reason: reason}) do
+  defp maybe_put_failure_details(payload, %{
+         operation: operation,
+         method: method,
+         url: url,
+         reason: reason
+       }) do
     Map.merge(payload, %{
       "operation" => Atom.to_string(operation),
       "method" => method |> Atom.to_string() |> String.upcase(),
@@ -813,6 +821,7 @@ defmodule Favn.Dev.Stack do
     IO.puts(
       "control node: node=#{node_names.control_full} distribution_port=#{distribution_ports.control}"
     )
+
     IO.puts("logs: web=#{services["web"].log_path}")
     IO.puts("logs: orchestrator=#{services["orchestrator"].log_path}")
     IO.puts("logs: runner=#{services["runner"].log_path}")

--- a/apps/favn_local/lib/favn/dev/state.ex
+++ b/apps/favn_local/lib/favn/dev/state.ex
@@ -208,12 +208,19 @@ defmodule Favn.Dev.State do
   @spec write_json(Path.t(), map()) :: :ok | {:error, term()}
   defp write_json(path, map) when is_map(map) do
     with :ok <- File.mkdir_p(Path.dirname(path)),
-         encoded <- JSON.encode_to_iodata!(map),
+         {:ok, encoded} <- encode_json(path, map),
          :ok <- File.write(path, [encoded, "\n"]) do
       :ok
     else
+      {:error, {:encode_failed, _path, _reason} = reason} -> {:error, reason}
       {:error, reason} -> {:error, {:write_failed, path, reason}}
     end
+  end
+
+  defp encode_json(path, map) when is_map(map) do
+    {:ok, JSON.encode_to_iodata!(map)}
+  rescue
+    error -> {:error, {:encode_failed, path, error}}
   end
 
   @spec delete_if_exists(Path.t()) :: :ok | {:error, term()}

--- a/apps/favn_local/lib/favn/dev/status.ex
+++ b/apps/favn_local/lib/favn/dev/status.ex
@@ -122,8 +122,8 @@ defmodule Favn.Dev.Status do
 
   defp internal_control(runtime, services) do
     %{
-      runner_node: internal_node(runtime, services, "runner"),
-      orchestrator_node: internal_node(runtime, services, "orchestrator"),
+      runner_node: internal_node(runtime, services, :runner, "runner"),
+      orchestrator_node: internal_node(runtime, services, :orchestrator, "orchestrator"),
       control_node: %{
         node_name: get_in(runtime, ["node_names", "control"]),
         distribution_port: get_in(runtime, ["distribution_ports", "control"])
@@ -131,14 +131,18 @@ defmodule Favn.Dev.Status do
     }
   end
 
-  defp internal_node(runtime, services, key) do
+  defp internal_node(runtime, services, service_key, runtime_key) do
+    service = Map.fetch!(services, service_key)
+
     %{
-      node_name: get_in(runtime, ["services", key, "node_name"]) || get_in(runtime, ["node_names", key]),
+      node_name:
+        get_in(runtime, ["services", runtime_key, "node_name"]) ||
+          get_in(runtime, ["node_names", runtime_key]),
       distribution_port:
-        get_in(runtime, ["services", key, "distribution_port"]) ||
-          get_in(runtime, ["distribution_ports", key]),
-      status: Map.fetch!(services, String.to_existing_atom(key)).status,
-      pid: Map.fetch!(services, String.to_existing_atom(key)).pid
+        get_in(runtime, ["services", runtime_key, "distribution_port"]) ||
+          get_in(runtime, ["distribution_ports", runtime_key]),
+      status: service.status,
+      pid: service.pid
     }
   end
 

--- a/apps/favn_local/test/dev_build_single_test.exs
+++ b/apps/favn_local/test/dev_build_single_test.exs
@@ -108,14 +108,6 @@ defmodule Favn.Dev.Build.SingleTest do
   test "build_single/1 rejects unsupported string storage without atomizing it", %{
     root_dir: root_dir
   } do
-    assert {:ok, :installed} =
-             Dev.install(
-               root_dir: root_dir,
-               skip_web_install: true,
-               skip_tool_checks: true,
-               skip_runtime_deps_install: true
-             )
-
     assert {:error, {:invalid_storage, "bogus"}} =
              Dev.build_single(
                root_dir: root_dir,

--- a/apps/favn_local/test/dev_build_single_test.exs
+++ b/apps/favn_local/test/dev_build_single_test.exs
@@ -105,6 +105,27 @@ defmodule Favn.Dev.Build.SingleTest do
     assert {:ok, %{"storage" => %{"mode" => "postgres"}}} = JSON.decode(assembly_json)
   end
 
+  test "build_single/1 rejects unsupported string storage without atomizing it", %{
+    root_dir: root_dir
+  } do
+    assert {:ok, :installed} =
+             Dev.install(
+               root_dir: root_dir,
+               skip_web_install: true,
+               skip_tool_checks: true,
+               skip_runtime_deps_install: true
+             )
+
+    assert {:error, {:invalid_storage, "bogus"}} =
+             Dev.build_single(
+               root_dir: root_dir,
+               storage: "bogus",
+               skip_compile: true,
+               skip_tool_checks: true,
+               skip_project_root_check: true
+             )
+  end
+
   test "build_single/1 requires install", %{root_dir: root_dir} do
     assert {:error, :install_required} =
              Dev.build_single(root_dir: root_dir, skip_compile: true, skip_tool_checks: true)

--- a/apps/favn_local/test/dev_lifecycle_test.exs
+++ b/apps/favn_local/test/dev_lifecycle_test.exs
@@ -81,11 +81,11 @@ defmodule Favn.Dev.LifecycleTest do
     ]
 
     assert {:error, {:start_failed, "orchestrator", _reason}} =
-              Dev.dev(
-                root_dir: root_dir,
-                orchestrator_port: free_port(),
-                web_port: free_port(),
-                service_specs_override: failing_specs,
+             Dev.dev(
+               root_dir: root_dir,
+               orchestrator_port: free_port(),
+               web_port: free_port(),
+               service_specs_override: failing_specs,
                skip_install_check: true,
                skip_bootstrap: true,
                skip_readiness: true
@@ -210,11 +210,11 @@ defmodule Favn.Dev.LifecycleTest do
 
     try do
       assert {:error, {:port_conflict, :web, ^port}} =
-                Dev.dev(
-                  root_dir: root_dir,
-                  web_port: port,
-                  orchestrator_port: free_port(),
-                  skip_runtime_compile: true,
+               Dev.dev(
+                 root_dir: root_dir,
+                 web_port: port,
+                 orchestrator_port: free_port(),
+                 skip_runtime_compile: true,
                  skip_install_check: true,
                  skip_bootstrap: true,
                  skip_readiness: true
@@ -229,7 +229,12 @@ defmodule Favn.Dev.LifecycleTest do
     port = RuntimeLaunch.distribution_port(:runner, root_dir: root_dir)
 
     {:ok, socket} =
-      :gen_tcp.listen(port, [:binary, {:active, false}, {:reuseaddr, false}, {:ip, {127, 0, 0, 1}}])
+      :gen_tcp.listen(port, [
+        :binary,
+        {:active, false},
+        {:reuseaddr, false},
+        {:ip, {127, 0, 0, 1}}
+      ])
 
     try do
       assert {:error, {:port_conflict, :runner_distribution, ^port}} =
@@ -252,10 +257,10 @@ defmodule Favn.Dev.LifecycleTest do
 
     assert {:error, {:postgres_unavailable, "127.0.0.1", 1, _reason}} =
              Dev.dev(
-                root_dir: root_dir,
-                orchestrator_port: free_port(),
-                web_port: free_port(),
-                storage: :postgres,
+               root_dir: root_dir,
+               orchestrator_port: free_port(),
+               web_port: free_port(),
+               storage: :postgres,
                postgres: [
                  hostname: "127.0.0.1",
                  port: 1,
@@ -277,10 +282,10 @@ defmodule Favn.Dev.LifecycleTest do
 
     assert {:error, {:postgres_misconfigured, :hostname}} =
              Dev.dev(
-                root_dir: root_dir,
-                orchestrator_port: free_port(),
-                web_port: free_port(),
-                storage: :postgres,
+               root_dir: root_dir,
+               orchestrator_port: free_port(),
+               web_port: free_port(),
+               storage: :postgres,
                postgres: [
                  hostname: "",
                  port: 5432,
@@ -313,6 +318,42 @@ defmodule Favn.Dev.LifecycleTest do
 
     assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
     assert :ok = Lock.with_lock([root_dir: root_dir], fn -> :ok end)
+  end
+
+  test "dev/1 returns web build failures instead of raising", %{root_dir: root_dir} do
+    root_dir = root_with_free_distribution_ports(root_dir)
+
+    case NodeControl.ensure_local_node_started("favn_web_failure_cookie") do
+      :ok ->
+        web_dir = Path.join(root_dir, "web/favn_web")
+        bin_dir = Path.join(root_dir, "bin")
+        npm = Path.join(bin_dir, "npm")
+
+        File.mkdir_p!(web_dir)
+        File.mkdir_p!(bin_dir)
+        File.write!(npm, "#!/usr/bin/env sh\nprintf 'asset build failed'\nexit 7\n")
+        File.chmod!(npm, 0o755)
+
+        System.put_env("PATH", bin_dir <> ":" <> System.get_env("PATH", ""))
+
+        assert {:error, {:web_build_failed, 7, "asset build failed"}} =
+                 Dev.dev(
+                   root_dir: root_dir,
+                   orchestrator_port: free_port(),
+                   web_port: free_port(),
+                   skip_install_check: true,
+                   skip_runtime_compile: true,
+                   skip_bootstrap: true,
+                   skip_readiness: true
+                 )
+
+        assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
+
+      {:error, reason} ->
+        IO.puts(
+          "Skipping web build failure test: distributed Erlang unavailable: #{inspect(reason)}"
+        )
+    end
   end
 
   test "dev/1 writes shortname-compatible node names in runtime", %{root_dir: root_dir} do
@@ -447,10 +488,12 @@ defmodule Favn.Dev.LifecycleTest do
 
   defp root_with_free_distribution_ports(base_root, attempt \\ 0)
 
-  defp root_with_free_distribution_ports(_base_root, 50), do: raise("could not find free distribution ports")
+  defp root_with_free_distribution_ports(_base_root, 50),
+    do: raise("could not find free distribution ports")
 
   defp root_with_free_distribution_ports(base_root, attempt) do
     root_dir = Path.join(base_root, "dist_#{attempt}")
+
     ports = [
       RuntimeLaunch.distribution_port(:runner, root_dir: root_dir),
       RuntimeLaunch.distribution_port(:orchestrator, root_dir: root_dir),
@@ -465,7 +508,12 @@ defmodule Favn.Dev.LifecycleTest do
   end
 
   defp port_free?(port) do
-    case :gen_tcp.listen(port, [:binary, {:active, false}, {:reuseaddr, false}, {:ip, {127, 0, 0, 1}}]) do
+    case :gen_tcp.listen(port, [
+           :binary,
+           {:active, false},
+           {:reuseaddr, false},
+           {:ip, {127, 0, 0, 1}}
+         ]) do
       {:ok, socket} ->
         :ok = :gen_tcp.close(socket)
         true

--- a/apps/favn_local/test/dev_state_test.exs
+++ b/apps/favn_local/test/dev_state_test.exs
@@ -49,6 +49,13 @@ defmodule Favn.Dev.StateTest do
     assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
   end
 
+  test "state writes return encode errors instead of raising", %{root_dir: root_dir} do
+    assert {:error, {:encode_failed, _path, _reason}} =
+             State.write_runtime(%{"pid" => self()}, root_dir: root_dir)
+
+    assert {:error, :not_found} = State.read_runtime(root_dir: root_dir)
+  end
+
   test "install and toolchain state roundtrip", %{root_dir: root_dir} do
     install = %{"schema_version" => 2, "fingerprint" => %{"consumer_mix_lock_sha256" => "abc"}}
     runtime = %{"schema_version" => 1, "materialized_root" => "/tmp/runtime"}


### PR DESCRIPTION
## Summary
- Remove unsafe atom creation from single-build storage parsing and simplify status service lookup.
- Return explicit errors for web asset build and state JSON encoding failures instead of raising.
- Add focused regression coverage for the changed favn_local failure paths.

## Checks
- mix format --check-formatted apps/favn_local/lib apps/favn_local/test apps/favn_local/mix.exs
- mix test test/dev_build_single_test.exs test/dev_status_test.exs test/dev_state_test.exs test/dev_lifecycle_test.exs
- mix compile --warnings-as-errors (from apps/favn_local)
- mix test (from apps/favn_local)
- mix credo --strict apps/favn_local
- mix xref graph --format stats --label compile-connected (from apps/favn_local)
- git diff --check

## Notes
- Scope is limited to apps/favn_local.
- No public Favn.Dev function names or arities changed.
- Dialyzer was not run because the child app does not expose the task and the root task is not app-scoped.