### PR TITLE
Refine storage adapter maintenance paths

### DIFF
--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -358,7 +358,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   @impl true
   def list_coverage_baselines(filters, opts) when is_list(filters) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts),
-         page_opts <- page_opts(filters),
+         {:ok, page_opts} <- page_opts(filters),
          {:ok, sql, params} <-
            build_select_query(
              coverage_baseline_select(),
@@ -431,7 +431,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   @impl true
   def list_backfill_windows(filters, opts) when is_list(filters) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts),
-         page_opts <- page_opts(filters),
+         {:ok, page_opts} <- page_opts(filters),
          {:ok, sql, params} <-
            build_select_query(
              backfill_window_select(),
@@ -501,7 +501,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   @impl true
   def list_asset_window_states(filters, opts) when is_list(filters) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts),
-         page_opts <- page_opts(filters),
+         {:ok, page_opts} <- page_opts(filters),
          {:ok, sql, params} <-
            build_select_query(
              asset_window_state_select(),
@@ -714,10 +714,7 @@ defmodule Favn.Storage.Adapter.Postgres do
 
   defp read_filters(filters), do: Keyword.drop(filters, [:limit, :offset])
 
-  defp page_opts(filters) do
-    {:ok, opts} = Page.normalize_opts(filters)
-    opts
-  end
+  defp page_opts(filters), do: Page.normalize_opts(filters)
 
   defp decode_coverage_baseline_row([
          baseline_id,

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
@@ -9,6 +9,17 @@ defmodule FavnStoragePostgres.Migrations do
     {20_260_415_100_000, CreateFoundation},
     {20_260_428_100_000, AddBackfillState}
   ]
+  @required_tables [
+    "public.favn_manifest_versions",
+    "public.favn_runtime_settings",
+    "public.favn_runs",
+    "public.favn_run_events",
+    "public.favn_scheduler_cursors",
+    "public.favn_pipeline_coverage_baselines",
+    "public.favn_backfill_windows",
+    "public.favn_asset_window_states",
+    "public.favn_run_write_seq"
+  ]
   @expected_versions Enum.map(@migrations, fn {version, _module} -> to_string(version) end)
 
   @spec migrate!(module()) :: :ok
@@ -27,24 +38,12 @@ defmodule FavnStoragePostgres.Migrations do
   end
 
   defp schema_objects_ready?(repo) do
-    required = [
-      "public.favn_manifest_versions",
-      "public.favn_runtime_settings",
-      "public.favn_runs",
-      "public.favn_run_events",
-      "public.favn_scheduler_cursors",
-      "public.favn_pipeline_coverage_baselines",
-      "public.favn_backfill_windows",
-      "public.favn_asset_window_states",
-      "public.favn_run_write_seq"
-    ]
-
-    placeholders = Enum.map_join(1..length(required), ",", &"$#{&1}")
+    placeholders = Enum.map_join(1..length(@required_tables), ",", &"$#{&1}")
 
     sql =
       "SELECT bool_and(to_regclass(name) IS NOT NULL) FROM unnest(ARRAY[#{placeholders}]::text[]) AS name"
 
-    case SQL.query(repo, sql, required) do
+    case SQL.query(repo, sql, @required_tables) do
       {:ok, %{rows: [[true]]}} -> true
       _ -> false
     end

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/supervisor.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/supervisor.ex
@@ -24,34 +24,34 @@ defmodule FavnStoragePostgres.Supervisor do
   end
 
   defp bootstrap_storage(repo_config, :auto) do
-    {:ok, pid} = Repo.start_link(Keyword.put(repo_config, :name, Repo))
-
-    try do
+    with_bootstrap_repo(repo_config, fn ->
       Migrations.migrate!(Repo)
-    after
-      GenServer.stop(pid)
-    end
-
-    :ok
+    end)
   end
 
   defp bootstrap_storage(repo_config, :manual) do
-    {:ok, pid} = Repo.start_link(Keyword.put(repo_config, :name, Repo))
-
-    try do
+    with_bootstrap_repo(repo_config, fn ->
       if Migrations.schema_ready?(Repo) do
         :ok
       else
         raise "favn postgres schema is not ready; run migrations or set migration_mode: :auto"
       end
+    end)
+  end
+
+  defp bootstrap_storage(_repo_config, mode) do
+    raise "invalid postgres migration mode: #{inspect(mode)}"
+  end
+
+  defp with_bootstrap_repo(repo_config, fun) when is_function(fun, 0) do
+    {:ok, pid} = Repo.start_link(Keyword.put(repo_config, :name, Repo))
+
+    try do
+      fun.()
     after
       GenServer.stop(pid)
     end
 
     :ok
-  end
-
-  defp bootstrap_storage(_repo_config, mode) do
-    raise "invalid postgres migration mode: #{inspect(mode)}"
   end
 end

--- a/apps/favn_storage_postgres/mix.exs
+++ b/apps/favn_storage_postgres/mix.exs
@@ -25,6 +25,7 @@ defmodule FavnStoragePostgres.MixProject do
   defp deps do
     [
       internal_dep(:favn_orchestrator, "../favn_orchestrator", runtime: false),
+      internal_dep(:favn, "../favn", only: :test, runtime: false),
       internal_dep(:favn_test_support, "../favn_test_support", only: :test),
       {:ecto_sql, "~> 3.13.4"},
       {:postgrex, "~> 0.22"}

--- a/apps/favn_storage_postgres/mix.exs
+++ b/apps/favn_storage_postgres/mix.exs
@@ -25,7 +25,7 @@ defmodule FavnStoragePostgres.MixProject do
   defp deps do
     [
       internal_dep(:favn_orchestrator, "../favn_orchestrator", runtime: false),
-      internal_dep(:favn, "../favn", only: :test, runtime: false),
+      internal_dep(:favn_core, "../favn_core", runtime: false),
       internal_dep(:favn_test_support, "../favn_test_support", only: :test),
       {:ecto_sql, "~> 3.13.4"},
       {:postgrex, "~> 0.22"}

--- a/apps/favn_storage_postgres/test/adapter_test.exs
+++ b/apps/favn_storage_postgres/test/adapter_test.exs
@@ -16,12 +16,7 @@ defmodule FavnStoragePostgres.AdapterTest do
     assert {:error, {:invalid_migration_mode, :bad}} =
              Adapter.child_spec(
                repo_mode: :managed,
-               repo_config: [
-                 hostname: "localhost",
-                 database: "favn",
-                 username: "postgres",
-                 password: "postgres"
-               ],
+               repo_config: repo_config(),
                migration_mode: :bad
              )
   end
@@ -30,12 +25,7 @@ defmodule FavnStoragePostgres.AdapterTest do
     assert {:ok, child_spec} =
              Adapter.child_spec(
                repo_mode: :managed,
-               repo_config: [
-                 hostname: "localhost",
-                 database: "favn",
-                 username: "postgres",
-                 password: "postgres"
-               ],
+               repo_config: repo_config(),
                migration_mode: :manual,
                supervisor_name: Module.concat([__MODULE__, "Supervisor"])
              )
@@ -67,5 +57,23 @@ defmodule FavnStoragePostgres.AdapterTest do
 
   test "invalid repo mode is rejected" do
     assert {:error, {:invalid_repo_mode, :bogus}} = Adapter.child_spec(repo_mode: :bogus)
+  end
+
+  test "read-model list APIs return invalid pagination errors" do
+    opts = [repo_mode: :managed, repo_config: repo_config()]
+    filters = [limit: 0]
+
+    assert {:error, :invalid_pagination} = Adapter.list_coverage_baselines(filters, opts)
+    assert {:error, :invalid_pagination} = Adapter.list_backfill_windows(filters, opts)
+    assert {:error, :invalid_pagination} = Adapter.list_asset_window_states(filters, opts)
+  end
+
+  defp repo_config do
+    [
+      hostname: "localhost",
+      database: "favn",
+      username: "postgres",
+      password: "postgres"
+    ]
   end
 end

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -367,7 +367,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def list_coverage_baselines(filters, opts) when is_list(filters) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts),
-         page_opts <- page_opts(filters),
+         {:ok, page_opts} <- page_opts(filters),
          {:ok, {where_sql, params}} <-
            build_filter_sql(read_filters(filters), coverage_baseline_filter_columns()) do
       sql =
@@ -461,7 +461,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def list_backfill_windows(filters, opts) when is_list(filters) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts),
-         page_opts <- page_opts(filters),
+         {:ok, page_opts} <- page_opts(filters),
          {:ok, {where_sql, params}} <-
            build_filter_sql(read_filters(filters), backfill_window_filter_columns()) do
       sql =
@@ -549,7 +549,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def list_asset_window_states(filters, opts) when is_list(filters) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts),
-         page_opts <- page_opts(filters),
+         {:ok, page_opts} <- page_opts(filters),
          {:ok, {where_sql, params}} <-
            build_filter_sql(read_filters(filters), asset_window_state_filter_columns()) do
       sql =
@@ -791,10 +791,7 @@ defmodule Favn.Storage.Adapter.SQLite do
 
   defp read_filters(filters), do: Keyword.drop(filters, [:limit, :offset])
 
-  defp page_opts(filters) do
-    {:ok, opts} = Page.normalize_opts(filters)
-    opts
-  end
+  defp page_opts(filters), do: Page.normalize_opts(filters)
 
   defp build_filter_sql([], _columns), do: {:ok, {"", []}}
 

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
@@ -9,6 +9,17 @@ defmodule FavnStorageSqlite.Migrations do
     {20_260_415_000_000, CreateFoundation},
     {20_260_428_100_000, AddBackfillState}
   ]
+  @required_tables [
+    "favn_manifest_versions",
+    "favn_runtime_settings",
+    "favn_runs",
+    "favn_run_events",
+    "favn_scheduler_cursors",
+    "favn_pipeline_coverage_baselines",
+    "favn_backfill_windows",
+    "favn_asset_window_states",
+    "favn_counters"
+  ]
   @expected_versions Enum.map(@migrations, fn {version, _module} -> to_string(version) end)
 
   @spec migrate!(module()) :: :ok
@@ -27,24 +38,12 @@ defmodule FavnStorageSqlite.Migrations do
   end
 
   defp schema_objects_ready?(repo) do
-    required = [
-      "favn_manifest_versions",
-      "favn_runtime_settings",
-      "favn_runs",
-      "favn_run_events",
-      "favn_scheduler_cursors",
-      "favn_pipeline_coverage_baselines",
-      "favn_backfill_windows",
-      "favn_asset_window_states",
-      "favn_counters"
-    ]
-
-    placeholders = Enum.map_join(1..length(required), ",", &"?#{&1}")
+    placeholders = Enum.map_join(1..length(@required_tables), ",", &"?#{&1}")
 
     sql =
-      "SELECT COUNT(*) = ?#{length(required) + 1} FROM sqlite_master WHERE type = 'table' AND name IN (#{placeholders})"
+      "SELECT COUNT(*) = ?#{length(@required_tables) + 1} FROM sqlite_master WHERE type = 'table' AND name IN (#{placeholders})"
 
-    params = required ++ [length(required)]
+    params = @required_tables ++ [length(@required_tables)]
 
     case SQL.query(repo, sql, params) do
       {:ok, %{rows: [[1]]}} -> true

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/supervisor.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/supervisor.ex
@@ -26,19 +26,13 @@ defmodule FavnStorageSqlite.Supervisor do
   defp bootstrap_storage(repo_name, repo_opts, :auto), do: run_migrations(repo_name, repo_opts)
 
   defp bootstrap_storage(repo_name, repo_opts, :manual) do
-    {:ok, pid} = Repo.start_link(Keyword.put(bootstrap_repo_opts(repo_opts), :name, repo_name))
-
-    try do
+    with_bootstrap_repo(repo_name, repo_opts, fn ->
       if Migrations.schema_ready?(repo_name) do
         :ok
       else
         raise "favn sqlite schema is not ready; run migrations or set migration_mode: :auto"
       end
-    after
-      GenServer.stop(pid)
-    end
-
-    :ok
+    end)
   end
 
   defp bootstrap_storage(_repo_name, _repo_opts, mode) do
@@ -46,10 +40,16 @@ defmodule FavnStorageSqlite.Supervisor do
   end
 
   defp run_migrations(repo_name, repo_opts) do
+    with_bootstrap_repo(repo_name, repo_opts, fn ->
+      Migrations.migrate!(repo_name)
+    end)
+  end
+
+  defp with_bootstrap_repo(repo_name, repo_opts, fun) when is_function(fun, 0) do
     {:ok, pid} = Repo.start_link(Keyword.put(bootstrap_repo_opts(repo_opts), :name, repo_name))
 
     try do
-      Migrations.migrate!(repo_name)
+      fun.()
     after
       GenServer.stop(pid)
     end

--- a/apps/favn_storage_sqlite/mix.exs
+++ b/apps/favn_storage_sqlite/mix.exs
@@ -25,6 +25,7 @@ defmodule FavnStorageSqlite.MixProject do
   defp deps do
     [
       internal_dep(:favn_orchestrator, "../favn_orchestrator", runtime: false),
+      internal_dep(:favn, "../favn", only: :test, runtime: false),
       internal_dep(:favn_test_support, "../favn_test_support", only: :test),
       {:ecto_sql, "~> 3.13.4"},
       {:ecto_sqlite3, "~> 0.22.0"}

--- a/apps/favn_storage_sqlite/mix.exs
+++ b/apps/favn_storage_sqlite/mix.exs
@@ -25,7 +25,7 @@ defmodule FavnStorageSqlite.MixProject do
   defp deps do
     [
       internal_dep(:favn_orchestrator, "../favn_orchestrator", runtime: false),
-      internal_dep(:favn, "../favn", only: :test, runtime: false),
+      internal_dep(:favn_core, "../favn_core", runtime: false),
       internal_dep(:favn_test_support, "../favn_test_support", only: :test),
       {:ecto_sql, "~> 3.13.4"},
       {:ecto_sqlite3, "~> 0.22.0"}

--- a/apps/favn_storage_sqlite/test/adapter_test.exs
+++ b/apps/favn_storage_sqlite/test/adapter_test.exs
@@ -121,6 +121,14 @@ defmodule FavnStorageSqlite.AdapterTest do
              Adapter.get_scheduler_state(key, opts)
   end
 
+  test "read-model list APIs return invalid pagination errors", %{opts: opts} do
+    filters = [limit: 0]
+
+    assert {:error, :invalid_pagination} = Adapter.list_coverage_baselines(filters, opts)
+    assert {:error, :invalid_pagination} = Adapter.list_backfill_windows(filters, opts)
+    assert {:error, :invalid_pagination} = Adapter.list_asset_window_states(filters, opts)
+  end
+
   @tag without_started_adapter: true
   test "rejects manual mode startup when schema is missing" do
     unique = System.unique_integer([:positive])

--- a/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
@@ -251,7 +251,7 @@ defmodule Favn.SQLiteStorageTest do
 
   test "persists and fetches scheduler state rows" do
     state = %SchedulerState{
-      pipeline_module: Favn.Test.Fixtures.Pipelines.SchedulerDailyPipeline,
+      pipeline_module: Favn.SQLiteStorageTest.Pipeline,
       schedule_id: :scheduler_daily,
       schedule_fingerprint: "fingerprint-v1",
       last_evaluated_at: DateTime.utc_now() |> DateTime.truncate(:second),
@@ -278,7 +278,7 @@ defmodule Favn.SQLiteStorageTest do
   end
 
   test "persists scheduler states for multiple schedule ids in same pipeline" do
-    pipeline = Favn.Test.Fixtures.Pipelines.SchedulerDailyPipeline
+    pipeline = Favn.SQLiteStorageTest.Pipeline
 
     first = %SchedulerState{
       pipeline_module: pipeline,
@@ -329,7 +329,7 @@ defmodule Favn.SQLiteStorageTest do
                ) VALUES (?1, ?2, ?3, ?4, ?5)
                """,
                [
-                 "Elixir.Favn.Test.Fixtures.Pipelines.SchedulerDailyPipeline",
+                 "Elixir.Favn.SQLiteStorageTest.Pipeline",
                  "scheduler_daily",
                  1,
                  DateTime.utc_now(),
@@ -339,7 +339,7 @@ defmodule Favn.SQLiteStorageTest do
 
     assert {:error, {:payload_decode_failed, _reason}} =
              OrchestratorStorage.get_scheduler_state(
-               {Favn.Test.Fixtures.Pipelines.SchedulerDailyPipeline, :scheduler_daily}
+               {Favn.SQLiteStorageTest.Pipeline, :scheduler_daily}
              )
   end
 

--- a/apps/favn_storage_sqlite/test/test_helper.exs
+++ b/apps/favn_storage_sqlite/test/test_helper.exs
@@ -1,6 +1,2 @@
-FavnTestSupport.Fixtures.compile_fixtures!([
-  :pipeline_assets
-])
-
 Logger.configure(level: :warning)
 ExUnit.start()


### PR DESCRIPTION
## Summary
- Return invalid pagination errors from SQLite and Postgres read-model list APIs instead of raising.
- Reduce lifecycle/schema-readiness duplication in storage supervisors and migration checks.
- Add focused adapter tests and test-only `:favn` deps so storage app tests compile independently.

## Issues Filed
- #218 for the storage adapter `child_spec/1` return contract mismatch.
- #219 for scheduler nil-key semantics across adapters.

## Checks
- `MIX_ENV=test mix test` in `apps/favn_storage_sqlite`
- `MIX_ENV=test mix test` in `apps/favn_storage_postgres`
- `mix compile --warnings-as-errors` in both storage apps
- `mix format --check-formatted` on touched files
- `mix credo diff --strict`
- `mix xref graph --format stats --label compile-connected` in both storage apps