### PR TITLE
Preflight SQL runtime config before planned runs

### DIFF
--- a/apps/favn_core/lib/favn/contracts/runner_work.ex
+++ b/apps/favn_core/lib/favn/contracts/runner_work.ex
@@ -1,6 +1,10 @@
 defmodule Favn.Contracts.RunnerWork do
   @moduledoc """
   Runner work request contract pinned to an immutable manifest version.
+
+  `planned_asset_refs` carries the complete selected asset set for the current
+  logical run. Runners use it for plan-level preflight checks before invoking
+  the current `asset_ref`.
   """
 
   @type t :: %__MODULE__{
@@ -9,6 +13,7 @@ defmodule Favn.Contracts.RunnerWork do
           manifest_content_hash: String.t(),
           asset_ref: {module(), atom()} | nil,
           asset_refs: [{module(), atom()}],
+          planned_asset_refs: [{module(), atom()}],
           params: map(),
           trigger: map(),
           metadata: map()
@@ -19,6 +24,7 @@ defmodule Favn.Contracts.RunnerWork do
             manifest_content_hash: nil,
             asset_ref: nil,
             asset_refs: [],
+            planned_asset_refs: [],
             params: %{},
             trigger: %{},
             metadata: %{}

--- a/apps/favn_core/test/contracts/contract_lock_test.exs
+++ b/apps/favn_core/test/contracts/contract_lock_test.exs
@@ -15,6 +15,7 @@ defmodule Favn.Contracts.ContractLockTest do
         :manifest_version_id,
         :metadata,
         :params,
+        :planned_asset_refs,
         :run_id,
         :trigger
       ]

--- a/apps/favn_core/test/contracts/runner_work_test.exs
+++ b/apps/favn_core/test/contracts/runner_work_test.exs
@@ -11,6 +11,7 @@ defmodule Favn.Contracts.RunnerWorkTest do
         manifest_content_hash: "abc",
         asset_ref: {MyApp.Asset, :asset},
         asset_refs: [{MyApp.Asset, :asset}],
+        planned_asset_refs: [{MyApp.Dependency, :asset}, {MyApp.Asset, :asset}],
         params: %{full_refresh: false},
         trigger: %{kind: :manual},
         metadata: %{requested_by: "operator"}
@@ -20,5 +21,6 @@ defmodule Favn.Contracts.RunnerWorkTest do
     assert work.manifest_content_hash == "abc"
     assert work.asset_ref == {MyApp.Asset, :asset}
     assert work.asset_refs == [{MyApp.Asset, :asset}]
+    assert work.planned_asset_refs == [{MyApp.Dependency, :asset}, {MyApp.Asset, :asset}]
   end
 end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -533,6 +533,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
       manifest_content_hash: version.content_hash,
       asset_ref: asset_ref,
       asset_refs: [asset_ref],
+      planned_asset_refs: planned_asset_refs(run_state),
       params: run_state.params,
       trigger:
         run_state.trigger
@@ -543,8 +544,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
           attempt: attempt,
           max_attempts: run_state.max_attempts,
           stage: stage,
-          node_key: node_key,
-          planned_asset_refs: planned_asset_refs(run_state)
+          node_key: node_key
         })
     }
   end
@@ -668,6 +668,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
         manifest_content_hash: version.content_hash,
         asset_ref: asset_ref,
         asset_refs: [asset_ref],
+        planned_asset_refs: planned_asset_refs(run_state),
         params: run_state.params,
         trigger: run_state.trigger,
         metadata:
@@ -675,8 +676,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
             attempt: attempt,
             max_attempts: max_attempts,
             stage: stage,
-            node_key: {asset_ref, nil},
-            planned_asset_refs: planned_asset_refs(run_state)
+            node_key: {asset_ref, nil}
           })
       }
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -543,7 +543,8 @@ defmodule FavnOrchestrator.RunServer.Execution do
           attempt: attempt,
           max_attempts: run_state.max_attempts,
           stage: stage,
-          node_key: node_key
+          node_key: node_key,
+          planned_asset_refs: planned_asset_refs(run_state)
         })
     }
   end
@@ -635,6 +636,16 @@ defmodule FavnOrchestrator.RunServer.Execution do
     |> Enum.map(fn {node_keys, stage} -> {stage, node_keys} end)
   end
 
+  defp planned_asset_refs(%RunState{plan: %Favn.Plan{topo_order: refs}})
+       when is_list(refs) and refs != [],
+       do: refs
+
+  defp planned_asset_refs(%RunState{target_refs: refs}) when is_list(refs) and refs != [],
+    do: refs
+
+  defp planned_asset_refs(%RunState{asset_ref: ref}) when is_tuple(ref), do: [ref]
+  defp planned_asset_refs(_run_state), do: []
+
   defp exit_to_timeout(_exit), do: {:error, :timeout}
 
   defp execute_ref_with_retry(
@@ -664,7 +675,8 @@ defmodule FavnOrchestrator.RunServer.Execution do
             attempt: attempt,
             max_attempts: max_attempts,
             stage: stage,
-            node_key: {asset_ref, nil}
+            node_key: {asset_ref, nil},
+            planned_asset_refs: planned_asset_refs(run_state)
           })
       }
 

--- a/apps/favn_orchestrator/test/orchestrator_runner_integration_test.exs
+++ b/apps/favn_orchestrator/test/orchestrator_runner_integration_test.exs
@@ -72,7 +72,7 @@ defmodule FavnOrchestrator.RunnerIntegrationTest do
     assert run.target_refs == [{__MODULE__.SleepAsset, :asset}]
   end
 
-  test "planned SQL runtime config is preflighted before an earlier Elixir dependency starts" do
+  test "pipeline SQL preflight fails before an earlier Elixir dependency stage starts" do
     configure_missing_secret_connection()
 
     version = preflight_manifest_version("mv_runner_sql_preflight")
@@ -81,12 +81,13 @@ defmodule FavnOrchestrator.RunnerIntegrationTest do
     assert :ok = FavnOrchestrator.register_manifest(version)
     assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
 
-    assert {:ok, run_id} = FavnOrchestrator.submit_asset_run(sql_ref)
+    assert {:ok, run_id} = FavnOrchestrator.submit_pipeline_run([sql_ref])
     assert {:ok, run} = await_terminal_run(run_id)
 
     assert run.status == :error
     assert run.error.type == :missing_runtime_config
     assert run.error.phase == :sql_preflight
+    assert run.error.details.sql_asset_refs == [sql_ref]
     assert [%{env: @missing_secret_env, secret?: true}] = run.error.details.errors
     refute_receive :orchestrator_preflight_elixir_executed, 200
   end

--- a/apps/favn_orchestrator/test/orchestrator_runner_integration_test.exs
+++ b/apps/favn_orchestrator/test/orchestrator_runner_integration_test.exs
@@ -5,22 +5,39 @@ defmodule FavnOrchestrator.RunnerIntegrationTest do
   alias Favn.Manifest.Asset
   alias Favn.Manifest.Graph
   alias Favn.Manifest.Pipeline
+  alias Favn.Manifest.SQLExecution
   alias Favn.Manifest.Version
+  alias Favn.RelationRef
+  alias Favn.RuntimeConfig.Ref
+  alias Favn.SQL.Template
   alias FavnOrchestrator
   alias FavnOrchestrator.Storage.Adapter.Memory
+
+  @missing_secret_env "FAVN_ORCH_PREFLIGHT_MISSING_SECRET"
 
   setup do
     previous_client = Application.get_env(:favn_orchestrator, :runner_client)
     previous_opts = Application.get_env(:favn_orchestrator, :runner_client_opts)
+    previous_modules = Application.get_env(:favn, :connection_modules)
+    previous_connections = Application.get_env(:favn, :connections)
+    previous_pid = Application.get_env(:favn_orchestrator, :preflight_test_pid)
 
     Application.put_env(:favn_orchestrator, :runner_client, FavnRunner)
     Application.put_env(:favn_orchestrator, :runner_client_opts, [])
+    Application.put_env(:favn_orchestrator, :preflight_test_pid, self())
+    System.delete_env(@missing_secret_env)
     Memory.reset()
     {:ok, _} = Application.ensure_all_started(:favn_runner)
+    Favn.Connection.Registry.reload(%{}, registry_name: FavnRunner.ConnectionRegistry)
 
     on_exit(fn ->
       Application.put_env(:favn_orchestrator, :runner_client, previous_client)
       Application.put_env(:favn_orchestrator, :runner_client_opts, previous_opts)
+      restore_app_env(:favn, :connection_modules, previous_modules)
+      restore_app_env(:favn, :connections, previous_connections)
+      restore_app_env(:favn_orchestrator, :preflight_test_pid, previous_pid)
+      System.delete_env(@missing_secret_env)
+      Favn.Connection.Registry.reload(%{}, registry_name: FavnRunner.ConnectionRegistry)
       Memory.reset()
     end)
 
@@ -53,6 +70,41 @@ defmodule FavnOrchestrator.RunnerIntegrationTest do
     assert run.status == :ok
     assert run.submit_kind == :pipeline
     assert run.target_refs == [{__MODULE__.SleepAsset, :asset}]
+  end
+
+  test "planned SQL runtime config is preflighted before an earlier Elixir dependency starts" do
+    configure_missing_secret_connection()
+
+    version = preflight_manifest_version("mv_runner_sql_preflight")
+    sql_ref = {__MODULE__.PreflightSQLAsset, :asset}
+
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    assert {:ok, run_id} = FavnOrchestrator.submit_asset_run(sql_ref)
+    assert {:ok, run} = await_terminal_run(run_id)
+
+    assert run.status == :error
+    assert run.error.type == :missing_runtime_config
+    assert run.error.phase == :sql_preflight
+    assert [%{env: @missing_secret_env, secret?: true}] = run.error.details.errors
+    refute_receive :orchestrator_preflight_elixir_executed, 200
+  end
+
+  test "unplanned SQL asset missing config does not block selected Elixir run" do
+    configure_missing_secret_connection()
+
+    version = preflight_manifest_version("mv_runner_sql_preflight_unplanned")
+    elixir_ref = {__MODULE__.PreflightElixirAsset, :asset}
+
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    assert {:ok, run_id} = FavnOrchestrator.submit_asset_run(elixir_ref)
+    assert {:ok, run} = await_terminal_run(run_id)
+
+    assert run.status == :ok
+    assert_receive :orchestrator_preflight_elixir_executed, 500
   end
 
   defp await_terminal_run(run_id, attempts \\ 60)
@@ -110,6 +162,76 @@ defmodule FavnOrchestrator.RunnerIntegrationTest do
     {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
     version
   end
+
+  defp preflight_manifest_version(manifest_version_id) do
+    elixir_ref = {__MODULE__.PreflightElixirAsset, :asset}
+    sql_ref = {__MODULE__.PreflightSQLAsset, :asset}
+
+    assets = [
+      %Asset{
+        ref: elixir_ref,
+        module: elem(elixir_ref, 0),
+        name: :asset,
+        type: :elixir,
+        execution: %{entrypoint: :asset, arity: 1},
+        depends_on: []
+      },
+      sql_asset(sql_ref, depends_on: [elixir_ref])
+    ]
+
+    manifest = %Manifest{
+      schema_version: 1,
+      runner_contract_version: 1,
+      assets: assets,
+      pipelines: [],
+      schedules: [],
+      graph: %Graph{
+        nodes: [elixir_ref, sql_ref],
+        edges: [%{from: elixir_ref, to: sql_ref}],
+        topo_order: [elixir_ref, sql_ref]
+      },
+      metadata: %{}
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
+    version
+  end
+
+  defp sql_asset(ref, opts) do
+    relation = RelationRef.new!(%{connection: :preflight_sql, name: "preflight_sql_asset"})
+
+    template =
+      Template.compile!("SELECT 1 AS id",
+        file: "test/orchestrator_sql_preflight.sql",
+        line: 1,
+        module: __MODULE__,
+        scope: :asset,
+        enforce_query_root: true
+      )
+
+    %Asset{
+      ref: ref,
+      module: elem(ref, 0),
+      name: :asset,
+      type: :sql,
+      execution: %{entrypoint: :asset, arity: 1},
+      depends_on: Keyword.get(opts, :depends_on, []),
+      relation: relation,
+      materialization: :table,
+      sql_execution: %SQLExecution{sql: "SELECT 1 AS id", template: template, sql_definitions: []}
+    }
+  end
+
+  defp configure_missing_secret_connection do
+    Application.put_env(:favn, :connection_modules, [__MODULE__.MissingSecretConnection])
+
+    Application.put_env(:favn, :connections,
+      preflight_sql: [database: ":memory:", password: Ref.secret_env!(@missing_secret_env)]
+    )
+  end
+
+  defp restore_app_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_app_env(app, key, value), do: Application.put_env(app, key, value)
 end
 
 defmodule FavnOrchestrator.RunnerIntegrationTest.SleepAsset do
@@ -122,4 +244,48 @@ defmodule FavnOrchestrator.RunnerIntegrationTest.SleepAsset do
 end
 
 defmodule FavnOrchestrator.RunnerIntegrationTest.DailyPipeline do
+end
+
+defmodule FavnOrchestrator.RunnerIntegrationTest.PreflightElixirAsset do
+  def asset(_ctx) do
+    if pid = Application.get_env(:favn_orchestrator, :preflight_test_pid) do
+      send(pid, :orchestrator_preflight_elixir_executed)
+    end
+
+    :ok
+  end
+end
+
+defmodule FavnOrchestrator.RunnerIntegrationTest.PreflightSQLAsset do
+end
+
+defmodule FavnOrchestrator.RunnerIntegrationTest.MissingSecretConnection do
+  @behaviour Favn.Connection
+
+  alias Favn.Connection.Definition
+
+  @impl true
+  def definition do
+    %Definition{
+      name: :preflight_sql,
+      adapter: FavnOrchestrator.RunnerIntegrationTest.FakeExecutionAdapter,
+      config_schema: [
+        %{key: :database, required: true, type: :path},
+        %{key: :password, required: true, secret: true, type: :string}
+      ]
+    }
+  end
+end
+
+defmodule FavnOrchestrator.RunnerIntegrationTest.FakeExecutionAdapter do
+  alias Favn.Connection.Resolved
+  alias Favn.SQL.Capabilities
+  alias Favn.SQL.Result
+
+  def connect(%Resolved{}, _opts), do: {:ok, :conn}
+  def disconnect(:conn, _opts), do: :ok
+  def capabilities(%Resolved{}, _opts), do: {:ok, %Capabilities{}}
+
+  def materialize(:conn, _write_plan, _opts),
+    do: {:ok, %Result{command: :insert, rows_affected: 1}}
 end

--- a/apps/favn_runner/lib/favn_runner/server.ex
+++ b/apps/favn_runner/lib/favn_runner/server.ex
@@ -12,6 +12,7 @@ defmodule FavnRunner.Server do
   alias FavnRunner.Inspection
   alias FavnRunner.ManifestResolver
   alias FavnRunner.ManifestStore
+  alias FavnRunner.SQLRuntimePreflight
   alias FavnRunner.Worker
 
   @type execution_id :: String.t()
@@ -103,24 +104,39 @@ defmodule FavnRunner.Server do
                server: FavnRunner.ManifestStore
              ),
            {:ok, asset} <- ManifestResolver.resolve_asset(version, asset_ref),
-           execution_id <- new_execution_id(),
-           {:ok, pid} <- start_worker(execution_id, work, version, asset) do
-        monitor_ref = Process.monitor(pid)
+           execution_id <- new_execution_id() do
+        case SQLRuntimePreflight.run(work, version) do
+          :ok ->
+            with {:ok, pid} <- start_worker(execution_id, work, version, asset) do
+              monitor_ref = Process.monitor(pid)
 
-        execution = %{
-          work: work,
-          status: :running,
-          pid: pid,
-          monitor_ref: monitor_ref,
-          events: []
-        }
+              execution = %{
+                work: work,
+                status: :running,
+                pid: pid,
+                monitor_ref: monitor_ref,
+                events: []
+              }
 
-        next_state =
-          state
-          |> put_in([:executions, execution_id], execution)
-          |> put_in([:monitor_to_execution, monitor_ref], execution_id)
+              next_state =
+                state
+                |> put_in([:executions, execution_id], execution)
+                |> put_in([:monitor_to_execution, monitor_ref], execution_id)
 
-        {{:ok, execution_id}, next_state}
+              {{:ok, execution_id}, next_state}
+            end
+
+          {:error, diagnostic} ->
+            execution = %{
+              work: work,
+              status: :completed,
+              result: preflight_failed_result(work, version, diagnostic),
+              events: []
+            }
+
+            next_state = put_in(state, [:executions, execution_id], execution)
+            {{:ok, execution_id}, next_state}
+        end
       end
 
     case reply do
@@ -315,6 +331,18 @@ defmodule FavnRunner.Server do
       asset_results: [],
       error: {:worker_crash, reason},
       metadata: work.metadata
+    }
+  end
+
+  defp preflight_failed_result(%RunnerWork{} = work, %Version{} = version, diagnostic) do
+    %RunnerResult{
+      run_id: work.run_id,
+      manifest_version_id: version.manifest_version_id,
+      manifest_content_hash: version.content_hash,
+      status: :error,
+      asset_results: [],
+      error: diagnostic,
+      metadata: work.metadata |> Kernel.||(%{}) |> Map.put(:preflight, :sql_runtime_config)
     }
   end
 

--- a/apps/favn_runner/lib/favn_runner/sql_runtime_preflight.ex
+++ b/apps/favn_runner/lib/favn_runner/sql_runtime_preflight.ex
@@ -1,0 +1,165 @@
+defmodule FavnRunner.SQLRuntimePreflight do
+  @moduledoc false
+
+  alias Favn.Connection.Error, as: ConnectionError
+  alias Favn.Connection.Loader
+  alias Favn.Connection.Registry, as: ConnectionRegistry
+  alias Favn.Contracts.RunnerWork
+  alias Favn.Manifest.Asset
+  alias Favn.Manifest.Version
+  alias Favn.RelationRef
+
+  @runner_registry FavnRunner.ConnectionRegistry
+
+  @spec run(RunnerWork.t(), Version.t()) :: :ok | {:error, map()}
+  def run(%RunnerWork{} = work, %Version{} = version) do
+    version
+    |> planned_assets(work)
+    |> sql_connection_names()
+    |> preflight_connections()
+  end
+
+  defp planned_assets(%Version{manifest: %{assets: assets}}, %RunnerWork{} = work)
+       when is_list(assets) do
+    by_ref = Map.new(assets, &{&1.ref, &1})
+
+    work
+    |> planned_refs()
+    |> Enum.flat_map(fn ref ->
+      case Map.fetch(by_ref, ref) do
+        {:ok, %Asset{} = asset} -> [asset]
+        :error -> []
+      end
+    end)
+  end
+
+  defp planned_assets(_version, _work), do: []
+
+  defp planned_refs(%RunnerWork{metadata: metadata} = work) when is_map(metadata) do
+    case Map.get(metadata, :planned_asset_refs) do
+      refs when is_list(refs) and refs != [] -> normalize_refs(refs)
+      _other -> planned_refs_without_metadata(work)
+    end
+  end
+
+  defp planned_refs(%RunnerWork{} = work), do: planned_refs_without_metadata(work)
+
+  defp planned_refs_without_metadata(%RunnerWork{asset_refs: refs})
+       when is_list(refs) and refs != [] do
+    normalize_refs(refs)
+  end
+
+  defp planned_refs_without_metadata(%RunnerWork{asset_ref: ref}) when is_tuple(ref), do: [ref]
+  defp planned_refs_without_metadata(_work), do: []
+
+  defp normalize_refs(refs) do
+    refs
+    |> Enum.filter(&valid_ref?/1)
+    |> Enum.uniq()
+    |> Enum.sort(&compare_refs/2)
+  end
+
+  defp sql_connection_names(assets) do
+    assets
+    |> Enum.flat_map(fn
+      %Asset{type: :sql, relation: %RelationRef{connection: connection}}
+      when is_atom(connection) ->
+        [connection]
+
+      _asset ->
+        []
+    end)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp preflight_connections([]), do: :ok
+
+  defp preflight_connections(connection_names) do
+    case Loader.resolve_required(connection_names) do
+      {:ok, _resolved} ->
+        :ok
+
+      {:error, errors} when is_list(errors) ->
+        errors
+        |> ignore_registry_resolved_missing_connections()
+        |> case do
+          [] -> :ok
+          remaining -> {:error, diagnostic(connection_names, remaining)}
+        end
+    end
+  end
+
+  defp ignore_registry_resolved_missing_connections(errors) do
+    Enum.reject(errors, fn
+      %ConnectionError{type: :missing_connection, connection: connection}
+      when is_atom(connection) ->
+        match?(
+          {:ok, _resolved},
+          ConnectionRegistry.fetch(connection, registry_name: @runner_registry)
+        )
+
+      _error ->
+        false
+    end)
+  catch
+    :exit, _reason -> errors
+  end
+
+  defp diagnostic(connection_names, errors) do
+    %{
+      type: :missing_runtime_config,
+      phase: :sql_preflight,
+      message: "missing required SQL runtime config",
+      details: %{
+        connections: connection_names,
+        errors: Enum.map(errors, &safe_error/1)
+      }
+    }
+  end
+
+  defp safe_error(%ConnectionError{} = error) do
+    details = error.details || %{}
+
+    %{
+      type: error.type,
+      connection: error.connection,
+      module: error.module,
+      key: Map.get(details, :key),
+      provider: Map.get(details, :provider),
+      env: Map.get(details, :env),
+      secret?: Map.get(details, :secret?, false),
+      message: safe_message(error, details)
+    }
+  end
+
+  defp safe_error(_error) do
+    %{type: :unknown, message: "SQL connection preflight failed"}
+  end
+
+  defp valid_ref?({module, name}) when is_atom(module) and is_atom(name), do: true
+  defp valid_ref?(_ref), do: false
+
+  defp safe_message(%ConnectionError{type: :missing_env}, %{env: env}) when is_binary(env),
+    do: "missing_env #{env}"
+
+  defp safe_message(
+         %ConnectionError{type: :missing_connection, connection: connection},
+         _details
+       ),
+       do: "connection definition not found for #{inspect(connection)}"
+
+  defp safe_message(%ConnectionError{type: :missing_required}, %{key: key}),
+    do: "missing required connection key #{inspect(key)}"
+
+  defp safe_message(%ConnectionError{type: :invalid_type}, %{key: key}),
+    do: "invalid connection config type for #{inspect(key)}"
+
+  defp safe_message(%ConnectionError{type: type}, _details),
+    do: "SQL connection preflight failed with #{type}"
+
+  defp compare_refs({left_module, left_name}, {right_module, right_name}) do
+    {Atom.to_string(left_module), Atom.to_string(left_name)} <=
+      {Atom.to_string(right_module), Atom.to_string(right_name)}
+  end
+end

--- a/apps/favn_runner/lib/favn_runner/sql_runtime_preflight.ex
+++ b/apps/favn_runner/lib/favn_runner/sql_runtime_preflight.ex
@@ -13,10 +13,12 @@ defmodule FavnRunner.SQLRuntimePreflight do
 
   @spec run(RunnerWork.t(), Version.t()) :: :ok | {:error, map()}
   def run(%RunnerWork{} = work, %Version{} = version) do
-    version
-    |> planned_assets(work)
-    |> sql_connection_names()
-    |> preflight_connections()
+    requirements =
+      version
+      |> planned_assets(work)
+      |> sql_connection_requirements()
+
+    preflight_connections(requirements)
   end
 
   defp planned_assets(%Version{manifest: %{assets: assets}}, %RunnerWork{} = work)
@@ -35,22 +37,18 @@ defmodule FavnRunner.SQLRuntimePreflight do
 
   defp planned_assets(_version, _work), do: []
 
-  defp planned_refs(%RunnerWork{metadata: metadata} = work) when is_map(metadata) do
-    case Map.get(metadata, :planned_asset_refs) do
-      refs when is_list(refs) and refs != [] -> normalize_refs(refs)
-      _other -> planned_refs_without_metadata(work)
-    end
-  end
+  defp planned_refs(%RunnerWork{planned_asset_refs: refs}) when is_list(refs) and refs != [],
+    do: normalize_refs(refs)
 
-  defp planned_refs(%RunnerWork{} = work), do: planned_refs_without_metadata(work)
+  defp planned_refs(%RunnerWork{} = work), do: planned_refs_without_plan(work)
 
-  defp planned_refs_without_metadata(%RunnerWork{asset_refs: refs})
+  defp planned_refs_without_plan(%RunnerWork{asset_refs: refs})
        when is_list(refs) and refs != [] do
     normalize_refs(refs)
   end
 
-  defp planned_refs_without_metadata(%RunnerWork{asset_ref: ref}) when is_tuple(ref), do: [ref]
-  defp planned_refs_without_metadata(_work), do: []
+  defp planned_refs_without_plan(%RunnerWork{asset_ref: ref}) when is_tuple(ref), do: [ref]
+  defp planned_refs_without_plan(_work), do: []
 
   defp normalize_refs(refs) do
     refs
@@ -59,23 +57,30 @@ defmodule FavnRunner.SQLRuntimePreflight do
     |> Enum.sort(&compare_refs/2)
   end
 
-  defp sql_connection_names(assets) do
-    assets
-    |> Enum.flat_map(fn
-      %Asset{type: :sql, relation: %RelationRef{connection: connection}}
-      when is_atom(connection) ->
-        [connection]
+  defp sql_connection_requirements(assets) do
+    entries =
+      Enum.flat_map(assets, fn
+        %Asset{type: :sql, ref: asset_ref, relation: %RelationRef{connection: connection}}
+        when is_atom(connection) ->
+          [{connection, asset_ref}]
 
-      _asset ->
-        []
-    end)
-    |> Enum.uniq()
-    |> Enum.sort()
+        _asset ->
+          []
+      end)
+
+    %{
+      connections: entries |> Enum.map(&elem(&1, 0)) |> Enum.uniq() |> Enum.sort(),
+      sql_asset_refs: entries |> Enum.map(&elem(&1, 1)) |> normalize_refs(),
+      connection_asset_refs:
+        entries
+        |> Enum.group_by(&elem(&1, 0), &elem(&1, 1))
+        |> Map.new(fn {connection, refs} -> {connection, normalize_refs(refs)} end)
+    }
   end
 
-  defp preflight_connections([]), do: :ok
+  defp preflight_connections(%{connections: []}), do: :ok
 
-  defp preflight_connections(connection_names) do
+  defp preflight_connections(%{connections: connection_names} = requirements) do
     case Loader.resolve_required(connection_names) do
       {:ok, _resolved} ->
         :ok
@@ -85,7 +90,7 @@ defmodule FavnRunner.SQLRuntimePreflight do
         |> ignore_registry_resolved_missing_connections()
         |> case do
           [] -> :ok
-          remaining -> {:error, diagnostic(connection_names, remaining)}
+          remaining -> {:error, diagnostic(requirements, remaining)}
         end
     end
   end
@@ -106,13 +111,15 @@ defmodule FavnRunner.SQLRuntimePreflight do
     :exit, _reason -> errors
   end
 
-  defp diagnostic(connection_names, errors) do
+  defp diagnostic(requirements, errors) do
     %{
       type: :missing_runtime_config,
       phase: :sql_preflight,
       message: "missing required SQL runtime config",
       details: %{
-        connections: connection_names,
+        connections: requirements.connections,
+        sql_asset_refs: requirements.sql_asset_refs,
+        connection_asset_refs: requirements.connection_asset_refs,
         errors: Enum.map(errors, &safe_error/1)
       }
     }

--- a/apps/favn_runner/test/execution/sql_asset_test.exs
+++ b/apps/favn_runner/test/execution/sql_asset_test.exs
@@ -80,7 +80,7 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
     assert %{type: :invalid_sql_asset_definition, phase: :runtime} = asset_result.error
   end
 
-  test "manifest sql execution reports backend failure when runtime connection is missing" do
+  test "manifest sql execution preflights missing runtime connection before execution" do
     Registry.reload(%{}, registry_name: FavnRunner.ConnectionRegistry)
 
     ref = {FavnRunner.ExecutionSQLAssetTest.MissingConnectionSQLAsset, :asset}
@@ -97,9 +97,12 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
     assert {:ok, result} = FavnRunner.run(work)
     assert result.status == :error
 
-    assert [asset_result] = result.asset_results
-    assert asset_result.status == :error
-    assert %{type: :backend_execution_failed, phase: :materialize} = asset_result.error
+    assert result.asset_results == []
+    assert result.error.type == :missing_runtime_config
+    assert result.error.phase == :sql_preflight
+
+    assert [%{type: :missing_connection, connection: :runner_sql_runtime}] =
+             result.error.details.errors
   end
 
   test "manifest sql execution redacts backend error details and causes" do

--- a/apps/favn_runner/test/sql_runtime_preflight_test.exs
+++ b/apps/favn_runner/test/sql_runtime_preflight_test.exs
@@ -1,0 +1,313 @@
+defmodule FavnRunner.SQLRuntimePreflightTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Connection.Registry
+  alias Favn.Connection.Resolved
+  alias Favn.Contracts.RunnerWork
+  alias Favn.Manifest
+  alias Favn.Manifest.Asset
+  alias Favn.Manifest.Graph
+  alias Favn.Manifest.SQLExecution
+  alias Favn.Manifest.Version
+  alias Favn.RelationRef
+  alias Favn.RuntimeConfig.Ref
+  alias Favn.SQL.Template
+
+  @missing_secret_env "FAVN_PREFLIGHT_MISSING_SECRET"
+  @optional_secret_env "FAVN_PREFLIGHT_OPTIONAL_SECRET"
+
+  setup do
+    previous_modules = Application.get_env(:favn, :connection_modules)
+    previous_connections = Application.get_env(:favn, :connections)
+    previous_pid = Application.get_env(:favn_runner, :preflight_test_pid)
+
+    Application.put_env(:favn_runner, :preflight_test_pid, self())
+    System.delete_env(@missing_secret_env)
+    System.delete_env(@optional_secret_env)
+    Registry.reload(%{}, registry_name: FavnRunner.ConnectionRegistry)
+
+    on_exit(fn ->
+      restore_app_env(:favn, :connection_modules, previous_modules)
+      restore_app_env(:favn, :connections, previous_connections)
+      restore_app_env(:favn_runner, :preflight_test_pid, previous_pid)
+      System.delete_env(@missing_secret_env)
+      System.delete_env(@optional_secret_env)
+      Registry.reload(%{}, registry_name: FavnRunner.ConnectionRegistry)
+    end)
+
+    :ok
+  end
+
+  test "Elixir-only planned run executes without SQL preflight failure" do
+    elixir_ref = {__MODULE__.CountingAsset, :asset}
+    version = register_manifest!([elixir_asset(elixir_ref)])
+    work = work(version, elixir_ref, [elixir_ref])
+
+    assert {:ok, result} = FavnRunner.run(work)
+    assert result.status == :ok
+    assert [%{ref: ^elixir_ref, status: :ok}] = result.asset_results
+    assert_receive :preflight_elixir_executed, 500
+  end
+
+  test "SQL-only planned run with valid registered config proceeds" do
+    reload_fake_connection(:preflight_sql)
+
+    sql_ref = {__MODULE__.SQLAsset, :asset}
+    version = register_manifest!([sql_asset(sql_ref, :preflight_sql)])
+
+    assert {:ok, result} = FavnRunner.run(work(version, sql_ref, [sql_ref]))
+    assert result.status == :ok
+    assert [%{ref: ^sql_ref, status: :ok}] = result.asset_results
+  end
+
+  test "SQL-only planned run with missing required secret env fails before execution" do
+    configure_missing_secret_connection()
+
+    sql_ref = {__MODULE__.SQLAsset, :asset}
+    version = register_manifest!([sql_asset(sql_ref, :preflight_sql)])
+
+    assert {:ok, result} = FavnRunner.run(work(version, sql_ref, [sql_ref]))
+    assert result.status == :error
+    assert result.asset_results == []
+    assert result.error.type == :missing_runtime_config
+    assert result.error.phase == :sql_preflight
+    assert result.error.details.connections == [:preflight_sql]
+
+    assert [%{type: :missing_env, env: @missing_secret_env, secret?: true}] =
+             result.error.details.errors
+
+    refute inspect(result) =~ "raw-secret"
+  end
+
+  test "mixed planned run fails before an earlier Elixir asset starts" do
+    configure_missing_secret_connection()
+
+    elixir_ref = {__MODULE__.CountingAsset, :asset}
+    sql_ref = {__MODULE__.SQLAsset, :asset}
+    version = register_manifest!([elixir_asset(elixir_ref), sql_asset(sql_ref, :preflight_sql)])
+
+    assert {:ok, result} = FavnRunner.run(work(version, elixir_ref, [elixir_ref, sql_ref]))
+    assert result.status == :error
+    assert result.asset_results == []
+    assert result.error.type == :missing_runtime_config
+    refute_receive :preflight_elixir_executed, 200
+  end
+
+  test "SQL asset outside the selected planned set does not fail Elixir execution" do
+    configure_missing_secret_connection()
+
+    elixir_ref = {__MODULE__.CountingAsset, :asset}
+    sql_ref = {__MODULE__.SQLAsset, :asset}
+    version = register_manifest!([elixir_asset(elixir_ref), sql_asset(sql_ref, :preflight_sql)])
+
+    assert {:ok, result} = FavnRunner.run(work(version, elixir_ref, [elixir_ref]))
+    assert result.status == :ok
+    assert [%{ref: ^elixir_ref, status: :ok}] = result.asset_results
+    assert_receive :preflight_elixir_executed, 500
+  end
+
+  test "shared SQL connection emits one missing-runtime-config diagnostic" do
+    configure_missing_secret_connection()
+
+    left_ref = {__MODULE__.SQLAsset, :left}
+    right_ref = {__MODULE__.SQLAsset, :right}
+
+    version =
+      register_manifest!([
+        sql_asset(left_ref, :preflight_sql),
+        sql_asset(right_ref, :preflight_sql)
+      ])
+
+    assert {:ok, result} = FavnRunner.run(work(version, left_ref, [left_ref, right_ref]))
+    assert result.status == :error
+    assert result.error.details.connections == [:preflight_sql]
+    assert [_one_error] = result.error.details.errors
+  end
+
+  test "missing optional SQL runtime ref does not fail preflight" do
+    Application.put_env(:favn, :connection_modules, [__MODULE__.OptionalSecretConnection])
+
+    Application.put_env(:favn, :connections,
+      preflight_sql: [
+        database: ":memory:",
+        token: Ref.env!(@optional_secret_env, secret?: true, required?: false)
+      ]
+    )
+
+    reload_fake_connection(:preflight_sql)
+
+    sql_ref = {__MODULE__.SQLAsset, :asset}
+    version = register_manifest!([sql_asset(sql_ref, :preflight_sql)])
+
+    assert {:ok, result} = FavnRunner.run(work(version, sql_ref, [sql_ref]))
+    assert result.status == :ok
+  end
+
+  test "preflight diagnostics do not echo raw invalid runtime config values" do
+    Application.put_env(:favn, :connection_modules, [__MODULE__.MissingSecretConnection])
+    Application.put_env(:favn, :connections, preflight_sql: "raw-secret-like-value")
+
+    sql_ref = {__MODULE__.SQLAsset, :asset}
+    version = register_manifest!([sql_asset(sql_ref, :preflight_sql)])
+
+    assert {:ok, result} = FavnRunner.run(work(version, sql_ref, [sql_ref]))
+    assert result.status == :error
+    assert result.error.type == :missing_runtime_config
+    refute inspect(result.error) =~ "raw-secret-like-value"
+  end
+
+  defp configure_missing_secret_connection do
+    Application.put_env(:favn, :connection_modules, [__MODULE__.MissingSecretConnection])
+
+    Application.put_env(:favn, :connections,
+      preflight_sql: [database: ":memory:", password: Ref.secret_env!(@missing_secret_env)]
+    )
+  end
+
+  defp elixir_asset(ref) do
+    %Asset{
+      ref: ref,
+      module: elem(ref, 0),
+      name: elem(ref, 1),
+      type: :elixir,
+      execution: %{entrypoint: elem(ref, 1), arity: 1}
+    }
+  end
+
+  defp sql_asset(ref, connection) do
+    relation = RelationRef.new!(%{connection: connection, name: Atom.to_string(elem(ref, 1))})
+
+    template =
+      Template.compile!("SELECT 1 AS id",
+        file: "test/sql_runtime_preflight.sql",
+        line: 1,
+        module: __MODULE__,
+        scope: elem(ref, 1),
+        enforce_query_root: true
+      )
+
+    %Asset{
+      ref: ref,
+      module: elem(ref, 0),
+      name: elem(ref, 1),
+      type: :sql,
+      execution: %{entrypoint: elem(ref, 1), arity: 1},
+      relation: relation,
+      materialization: :table,
+      sql_execution: %SQLExecution{sql: "SELECT 1 AS id", template: template, sql_definitions: []}
+    }
+  end
+
+  defp register_manifest!(assets) do
+    refs = Enum.map(assets, & &1.ref)
+
+    manifest = %Manifest{
+      schema_version: 1,
+      runner_contract_version: 1,
+      assets: assets,
+      pipelines: [],
+      schedules: [],
+      graph: %Graph{nodes: refs, edges: [], topo_order: refs},
+      metadata: %{}
+    }
+
+    {:ok, version} =
+      Version.new(manifest,
+        manifest_version_id:
+          "mv_preflight_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)
+      )
+
+    :ok = FavnRunner.register_manifest(version)
+    version
+  end
+
+  defp work(%Version{} = version, asset_ref, planned_refs) do
+    %RunnerWork{
+      run_id: "run_preflight_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower),
+      manifest_version_id: version.manifest_version_id,
+      manifest_content_hash: version.content_hash,
+      asset_ref: asset_ref,
+      asset_refs: [asset_ref],
+      metadata: %{planned_asset_refs: planned_refs}
+    }
+  end
+
+  defp reload_fake_connection(name) do
+    Registry.reload(
+      %{
+        name => %Resolved{
+          name: name,
+          adapter: __MODULE__.FakeExecutionAdapter,
+          module: __MODULE__,
+          config: %{}
+        }
+      },
+      registry_name: FavnRunner.ConnectionRegistry
+    )
+  end
+
+  defp restore_app_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_app_env(app, key, value), do: Application.put_env(app, key, value)
+end
+
+defmodule FavnRunner.SQLRuntimePreflightTest.CountingAsset do
+  def asset(_ctx) do
+    if pid = Application.get_env(:favn_runner, :preflight_test_pid) do
+      send(pid, :preflight_elixir_executed)
+    end
+
+    :ok
+  end
+end
+
+defmodule FavnRunner.SQLRuntimePreflightTest.SQLAsset do
+end
+
+defmodule FavnRunner.SQLRuntimePreflightTest.MissingSecretConnection do
+  @behaviour Favn.Connection
+
+  alias Favn.Connection.Definition
+
+  @impl true
+  def definition do
+    %Definition{
+      name: :preflight_sql,
+      adapter: FavnRunner.SQLRuntimePreflightTest.FakeExecutionAdapter,
+      config_schema: [
+        %{key: :database, required: true, type: :path},
+        %{key: :password, required: true, secret: true, type: :string}
+      ]
+    }
+  end
+end
+
+defmodule FavnRunner.SQLRuntimePreflightTest.OptionalSecretConnection do
+  @behaviour Favn.Connection
+
+  alias Favn.Connection.Definition
+
+  @impl true
+  def definition do
+    %Definition{
+      name: :preflight_sql,
+      adapter: FavnRunner.SQLRuntimePreflightTest.FakeExecutionAdapter,
+      config_schema: [
+        %{key: :database, required: true, type: :path},
+        %{key: :token, secret: true}
+      ]
+    }
+  end
+end
+
+defmodule FavnRunner.SQLRuntimePreflightTest.FakeExecutionAdapter do
+  alias Favn.Connection.Resolved
+  alias Favn.SQL.Capabilities
+  alias Favn.SQL.Result
+
+  def connect(%Resolved{}, _opts), do: {:ok, :conn}
+  def disconnect(:conn, _opts), do: :ok
+  def capabilities(%Resolved{}, _opts), do: {:ok, %Capabilities{}}
+
+  def materialize(:conn, _write_plan, _opts),
+    do: {:ok, %Result{command: :insert, rows_affected: 1}}
+end

--- a/apps/favn_runner/test/sql_runtime_preflight_test.exs
+++ b/apps/favn_runner/test/sql_runtime_preflight_test.exs
@@ -72,6 +72,7 @@ defmodule FavnRunner.SQLRuntimePreflightTest do
     assert result.error.type == :missing_runtime_config
     assert result.error.phase == :sql_preflight
     assert result.error.details.connections == [:preflight_sql]
+    assert result.error.details.sql_asset_refs == [sql_ref]
 
     assert [%{type: :missing_env, env: @missing_secret_env, secret?: true}] =
              result.error.details.errors
@@ -90,6 +91,7 @@ defmodule FavnRunner.SQLRuntimePreflightTest do
     assert result.status == :error
     assert result.asset_results == []
     assert result.error.type == :missing_runtime_config
+    assert result.error.details.sql_asset_refs == [sql_ref]
     refute_receive :preflight_elixir_executed, 200
   end
 
@@ -121,6 +123,7 @@ defmodule FavnRunner.SQLRuntimePreflightTest do
     assert {:ok, result} = FavnRunner.run(work(version, left_ref, [left_ref, right_ref]))
     assert result.status == :error
     assert result.error.details.connections == [:preflight_sql]
+    assert result.error.details.sql_asset_refs == [left_ref, right_ref]
     assert [_one_error] = result.error.details.errors
   end
 
@@ -228,7 +231,8 @@ defmodule FavnRunner.SQLRuntimePreflightTest do
       manifest_content_hash: version.content_hash,
       asset_ref: asset_ref,
       asset_refs: [asset_ref],
-      metadata: %{planned_asset_refs: planned_refs}
+      planned_asset_refs: planned_refs,
+      metadata: %{}
     }
   end
 

--- a/apps/favn_sql_runtime/lib/favn/connection/error.ex
+++ b/apps/favn_sql_runtime/lib/favn/connection/error.ex
@@ -9,10 +9,11 @@ defmodule Favn.Connection.Error do
   @type type ::
           :invalid_connection_modules
           | :invalid_connections_config
-          | :invalid_module
-          | :invalid_definition
-          | :duplicate_name
-          | :missing_required
+           | :invalid_module
+           | :invalid_definition
+           | :duplicate_name
+          | :missing_connection
+           | :missing_required
           | :missing_env
           | :unknown_keys
           | :invalid_type

--- a/apps/favn_sql_runtime/lib/favn/connection/loader.ex
+++ b/apps/favn_sql_runtime/lib/favn/connection/loader.ex
@@ -16,6 +16,20 @@ defmodule Favn.Connection.Loader do
     end
   end
 
+  @spec resolve_required([atom()]) :: {:ok, %{atom() => Favn.Connection.Resolved.t()}} | {:error, [Error.t()]}
+  def resolve_required(names) when is_list(names) do
+    required_names = names |> Enum.filter(&is_atom/1) |> Enum.uniq() |> Enum.sort()
+
+    with {:ok, modules} <- configured_modules(),
+         {:ok, runtime_connections} <- configured_runtime_connections(),
+         {:ok, definitions} <- load_definitions(modules),
+         selected_definitions <- select_required_definitions(definitions, required_names),
+         :ok <- validate_missing_required_definitions(selected_definitions, required_names),
+         :ok <- validate_duplicate_names(selected_definitions) do
+      resolve_connections(selected_definitions, Map.take(runtime_connections, required_names))
+    end
+  end
+
   @spec configured_modules() :: {:ok, [module()]} | {:error, [Error.t()]}
   def configured_modules do
     case Application.get_env(:favn, :connection_modules, []) do
@@ -191,6 +205,33 @@ defmodule Favn.Connection.Loader do
       {:ok, Map.new(resolved_entries)}
     else
       {:error, Enum.reverse(errors)}
+    end
+  end
+
+  defp select_required_definitions(definitions, required_names) do
+    required = MapSet.new(required_names)
+    Enum.filter(definitions, &MapSet.member?(required, &1.name))
+  end
+
+  defp validate_missing_required_definitions(definitions, required_names) do
+    found_names = definitions |> Enum.map(& &1.name) |> MapSet.new()
+
+    missing_names =
+      required_names
+      |> Enum.reject(&MapSet.member?(found_names, &1))
+      |> Enum.sort()
+
+    if missing_names == [] do
+      :ok
+    else
+      {:error,
+       Enum.map(missing_names, fn name ->
+         %Error{
+           type: :missing_connection,
+           connection: name,
+           message: "connection definition not found for #{inspect(name)}"
+         }
+       end)}
     end
   end
 

--- a/apps/favn_sql_runtime/lib/favn/connection/loader.ex
+++ b/apps/favn_sql_runtime/lib/favn/connection/loader.ex
@@ -21,12 +21,12 @@ defmodule Favn.Connection.Loader do
     required_names = names |> Enum.filter(&is_atom/1) |> Enum.uniq() |> Enum.sort()
 
     with {:ok, modules} <- configured_modules(),
-         {:ok, runtime_connections} <- configured_runtime_connections(),
+         {:ok, runtime_connections} <- configured_required_runtime_connections(required_names),
          {:ok, definitions} <- load_definitions(modules),
          selected_definitions <- select_required_definitions(definitions, required_names),
          :ok <- validate_missing_required_definitions(selected_definitions, required_names),
          :ok <- validate_duplicate_names(selected_definitions) do
-      resolve_connections(selected_definitions, Map.take(runtime_connections, required_names))
+      resolve_connections(selected_definitions, runtime_connections)
     end
   end
 
@@ -60,6 +60,37 @@ defmodule Favn.Connection.Loader do
 
       entries when is_map(entries) ->
         normalize_map_connections(entries)
+
+      other ->
+        {:error,
+         [%Error{type: :invalid_connections_config, message: invalid_connections_message(other)}]}
+    end
+  end
+
+  defp configured_required_runtime_connections(required_names) do
+    required = MapSet.new(required_names)
+
+    case Application.get_env(:favn, :connections, []) do
+      entries when is_list(entries) ->
+        if Keyword.keyword?(entries) do
+          entries
+          |> Enum.filter(fn {name, _values} -> MapSet.member?(required, name) end)
+          |> normalize_keyword_connections()
+        else
+          {:error,
+           [
+             %Error{
+               type: :invalid_connections_config,
+               message: "config :favn, :connections list must be a keyword list"
+             }
+           ]}
+        end
+
+      entries when is_map(entries) ->
+        entries
+        |> Enum.filter(fn {name, _values} -> MapSet.member?(required, name) end)
+        |> Map.new()
+        |> normalize_map_connections()
 
       other ->
         {:error,

--- a/docs/structure/favn_runner.md
+++ b/docs/structure/favn_runner.md
@@ -9,6 +9,8 @@ Code:
 - `apps/favn_runner/lib/favn_runner/`
 - `apps/favn_runner/lib/favn_runner/production_runtime_config.ex` owns
   runner-side production env validation for the first local single-node setup
+- `apps/favn_runner/lib/favn_runner/sql_runtime_preflight.ex` validates planned SQL
+  connection runtime config before worker execution begins
 - `apps/favn_runner/lib/favn_runner/sql/materialization_planner.ex` owns runner SQL
   asset materialization planning and emits shared `%Favn.SQL.WritePlan{}` values
 - runner-owned execution modules under `apps/favn_runner/lib/favn/`
@@ -17,6 +19,8 @@ Tests:
 - `apps/favn_runner/test/`
 - `apps/favn_runner/test/sql/materialization_planner_test.exs` covers the explicit
   runner-owned planner namespace and write-plan contract handoff
+- `apps/favn_runner/test/sql_runtime_preflight_test.exs` covers planned SQL
+  connection runtime config preflight and redacted diagnostics
 - App-local tests use manifest-shaped fixtures and fake SQL adapters instead of
   authoring DSL fixtures or concrete runner plugins from sibling apps.
 - Connection loader tests declare the authoring app as a test-only dependency so


### PR DESCRIPTION
## Summary
- Adds runner-side SQL runtime config preflight before any worker starts for a planned run.
- Passes the current planned asset set from the orchestrator to the runner so preflight checks only assets selected for this run.
- Resolves required SQL connection runtime refs/config without opening database connections and returns safe structured diagnostics on failure.

## Preflight Design
The orchestrator records the selected `Favn.Plan.topo_order` as `:planned_asset_refs` in runner work metadata. `FavnRunner.Server.submit_work/1` invokes `FavnRunner.SQLRuntimePreflight` after manifest/target resolution and before `FavnRunner.Worker` starts. If preflight fails, the runner stores a normal completed execution result with `status: :error`, no `asset_results`, and a `:sql_preflight` diagnostic.

## Runtime Refs Checked
Only required SQL connection runtime config for named connections used by planned SQL assets is resolved. Optional missing refs do not fail preflight. Elixir asset runtime refs are intentionally out of scope.

## Where The Preflight Runs
Preflight runs in `favn_runner`, in `FavnRunner.Server.submit_work/1`, before `start_worker/4`. This keeps runner-side secret resolution out of the orchestrator while still using the planned asset set selected by the orchestrator.

## Redaction Behavior
Diagnostics include connection name, schema key, provider, env/ref key, and `secret?` metadata. They do not include resolved values or raw invalid runtime config values. Preflight does not open adapters or database connections.

## Test Evidence
- `mix format`
- `mix compile --warnings-as-errors`
- `apps/favn_runner`: `mix test` passed, 68 tests
- `apps/favn_sql_runtime`: `mix test` passed, 25 tests
- `mix xref graph --format stats --label compile-connected` passed for `favn_runner`, `favn_sql_runtime`, and `favn_orchestrator`

## Verification Notes
- `mix credo --strict` was not available in this workspace (`credo` task not found).
- `mix dialyzer` was not available in this workspace (`dialyzer` task not found).
- `apps/favn_orchestrator` app-local test execution is blocked by an existing test-support load-path issue compiling fixtures that use `Favn.Assets`.
- Root targeted orchestrator test execution is blocked by an existing `favn` doctest documentation issue.

Closes #255