### PR TITLE
Refactor favn authoring internals

### DIFF
--- a/apps/favn/lib/favn.ex
+++ b/apps/favn/lib/favn.ex
@@ -241,36 +241,28 @@ defmodule Favn do
   @spec render(module() | Favn.Ref.t() | Favn.Asset.t(), keyword()) ::
           {:ok, term()} | {:error, term()}
   def render(asset_input, opts \\ []) when is_list(opts) do
-    with {:ok, asset} <- SQLAssetInput.normalize(asset_input) do
-      sql_runtime_call(:render, [asset, opts])
-    end
+    normalized_sql_asset_call(:render, asset_input, opts)
   end
 
   @doc false
   @spec preview(module() | Favn.Ref.t() | Favn.Asset.t(), keyword()) ::
           {:ok, term()} | {:error, term()}
   def preview(asset_input, opts \\ []) when is_list(opts) do
-    with {:ok, asset} <- SQLAssetInput.normalize(asset_input) do
-      sql_runtime_call(:preview, [asset, opts])
-    end
+    normalized_sql_asset_call(:preview, asset_input, opts)
   end
 
   @doc false
   @spec explain(module() | Favn.Ref.t() | Favn.Asset.t(), keyword()) ::
           {:ok, term()} | {:error, term()}
   def explain(asset_input, opts \\ []) when is_list(opts) do
-    with {:ok, asset} <- SQLAssetInput.normalize(asset_input) do
-      sql_runtime_call(:explain, [asset, opts])
-    end
+    normalized_sql_asset_call(:explain, asset_input, opts)
   end
 
   @doc false
   @spec materialize(module() | Favn.Ref.t() | Favn.Asset.t(), keyword()) ::
           {:ok, term()} | {:error, term()}
   def materialize(asset_input, opts \\ []) when is_list(opts) do
-    with {:ok, asset} <- SQLAssetInput.normalize(asset_input) do
-      sql_runtime_call(:materialize, [asset, opts])
-    end
+    normalized_sql_asset_call(:materialize, asset_input, opts)
   end
 
   @doc false
@@ -321,16 +313,22 @@ defmodule Favn do
     scheduler_runtime_call(:list_scheduled_pipelines)
   end
 
-  defp orchestrator_runtime_call(function_name, args)
-       when is_atom(function_name) and is_list(args) do
-    orchestrator = FavnOrchestrator
+  defp normalized_sql_asset_call(runtime_function, asset_input, opts)
+       when is_atom(runtime_function) and is_list(opts) do
+    with {:ok, asset} <- SQLAssetInput.normalize(asset_input) do
+      sql_runtime_call(runtime_function, [asset, opts])
+    end
+  end
 
-    with {:module, ^orchestrator} <- Code.ensure_loaded(orchestrator),
-         arity <- length(args),
-         true <- function_exported?(orchestrator, function_name, arity) do
+  defp orchestrator_runtime_call(runtime_function, runtime_args)
+       when is_atom(runtime_function) and is_list(runtime_args) do
+    orchestrator_module = FavnOrchestrator
+    arity = length(runtime_args)
+
+    if runtime_function_exported?(orchestrator_module, runtime_function, arity) do
       try do
-        orchestrator
-        |> apply(function_name, args)
+        orchestrator_module
+        |> apply(runtime_function, runtime_args)
         |> normalize_orchestrator_result()
       rescue
         UndefinedFunctionError ->
@@ -346,7 +344,7 @@ defmodule Favn do
           {:error, {:runtime_call_exited, reason}}
       end
     else
-      _ -> {:error, :runtime_not_available}
+      {:error, :runtime_not_available}
     end
   end
 
@@ -358,14 +356,13 @@ defmodule Favn do
 
   defp normalize_orchestrator_result(other), do: other
 
-  defp scheduler_runtime_call(function_name) when is_atom(function_name) do
-    scheduler = Favn.Scheduler
+  defp scheduler_runtime_call(runtime_function) when is_atom(runtime_function) do
+    scheduler_module = Favn.Scheduler
 
-    with {:module, ^scheduler} <- Code.ensure_loaded(scheduler),
-         true <- function_exported?(scheduler, function_name, 0) do
+    if runtime_function_exported?(scheduler_module, runtime_function, 0) do
       try do
-        scheduler
-        |> apply(function_name, [])
+        scheduler_module
+        |> apply(runtime_function, [])
         |> normalize_scheduler_result()
       rescue
         UndefinedFunctionError ->
@@ -381,7 +378,7 @@ defmodule Favn do
           {:error, {:runtime_call_exited, reason}}
       end
     else
-      _ -> {:error, :runtime_not_available}
+      {:error, :runtime_not_available}
     end
   end
 
@@ -390,16 +387,23 @@ defmodule Favn do
 
   defp normalize_scheduler_result(other), do: other
 
-  defp sql_runtime_call(function_name, args)
-       when is_atom(function_name) and is_list(args) do
+  defp sql_runtime_call(runtime_function, runtime_args)
+       when is_atom(runtime_function) and is_list(runtime_args) do
     runtime_module = Favn.SQLAsset.Runtime
+    arity = length(runtime_args)
 
-    with {:module, ^runtime_module} <- Code.ensure_loaded(runtime_module),
-         arity <- length(args),
-         true <- function_exported?(runtime_module, function_name, arity) do
-      apply(runtime_module, function_name, args)
+    if runtime_function_exported?(runtime_module, runtime_function, arity) do
+      apply(runtime_module, runtime_function, runtime_args)
     else
-      _ -> {:error, :runtime_not_available}
+      {:error, :runtime_not_available}
+    end
+  end
+
+  defp runtime_function_exported?(runtime_module, runtime_function, arity)
+       when is_atom(runtime_module) and is_atom(runtime_function) and is_integer(arity) do
+    case Code.ensure_loaded(runtime_module) do
+      {:module, ^runtime_module} -> function_exported?(runtime_module, runtime_function, arity)
+      _other -> false
     end
   end
 end

--- a/apps/favn_authoring/lib/favn.ex
+++ b/apps/favn_authoring/lib/favn.ex
@@ -56,8 +56,7 @@ defmodule FavnAuthoring do
   """
   @spec list_assets() :: {:ok, [asset()]} | {:error, term()}
   def list_assets do
-    modules = Application.get_env(:favn, :asset_modules, [])
-    list_assets(modules)
+    list_assets(default_asset_modules())
   end
 
   @doc """
@@ -65,16 +64,16 @@ defmodule FavnAuthoring do
   """
   @spec list_assets(module() | [module()]) :: {:ok, [asset()]} | {:error, term()}
   def list_assets(module) when is_atom(module) do
-    case Application.get_env(:favn, :asset_modules, :unset) do
+    case configured_asset_modules() do
       modules when is_list(modules) ->
         if module in modules do
           list_assets_for_module_from_catalog(module, modules)
         else
-          compile_module_assets(module)
+          Compiler.compile_module_assets(module)
         end
 
       _other ->
-        compile_module_assets(module)
+        Compiler.compile_module_assets(module)
     end
   end
 
@@ -100,13 +99,6 @@ defmodule FavnAuthoring do
         [] -> {:error, :not_asset_module}
         module_assets -> {:ok, module_assets}
       end
-    end
-  end
-
-  defp compile_module_assets(module) when is_atom(module) do
-    case Compiler.compile_module_assets(module) do
-      {:ok, assets} -> {:ok, assets}
-      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -202,16 +194,32 @@ defmodule FavnAuthoring do
 
   defp with_default_manifest_modules(opts) when is_list(opts) do
     opts
-    |> Keyword.put_new(:asset_modules, Application.get_env(:favn, :asset_modules, []))
-    |> Keyword.put_new(:pipeline_modules, Application.get_env(:favn, :pipeline_modules, []))
-    |> Keyword.put_new(:schedule_modules, Application.get_env(:favn, :schedule_modules, []))
+    |> Keyword.put_new(:asset_modules, default_asset_modules())
+    |> Keyword.put_new(:pipeline_modules, default_pipeline_modules())
+    |> Keyword.put_new(:schedule_modules, default_schedule_modules())
+  end
+
+  defp configured_asset_modules do
+    Application.get_env(:favn, :asset_modules, :unset)
+  end
+
+  defp default_asset_modules do
+    Application.get_env(:favn, :asset_modules, [])
+  end
+
+  defp default_pipeline_modules do
+    Application.get_env(:favn, :pipeline_modules, [])
+  end
+
+  defp default_schedule_modules do
+    Application.get_env(:favn, :schedule_modules, [])
   end
 
   @doc false
   @spec plan_asset_run(asset_ref() | [asset_ref()], keyword()) ::
           {:ok, Favn.Plan.t()} | {:error, term()}
   def plan_asset_run(target_refs, opts \\ []) do
-    opts = Keyword.put_new(opts, :asset_modules, Application.get_env(:favn, :asset_modules, []))
+    opts = Keyword.put_new(opts, :asset_modules, default_asset_modules())
     Planner.plan(target_refs, opts)
   end
 

--- a/apps/favn_authoring/lib/favn/sql_asset/input.ex
+++ b/apps/favn_authoring/lib/favn/sql_asset/input.ex
@@ -1,67 +1,80 @@
 defmodule Favn.SQLAsset.Input do
   @moduledoc false
 
+  alias Favn.Asset
   alias Favn.SQLAsset.Compiler, as: SQLAssetCompiler
+  alias Favn.SQLAsset.Definition, as: SQLAssetDefinition
 
   @type input :: module() | Favn.asset_ref() | Favn.asset()
 
   @spec normalize(input()) :: {:ok, Favn.asset()} | {:error, map() | struct()}
-  def normalize(%Favn.Asset{type: :sql} = asset), do: {:ok, asset}
+  def normalize(%Asset{type: :sql} = asset), do: {:ok, asset}
 
-  def normalize(%Favn.Asset{} = asset) do
+  def normalize(%Asset{} = asset) do
     {:error, error(:not_sql_asset, "asset #{inspect(asset.ref)} is not a SQL asset", asset.ref)}
   end
 
   def normalize({module, name} = ref) when is_atom(module) and is_atom(name) do
     case name do
       :asset ->
-        resolve_sql_asset_module(module, ref)
+        resolve_sql_asset_module(module)
 
       _other ->
-        {:error,
-         error(
-           :invalid_asset_input,
-           "invalid SQL asset ref #{inspect(ref)}; expected {module, :asset}",
-           ref,
-           %{reason: :invalid_sql_asset_ref_name}
-         )}
+        {:error, invalid_ref_name_error(ref)}
     end
   end
 
   def normalize(module) when is_atom(module) do
-    resolve_sql_asset_module(module, {module, :asset})
+    resolve_sql_asset_module(module)
   end
 
   def normalize(other) do
-    {:error,
-     error(
-       :invalid_asset_input,
-       "invalid SQL asset input; expected module, {module, :asset}, or %Favn.Asset{}",
-       nil,
-       %{input: other}
-     )}
+    {:error, invalid_input_error(other)}
   end
 
-  defp resolve_sql_asset_module(module, asset_ref) do
+  defp resolve_sql_asset_module(module) do
+    asset_ref = {module, :asset}
+
     case SQLAssetCompiler.fetch_definition(module) do
-      {:ok, %Favn.SQLAsset.Definition{asset: %Favn.Asset{} = asset}} ->
+      {:ok, %SQLAssetDefinition{asset: %Asset{} = asset}} ->
         {:ok, asset}
 
       {:error, _reason} ->
         case FavnAuthoring.get_asset(module) do
-          {:ok, %Favn.Asset{} = asset} ->
+          {:ok, %Asset{} = asset} ->
             normalize(asset)
 
           {:error, reason} ->
-            {:error,
-             error(
-               :invalid_asset_input,
-               "could not resolve SQL asset #{inspect(module)}",
-               asset_ref,
-               %{reason: reason}
-             )}
+            {:error, unresolved_asset_error(module, asset_ref, reason)}
         end
     end
+  end
+
+  defp invalid_ref_name_error(ref) do
+    error(
+      :invalid_asset_input,
+      "invalid SQL asset ref #{inspect(ref)}; expected {module, :asset}",
+      ref,
+      %{reason: :invalid_sql_asset_ref_name}
+    )
+  end
+
+  defp invalid_input_error(input) do
+    error(
+      :invalid_asset_input,
+      "invalid SQL asset input; expected module, {module, :asset}, or %Favn.Asset{}",
+      nil,
+      %{input: input}
+    )
+  end
+
+  defp unresolved_asset_error(module, asset_ref, reason) do
+    error(
+      :invalid_asset_input,
+      "could not resolve SQL asset #{inspect(module)}",
+      asset_ref,
+      %{reason: reason}
+    )
   end
 
   defp error(type, message, asset_ref, details \\ %{}) do

--- a/apps/favn_authoring/test/favn_authoring_test.exs
+++ b/apps/favn_authoring/test/favn_authoring_test.exs
@@ -1,0 +1,41 @@
+defmodule FavnAuthoringTest do
+  use ExUnit.Case, async: false
+
+  defmodule ConfiguredAsset do
+    use Favn.Asset
+
+    def asset(_ctx), do: :ok
+  end
+
+  defmodule DirectAsset do
+    use Favn.Asset
+
+    def asset(_ctx), do: :ok
+  end
+
+  setup do
+    previous_assets = Application.get_env(:favn, :asset_modules)
+
+    on_exit(fn ->
+      restore_env(:asset_modules, previous_assets)
+    end)
+
+    :ok
+  end
+
+  test "list_assets/0 uses configured asset modules" do
+    Application.put_env(:favn, :asset_modules, [ConfiguredAsset])
+
+    assert {:ok, [%Favn.Asset{ref: {ConfiguredAsset, :asset}}]} = FavnAuthoring.list_assets()
+  end
+
+  test "list_assets/1 compiles an omitted module directly" do
+    Application.put_env(:favn, :asset_modules, [ConfiguredAsset])
+
+    assert {:ok, [%Favn.Asset{ref: {DirectAsset, :asset}}]} =
+             FavnAuthoring.list_assets(DirectAsset)
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:favn, key)
+  defp restore_env(key, value), do: Application.put_env(:favn, key, value)
+end

--- a/apps/favn_authoring/test/sql_asset_input_test.exs
+++ b/apps/favn_authoring/test/sql_asset_input_test.exs
@@ -1,0 +1,79 @@
+defmodule Favn.SQLAssetInputTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.SQLAsset.Input
+
+  defmodule SQLAsset do
+    use Favn.Namespace, relation: [connection: :warehouse, catalog: "test", schema: "public"]
+    use Favn.SQLAsset
+
+    @materialized :table
+    query do
+      ~SQL"select 1 as id"
+    end
+  end
+
+  test "returns SQL asset structs unchanged" do
+    asset = %Favn.Asset{ref: {__MODULE__, :asset}, type: :sql}
+
+    assert {:ok, ^asset} = Input.normalize(asset)
+  end
+
+  test "rejects non-SQL asset structs" do
+    asset = %Favn.Asset{ref: {__MODULE__, :asset}, type: :elixir}
+
+    assert {:error, error} = Input.normalize(asset)
+
+    assert %{type: :not_sql_asset, phase: :render, asset_ref: {__MODULE__, :asset}} =
+             payload(error)
+  end
+
+  test "rejects non-asset SQL refs" do
+    assert {:error, error} = Input.normalize({SQLAsset, :other})
+
+    assert %{
+             type: :invalid_asset_input,
+             phase: :render,
+             asset_ref: {SQLAsset, :other},
+             details: %{reason: :invalid_sql_asset_ref_name}
+           } = payload(error)
+  end
+
+  test "rejects invalid input shapes" do
+    input = %{unexpected: true}
+
+    assert {:error, error} = Input.normalize(input)
+
+    assert %{
+             type: :invalid_asset_input,
+             phase: :render,
+             asset_ref: nil,
+             details: %{input: ^input}
+           } = payload(error)
+  end
+
+  test "resolves SQL asset modules" do
+    assert {:ok, %Favn.Asset{ref: {SQLAsset, :asset}, type: :sql}} = Input.normalize(SQLAsset)
+
+    assert {:ok, %Favn.Asset{ref: {SQLAsset, :asset}, type: :sql}} =
+             Input.normalize({SQLAsset, :asset})
+  end
+
+  test "preserves unresolved module reason in error details" do
+    module = Favn.SQLAssetInputTest.MissingAsset
+
+    assert {:error, error} = Input.normalize(module)
+
+    assert %{
+             type: :invalid_asset_input,
+             phase: :render,
+             asset_ref: {^module, :asset},
+             details: %{reason: reason}
+           } = payload(error)
+
+    assert reason in [:not_asset_module, :asset_not_found]
+  end
+
+  defp payload(%_struct{} = error), do: Map.from_struct(error)
+  defp payload(error), do: error
+end


### PR DESCRIPTION
## Summary
- Simplify repeated SQL runtime facade calls and runtime availability checks in `Favn`.
- Centralize authoring default module config reads and remove a redundant compiler wrapper.
- Clarify SQL asset input normalization errors and add focused tests for touched contracts.

## Validation
- `mix format --check-formatted` in `apps/favn_authoring`
- `mix compile --warnings-as-errors` in `apps/favn_authoring`
- `mix test` in `apps/favn_authoring`
- `mix format --check-formatted` in `apps/favn`
- `mix compile --warnings-as-errors` in `apps/favn`
- `mix test` in `apps/favn`
- `mix credo --strict --files-included "apps/favn_authoring/{lib,test}/**/*.{ex,exs}" --files-included "apps/favn/{lib,test}/**/*.{ex,exs}"`
- `mix xref graph --format stats --label compile-connected` in both apps
- `mix xref graph --format cycles --label compile-connected` in both apps