### PR TITLE
Refactor favn_core internals for clarity

### DIFF
--- a/apps/favn_core/lib/favn/assets/compiler.ex
+++ b/apps/favn_core/lib/favn/assets/compiler.ex
@@ -70,23 +70,12 @@ defmodule Favn.Assets.Compiler do
 
   defp normalize_assets(_), do: {:error, :invalid_compiled_assets}
 
-  defp normalize_compiled_assets(assets, module) do
-    normalize_assets(assets)
-    |> case do
-      {:ok, assets} ->
-        try do
-          validate_single_asset_depends_shorthand!(module)
-          resolve_relations(assets, module)
-        rescue
-          error in ArgumentError -> {:error, {:invalid_compiled_assets, error.message}}
-        end
+  defp normalize_compiled_assets(assets, module), do: normalize_and_resolve_assets(assets, module)
 
-      {:error, _reason} = error ->
-        error
-    end
-  end
+  defp normalize_module_assets(assets, module) when is_list(assets),
+    do: normalize_and_resolve_assets(assets, module)
 
-  defp normalize_module_assets(assets, module) when is_list(assets) do
+  defp normalize_and_resolve_assets(assets, module) do
     normalize_assets(assets)
     |> case do
       {:ok, assets} ->
@@ -149,10 +138,10 @@ defmodule Favn.Assets.Compiler do
   end
 
   defp resolve_relations(assets, module) do
-    defaults = namespace_defaults(module)
+    relation_defaults = namespace_defaults(module)
 
     try do
-      assets = Enum.map(assets, &resolve_relation(&1, defaults))
+      assets = Enum.map(assets, &resolve_relation(&1, relation_defaults))
       :ok = RelationResolver.ensure_unique_relation_owners!(assets)
       {:ok, assets}
     rescue
@@ -160,27 +149,31 @@ defmodule Favn.Assets.Compiler do
     end
   end
 
-  defp resolve_relation(asset, defaults) when is_map(asset) do
+  defp resolve_relation(asset, relation_defaults) when is_map(asset) do
     inferred_name = RelationResolver.inferred_relation_name_for_asset(asset)
 
     asset_module = Map.get(asset, :module)
     asset_name = Map.get(asset, :name)
 
     relation =
-      case fetch_raw_relation(asset_module, asset_name) do
+      case fetch_authored_relation(asset_module, asset_name) do
         nil ->
-          resolve_existing_relation(Map.get(asset, :relation), defaults, inferred_name)
+          resolve_existing_relation(Map.get(asset, :relation), relation_defaults, inferred_name)
 
         authored_value ->
-          RelationResolver.resolve_explicit_relation!(authored_value, defaults, inferred_name)
+          RelationResolver.resolve_explicit_relation!(
+            authored_value,
+            relation_defaults,
+            inferred_name
+          )
       end
 
     asset
     |> Map.put(:relation, relation)
-    |> resolve_relation_inputs(defaults)
+    |> resolve_relation_inputs(relation_defaults)
   end
 
-  defp fetch_raw_relation(module, name) do
+  defp fetch_authored_relation(module, name) do
     with true <- function_exported?(module, :__favn_assets_raw__, 0),
          entries when is_list(entries) <- module.__favn_assets_raw__(),
          %{relation: relation} <- Enum.find(entries, &(Map.get(&1, :name) == name)) do
@@ -195,25 +188,26 @@ defmodule Favn.Assets.Compiler do
 
   defp resolve_existing_relation(nil, _defaults, _inferred_name), do: nil
 
-  defp resolve_existing_relation(%Favn.RelationRef{} = existing, defaults, inferred_name) do
+  defp resolve_existing_relation(%Favn.RelationRef{} = existing, relation_defaults, inferred_name) do
     existing
     |> Map.from_struct()
-    |> RelationResolver.resolve_explicit_relation!(defaults, inferred_name)
+    |> RelationResolver.resolve_explicit_relation!(relation_defaults, inferred_name)
   end
 
-  defp resolve_existing_relation(existing, defaults, inferred_name)
+  defp resolve_existing_relation(existing, relation_defaults, inferred_name)
        when is_map(existing) or is_list(existing) or existing == true do
-    RelationResolver.resolve_explicit_relation!(existing, defaults, inferred_name)
+    RelationResolver.resolve_explicit_relation!(existing, relation_defaults, inferred_name)
   end
 
-  defp resolve_relation_inputs(asset, defaults) when is_map(asset) and is_map(defaults) do
+  defp resolve_relation_inputs(asset, relation_defaults)
+       when is_map(asset) and is_map(relation_defaults) do
     relation_inputs =
       asset
       |> Map.get(:relation_inputs, [])
       |> Enum.map(fn
         %Favn.Asset.RelationInput{relation_ref: %Favn.RelationRef{} = relation_ref} = input ->
           resolved_relation =
-            resolve_existing_relation(relation_ref, defaults, relation_ref.name)
+            resolve_existing_relation(relation_ref, relation_defaults, relation_ref.name)
 
           %{input | relation_ref: resolved_relation}
 

--- a/apps/favn_core/lib/favn/assets/planner.ex
+++ b/apps/favn_core/lib/favn/assets/planner.ex
@@ -206,18 +206,18 @@ defmodule Favn.Assets.Planner do
 
   defp build_windowed_graph(index, anchors) do
     with {:ok, ref_nodes} <- build_ref_nodes_by_ref(index, anchors) do
-      nodes =
-        index.topo_order
-        |> Enum.flat_map(fn ref ->
-          Enum.map(Map.fetch!(ref_nodes, ref), fn node ->
-            upstream = build_edges(node, index.upstream |> Map.fetch!(ref), ref_nodes)
-            downstream = build_edges(node, index.downstream |> Map.fetch!(ref), ref_nodes)
-            Map.merge(node, %{upstream: upstream, downstream: downstream})
-          end)
-        end)
-
-      {:ok, %{nodes: nodes, ref_nodes: ref_nodes}}
+      {:ok, %{nodes: build_windowed_nodes(index, ref_nodes), ref_nodes: ref_nodes}}
     end
+  end
+
+  defp build_windowed_nodes(index, ref_nodes) do
+    Enum.flat_map(index.topo_order, fn ref ->
+      Enum.map(Map.fetch!(ref_nodes, ref), fn node ->
+        upstream = build_edges(node, index.upstream |> Map.fetch!(ref), ref_nodes)
+        downstream = build_edges(node, index.downstream |> Map.fetch!(ref), ref_nodes)
+        Map.merge(node, %{upstream: upstream, downstream: downstream})
+      end)
+    end)
   end
 
   defp build_ref_nodes_by_ref(index, anchors) do
@@ -262,14 +262,14 @@ defmodule Favn.Assets.Planner do
   defp asset_window_spec(_asset), do: nil
 
   defp expand_windows(%Anchor{} = anchor_window, %Spec{} = spec) do
-    count =
+    window_count =
       window_units_between(spec.kind, anchor_window.start_at, anchor_window.end_at, spec.timezone)
 
-    total = max(count + spec.lookback, 1)
+    runtime_window_count = max(window_count + spec.lookback, 1)
     anchor_start = floor_to_kind(anchor_window.start_at, spec.kind, spec.timezone)
     first_start = shift_kind(anchor_start, spec.kind, -spec.lookback)
 
-    for offset <- 0..(total - 1) do
+    for offset <- 0..(runtime_window_count - 1) do
       start_at = shift_kind(first_start, spec.kind, offset)
       end_at = shift_kind(start_at, spec.kind, 1)
       Runtime.new!(spec.kind, start_at, end_at, anchor_window.key, timezone: spec.timezone)
@@ -290,9 +290,9 @@ defmodule Favn.Assets.Planner do
   end
 
   defp month_diff(start_at, end_at) do
-    s = DateTime.to_date(start_at)
-    e = DateTime.to_date(end_at)
-    (e.year - s.year) * 12 + (e.month - s.month)
+    start_date = DateTime.to_date(start_at)
+    end_date = DateTime.to_date(end_at)
+    (end_date.year - start_date.year) * 12 + (end_date.month - start_date.month)
   end
 
   defp floor_to_kind(datetime, :hour, timezone),
@@ -398,9 +398,9 @@ defmodule Favn.Assets.Planner do
   defp node_action(%{type: :source}), do: :observe
   defp node_action(_asset), do: :run
 
-  defp build_stages(index, stage_map) do
+  defp build_stages(index, ref_stage_map) do
     index.topo_order
-    |> Enum.group_by(&Map.fetch!(stage_map, &1))
+    |> Enum.group_by(&Map.fetch!(ref_stage_map, &1))
     |> Enum.sort_by(&elem(&1, 0))
     |> Enum.map(fn {_rank, refs} -> Enum.sort(refs) end)
   end

--- a/apps/favn_core/lib/favn/backfill/range_request.ex
+++ b/apps/favn_core/lib/favn/backfill/range_request.ex
@@ -204,13 +204,15 @@ defmodule Favn.Backfill.RangeRequest do
   defp normalize_reference(opts) do
     relative_to = Keyword.get(opts, :relative_to)
     baseline = Keyword.get(opts, :baseline)
+    relative_to_datetime = parse_datetime(relative_to)
+    coverage_until_datetime = parse_datetime(coverage_until(baseline))
 
     cond do
-      match?(%DateTime{}, parse_datetime(relative_to)) ->
-        {:ok, parse_datetime(relative_to), baseline}
+      match?(%DateTime{}, relative_to_datetime) ->
+        {:ok, relative_to_datetime, baseline}
 
-      match?(%DateTime{}, parse_datetime(coverage_until(baseline))) ->
-        {:ok, parse_datetime(coverage_until(baseline)), normalize_baseline(baseline)}
+      match?(%DateTime{}, coverage_until_datetime) ->
+        {:ok, coverage_until_datetime, normalize_baseline(baseline)}
 
       true ->
         {:error, {:missing_backfill_reference, opts}}

--- a/apps/favn_core/lib/favn/backfill/range_resolver.ex
+++ b/apps/favn_core/lib/favn/backfill/range_resolver.ex
@@ -37,14 +37,14 @@ defmodule Favn.Backfill.RangeResolver do
   end
 
   defp resolve_request(%RangeRequest{mode: :explicit} = request) do
-    with {:ok, from_anchor} <- single_anchor(request.kind, request.from, request.timezone),
-         {:ok, to_anchor} <- single_anchor(request.kind, request.to, request.timezone),
+    with {:ok, from_anchor} <- request_anchor(request.kind, request.from, request.timezone),
+         {:ok, to_anchor} <- request_anchor(request.kind, request.to, request.timezone),
          :ok <- validate_order(from_anchor.start_at, to_anchor.end_at),
          {:ok, anchors} <-
            Anchor.expand_range(request.kind, from_anchor.start_at, to_anchor.end_at,
              timezone: request.timezone
            ) do
-      resolved(request.kind, request.timezone, anchors, length(anchors), nil)
+      build_resolved_range(request.kind, request.timezone, anchors, length(anchors), nil)
     end
   end
 
@@ -54,16 +54,16 @@ defmodule Favn.Backfill.RangeResolver do
     with {:ok, end_at} <- exclusive_end_boundary(reference, kind, request.timezone),
          {:ok, start_at} <- shift_kind(end_at, kind, -count),
          {:ok, anchors} <- Anchor.expand_range(kind, start_at, end_at, timezone: request.timezone) do
-      resolved(kind, request.timezone, anchors, count, reference)
+      build_resolved_range(kind, request.timezone, anchors, count, reference)
     end
   end
 
-  defp single_anchor(kind, value, timezone) do
+  defp request_anchor(kind, value, timezone) do
     %Request{kind: kind, value: value, timezone: timezone}
     |> Request.to_anchor(timezone)
   end
 
-  defp resolved(kind, timezone, anchors, requested_count, reference) do
+  defp build_resolved_range(kind, timezone, anchors, requested_count, reference) do
     {:ok,
      %{
        kind: kind,

--- a/apps/favn_core/lib/favn/manifest/generator.ex
+++ b/apps/favn_core/lib/favn/manifest/generator.ex
@@ -85,22 +85,9 @@ defmodule Favn.Manifest.Generator do
   end
 
   defp manifest_from_catalog(%Catalog{} = catalog) do
-    assets =
-      catalog.assets
-      |> Enum.map(&ManifestAsset.from_asset/1)
-      |> Enum.sort(&compare_assets/2)
-
-    pipelines =
-      catalog.pipelines
-      |> Enum.map(&ManifestPipeline.from_definition/1)
-      |> Enum.sort(&compare_pipelines/2)
-
-    schedules =
-      catalog.schedules
-      |> Enum.map(fn {module, name, schedule} ->
-        ManifestSchedule.from_schedule(module, name, schedule)
-      end)
-      |> Enum.sort(&compare_schedules/2)
+    assets = manifest_assets_from_catalog(catalog)
+    pipelines = manifest_pipelines_from_catalog(catalog)
+    schedules = manifest_schedules_from_catalog(catalog)
 
     with {:ok, graph} <- Graph.build(assets) do
       {:ok,
@@ -114,6 +101,26 @@ defmodule Favn.Manifest.Generator do
          metadata: %{}
        }}
     end
+  end
+
+  defp manifest_assets_from_catalog(%Catalog{} = catalog) do
+    catalog.assets
+    |> Enum.map(&ManifestAsset.from_asset/1)
+    |> Enum.sort(&compare_assets/2)
+  end
+
+  defp manifest_pipelines_from_catalog(%Catalog{} = catalog) do
+    catalog.pipelines
+    |> Enum.map(&ManifestPipeline.from_definition/1)
+    |> Enum.sort(&compare_pipelines/2)
+  end
+
+  defp manifest_schedules_from_catalog(%Catalog{} = catalog) do
+    catalog.schedules
+    |> Enum.map(fn {module, name, schedule} ->
+      ManifestSchedule.from_schedule(module, name, schedule)
+    end)
+    |> Enum.sort(&compare_schedules/2)
   end
 
   defp resolve_modules(opts, key) do
@@ -171,18 +178,9 @@ defmodule Favn.Manifest.Generator do
   defp compile_schedules(modules) when is_list(modules) do
     modules
     |> Enum.reduce_while({:ok, []}, fn module, {:ok, acc} ->
-      with {:module, ^module} <- Code.ensure_loaded(module),
-           true <- function_exported?(module, :__favn_schedules__, 0) do
-        schedules =
-          module
-          |> then(& &1.__favn_schedules__())
-          |> Map.to_list()
-          |> Enum.sort_by(&elem(&1, 0))
-          |> Enum.map(fn {name, schedule} -> {module, name, schedule} end)
-
-        {:cont, {:ok, schedules ++ acc}}
-      else
-        _ -> {:halt, {:error, {:schedule_compile_failed, module, :not_schedule_module}}}
+      case compile_module_schedules(module) do
+        {:ok, schedules} -> {:cont, {:ok, schedules ++ acc}}
+        {:error, reason} -> {:halt, {:error, {:schedule_compile_failed, module, reason}}}
       end
     end)
     |> case do
@@ -192,6 +190,22 @@ defmodule Favn.Manifest.Generator do
   end
 
   defp compile_schedules(_invalid), do: {:error, :invalid_schedule_modules}
+
+  defp compile_module_schedules(module) do
+    with {:module, ^module} <- Code.ensure_loaded(module),
+         true <- function_exported?(module, :__favn_schedules__, 0) do
+      schedules =
+        module
+        |> then(& &1.__favn_schedules__())
+        |> Map.to_list()
+        |> Enum.sort_by(&elem(&1, 0))
+        |> Enum.map(fn {name, schedule} -> {module, name, schedule} end)
+
+      {:ok, schedules}
+    else
+      _ -> {:error, :not_schedule_module}
+    end
+  end
 
   defp compare_assets(left, right), do: compare_refs(left.ref, right.ref)
 

--- a/apps/favn_core/lib/favn/pipeline/resolver.ex
+++ b/apps/favn_core/lib/favn/pipeline/resolver.ex
@@ -27,7 +27,7 @@ defmodule Favn.Pipeline.Resolver do
     trigger = Keyword.get(opts, :trigger, %{kind: :manual})
     params = Keyword.get(opts, :params, %{})
     anchor_window = Keyword.get(opts, :anchor_window)
-    assets_opt = Keyword.get(opts, :assets)
+    assets_input = Keyword.get(opts, :assets)
     schedule_lookup = Keyword.get(opts, :schedule_lookup)
     default_timezone = Schedule.default_timezone()
 
@@ -38,27 +38,13 @@ defmodule Favn.Pipeline.Resolver do
          :ok <- validate_trigger(trigger),
          :ok <- validate_anchor_window(anchor_window),
          :ok <- validate_schedule_lookup(schedule_lookup),
-         :ok <- validate_assets_opt(assets_opt),
+         :ok <- validate_assets_input(assets_input),
          {:ok, schedule} <-
            resolve_schedule(definition.schedule, default_timezone, schedule_lookup),
-         {:ok, assets} <- resolve_assets(assets_opt),
+         {:ok, assets} <- resolve_assets(assets_input),
          {:ok, target_refs} <- resolve_selectors(selectors, assets) do
-      pipeline_ctx = %{
-        id: definition.name,
-        name: definition.name,
-        run_kind: :pipeline,
-        resolved_refs: target_refs,
-        deps: definition.deps,
-        config: definition.config,
-        meta: definition.meta,
-        trigger: trigger,
-        params: params,
-        anchor_window: anchor_window,
-        window: definition.window,
-        schedule: schedule,
-        source: definition.source,
-        outputs: definition.outputs
-      }
+      pipeline_ctx =
+        build_pipeline_ctx(definition, target_refs, trigger, params, anchor_window, schedule)
 
       {:ok,
        %Resolution{
@@ -129,9 +115,9 @@ defmodule Favn.Pipeline.Resolver do
   defp validate_schedule_lookup(fun) when is_function(fun, 2), do: :ok
   defp validate_schedule_lookup(other), do: {:error, {:invalid_schedule_lookup, other}}
 
-  defp validate_assets_opt(nil), do: {:error, :missing_assets}
-  defp validate_assets_opt(values) when is_list(values), do: :ok
-  defp validate_assets_opt(other), do: {:error, {:invalid_assets_opt, other}}
+  defp validate_assets_input(nil), do: {:error, :missing_assets}
+  defp validate_assets_input(values) when is_list(values), do: :ok
+  defp validate_assets_input(other), do: {:error, {:invalid_assets_opt, other}}
 
   defp resolve_assets(nil), do: {:error, :missing_assets}
   defp resolve_assets(values), do: {:ok, values}
@@ -160,13 +146,13 @@ defmodule Favn.Pipeline.Resolver do
   defp resolve_selectors(selectors, assets) when is_list(selectors) do
     assets_by_ref = Map.new(assets, &{&1.ref, &1})
 
-    with {:ok, refs} <- do_resolve_selectors(selectors, assets, assets_by_ref) do
+    with {:ok, refs} <- collect_selector_refs(selectors, assets, assets_by_ref) do
       refs = refs |> Enum.uniq() |> Enum.sort()
       if refs == [], do: {:error, :pipeline_resolved_empty}, else: {:ok, refs}
     end
   end
 
-  defp do_resolve_selectors(selectors, assets, assets_by_ref) do
+  defp collect_selector_refs(selectors, assets, assets_by_ref) do
     Enum.reduce_while(selectors, {:ok, []}, fn selector, {:ok, acc} ->
       case selector_refs(selector, assets, assets_by_ref) do
         {:ok, refs} -> {:cont, {:ok, refs ++ acc}}
@@ -220,5 +206,24 @@ defmodule Favn.Pipeline.Resolver do
       values when is_list(values) -> values
       _ -> []
     end
+  end
+
+  defp build_pipeline_ctx(definition, target_refs, trigger, params, anchor_window, schedule) do
+    %{
+      id: definition.name,
+      name: definition.name,
+      run_kind: :pipeline,
+      resolved_refs: target_refs,
+      deps: definition.deps,
+      config: definition.config,
+      meta: definition.meta,
+      trigger: trigger,
+      params: params,
+      anchor_window: anchor_window,
+      window: definition.window,
+      schedule: schedule,
+      source: definition.source,
+      outputs: definition.outputs
+    }
   end
 end

--- a/apps/favn_core/lib/favn_core.ex
+++ b/apps/favn_core/lib/favn_core.ex
@@ -1,10 +1,14 @@
 defmodule FavnCore do
   @moduledoc """
-  Documentation for `FavnCore`.
+  Internal application marker for the `:favn_core` app.
+
+  The shared contracts and implementation modules in this app live under the
+  `Favn.*` namespace. This module is kept as a lightweight app-level smoke
+  surface for the generated Mix project scaffold.
   """
 
   @doc """
-  Hello world.
+  Returns the existing scaffold smoke value.
 
   ## Examples
 

--- a/apps/favn_core/test/favn_core_test.exs
+++ b/apps/favn_core/test/favn_core_test.exs
@@ -2,7 +2,7 @@ defmodule FavnCoreTest do
   use ExUnit.Case
   doctest FavnCore
 
-  test "greets the world" do
+  test "keeps the app-level scaffold smoke value" do
     assert FavnCore.hello() == :world
   end
 end

--- a/apps/favn_core/test/pipeline/resolver_parity_test.exs
+++ b/apps/favn_core/test/pipeline/resolver_parity_test.exs
@@ -1,5 +1,5 @@
 defmodule Favn.Pipeline.ResolverParityTest do
-  use ExUnit.Case, async: true
+  use ExUnit.Case, async: false
 
   alias Favn.Pipeline.Definition
   alias Favn.Pipeline.Resolver


### PR DESCRIPTION
## Summary
- Consolidate duplicated private asset-normalization flow and clarify relation-resolution naming in `favn_core`.
- Split dense manifest/planner/pipeline/backfill private code into clearer behavior-preserving helpers.
- Keep `favn_core` tests safer by making env-mutating resolver parity coverage non-async.

## Validation
- `mix format --check-formatted` on touched files
- `mix compile --warnings-as-errors` from `apps/favn_core`
- `mix test test/pipeline/resolver_parity_test.exs test/backfill/range_resolver_test.exs test/manifest/build_test.exs test/favn_core_test.exs` from `apps/favn_core`
- `mix xref graph --format stats --label compile-connected` from `apps/favn_core`
- `mix credo --strict --files-included "apps/favn_core/lib/**/*.ex,apps/favn_core/test/**/*.exs"`

## Notes
- Public contracts and project boundaries are intended to be preserved.
- Follow-up issues filed for larger hardening/test-boundary findings: #201, #202, #203.