### PR TITLE
Refine SQL runtime and runner internals

### DIFF
--- a/apps/favn_runner/lib/favn/sql/materialization_planner.ex
+++ b/apps/favn_runner/lib/favn/sql/materialization_planner.ex
@@ -34,25 +34,29 @@ defmodule Favn.SQL.MaterializationPlanner do
       if target_exists? do
         incremental_write_plan(render, strategy, opts, effective_window)
       else
-        {:ok,
-         table_write_plan(render)
-         |> Map.merge(%{
-           materialization: :incremental,
-           strategy: strategy,
-           mode: :bootstrap,
-           transactional?: false,
-           window: effective_window,
-           effective_window: effective_window,
-           bootstrap?: true,
-           metadata: %{
-             mode: :bootstrap,
-             bootstrap?: true,
-             strategy: strategy,
-             effective_window: effective_window
-           }
-         })}
+        bootstrap_write_plan(render, strategy, effective_window)
       end
     end
+  end
+
+  defp bootstrap_write_plan(%Render{} = render, strategy, %IncrementalWindow{} = window) do
+    {:ok,
+     table_write_plan(render)
+     |> Map.merge(%{
+       materialization: :incremental,
+       strategy: strategy,
+       mode: :bootstrap,
+       transactional?: false,
+       window: window,
+       effective_window: window,
+       bootstrap?: true,
+       metadata: %{
+         mode: :bootstrap,
+         bootstrap?: true,
+         strategy: strategy,
+         effective_window: window
+       }
+     })}
   end
 
   defp incremental_write_plan(%Render{} = render, :append, _opts, %IncrementalWindow{} = window) do
@@ -127,14 +131,7 @@ defmodule Favn.SQL.MaterializationPlanner do
   end
 
   defp target_exists?(%Session{} = session, %Render{} = render) do
-    ref =
-      RelationRef.new!(%{
-        catalog: render.relation.catalog,
-        schema: render.relation.schema,
-        name: render.relation.name
-      })
-
-    case Client.relation(session, ref) do
+    case Client.relation(session, target_ref(render)) do
       {:ok, nil} -> {:ok, false}
       {:ok, _relation} -> {:ok, true}
       {:error, reason} -> planning_error(render, "failed to inspect incremental target", reason)
@@ -176,14 +173,7 @@ defmodule Favn.SQL.MaterializationPlanner do
        ) do
     column = opts |> Keyword.fetch!(:window_column) |> normalize_column_name()
 
-    ref =
-      RelationRef.new!(%{
-        catalog: render.relation.catalog,
-        schema: render.relation.schema,
-        name: render.relation.name
-      })
-
-    with {:ok, columns} <- Client.columns(session, ref),
+    with {:ok, columns} <- Client.columns(session, target_ref(render)),
          :ok <- ensure_column_present(Enum.map(columns, & &1.name), column, render, :target) do
       {:ok, :ok}
     else
@@ -245,6 +235,14 @@ defmodule Favn.SQL.MaterializationPlanner do
        message: message,
        cause: reason
      }}
+  end
+
+  defp target_ref(%Render{} = render) do
+    RelationRef.new!(%{
+      catalog: render.relation.catalog,
+      schema: render.relation.schema,
+      name: render.relation.name
+    })
   end
 
   defp relation(%Render{} = render, type) do

--- a/apps/favn_runner/lib/favn_runner/worker.ex
+++ b/apps/favn_runner/lib/favn_runner/worker.ex
@@ -181,6 +181,7 @@ defmodule FavnRunner.Worker do
 
   defp asset_result(%Asset{} = asset, started_at, finished_at, status, meta, error) do
     meta = RuntimeConfigRedactor.redact(meta, asset.runtime_config || %{})
+    duration_ms = duration_ms(started_at, finished_at)
 
     %AssetResult{
       ref: asset.ref,
@@ -188,7 +189,7 @@ defmodule FavnRunner.Worker do
       status: status,
       started_at: started_at,
       finished_at: finished_at,
-      duration_ms: max(DateTime.diff(finished_at, started_at, :millisecond), 0),
+      duration_ms: duration_ms,
       meta: meta,
       error: error,
       attempt_count: 1,
@@ -198,13 +199,17 @@ defmodule FavnRunner.Worker do
           attempt: 1,
           started_at: started_at,
           finished_at: finished_at,
-          duration_ms: max(DateTime.diff(finished_at, started_at, :millisecond), 0),
+          duration_ms: duration_ms,
           status: status,
           meta: meta,
           error: error
         }
       ]
     }
+  end
+
+  defp duration_ms(started_at, finished_at) do
+    max(DateTime.diff(finished_at, started_at, :millisecond), 0)
   end
 
   defp emit_event(server, execution_id, work, event_type, payload) do

--- a/apps/favn_sql_runtime/lib/favn/connection/validator.ex
+++ b/apps/favn_sql_runtime/lib/favn/connection/validator.ex
@@ -50,8 +50,8 @@ defmodule Favn.Connection.Validator do
          {:ok, resolved_values} <- resolve_runtime_refs(definition, merged) do
       errors =
         []
-        |> validate_required(definition, %{}, resolved_values)
-        |> validate_types(definition, %{}, resolved_values)
+        |> validate_required(definition, resolved_values)
+        |> validate_types(definition, resolved_values)
 
       if errors == [] do
         required_keys =
@@ -106,17 +106,12 @@ defmodule Favn.Connection.Validator do
       |> Enum.filter(&Map.get(&1, :secret, false))
       |> Enum.map(& &1.key)
 
-    top_level_runtime_secret_fields =
-      values
-      |> Enum.filter(fn {_key, value} -> match?(%Favn.RuntimeConfig.Ref{secret?: true}, value) end)
-      |> Enum.map(&elem(&1, 0))
-
-    nested_runtime_secret_fields =
+    runtime_secret_fields =
       values
       |> Enum.filter(fn {_key, value} -> nested_secret_ref?(value) end)
       |> Enum.map(&elem(&1, 0))
 
-    (schema_secret_fields ++ top_level_runtime_secret_fields ++ nested_runtime_secret_fields)
+    (schema_secret_fields ++ runtime_secret_fields)
     |> Enum.uniq()
     |> Enum.sort()
   end
@@ -307,13 +302,11 @@ defmodule Favn.Connection.Validator do
     ]
   end
 
-  defp validate_required(errors, definition, defaults, runtime_values) do
-    merged = Map.merge(defaults, runtime_values)
-
+  defp validate_required(errors, definition, values) do
     definition.config_schema
     |> Enum.filter(&Map.get(&1, :required, false))
     |> Enum.reduce(errors, fn field, acc ->
-      case Map.fetch(merged, field.key) do
+      case Map.fetch(values, field.key) do
         {:ok, value} when not is_nil(value) ->
           acc
 
@@ -333,11 +326,9 @@ defmodule Favn.Connection.Validator do
     end)
   end
 
-  defp validate_types(errors, definition, defaults, runtime_values) do
-    merged = Map.merge(defaults, runtime_values)
-
+  defp validate_types(errors, definition, values) do
     Enum.reduce(definition.config_schema, errors, fn field, acc ->
-      case Map.fetch(merged, field.key) do
+      case Map.fetch(values, field.key) do
         {:ok, value} -> validate_field_value(acc, definition, field, value)
         :error -> acc
       end

--- a/apps/favn_sql_runtime/lib/favn/sql/admission.ex
+++ b/apps/favn_sql_runtime/lib/favn/sql/admission.ex
@@ -10,8 +10,13 @@ defmodule Favn.SQL.Admission do
     load merge pragma set truncate update vacuum
   )
 
-  @spec with_permit(Session.t(), atom(), iodata() | term(), (() -> term())) :: term()
-  def with_permit(%Session{concurrency_policy: %ConcurrencyPolicy{} = policy}, operation, payload, fun)
+  @spec with_permit(Session.t(), atom(), iodata() | term(), (-> term())) :: term()
+  def with_permit(
+        %Session{concurrency_policy: %ConcurrencyPolicy{} = policy},
+        operation,
+        payload,
+        fun
+      )
       when is_function(fun, 0) do
     if permit_required?(policy, operation, payload) do
       acquire_and_run(policy, fun)
@@ -24,13 +29,16 @@ defmodule Favn.SQL.Admission do
 
   @spec acquire_session(ConcurrencyPolicy.t() | nil) :: term()
   def acquire_session(%ConcurrencyPolicy{scope: scope} = policy) do
-    if permit_required?(policy, :connect, nil) do
-      if already_holding?(scope) do
+    cond do
+      not permit_required?(policy, :connect, nil) ->
+        nil
+
+      already_holding?(scope) ->
         increment_held(scope)
         {:borrowed, scope, self()}
-      else
+
+      true ->
         acquire_lease(policy)
-      end
     end
   end
 
@@ -38,10 +46,7 @@ defmodule Favn.SQL.Admission do
 
   @spec release_session(term()) :: :ok
   def release_session({_kind, scope, owner}) when owner == self() do
-    if decrement_held(scope) == 0 do
-      Limiter.release(scope)
-    end
-
+    release_held_scope(scope)
     :ok
   end
 
@@ -84,14 +89,13 @@ defmodule Favn.SQL.Admission do
       try do
         fun.()
       after
-        if decrement_held(scope) == 0 do
-          Limiter.release(scope)
-        end
+        release_held_scope(scope)
       end
     end
   end
 
-  defp acquire_lease(%ConcurrencyPolicy{scope: scope, limit: limit}), do: acquire_lease(scope, limit)
+  defp acquire_lease(%ConcurrencyPolicy{scope: scope, limit: limit}),
+    do: acquire_lease(scope, limit)
 
   defp acquire_lease(scope, limit) do
     :ok = Limiter.acquire(scope, limit)
@@ -101,7 +105,8 @@ defmodule Favn.SQL.Admission do
 
   defp already_holding?(scope), do: Map.get(held(), scope, 0) > 0
 
-  defp increment_held(scope), do: Process.put(@permit_key, Map.update(held(), scope, 1, &(&1 + 1)))
+  defp increment_held(scope),
+    do: Process.put(@permit_key, Map.update(held(), scope, 1, &(&1 + 1)))
 
   defp decrement_held(scope) do
     next =
@@ -112,6 +117,12 @@ defmodule Favn.SQL.Admission do
 
     Process.put(@permit_key, next)
     Map.get(next, scope, 0)
+  end
+
+  defp release_held_scope(scope) do
+    if decrement_held(scope) == 0 do
+      Limiter.release(scope)
+    end
   end
 
   defp held do

--- a/apps/favn_sql_runtime/lib/favn/sql/admission/limiter.ex
+++ b/apps/favn_sql_runtime/lib/favn/sql/admission/limiter.ex
@@ -3,6 +3,8 @@ defmodule Favn.SQL.Admission.Limiter do
 
   use GenServer
 
+  @initial_state %{limits: %{}, holders: %{}, queues: %{}, monitors: %{}}
+
   @type scope :: term()
 
   @spec acquire(scope(), pos_integer()) :: :ok
@@ -33,7 +35,7 @@ defmodule Favn.SQL.Admission.Limiter do
 
   @impl true
   def init(_opts) do
-    {:ok, %{limits: %{}, holders: %{}, queues: %{}, monitors: %{}}}
+    {:ok, initial_state()}
   end
 
   @impl true
@@ -49,7 +51,7 @@ defmodule Favn.SQL.Admission.Limiter do
 
   def handle_call(:reset, _from, state) do
     Enum.each(Map.keys(state.monitors), &Process.demonitor(&1, [:flush]))
-    {:reply, :ok, %{limits: %{}, holders: %{}, queues: %{}, monitors: %{}}}
+    {:reply, :ok, initial_state()}
   end
 
   @impl true
@@ -73,6 +75,8 @@ defmodule Favn.SQL.Admission.Limiter do
         {:noreply, %{state | monitors: monitors} |> remove_waiter(scope, monitor_ref)}
     end
   end
+
+  defp initial_state, do: @initial_state
 
   defp available?(state, scope) do
     active_count(state, scope) < Map.fetch!(state.limits, scope)
@@ -123,7 +127,9 @@ defmodule Favn.SQL.Admission.Limiter do
     end
   end
 
-  defp put_scope_holders(state, scope, []), do: %{state | holders: Map.delete(state.holders, scope)}
+  defp put_scope_holders(state, scope, []),
+    do: %{state | holders: Map.delete(state.holders, scope)}
+
   defp put_scope_holders(state, scope, holders), do: put_in(state, [:holders, scope], holders)
 
   defp enqueue_waiter(state, scope, {pid, _tag} = from) do


### PR DESCRIPTION
## Summary
- Simplify private connection validation and SQL admission permit internals without changing public contracts.
- Extract small runner helpers for materialization planning and worker duration calculation.
- Keep changes scoped to `favn_sql_runtime` and `favn_runner`.

## Tests
- `mix format --check-formatted apps/favn_sql_runtime/lib/favn/connection/validator.ex apps/favn_sql_runtime/lib/favn/sql/admission.ex apps/favn_sql_runtime/lib/favn/sql/admission/limiter.ex apps/favn_runner/lib/favn_runner/worker.ex apps/favn_runner/lib/favn/sql/materialization_planner.ex`
- `mix compile --warnings-as-errors` in `apps/favn_sql_runtime`
- `mix test` in `apps/favn_sql_runtime`
- `mix compile --warnings-as-errors` in `apps/favn_runner`
- `mix cmd --app favn_runner mix test test/worker_test.exs`

## Notes
- `apps/favn_runner` app-local SQL execution tests currently fail because sibling/test dependency modules are unavailable from that app context; filed #213 for that test-boundary gap.