### PR TITLE
Clarify consumer local storage setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,11 +115,17 @@ Do not add internal runtime apps as ordinary consumer dependencies. Storage
 adapters such as `favn_storage_sqlite` and `favn_storage_postgres`, runtime apps
 such as `favn_orchestrator`, `favn_runner`, and `favn_local`, and the web app are
 owned by Favn's runtime/package tooling rather than by authored business code.
+Local SQLite control-plane storage is selected with `config :favn, :local` or
+`mix favn.dev --sqlite`, not by adding `:favn_storage_sqlite` to the consumer
+project.
 
 Multiple `git` dependencies with different `subdir` values from this monorepo
 are not the supported plugin-consumption model before Hex packaging because Mix
 checks them out as separate dependency projects. For real external consumption,
 Favn packages will be published as normal package dependencies.
+If a private git/subdir setup currently needs direct `override: true` entries for
+internal apps to satisfy Mix, treat that as a temporary private-development
+workaround only. It is not the intended consumer dependency model.
 
 ### 2. Define an asset
 
@@ -515,6 +521,11 @@ Storage modes:
 - `mix favn.dev --postgres` forces Postgres
 - `mix favn.dev --scheduler` enables local scheduled runs
 - `mix favn.dev --no-scheduler` disables local scheduled runs and overrides config
+
+Do not add `:favn_storage_sqlite` to a consumer `mix.exs` for local SQLite
+control-plane storage. The SQLite storage adapter is owned by Favn's local
+runtime/package setup under `.favn/`; consumer projects select it through the
+local config above or `mix favn.dev --sqlite`.
 
 `mix favn.build.single` emits a verified project-local backend-only SQLite launcher under
 `.favn/dist/single/<build_id>/`. Configure it by copying

--- a/apps/favn/lib/favn/ai.ex
+++ b/apps/favn/lib/favn/ai.ex
@@ -19,6 +19,18 @@ defmodule Favn.AI do
   - integration clients, pipelines, triggers, and reusable SQL live outside the
     warehouse asset tree.
 
+  ## Consumer Dependency Shape
+
+  A normal consumer project depends on `:favn` for the public DSL, helper
+  functions, and `mix favn.*` tasks. Add `:favn_duckdb` only when the project
+  executes DuckDB-backed SQL assets or uses DuckDB through `Favn.SQLClient`.
+
+  Do not add internal runtime/control-plane apps such as `:favn_storage_sqlite`,
+  `:favn_orchestrator`, `:favn_runner`, `:favn_local`, `:favn_core`, or
+  `:favn_sql_runtime` as ordinary consumer dependencies. Local SQLite
+  control-plane storage is selected through `config :favn, :local` or
+  `mix favn.dev --sqlite`.
+
   ## What To Read
 
   - To author one Elixir asset, read `Favn.Asset`, then `Favn.Namespace` and

--- a/apps/favn_authoring/lib/favn/connection.ex
+++ b/apps/favn_authoring/lib/favn/connection.ex
@@ -57,6 +57,10 @@ defmodule Favn.Connection do
   DuckDB connections that need DuckLake session setup can include the DuckDB-owned
   bootstrap schema field:
 
+  `Favn.SQL.Adapter.DuckDB` is provided by the public `:favn_duckdb`
+  adapter/plugin dependency. Consumers should add `:favn_duckdb` for DuckDB
+  execution rather than depending on internal SQL runtime or runner apps directly.
+
       %Favn.Connection.Definition{
         name: :warehouse,
         adapter: Favn.SQL.Adapter.DuckDB,

--- a/apps/favn_duckdb/lib/favn/sql/adapter/duckdb.ex
+++ b/apps/favn_duckdb/lib/favn/sql/adapter/duckdb.ex
@@ -12,6 +12,15 @@ defmodule Favn.SQL.Adapter.DuckDB do
   Bulk ingestion paths should prefer the DuckDB Appender path for substantial
   insert workloads instead of repeated prepared inserts.
 
+  ## Consumer setup
+
+  This adapter is exposed through the public `:favn_duckdb` package/plugin. Add
+  `:favn_duckdb` when a consumer project needs DuckDB-backed SQL assets,
+  `Favn.SQLClient` DuckDB connections, or DuckDB/DuckLake bootstrap support.
+
+  Do not add internal apps such as `:favn_sql_runtime` or `:favn_runner`
+  directly to consumer `mix.exs` files for DuckDB support.
+
   ## DuckLake bootstrap example
 
       defmodule MyApp.Connections.Warehouse do

--- a/apps/favn_local/README.md
+++ b/apps/favn_local/README.md
@@ -123,6 +123,16 @@ Storage selection:
 - `mix favn.dev --sqlite` forces `:sqlite`
 - `mix favn.dev --postgres` forces `:postgres`
 
+### Consumer dependency boundary
+
+Consumer projects select local control-plane storage through `config :favn,
+:local` or local tooling flags such as `mix favn.dev --sqlite`.
+
+Do not add `:favn_storage_sqlite`, `:favn_orchestrator`, `:favn_runner`, or
+`:favn_local` directly to a normal consumer `mix.exs` for local development.
+Those apps are Favn-owned runtime/package components materialized under `.favn/`
+by `mix favn.install` and used by `mix favn.dev`.
+
 Scheduler selection:
 
 - default: disabled

--- a/examples/basic-workflow-tutorial/README.md
+++ b/examples/basic-workflow-tutorial/README.md
@@ -332,11 +332,17 @@ config :favn, :local,
 
 Alternative modes:
 - `:memory` for ephemeral local state (fast, but not persisted)
-- `:sqlite` for SQLite-backed local control-plane state once configured with
-  `favn_storage_sqlite`
+- `:sqlite` for SQLite-backed local control-plane state, selected with
+  `config :favn, :local, storage: :sqlite, sqlite_path: "..."` or
+  `mix favn.dev --sqlite`
 - `:postgres` for Postgres-backed local control-plane storage
 
+Do not add `:favn_storage_sqlite` to this consumer project's `mix.exs` for local
+control-plane storage. SQLite storage is owned by Favn's local runtime/package
+setup under `.favn/`; the consumer selects it through local config or CLI flags.
+
 You can also switch at runtime with flags:
+- `mix favn.dev --sqlite`
 - `mix favn.dev --postgres`
 
 ### 3) Change DuckDB execution placement


### PR DESCRIPTION
## Summary
- Clarify that consumers select SQLite local control-plane storage through `config :favn, :local` or `mix favn.dev --sqlite`, not by depending on `:favn_storage_sqlite`.
- Clarify that DuckDB support is added through the public `:favn_duckdb` adapter/plugin dependency.
- Document private git/subdir `override: true` entries as temporary development workarounds, not the conceptual consumer dependency model.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`

Closes #285.