### PR TITLE
Refine DuckDB adapter error handling

### DIFF
--- a/apps/favn_duckdb/lib/favn/sql/adapter/duckdb.ex
+++ b/apps/favn_duckdb/lib/favn/sql/adapter/duckdb.ex
@@ -566,21 +566,27 @@ defmodule Favn.SQL.Adapter.DuckDB do
   end
 
   defp fetch_rows(%Conn{} = conn, result_ref) do
-    columns =
-      case conn.client.columns(result_ref) do
-        cols when is_list(cols) -> Enum.map(cols, &to_string/1)
-        _ -> []
-      end
-
-    rows =
-      case conn.client.fetch_all(result_ref) do
-        rows when is_list(rows) -> Enum.map(rows, &normalize_row(&1, columns))
-        other -> other
-      end
-
-    if is_list(rows), do: {:ok, rows, columns}, else: {:error, rows}
+    case fetch_columns(conn, result_ref) do
+      {:ok, columns} -> fetch_all_rows(conn, result_ref, columns)
+      {:error, reason} -> {:error, reason}
+    end
   after
     _ = safe_release(conn, result_ref)
+  end
+
+  defp fetch_columns(%Conn{} = conn, result_ref) do
+    case conn.client.columns(result_ref) do
+      {:error, reason} -> {:error, reason}
+      cols when is_list(cols) -> {:ok, Enum.map(cols, &to_string/1)}
+      _other -> {:ok, []}
+    end
+  end
+
+  defp fetch_all_rows(%Conn{} = conn, result_ref, columns) do
+    case conn.client.fetch_all(result_ref) do
+      rows when is_list(rows) -> {:ok, Enum.map(rows, &normalize_row(&1, columns)), columns}
+      other -> {:error, other}
+    end
   end
 
   defp normalize_row(row, _columns) when is_map(row) do

--- a/apps/favn_duckdb/lib/favn/sql/adapter/duckdb/bootstrap.ex
+++ b/apps/favn_duckdb/lib/favn/sql/adapter/duckdb/bootstrap.ex
@@ -105,11 +105,9 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
   defp normalize_extension_name(name) when name in @extension_names, do: {:ok, name}
 
   defp normalize_extension_name(name) when is_binary(name) do
-    name
-    |> String.to_existing_atom()
-    |> normalize_extension_name()
-  rescue
-    ArgumentError -> {:error, {:unsupported_extension, name}}
+    Enum.find_value(@extension_names, {:error, {:unsupported_extension, name}}, fn extension ->
+      if Atom.to_string(extension) == name, do: {:ok, extension}
+    end)
   end
 
   defp normalize_extension_name(name), do: {:error, {:unsupported_extension, name}}
@@ -160,16 +158,16 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
   defp normalize_attach(config) do
     with {:ok, attach} <- normalize_keyword_config(config, :attach),
          {:ok, name} <- normalize_identifier(Keyword.get(attach, :name)),
-         :ok <- require_value(attach, :metadata),
-         :ok <- require_value(attach, :data_path) do
+         {:ok, metadata} <- fetch_present_value(attach, :metadata),
+         {:ok, data_path} <- fetch_present_value(attach, :data_path) do
       case Keyword.get(attach, :type) do
         :ducklake ->
           {:ok,
            %{
              name: name,
              type: :ducklake,
-             metadata: Keyword.fetch!(attach, :metadata),
-             data_path: Keyword.fetch!(attach, :data_path)
+             metadata: metadata,
+             data_path: data_path
            }}
 
         other ->
@@ -198,11 +196,17 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
   defp normalize_keyword_config(_config, context),
     do: {:error, {:invalid_bootstrap_config, context}}
 
-  defp require_value(keyword, key) do
-    if present_string?(Keyword.get(keyword, key)) do
-      :ok
-    else
-      {:error, {:missing_attach_field, key}}
+  defp fetch_present_value(keyword, key) do
+    case Keyword.fetch(keyword, key) do
+      {:ok, value} ->
+        if present_string?(value) do
+          {:ok, value}
+        else
+          {:error, {:missing_attach_field, key}}
+        end
+
+      _missing_or_blank ->
+        {:error, {:missing_attach_field, key}}
     end
   end
 

--- a/apps/favn_duckdb/test/sql/adapter/duckdb_bootstrap_test.exs
+++ b/apps/favn_duckdb/test/sql/adapter/duckdb_bootstrap_test.exs
@@ -95,6 +95,15 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
     assert {:error, :expected_duckdb_bootstrap_keyword_or_map} = validator.(:invalid)
   end
 
+  test "schema field accepts supported extension names as binaries" do
+    assert %{type: {:custom, validator}} = DuckDB.bootstrap_schema_field()
+
+    assert :ok = validator.(extensions: [install: ["ducklake"], load: ["postgres", "azure"]])
+
+    assert {:error, {:unsupported_extension, "unknown"}} =
+             validator.(extensions: [load: ["unknown"]])
+  end
+
   test "runs DuckLake bootstrap statements in configured order" do
     {:ok, conn} = DuckDB.connect(resolved(), duckdb_client: FakeClient)
 

--- a/apps/favn_duckdb/test/sql/adapter/duckdb_hardening_test.exs
+++ b/apps/favn_duckdb/test/sql/adapter/duckdb_hardening_test.exs
@@ -69,12 +69,18 @@ defmodule FavnDuckdb.SQLAdapterDuckDBHardeningTest do
     def columns(result_ref) do
       record({:columns, result_ref})
 
-      sql = result_sql(result_ref)
+      case mode(:columns_mode, :ok) do
+        :ok ->
+          sql = result_sql(result_ref)
 
-      if is_binary(sql) and String.contains?(sql, "count(*) AS row_count") do
-        ["row_count"]
-      else
-        ["value"]
+          if is_binary(sql) and String.contains?(sql, "count(*) AS row_count") do
+            ["row_count"]
+          else
+            ["value"]
+          end
+
+        :error ->
+          {:error, :columns_failed}
       end
     end
 
@@ -184,6 +190,7 @@ defmodule FavnDuckdb.SQLAdapterDuckDBHardeningTest do
       :connection_mode,
       :query_mode,
       :fetch_mode,
+      :columns_mode,
       :begin_mode,
       :commit_mode,
       :rollback_mode,
@@ -308,6 +315,26 @@ defmodule FavnDuckdb.SQLAdapterDuckDBHardeningTest do
 
     assert Enum.any?(events(), fn
              {:release, ^result_ref} -> true
+             _ -> false
+           end)
+  end
+
+  test "query columns error releases result handle" do
+    Application.put_env(:favn, :columns_mode, :error)
+    {:ok, conn} = DuckDB.connect(resolved(), duckdb_client: FakeClient)
+
+    assert {:error, %Error{type: :execution_error, operation: :query}} =
+             DuckDB.query(conn, "SELECT 1", [])
+
+    {result_ref, _sql} = last_result_ref!()
+
+    assert Enum.any?(events(), fn
+             {:release, ^result_ref} -> true
+             _ -> false
+           end)
+
+    refute Enum.any?(events(), fn
+             {:fetch_all, ^result_ref} -> true
              _ -> false
            end)
   end


### PR DESCRIPTION
## Summary
- Surface DuckDB client column lookup failures as normalized adapter query errors while preserving result-handle cleanup.
- Replace exception-driven DuckDB bootstrap extension normalization with explicit allow-list lookup.
- Avoid bang access after bootstrap attach validation and add focused regression coverage.

## Tests
- `MIX_ENV=test mix test --no-start` from `apps/favn_duckdb`
- `mix compile --warnings-as-errors` from `apps/favn_duckdb`
- `mix format --check-formatted lib/favn/sql/adapter/duckdb.ex lib/favn/sql/adapter/duckdb/bootstrap.ex test/sql/adapter/duckdb_bootstrap_test.exs test/sql/adapter/duckdb_hardening_test.exs` from `apps/favn_duckdb`