### PR TITLE
Clarify app-local test boundaries

### DIFF
--- a/apps/favn_authoring/test/assets/compiler_parity_test.exs
+++ b/apps/favn_authoring/test/assets/compiler_parity_test.exs
@@ -1,4 +1,4 @@
-defmodule Favn.Assets.CompilerParityTest do
+defmodule FavnAuthoring.Assets.CompilerParityTest do
   use ExUnit.Case, async: false
 
   alias Favn.Asset

--- a/apps/favn_authoring/test/assets/compiler_parity_test.exs
+++ b/apps/favn_authoring/test/assets/compiler_parity_test.exs
@@ -389,7 +389,7 @@ defmodule FavnAuthoring.Assets.CompilerParityTest do
     dir =
       Path.join(
         System.tmp_dir!(),
-        "favn_core_loadable_modules_#{System.unique_integer([:positive])}"
+        "favn_authoring_loadable_modules_#{System.unique_integer([:positive])}"
       )
 
     File.mkdir_p!(dir)
@@ -410,7 +410,7 @@ defmodule FavnAuthoring.Assets.CompilerParityTest do
     dir =
       Path.join(
         System.tmp_dir!(),
-        "favn_core_parallel_modules_#{System.unique_integer([:positive])}"
+        "favn_authoring_parallel_modules_#{System.unique_integer([:positive])}"
       )
 
     File.mkdir_p!(dir)

--- a/apps/favn_authoring/test/assets/graph_planner_parity_test.exs
+++ b/apps/favn_authoring/test/assets/graph_planner_parity_test.exs
@@ -1,4 +1,4 @@
-defmodule Favn.Assets.GraphPlannerParityTest do
+defmodule FavnAuthoring.Assets.GraphPlannerParityTest do
   use ExUnit.Case, async: false
 
   alias Favn.Assets.GraphIndex

--- a/apps/favn_authoring/test/boundary_explicit_inputs_test.exs
+++ b/apps/favn_authoring/test/boundary_explicit_inputs_test.exs
@@ -1,0 +1,29 @@
+defmodule FavnAuthoring.BoundaryExplicitInputsTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Assets.Planner
+
+  defmodule RawAsset do
+    use Favn.Asset
+
+    def asset(_ctx), do: :ok
+  end
+
+  defmodule GoldAsset do
+    use Favn.Asset
+
+    @depends RawAsset
+    def asset(_ctx), do: :ok
+  end
+
+  test "planner builds from explicit authoring asset modules input" do
+    assert {:ok, plan} =
+             Planner.plan({GoldAsset, :asset},
+               asset_modules: [RawAsset, GoldAsset],
+               dependencies: :all
+             )
+
+    assert plan.target_refs == [{GoldAsset, :asset}]
+    assert plan.topo_order == [{RawAsset, :asset}, {GoldAsset, :asset}]
+  end
+end

--- a/apps/favn_authoring/test/schedule_dsl_test.exs
+++ b/apps/favn_authoring/test/schedule_dsl_test.exs
@@ -1,0 +1,78 @@
+defmodule FavnAuthoring.ScheduleDSLTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Triggers.Schedules
+
+  test "schedule DSL fetch validates modules and missing schedules" do
+    assert {:error, :not_schedule_module} = Schedules.fetch(Favn.Window, :daily)
+
+    module_name = Module.concat(__MODULE__, "NoSchedules#{System.unique_integer([:positive])}")
+
+    Code.compile_string(
+      """
+      defmodule #{inspect(module_name)} do
+        use Favn.Triggers.Schedules
+      end
+      """,
+      "test/schedule_dsl_test.exs"
+    )
+
+    assert {:error, {:schedule_not_found, :missing}} = Schedules.fetch(module_name, :missing)
+  end
+
+  test "Schedules.fetch/2 loads valid schedule modules before export checks" do
+    module = Module.concat(__MODULE__, "LoadableSchedules#{System.unique_integer([:positive])}")
+
+    compile_loadable_module!(
+      module,
+      """
+      defmodule #{inspect(module)} do
+        use Favn.Triggers.Schedules
+
+        schedule :daily, cron: "0 3 * * *", timezone: "Etc/UTC"
+      end
+      """
+    )
+
+    with_unloaded_module(module, fn ->
+      assert {:ok, schedule} = Schedules.fetch(module, :daily)
+      assert schedule.ref == {module, :daily}
+      assert schedule.cron == "0 3 * * *"
+      assert schedule.timezone == "Etc/UTC"
+    end)
+  end
+
+  defp with_unloaded_module(module, fun) when is_atom(module) and is_function(fun, 0) do
+    assert {:module, ^module} = Code.ensure_loaded(module)
+
+    :code.purge(module)
+    :code.delete(module)
+
+    try do
+      fun.()
+    after
+      assert {:module, ^module} = Code.ensure_loaded(module)
+    end
+  end
+
+  defp compile_loadable_module!(module, source) when is_atom(module) and is_binary(source) do
+    dir =
+      Path.join(
+        System.tmp_dir!(),
+        "favn_schedule_loadable_modules_#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(dir)
+
+    file_path = Path.join(dir, "#{Macro.underscore(Atom.to_string(module))}.ex")
+    File.mkdir_p!(Path.dirname(file_path))
+    File.write!(file_path, source)
+
+    Code.prepend_path(dir)
+
+    assert {:ok, modules, _diagnostics} =
+             Kernel.ParallelCompiler.compile_to_path([file_path], dir, return_diagnostics: true)
+
+    assert module in modules
+  end
+end

--- a/apps/favn_core/lib/favn/sql_asset/definition.ex
+++ b/apps/favn_core/lib/favn/sql_asset/definition.ex
@@ -23,7 +23,7 @@ defmodule Favn.SQLAsset.Definition do
           required(:ref) => {module(), atom()},
           required(:relation) => Favn.RelationRef.t(),
           required(:file) => String.t(),
-          optional(:window_spec) => Favn.Window.Spec.t() | nil,
+          required(:window_spec) => Favn.Window.Spec.t() | nil,
           optional(atom()) => term()
         }
 

--- a/apps/favn_core/lib/favn/sql_asset/definition.ex
+++ b/apps/favn_core/lib/favn/sql_asset/definition.ex
@@ -3,7 +3,6 @@ defmodule Favn.SQLAsset.Definition do
   Internal compiled SQL asset definition used by the SQL asset frontend.
   """
 
-  alias Favn.Asset
   alias Favn.Asset.RelationInput
   alias Favn.SQL
   alias Favn.SQLAsset.Materialization
@@ -20,9 +19,17 @@ defmodule Favn.SQLAsset.Definition do
     raw_asset: nil
   ]
 
+  @type asset :: %{
+          required(:ref) => {module(), atom()},
+          required(:relation) => Favn.RelationRef.t(),
+          required(:file) => String.t(),
+          optional(:window_spec) => Favn.Window.Spec.t() | nil,
+          optional(atom()) => term()
+        }
+
   @type t :: %__MODULE__{
           module: module(),
-          asset: Asset.t(),
+          asset: asset(),
           sql: String.t(),
           template: SQL.Template.t(),
           materialization: Materialization.t(),

--- a/apps/favn_core/test/boundary_explicit_inputs_test.exs
+++ b/apps/favn_core/test/boundary_explicit_inputs_test.exs
@@ -7,19 +7,6 @@ defmodule Favn.BoundaryExplicitInputsTest do
   alias Favn.Pipeline.Resolver
   alias Favn.Triggers.Schedule
 
-  defmodule RawAsset do
-    use Favn.Asset
-
-    def asset(_ctx), do: :ok
-  end
-
-  defmodule GoldAsset do
-    use Favn.Asset
-
-    @depends RawAsset
-    def asset(_ctx), do: :ok
-  end
-
   test "planner builds from explicit graph index input" do
     assets = [
       %{ref: {MyApp.Raw, :asset}, module: MyApp.Raw, name: :asset, depends_on: []},
@@ -45,17 +32,6 @@ defmodule Favn.BoundaryExplicitInputsTest do
 
   test "planner rejects missing explicit graph input" do
     assert {:error, :missing_graph_index_input} = Planner.plan({MyApp.Gold, :asset})
-  end
-
-  test "planner builds from explicit asset modules input" do
-    assert {:ok, plan} =
-             Planner.plan({GoldAsset, :asset},
-               asset_modules: [RawAsset, GoldAsset],
-               dependencies: :all
-             )
-
-    assert plan.target_refs == [{GoldAsset, :asset}]
-    assert plan.topo_order == [{RawAsset, :asset}, {GoldAsset, :asset}]
   end
 
   test "resolver resolves from explicit assets and schedule lookup" do

--- a/apps/favn_core/test/schedule_test.exs
+++ b/apps/favn_core/test/schedule_test.exs
@@ -2,27 +2,11 @@ defmodule Favn.ScheduleTest do
   use ExUnit.Case, async: true
 
   alias Favn.Triggers.Schedule
-  alias Favn.Triggers.Schedules
 
-  test "schedule constructors apply default timezone and validate refs" do
+  test "schedule constructors apply default timezone" do
     assert {:ok, unresolved} = Schedule.new_inline(cron: "0 3 * * *")
     assert {:ok, resolved} = Schedule.apply_default_timezone(unresolved, "Etc/UTC")
     assert resolved.timezone == "Etc/UTC"
-
-    assert {:error, :not_schedule_module} = Schedules.fetch(Favn.Window, :daily)
-
-    module_name = Module.concat(__MODULE__, "NoSchedules#{System.unique_integer([:positive])}")
-
-    Code.compile_string(
-      """
-      defmodule #{inspect(module_name)} do
-        use Favn.Triggers.Schedules
-      end
-      """,
-      "test/schedule_test.exs"
-    )
-
-    assert {:error, {:schedule_not_found, :missing}} = Schedules.fetch(module_name, :missing)
   end
 
   test "schedule cron validation accepts five-field and six-field expressions" do
@@ -40,61 +24,5 @@ defmodule Favn.ScheduleTest do
 
     assert {:error, {:invalid_schedule_cron, "0 0 0 * * * *"}} =
              Schedule.new_inline(cron: "0 0 0 * * * *")
-  end
-
-  test "Schedules.fetch/2 loads valid schedule modules before export checks" do
-    module = Module.concat(__MODULE__, "LoadableSchedules#{System.unique_integer([:positive])}")
-
-    compile_loadable_module!(
-      module,
-      """
-      defmodule #{inspect(module)} do
-        use Favn.Triggers.Schedules
-
-        schedule :daily, cron: "0 3 * * *", timezone: "Etc/UTC"
-      end
-      """
-    )
-
-    with_unloaded_module(module, fn ->
-      assert {:ok, schedule} = Schedules.fetch(module, :daily)
-      assert schedule.ref == {module, :daily}
-      assert schedule.cron == "0 3 * * *"
-      assert schedule.timezone == "Etc/UTC"
-    end)
-  end
-
-  defp with_unloaded_module(module, fun) when is_atom(module) and is_function(fun, 0) do
-    assert {:module, ^module} = Code.ensure_loaded(module)
-
-    :code.purge(module)
-    :code.delete(module)
-
-    try do
-      fun.()
-    after
-      assert {:module, ^module} = Code.ensure_loaded(module)
-    end
-  end
-
-  defp compile_loadable_module!(module, source) when is_atom(module) and is_binary(source) do
-    dir =
-      Path.join(
-        System.tmp_dir!(),
-        "favn_schedule_loadable_modules_#{System.unique_integer([:positive])}"
-      )
-
-    File.mkdir_p!(dir)
-
-    file_path = Path.join(dir, "#{Macro.underscore(Atom.to_string(module))}.ex")
-    File.mkdir_p!(Path.dirname(file_path))
-    File.write!(file_path, source)
-
-    Code.prepend_path(dir)
-
-    assert {:ok, modules, _diagnostics} =
-             Kernel.ParallelCompiler.compile_to_path([file_path], dir, return_diagnostics: true)
-
-    assert module in modules
   end
 end

--- a/apps/favn_runner/lib/favn/sql_asset/runtime.ex
+++ b/apps/favn_runner/lib/favn/sql_asset/runtime.ex
@@ -306,22 +306,21 @@ defmodule Favn.SQLAsset.Runtime do
          %Asset{type: :sql, sql_execution: %SQLExecution{} = payload} = asset,
          %Version{} = version
        ) do
-    asset_stub =
-      struct(Favn.Asset, %{
-        module: asset.module,
-        name: asset.name,
-        entrypoint: :asset,
-        ref: asset.ref,
-        arity: 1,
-        type: :sql,
-        file: "manifest",
-        line: 1,
-        config: asset.config || %{},
-        window_spec: asset.window,
-        relation: asset.relation,
-        materialization: asset.materialization,
-        relation_inputs: asset.relation_inputs || []
-      })
+    asset_stub = %{
+      module: asset.module,
+      name: asset.name,
+      entrypoint: :asset,
+      ref: asset.ref,
+      arity: 1,
+      type: :sql,
+      file: "manifest",
+      line: 1,
+      config: asset.config || %{},
+      window_spec: asset.window,
+      relation: asset.relation,
+      materialization: asset.materialization,
+      relation_inputs: asset.relation_inputs || []
+    }
 
     {:ok,
      %Definition{

--- a/apps/favn_runner/mix.exs
+++ b/apps/favn_runner/mix.exs
@@ -27,6 +27,7 @@ defmodule FavnRunner.MixProject do
     [
       internal_dep(:favn_core, "../favn_core"),
       internal_dep(:favn_sql_runtime, "../favn_sql_runtime"),
+      internal_dep(:favn_authoring, "../favn_authoring", only: :test),
       internal_dep(:favn_test_support, "../favn_test_support", only: :test)
     ]
   end

--- a/apps/favn_runner/test/execution/sql_asset_test.exs
+++ b/apps/favn_runner/test/execution/sql_asset_test.exs
@@ -24,34 +24,14 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
       end
 
       Registry.reload(%{}, registry_name: FavnRunner.ConnectionRegistry)
-
-      worker_module = Module.concat([FavnDuckdb, Worker])
-
-      if Process.whereis(worker_module) do
-        GenServer.stop(worker_module, :normal, 1_000)
-      end
     end)
 
-    :ok =
-      Registry.reload(
-        %{
-          duckdb_runtime: %Resolved{
-            name: :duckdb_runtime,
-            adapter: Favn.SQL.Adapter.DuckDB,
-            module: __MODULE__,
-            config: %{database: ":memory:"}
-          }
-        },
-        registry_name: FavnRunner.ConnectionRegistry
-      )
+    reload_fake_connection(:runner_sql_runtime, __MODULE__.FakeExecutionAdapter)
 
     :ok
   end
 
-  test "executes manifest-pinned sql asset in in_process mode" do
-    plugin_module = Module.concat([FavnDuckdb])
-    Application.put_env(:favn, :runner_plugins, [{plugin_module, execution_mode: :in_process}])
-
+  test "executes manifest-pinned sql asset through declared runner SQL runtime" do
     ref = {FavnRunner.ExecutionSQLAssetTest.SQLAsset, :asset}
     version = register_sql_manifest!(ref)
 
@@ -68,38 +48,7 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
     assert [%{status: :ok}] = result.asset_results
   end
 
-  test "executes manifest-pinned sql asset in separate_process mode" do
-    plugin_module = Module.concat([FavnDuckdb])
-    worker_module = Module.concat([FavnDuckdb, Worker])
-    client_module = Module.concat([Favn, SQL, Adapter, DuckDB, Client, Duckdbex])
-
-    Application.put_env(:favn, :runner_plugins, [
-      {plugin_module, execution_mode: :separate_process, worker_name: worker_module}
-    ])
-
-    {:ok, _pid} =
-      worker_module.start_link(name: worker_module, client: client_module)
-
-    ref = {FavnRunner.ExecutionSQLAssetTest.SQLAsset, :asset}
-    version = register_sql_manifest!(ref)
-
-    work =
-      %RunnerWork{
-        run_id: "run_sql_separate_process",
-        manifest_version_id: version.manifest_version_id,
-        manifest_content_hash: version.content_hash,
-        asset_ref: ref
-      }
-
-    assert {:ok, result} = FavnRunner.run(work)
-    assert result.status == :ok
-    assert [%{status: :ok}] = result.asset_results
-  end
-
   test "manifest execution does not fall back to compiled modules for deferred refs" do
-    plugin_module = Module.concat([FavnDuckdb])
-    Application.put_env(:favn, :runner_plugins, [{plugin_module, execution_mode: :in_process}])
-
     ref = {FavnRunner.ExecutionSQLAssetTest.ManifestOnlySQLAsset, :asset}
     version = register_manifest_with_missing_relation!(ref)
 
@@ -120,9 +69,6 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
   end
 
   test "manifest execution fails when sql payload is missing" do
-    plugin_module = Module.concat([FavnDuckdb])
-    Application.put_env(:favn, :runner_plugins, [{plugin_module, execution_mode: :in_process}])
-
     ref = {FavnRunner.ExecutionSQLAssetTest.MissingPayloadSQLAsset, :asset}
     version = register_manifest_without_sql_execution!(ref)
 
@@ -143,9 +89,6 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
   end
 
   test "manifest sql execution reports backend failure when runtime connection is missing" do
-    plugin_module = Module.concat([FavnDuckdb])
-    Application.put_env(:favn, :runner_plugins, [{plugin_module, execution_mode: :in_process}])
-
     Registry.reload(%{}, registry_name: FavnRunner.ConnectionRegistry)
 
     ref = {FavnRunner.ExecutionSQLAssetTest.MissingConnectionSQLAsset, :asset}
@@ -265,7 +208,7 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
   end
 
   defp register_sql_manifest!(ref) do
-    relation = RelationRef.new!(%{connection: :duckdb_runtime, name: "manifest_sql_asset"})
+    relation = RelationRef.new!(%{connection: :runner_sql_runtime, name: "manifest_sql_asset"})
 
     template =
       Template.compile!("SELECT 1 AS id",
@@ -317,7 +260,7 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
       Module.concat([__MODULE__, "HiddenSource#{System.unique_integer([:positive])}"])
 
     relation =
-      RelationRef.new!(%{connection: :duckdb_runtime, name: "manifest_sql_asset_missing"})
+      RelationRef.new!(%{connection: :runner_sql_runtime, name: "manifest_sql_asset_missing"})
 
     template =
       Template.compile!("SELECT * FROM #{inspect(deferred_module)}",
@@ -331,9 +274,6 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
     Code.compile_string(
       """
       defmodule #{inspect(deferred_module)} do
-        use Favn.Asset
-
-        def asset(_ctx), do: :ok
       end
       """,
       "test/dynamic_manifest_hidden_source_asset.exs"
@@ -377,7 +317,7 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
 
   defp register_manifest_without_sql_execution!(ref) do
     relation =
-      RelationRef.new!(%{connection: :duckdb_runtime, name: "manifest_sql_asset_missing"})
+      RelationRef.new!(%{connection: :runner_sql_runtime, name: "manifest_sql_asset_missing"})
 
     manifest =
       %Manifest{
@@ -410,6 +350,21 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
     :ok = FavnRunner.register_manifest(version)
     version
   end
+
+  defp reload_fake_connection(name, adapter) when is_atom(name) and is_atom(adapter) do
+    :ok =
+      Registry.reload(
+        %{
+          name => %Resolved{
+            name: name,
+            adapter: adapter,
+            module: __MODULE__,
+            config: %{}
+          }
+        },
+        registry_name: FavnRunner.ConnectionRegistry
+      )
+  end
 end
 
 defmodule FavnRunner.ExecutionSQLAssetTest.SQLAsset do
@@ -440,4 +395,17 @@ defmodule FavnRunner.ExecutionSQLAssetTest.FakeInspectionAdapter do
        cause: %{token: "do-not-leak"}
      }}
   end
+end
+
+defmodule FavnRunner.ExecutionSQLAssetTest.FakeExecutionAdapter do
+  alias Favn.Connection.Resolved
+  alias Favn.SQL.Capabilities
+  alias Favn.SQL.Result
+
+  def connect(%Resolved{}, _opts), do: {:ok, :conn}
+  def disconnect(:conn, _opts), do: :ok
+  def capabilities(%Resolved{}, _opts), do: {:ok, %Capabilities{}}
+
+  def materialize(:conn, _write_plan, _opts),
+    do: {:ok, %Result{command: :insert, rows_affected: 1}}
 end

--- a/apps/favn_runner/test/execution/sql_asset_test.exs
+++ b/apps/favn_runner/test/execution/sql_asset_test.exs
@@ -14,15 +14,7 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
   alias Favn.SQL.Template
 
   setup do
-    previous_runner_plugins = Application.get_env(:favn, :runner_plugins)
-
     on_exit(fn ->
-      if is_nil(previous_runner_plugins) do
-        Application.delete_env(:favn, :runner_plugins)
-      else
-        Application.put_env(:favn, :runner_plugins, previous_runner_plugins)
-      end
-
       Registry.reload(%{}, registry_name: FavnRunner.ConnectionRegistry)
     end)
 

--- a/apps/favn_runner/test/favn_runner_test.exs
+++ b/apps/favn_runner/test/favn_runner_test.exs
@@ -6,11 +6,8 @@ defmodule FavnRunnerTest do
   alias Favn.Manifest.Asset
   alias Favn.Manifest.Graph
   alias Favn.Manifest.Version
-  alias FavnTestSupport.Fixtures
 
   setup do
-    Fixtures.compile_fixture!(:runner_assets)
-
     manifest_version = "mv_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)
 
     manifest =
@@ -39,17 +36,17 @@ defmodule FavnRunnerTest do
     %{version: version}
   end
 
-  test "runs a shared fixture asset through runner execution boundary", %{version: version} do
-    fixture_ref = {Favn.Test.Fixtures.Assets.Runner.RunnerAssets, :base}
+  test "runs a local plain Elixir asset through runner execution boundary", %{version: version} do
+    fixture_ref = {FavnRunnerTest.PlainElixirAsset, :asset}
 
     fixture_manifest =
       build_manifest([
         %Asset{
           ref: fixture_ref,
           module: elem(fixture_ref, 0),
-          name: :base,
+          name: :asset,
           type: :elixir,
-          execution: %{entrypoint: :base, arity: 1}
+          execution: %{entrypoint: :asset, arity: 1}
         }
       ])
 
@@ -139,6 +136,13 @@ defmodule FavnRunnerTest do
       metadata: %{}
     }
   end
+end
+
+defmodule FavnRunnerTest.PlainElixirAsset do
+  alias Favn.Run.Context
+
+  @spec asset(Context.t()) :: {:ok, map()}
+  def asset(%Context{} = ctx), do: {:ok, %{partition: ctx.params[:partition]}}
 end
 
 defmodule FavnRunnerTest.ElixirAsset do

--- a/docs/structure/favn_authoring.md
+++ b/docs/structure/favn_authoring.md
@@ -10,6 +10,10 @@ Code:
 
 Tests:
 - `apps/favn_authoring/test/`
+- `apps/favn_authoring/test/assets/` owns authoring DSL parity coverage for the
+  core compiler and planner.
+- Schedule DSL fetch/load coverage lives here because `Favn.Triggers.Schedules`
+  is an authoring macro layered on core schedule values.
 
 Use when changing asset, SQL asset, pipeline, namespace, source, connection, or
 authoring documentation behavior.

--- a/docs/structure/favn_core.md
+++ b/docs/structure/favn_core.md
@@ -8,6 +8,8 @@ Code:
 
 Tests:
 - `apps/favn_core/test/`
+- App-local tests must use only `favn_core` and declared test support; authoring
+  DSL parity tests live in `favn_authoring`.
 
 Use when changing manifest generation/serialization, graph planning, dependency
 inference, windows, schedules, runtime config refs, backfill range resolution, or

--- a/docs/structure/favn_runner.md
+++ b/docs/structure/favn_runner.md
@@ -11,6 +11,10 @@ Code:
 
 Tests:
 - `apps/favn_runner/test/`
+- App-local tests use manifest-shaped fixtures and fake SQL adapters instead of
+  authoring DSL fixtures or concrete runner plugins from sibling apps.
+- Connection loader tests declare the authoring app as a test-only dependency so
+  local connection fixtures can use the public `Favn.Connection` behaviour.
 
 Use when changing asset execution, runner protocol behavior, cancellation,
 timeouts, manifest registration/resolution, plugin config, SQL asset execution,


### PR DESCRIPTION
## Summary
- Move authoring DSL-dependent compiler, planner, and schedule coverage out of `favn_core` and into `favn_authoring`.
- Keep `favn_runner` app-local tests on declared boundaries by using manifest-shaped local fixtures and fake SQL adapters instead of shared authoring fixtures or DuckDB plugin modules.
- Update structure docs to clarify app-local test ownership and test-only dependencies.

Closes #203.
Closes #213.

## Tests
- `mix test` from `apps/favn_core`
- `mix test` from `apps/favn_authoring`
- `mix test` from `apps/favn_runner`
- `mix format`
- `mix compile --warnings-as-errors && mix test && mix credo --strict && mix dialyzer && mix xref graph --format stats --label compile-connected`