### PR TITLE
Add orchestrator-backed asset catalogue

### DIFF
--- a/.opencode/skills/favn-design-system/SKILL.md
+++ b/.opencode/skills/favn-design-system/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: favn-design-system
+description: Use when creating or changing reusable low-level UI components, design primitives, visual surface classes, core component APIs, Favn theme tokens, glass/HUD styling, responsive density, or Storybook visual contracts in apps/favn_view.
+---
+
+# Favn Design System Skill
+
+Use this skill before designing or changing reusable low-level UI components in
+`apps/favn_view`.
+
+## Core Rules
+
+- Load `phoenix-liveview` as well for LiveView, HEEx, components, and Storybook work.
+- Read `https://daisyui.com/llms.txt` before changing DaisyUI-backed primitives or theme styling.
+- DaisyUI primitives come first, but Favn-specific polish belongs in named design-system classes, not one-off component utility piles.
+- Keep the visual system dark-first and light-mode compatible through DaisyUI theme tokens.
+- Do not hardcode Tailwind palette colors for product UI surfaces. Use `base-*`, `primary`, `info`, `success`, `warning`, `error`, and token mixes.
+- Every reusable visual primitive needs a Storybook story or an existing Storybook story that exercises the changed state.
+
+## Visual Language
+
+Favn should feel like a calm operator HUD:
+
+- dark atmospheric shell
+- blue-tinted glass surfaces
+- sparse, high-signal content
+- icon-first controls
+- soft borders and glows
+- progressive disclosure through rails/docks
+- compact lists, not crowded dashboards
+
+Avoid:
+
+- generic admin cards
+- opaque gray glass blocks
+- inconsistent border radii between similar surfaces
+- local component classes that override the design system without a reason
+- oversized list rows that make operational scanning slow
+
+## Surface Levels
+
+Use the shared surface classes from `apps/favn_view/assets/css/app.css`:
+
+- `favn-surface-panel`: large panels and page sections.
+- `favn-surface-list`: repeated list cards/rows where scan density matters.
+- `favn-surface-control`: search fields, selects, dropdown triggers, and compact controls.
+- `favn-surface-rail`: global nav rails, page mode rails, and mobile docks.
+
+Page-local mode rails and mobile mode docks should read as one grouped Favn card
+surface with fully rounded corners. Do not style rail items as disconnected
+buttons or sharp segmented tabs. The active mode may be lit inside the group,
+but the group itself should remain a continuous rounded glass card.
+
+Compatibility aliases may exist, such as `favn-glass-panel`, `favn-control-glass`,
+and `favn-icon-rail`, but new component work should prefer the semantic surface
+classes above.
+
+## Density Rules
+
+- Mobile catalogue/list rows should show multiple items per viewport.
+- Keep repeated list cards compact: small padding, tight metadata, and one clear action affordance.
+- Controls should be visually related to cards, but slightly less dominant than the list itself.
+- Rails/docks may be more chrome-like, but should not compete with primary content.
+- Use one spacing rhythm per screen: control gap, list gap, and dock spacing should feel intentional.
+
+## Component Rules
+
+- Every UI element used in product screens must be a reusable component with a Storybook story, down to low-level controls such as buttons, icon buttons, dropdown/select controls, input boxes, badges, cards, rails, and docks.
+- Editing a component is incomplete until its Storybook story has been opened with Playwright and visually inspected.
+- Always evaluate pixel-perfectness against the approved design reference or current Storybook contract. If spacing, surface strength, radius, typography, icon weight, focus state, or density is visibly off, improve it before finishing.
+- Low-level components should expose variants before callers hand-roll surface utilities.
+- Prefer classes like `favn-surface-control` or `favn-surface-list` over copying border/background/shadow utility stacks.
+- Component-specific layout belongs in the component. Cross-component color, glass, border, glow, and interaction styling belongs in CSS design-system classes.
+- If a component must diverge from the surface system, document why in the component or Storybook story.
+
+## Storybook Review
+
+For reusable visual work, inspect Storybook with Playwright at minimum:
+
+- mobile viewport around `390x844`
+- desktop viewport around `1440x1000`
+- dark theme first
+- light theme when the changed primitive is theme-sensitive
+
+Look for:
+
+- consistent surface strength across panels, controls, list cards, and rails
+- consistent radius family
+- readable text contrast
+- usable focus states
+- no DaisyUI default styling leaking through unintentionally
+
+Do not rely on automated tests alone for UI component changes. Storybook plus
+Playwright visual inspection is required for reusable component edits.
+
+## Testing
+
+When changes are limited to `apps/favn_view`, use app-local verification:
+
+```bash
+cd apps/favn_view && mix format && mix compile --warnings-as-errors && mix test
+```
+
+Use broader umbrella tests only for cross-app/shared-contract changes or when the
+user explicitly requests them.

--- a/.opencode/skills/favn-design-system/SKILL.md
+++ b/.opencode/skills/favn-design-system/SKILL.md
@@ -65,8 +65,8 @@ classes above.
 
 ## Component Rules
 
-- Every UI element used in product screens must be a reusable component with a Storybook story, down to low-level controls such as buttons, icon buttons, dropdown/select controls, input boxes, badges, cards, rails, and docks.
-- Editing a component is incomplete until its Storybook story has been opened with Playwright and visually inspected.
+- Reusable Favn-specific components, page components, and customized primitives need Storybook coverage. Plain DaisyUI primitives do not need wrappers or stories unless they are reused as a Favn-specific pattern or customized beyond local composition.
+- Editing a reusable Favn-specific component is incomplete until its Storybook story has been opened with Playwright and visually inspected.
 - Always evaluate pixel-perfectness against the approved design reference or current Storybook contract. If spacing, surface strength, radius, typography, icon weight, focus state, or density is visibly off, improve it before finishing.
 - Low-level components should expose variants before callers hand-roll surface utilities.
 - Prefer classes like `favn-surface-control` or `favn-surface-list` over copying border/background/shadow utility stacks.

--- a/.opencode/skills/phoenix-liveview/SKILL.md
+++ b/.opencode/skills/phoenix-liveview/SKILL.md
@@ -12,6 +12,7 @@ JavaScript when necessary.
 
 ## Core Rules
 
+- Load `favn-design-system` as well before creating or changing reusable low-level UI primitives, Favn surface classes, theme tokens, glass/HUD styling, or Storybook visual contracts.
 - Always use the `tidewave_view` MCP when the `apps/favn_view` runtime is running and the task involves LiveView/UI routes, rendered behavior, logs, source lookup, runtime inspection, or Phoenix/LiveView docs.
 - If `tidewave_view` is unavailable because the runtime is not running, say so explicitly and continue with static inspection only when that is sufficient.
 - `favn_view` is a thin UI/API boundary.
@@ -218,6 +219,13 @@ Use these docs for details when implementing:
 - Prefer `Phoenix.LiveViewTest` selectors such as `element/2`, `has_element?/2`, and forms over raw HTML assertions.
 - Test behavior and outcomes, not implementation details.
 - Keep placeholder stories/tooling stories separate from product UI work.
+- When changes are limited to `apps/favn_view`, do not run umbrella-level tests by default. Run the `favn_view` app-local test suite instead:
+
+```bash
+cd apps/favn_view && mix test
+```
+
+- Use umbrella-level tests only when the change crosses app boundaries, changes shared dependencies/contracts, or the user explicitly requests broader verification.
 
 ## Favn LiveView UI Philosophy
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Load the relevant repo-local OpenCode skill before framework-specific work:
 - `favn-architecture`: app boundaries, public facades, manifests, orchestration contracts, cross-app dependencies, and deployment assumptions.
 - `phoenix-web-api`: Phoenix Endpoint, Router, Controller, Plug, and API work, especially in `apps/favn_orchestrator`.
 - `phoenix-liveview`: LiveView, HEEx, components, layouts, Storybook, Tidewave, and UI work in `apps/favn_view`.
+- `favn-design-system`: reusable low-level UI components, Favn surface classes, theme tokens, glass/HUD styling, and Storybook visual contracts in `apps/favn_view`.
 - `ecto-storage`: repos, migrations, Ecto queries, transactions, storage adapters, SQL sandbox, and persistence tests.
 - When working with front-end components webfetch and read DaisyUI docs `https://daisyui.com/llms.txt`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -101,4 +101,7 @@ Run the narrowest useful check first. Before finishing changes, run:
 - `mix compile --warnings-as-errors`
 - `mix test`
 
+For app-scoped changes, run compile/test from each affected app directory rather
+than using umbrella `mix do --app ...`, which can trigger unrelated app suites.
+
 If dependencies change, update lockfiles and run the relevant verification.

--- a/apps/favn/lib/favn.ex
+++ b/apps/favn/lib/favn.ex
@@ -65,6 +65,7 @@ defmodule Favn do
   @type dependencies_mode :: :all | :none
   @type list_runs_opts :: [
           status: :running | :ok | :error | :cancelled | :timed_out,
+          manifest_version_id: String.t(),
           limit: pos_integer()
         ]
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -13,12 +13,14 @@ defmodule FavnOrchestrator do
   alias Favn.Manifest.Version
   alias Favn.Window.Anchor
   alias Favn.Window.Policy
+  alias FavnOrchestrator.AssetFreshnessState
   alias FavnOrchestrator.Backfill.Repair, as: BackfillRepair
   alias FavnOrchestrator.BackfillManager
   alias FavnOrchestrator.Diagnostics
   alias FavnOrchestrator.Events
   alias FavnOrchestrator.Freshness.Query, as: FreshnessQuery
   alias FavnOrchestrator.ManifestStore
+  alias FavnOrchestrator.Page
   alias FavnOrchestrator.Projector
   alias FavnOrchestrator.RunEvent
   alias FavnOrchestrator.RunManager
@@ -53,6 +55,19 @@ defmodule FavnOrchestrator do
           required(:manifest_version_id) => String.t(),
           required(:assets) => [manifest_target_option()],
           required(:pipelines) => [manifest_target_option()]
+        }
+
+  @type asset_catalogue_entry :: %{
+          required(:target_id) => String.t(),
+          required(:label) => String.t(),
+          optional(:asset_ref) => String.t(),
+          optional(:type) => String.t(),
+          optional(:relation) => map() | nil,
+          optional(:metadata) => map(),
+          required(:status) => :healthy | :running | :failed | :unknown,
+          required(:latest_run_id) => String.t() | nil,
+          required(:latest_run_status) => atom() | nil,
+          required(:latest_run_at) => DateTime.t() | nil
         }
 
   @doc """
@@ -169,6 +184,23 @@ defmodule FavnOrchestrator do
   def active_manifest_targets do
     with {:ok, manifest_version_id} <- active_manifest() do
       manifest_targets(manifest_version_id)
+    end
+  end
+
+  @doc """
+  Returns operator-facing catalogue entries for the currently active manifest.
+
+  Entries are manifest target metadata enriched with latest known freshness/run
+  state. Missing runtime state is represented explicitly as `:unknown` with no
+  latest run timestamp.
+  """
+  @spec active_asset_catalogue() :: {:ok, [asset_catalogue_entry()]} | {:error, term()}
+  def active_asset_catalogue do
+    with {:ok, manifest_version_id} <- active_manifest(),
+         {:ok, version} <- get_manifest(manifest_version_id),
+         {:ok, freshness_states} <- catalogue_freshness_states(),
+         {:ok, runs} <- list_runs(limit: Page.max_limit()) do
+      {:ok, asset_catalogue_entries(version, freshness_states, runs)}
     end
   end
 
@@ -748,23 +780,59 @@ defmodule FavnOrchestrator do
   defp manifest_asset_targets(%Version{} = version) do
     version.manifest.assets
     |> List.wrap()
-    |> Enum.map(fn asset ->
-      target_ref = asset.ref
+    |> Enum.map(&manifest_asset_target/1)
+    |> Enum.sort_by(& &1.label)
+  end
 
-      %{
-        target_id: target_id_for_asset(target_ref),
-        label: inspect(target_ref),
-        asset_ref: ref_to_string(target_ref),
-        type: atom_name(asset.type),
-        relation: relation_dto(asset.relation),
-        metadata: normalize_map(asset.metadata),
-        runtime_config: normalize_data(asset.runtime_config),
-        depends_on: Enum.map(List.wrap(asset.depends_on), &ref_to_string/1),
-        materialization: normalize_data(asset.materialization),
-        window: normalize_data(asset.window)
-      }
+  defp catalogue_freshness_states do
+    case list_asset_freshness(limit: Page.max_limit()) do
+      {:ok, page} -> {:ok, page.items}
+      {:error, :asset_freshness_state_not_supported} -> {:ok, []}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp asset_catalogue_entries(%Version{} = version, freshness_states, runs) do
+    freshness_by_ref = Map.new(freshness_states, &{freshness_ref_string(&1), &1})
+
+    runs_by_ref =
+      runs
+      |> Enum.flat_map(&run_ref_entries/1)
+      |> Enum.group_by(fn {ref_string, _run} -> ref_string end, fn {_ref_string, run} -> run end)
+      |> Map.new(fn {ref_string, ref_runs} -> {ref_string, latest_run(ref_runs)} end)
+
+    version.manifest.assets
+    |> List.wrap()
+    |> Enum.map(fn asset ->
+      target = manifest_asset_target(asset)
+      ref_string = ref_to_string(asset.ref)
+      freshness = Map.get(freshness_by_ref, ref_string)
+      run = Map.get(runs_by_ref, ref_string)
+
+      target
+      |> Map.put(:status, catalogue_status(freshness, run))
+      |> Map.put(:latest_run_id, latest_run_id(freshness, run))
+      |> Map.put(:latest_run_status, latest_run_status(freshness, run))
+      |> Map.put(:latest_run_at, latest_run_at(freshness, run))
     end)
     |> Enum.sort_by(& &1.label)
+  end
+
+  defp manifest_asset_target(asset) do
+    target_ref = asset.ref
+
+    %{
+      target_id: target_id_for_asset(target_ref),
+      label: inspect(target_ref),
+      asset_ref: ref_to_string(target_ref),
+      type: atom_name(asset.type),
+      relation: relation_dto(asset.relation),
+      metadata: normalize_map(asset.metadata),
+      runtime_config: normalize_data(asset.runtime_config),
+      depends_on: Enum.map(List.wrap(asset.depends_on), &ref_to_string/1),
+      materialization: normalize_data(asset.materialization),
+      window: normalize_data(asset.window)
+    }
   end
 
   defp manifest_pipeline_targets(%Version{} = version) do
@@ -781,6 +849,82 @@ defmodule FavnOrchestrator do
     end)
     |> Enum.sort_by(& &1.label)
   end
+
+  defp freshness_ref_string(%AssetFreshnessState{} = state) do
+    ref_to_string({state.asset_ref_module, state.asset_ref_name})
+  end
+
+  defp run_ref_entries(run) do
+    refs =
+      [run.asset_ref | List.wrap(run.target_refs)] ++
+        ((run.asset_results || %{})
+         |> Map.keys()
+         |> List.wrap())
+
+    refs
+    |> Enum.filter(&match?({_module, _name}, &1))
+    |> Enum.uniq()
+    |> Enum.map(&{ref_to_string(&1), run})
+  end
+
+  defp latest_run(runs) do
+    Enum.max_by(
+      runs,
+      &DateTime.to_unix(run_time_sort_key(&1), :microsecond),
+      &>=/2,
+      fn -> nil end
+    )
+  end
+
+  defp run_time_sort_key(run), do: run.finished_at || run.started_at || DateTime.from_unix!(0)
+
+  defp catalogue_status(%AssetFreshnessState{} = freshness, _run) do
+    case freshness.latest_attempt_status || freshness.status do
+      status when status in [:ok, :skipped_fresh] -> :healthy
+      :running -> :running
+      status when status in [:error, :cancelled, :timed_out, :blocked] -> :failed
+      _other -> :unknown
+    end
+  end
+
+  defp catalogue_status(nil, run), do: run_status(run)
+
+  defp run_status(nil), do: :unknown
+  defp run_status(%{status: status}) when status in [:pending, :running], do: :running
+  defp run_status(%{status: :ok}), do: :healthy
+
+  defp run_status(%{status: status}) when status in [:partial, :error, :cancelled, :timed_out],
+    do: :failed
+
+  defp run_status(_run), do: :unknown
+
+  defp latest_run_id(%AssetFreshnessState{latest_attempt_run_id: id}, _run) when is_binary(id),
+    do: id
+
+  defp latest_run_id(%AssetFreshnessState{latest_success_run_id: id}, _run) when is_binary(id),
+    do: id
+
+  defp latest_run_id(_freshness, %{id: id}) when is_binary(id), do: id
+  defp latest_run_id(_freshness, _run), do: nil
+
+  defp latest_run_status(%AssetFreshnessState{latest_attempt_status: status}, _run)
+       when not is_nil(status),
+       do: status
+
+  defp latest_run_status(%AssetFreshnessState{status: status}, _run) when not is_nil(status),
+    do: status
+
+  defp latest_run_status(_freshness, %{status: status}), do: status
+  defp latest_run_status(_freshness, _run), do: nil
+
+  defp latest_run_at(%AssetFreshnessState{latest_attempt_at: at}, _run) when not is_nil(at),
+    do: at
+
+  defp latest_run_at(%AssetFreshnessState{latest_success_at: at}, _run) when not is_nil(at),
+    do: at
+
+  defp latest_run_at(_freshness, run) when not is_nil(run), do: run.finished_at || run.started_at
+  defp latest_run_at(_freshness, _run), do: nil
 
   defp window_policy_dto(nil), do: nil
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -198,8 +198,8 @@ defmodule FavnOrchestrator do
   def active_asset_catalogue do
     with {:ok, manifest_version_id} <- active_manifest(),
          {:ok, version} <- get_manifest(manifest_version_id),
-         {:ok, freshness_states} <- catalogue_freshness_states(),
-         {:ok, runs} <- list_runs(limit: Page.max_limit()) do
+         {:ok, freshness_states} <- catalogue_freshness_states(manifest_version_id),
+         {:ok, runs} <- catalogue_runs(manifest_version_id) do
       {:ok, asset_catalogue_entries(version, freshness_states, runs)}
     end
   end
@@ -784,12 +784,20 @@ defmodule FavnOrchestrator do
     |> Enum.sort_by(& &1.label)
   end
 
-  defp catalogue_freshness_states do
-    case list_asset_freshness(limit: Page.max_limit()) do
+  defp catalogue_freshness_states(manifest_version_id) do
+    case list_asset_freshness(
+           manifest_version_id: manifest_version_id,
+           freshness_key: Favn.Freshness.Key.latest(),
+           limit: Page.max_limit()
+         ) do
       {:ok, page} -> {:ok, page.items}
       {:error, :asset_freshness_state_not_supported} -> {:ok, []}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  defp catalogue_runs(manifest_version_id) do
+    list_runs(manifest_version_id: manifest_version_id)
   end
 
   defp asset_catalogue_entries(%Version{} = version, freshness_states, runs) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -1087,11 +1087,18 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   defp normalize_put_run_reply({{:error, reason}, runs}), do: {{:error, reason}, runs}
 
   defp filter_runs(runs, run_opts) do
-    case Keyword.get(run_opts, :status) do
-      nil -> runs
-      status -> Enum.filter(runs, &(&1.status == status))
-    end
+    Enum.filter(runs, fn run ->
+      matches_run_filter?(run, :status, Keyword.get(run_opts, :status)) and
+        matches_run_filter?(
+          run,
+          :manifest_version_id,
+          Keyword.get(run_opts, :manifest_version_id)
+        )
+    end)
   end
+
+  defp matches_run_filter?(_run, _field, nil), do: true
+  defp matches_run_filter?(run, field, expected), do: Map.get(run, field) == expected
 
   defp run_sort_key(%RunState{updated_at: %DateTime{} = updated_at}),
     do: DateTime.to_unix(updated_at, :microsecond)

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -4,10 +4,14 @@ defmodule FavnOrchestrator.ManifestStoreTest do
   alias Favn.Manifest
   alias Favn.Manifest.Pipeline
   alias Favn.Manifest.Version
+  alias Favn.Run.AssetResult
   alias Favn.Window.Policy
   alias Favn.Window.Spec, as: WindowSpec
   alias FavnOrchestrator
+  alias FavnOrchestrator.AssetFreshnessState
   alias FavnOrchestrator.ManifestStore
+  alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.Adapter.Memory
 
   setup do
@@ -92,6 +96,33 @@ defmodule FavnOrchestrator.ManifestStoreTest do
              timezone: nil,
              allow_full_load: false
            }
+
+    finished_at = DateTime.add(DateTime.utc_now(), -300, :second)
+
+    assert :ok =
+             Storage.put_run(run_state("run_asset_a", {MyApp.AssetA, :asset}, :ok, finished_at))
+
+    assert {:ok, freshness} =
+             AssetFreshnessState.new(%{
+               asset_ref_module: MyApp.AssetA,
+               asset_ref_name: :asset,
+               freshness_key: "latest",
+               status: :ok,
+               latest_success_run_id: "run_asset_a",
+               latest_success_at: finished_at,
+               latest_attempt_status: :ok,
+               latest_attempt_at: finished_at,
+               updated_at: finished_at
+             })
+
+    assert :ok = Storage.put_asset_freshness_state(freshness)
+
+    assert {:ok, [entry]} = FavnOrchestrator.active_asset_catalogue()
+    assert entry.target_id == "asset:Elixir.MyApp.AssetA:asset"
+    assert entry.status == :healthy
+    assert entry.latest_run_id == "run_asset_a"
+    assert entry.latest_run_status == :ok
+    assert entry.latest_run_at == finished_at
   end
 
   test "publishes duplicate content under the existing canonical manifest version" do
@@ -117,5 +148,32 @@ defmodule FavnOrchestrator.ManifestStoreTest do
 
     {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
     version
+  end
+
+  defp run_state(id, ref, status, finished_at) do
+    RunState.new(
+      id: id,
+      manifest_version_id: "mv_a",
+      manifest_content_hash: "hash_a",
+      asset_ref: ref,
+      target_refs: [ref]
+    )
+    |> RunState.transition(
+      status: status,
+      result: %{
+        asset_results: [
+          %AssetResult{
+            ref: ref,
+            stage: 0,
+            status: status,
+            started_at: DateTime.add(finished_at, -1, :second),
+            finished_at: finished_at,
+            duration_ms: 1
+          }
+        ]
+      }
+    )
+    |> Map.put(:updated_at, finished_at)
+    |> RunState.with_snapshot_hash()
   end
 end

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -98,9 +98,23 @@ defmodule FavnOrchestrator.ManifestStoreTest do
            }
 
     finished_at = DateTime.add(DateTime.utc_now(), -300, :second)
+    old_finished_at = DateTime.add(finished_at, -3_600, :second)
 
     assert :ok =
-             Storage.put_run(run_state("run_asset_a", {MyApp.AssetA, :asset}, :ok, finished_at))
+             Storage.put_run(
+               run_state(
+                 "run_old_asset_a",
+                 {MyApp.AssetA, :asset},
+                 :error,
+                 old_finished_at,
+                 "mv_old"
+               )
+             )
+
+    assert :ok =
+             Storage.put_run(
+               run_state("run_asset_a", {MyApp.AssetA, :asset}, :ok, finished_at, "mv_a")
+             )
 
     assert {:ok, freshness} =
              AssetFreshnessState.new(%{
@@ -112,10 +126,26 @@ defmodule FavnOrchestrator.ManifestStoreTest do
                latest_success_at: finished_at,
                latest_attempt_status: :ok,
                latest_attempt_at: finished_at,
+               manifest_version_id: "mv_a",
                updated_at: finished_at
              })
 
     assert :ok = Storage.put_asset_freshness_state(freshness)
+
+    assert {:ok, stale_window_freshness} =
+             AssetFreshnessState.new(%{
+               asset_ref_module: MyApp.AssetA,
+               asset_ref_name: :asset,
+               freshness_key: "calendar:day:Etc/UTC:2026-05-09",
+               status: :error,
+               latest_attempt_run_id: "run_old_asset_a",
+               latest_attempt_status: :error,
+               latest_attempt_at: old_finished_at,
+               manifest_version_id: "mv_a",
+               updated_at: old_finished_at
+             })
+
+    assert :ok = Storage.put_asset_freshness_state(stale_window_freshness)
 
     assert {:ok, [entry]} = FavnOrchestrator.active_asset_catalogue()
     assert entry.target_id == "asset:Elixir.MyApp.AssetA:asset"
@@ -150,10 +180,10 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     version
   end
 
-  defp run_state(id, ref, status, finished_at) do
+  defp run_state(id, ref, status, finished_at, manifest_version_id) do
     RunState.new(
       id: id,
-      manifest_version_id: "mv_a",
+      manifest_version_id: manifest_version_id,
       manifest_content_hash: "hash_a",
       asset_ref: ref,
       target_refs: [ref]

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -1472,29 +1472,30 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   defp list_runs_query(run_opts) do
-    status = Keyword.get(run_opts, :status)
     limit = Keyword.get(run_opts, :limit)
+    filters = Keyword.take(run_opts, [:status, :manifest_version_id])
 
-    cond do
-      is_nil(status) and is_nil(limit) ->
-        {run_snapshot_select() <> " ORDER BY r.updated_seq DESC, r.run_id DESC", []}
+    {where_sql, params} = run_filter_sql(filters)
+    limit_sql = if is_integer(limit) and limit > 0, do: " LIMIT $#{length(params) + 1}", else: ""
+    params = if limit_sql == "", do: params, else: params ++ [limit]
 
-      is_nil(status) ->
-        {run_snapshot_select() <> " ORDER BY r.updated_seq DESC, r.run_id DESC LIMIT $1", [limit]}
+    {run_snapshot_select() <>
+       where_sql <> " ORDER BY r.updated_seq DESC, r.run_id DESC" <> limit_sql, params}
+  end
 
-      is_nil(limit) ->
-        {
-          run_snapshot_select() <>
-            " WHERE r.status = $1 ORDER BY r.updated_seq DESC, r.run_id DESC",
-          [Atom.to_string(status)]
-        }
+  defp run_filter_sql(filters) do
+    filters
+    |> Enum.reduce({[], []}, fn
+      {:status, status}, {clauses, params} ->
+        {clauses ++ ["r.status = $#{length(params) + 1}"], params ++ [Atom.to_string(status)]}
 
-      true ->
-        {
-          run_snapshot_select() <>
-            " WHERE r.status = $1 ORDER BY r.updated_seq DESC, r.run_id DESC LIMIT $2",
-          [Atom.to_string(status), limit]
-        }
+      {:manifest_version_id, manifest_version_id}, {clauses, params} ->
+        {clauses ++ ["r.manifest_version_id = $#{length(params) + 1}"],
+         params ++ [manifest_version_id]}
+    end)
+    |> case do
+      {[], params} -> {"", params}
+      {clauses, params} -> {" WHERE " <> Enum.join(clauses, " AND "), params}
     end
   end
 

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -2003,29 +2003,30 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   defp list_runs_query(run_opts) do
-    status = Keyword.get(run_opts, :status)
     limit = Keyword.get(run_opts, :limit)
+    filters = Keyword.take(run_opts, [:status, :manifest_version_id])
 
-    cond do
-      is_nil(status) and is_nil(limit) ->
-        {run_snapshot_select() <> " ORDER BY r.updated_seq DESC, r.run_id DESC", []}
+    {where_sql, params} = run_filter_sql(filters)
+    limit_sql = if is_integer(limit) and limit > 0, do: " LIMIT ?#{length(params) + 1}", else: ""
+    params = if limit_sql == "", do: params, else: params ++ [limit]
 
-      is_nil(status) ->
-        {run_snapshot_select() <> " ORDER BY r.updated_seq DESC, r.run_id DESC LIMIT ?1", [limit]}
+    {run_snapshot_select() <>
+       where_sql <> " ORDER BY r.updated_seq DESC, r.run_id DESC" <> limit_sql, params}
+  end
 
-      is_nil(limit) ->
-        {
-          run_snapshot_select() <>
-            " WHERE r.status = ?1 ORDER BY r.updated_seq DESC, r.run_id DESC",
-          [Atom.to_string(status)]
-        }
+  defp run_filter_sql(filters) do
+    filters
+    |> Enum.reduce({[], []}, fn
+      {:status, status}, {clauses, params} ->
+        {clauses ++ ["r.status = ?#{length(params) + 1}"], params ++ [Atom.to_string(status)]}
 
-      true ->
-        {
-          run_snapshot_select() <>
-            " WHERE r.status = ?1 ORDER BY r.updated_seq DESC, r.run_id DESC LIMIT ?2",
-          [Atom.to_string(status), limit]
-        }
+      {:manifest_version_id, manifest_version_id}, {clauses, params} ->
+        {clauses ++ ["r.manifest_version_id = ?#{length(params) + 1}"],
+         params ++ [manifest_version_id]}
+    end)
+    |> case do
+      {[], params} -> {"", params}
+      {clauses, params} -> {" WHERE " <> Enum.join(clauses, " AND "), params}
     end
   end
 

--- a/apps/favn_view/assets/css/app.css
+++ b/apps/favn_view/assets/css/app.css
@@ -109,6 +109,7 @@
     position: relative;
     min-height: 100vh;
     overflow: hidden;
+    font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
     background:
       radial-gradient(circle at 16% 58%, color-mix(in oklab, var(--color-primary) 32%, transparent), transparent 22rem),
       radial-gradient(circle at 90% 92%, color-mix(in oklab, var(--color-secondary) 42%, transparent), transparent 24rem),
@@ -116,21 +117,224 @@
       var(--color-base-100);
   }
 
+  .favn-surface-panel,
   .favn-glass-panel {
-    border: var(--border) solid color-mix(in oklab, var(--color-base-content) 18%, transparent);
-    background: color-mix(in oklab, var(--color-base-200) 58%, transparent);
+    border: var(--border) solid color-mix(in oklab, var(--color-primary) 24%, color-mix(in oklab, var(--color-base-content) 8%, transparent));
+    background:
+      radial-gradient(circle at 0 35%, color-mix(in oklab, var(--color-primary) 18%, transparent), transparent 14rem),
+      color-mix(in oklab, var(--color-base-200) 36%, transparent);
     box-shadow:
-      0 1px 0 color-mix(in oklab, var(--color-base-content) 20%, transparent) inset,
-      0 32px 90px color-mix(in oklab, var(--color-primary) 18%, transparent),
-      0 18px 55px color-mix(in oklab, var(--color-base-100) 65%, transparent);
-    backdrop-filter: blur(30px) saturate(145%);
+      0 1px 0 color-mix(in oklab, var(--color-base-content) 12%, transparent) inset,
+      0 20px 70px color-mix(in oklab, var(--color-primary) 12%, transparent),
+      0 14px 40px color-mix(in oklab, var(--color-base-100) 54%, transparent);
+    backdrop-filter: blur(24px) saturate(135%);
   }
 
+  .favn-surface-list {
+    border: var(--border) solid color-mix(in oklab, var(--color-primary) 22%, color-mix(in oklab, var(--color-base-content) 7%, transparent));
+    background:
+      radial-gradient(circle at 0 45%, color-mix(in oklab, var(--color-primary) 16%, transparent), transparent 11rem),
+      color-mix(in oklab, var(--color-base-200) 32%, transparent);
+    box-shadow:
+      0 1px 0 color-mix(in oklab, var(--color-base-content) 10%, transparent) inset,
+      0 14px 46px color-mix(in oklab, var(--color-primary) 8%, transparent),
+      0 10px 32px color-mix(in oklab, var(--color-base-100) 46%, transparent);
+    backdrop-filter: blur(22px) saturate(132%);
+  }
+
+  .glass.favn-glass-panel {
+    border-color: color-mix(in oklab, var(--color-primary) 24%, color-mix(in oklab, var(--color-base-content) 8%, transparent)) !important;
+    background:
+      radial-gradient(circle at 0 35%, color-mix(in oklab, var(--color-primary) 18%, transparent), transparent 14rem),
+      color-mix(in oklab, var(--color-base-200) 36%, transparent) !important;
+    box-shadow:
+      0 1px 0 color-mix(in oklab, var(--color-base-content) 12%, transparent) inset,
+      0 20px 70px color-mix(in oklab, var(--color-primary) 12%, transparent),
+      0 14px 40px color-mix(in oklab, var(--color-base-100) 54%, transparent) !important;
+  }
+
+  .glass.favn-surface-list {
+    border-color: color-mix(in oklab, var(--color-primary) 22%, color-mix(in oklab, var(--color-base-content) 7%, transparent)) !important;
+    background:
+      radial-gradient(circle at 0 45%, color-mix(in oklab, var(--color-primary) 16%, transparent), transparent 11rem),
+      color-mix(in oklab, var(--color-base-200) 32%, transparent) !important;
+    box-shadow:
+      0 1px 0 color-mix(in oklab, var(--color-base-content) 10%, transparent) inset,
+      0 14px 46px color-mix(in oklab, var(--color-primary) 8%, transparent),
+      0 10px 32px color-mix(in oklab, var(--color-base-100) 46%, transparent) !important;
+  }
+
+  .favn-surface-control,
+  .favn-control-glass {
+    min-height: 2.875rem;
+    border-color: color-mix(in oklab, var(--color-primary) 26%, color-mix(in oklab, var(--color-base-content) 9%, transparent)) !important;
+    background:
+      radial-gradient(circle at 0 45%, color-mix(in oklab, var(--color-primary) 16%, transparent), transparent 9rem),
+      color-mix(in oklab, var(--color-base-200) 32%, transparent) !important;
+    box-shadow:
+      0 1px 0 color-mix(in oklab, var(--color-base-content) 10%, transparent) inset,
+      0 0 0 1px color-mix(in oklab, var(--color-primary) 10%, transparent) inset,
+      0 10px 30px color-mix(in oklab, var(--color-base-100) 32%, transparent) !important;
+    backdrop-filter: blur(20px) saturate(130%);
+    color: color-mix(in oklab, var(--color-base-content) 88%, transparent);
+    transition:
+      border-color 160ms ease,
+      box-shadow 160ms ease,
+      background-color 160ms ease;
+  }
+
+  .input.favn-surface-control,
+  .select.favn-surface-control,
+  .input.favn-control-glass,
+  .select.favn-control-glass {
+    height: auto;
+  }
+
+  .favn-surface-control-lg {
+    min-height: 3.25rem;
+  }
+
+  .favn-control-glass:hover,
+  .favn-control-glass:focus-within,
+  .favn-surface-control:hover,
+  .favn-surface-control:focus-within {
+    border-color: color-mix(in oklab, var(--color-primary) 44%, transparent) !important;
+    background:
+      radial-gradient(circle at 0 45%, color-mix(in oklab, var(--color-primary) 22%, transparent), transparent 9rem),
+      color-mix(in oklab, var(--color-base-200) 38%, transparent) !important;
+    box-shadow:
+      0 1px 0 color-mix(in oklab, var(--color-base-content) 12%, transparent) inset,
+      0 0 0 1px color-mix(in oklab, var(--color-primary) 16%, transparent) inset,
+      0 14px 38px color-mix(in oklab, var(--color-primary) 10%, transparent) !important;
+  }
+
+  .favn-control-glass :is(input, select),
+  .favn-surface-control :is(input, select) {
+    color: inherit;
+  }
+
+  .favn-control-glass :is(input::placeholder),
+  .favn-surface-control :is(input::placeholder) {
+    color: color-mix(in oklab, var(--color-base-content) 52%, transparent);
+  }
+
+  .favn-control-glass option,
+  select.favn-control-glass option,
+  .favn-surface-control option,
+  select.favn-surface-control option {
+    background-color: var(--color-base-200);
+    color: var(--color-base-content);
+  }
+
+  .favn-surface-rail,
   .favn-icon-rail {
-    border: var(--border) solid color-mix(in oklab, var(--color-base-content) 14%, transparent);
-    background: color-mix(in oklab, var(--color-base-200) 44%, transparent);
-    box-shadow: 0 18px 60px color-mix(in oklab, var(--color-base-100) 58%, transparent);
-    backdrop-filter: blur(24px) saturate(135%);
+    border: var(--border) solid color-mix(in oklab, var(--color-primary) 20%, color-mix(in oklab, var(--color-base-content) 8%, transparent));
+    background:
+      radial-gradient(circle at 50% 0, color-mix(in oklab, var(--color-primary) 14%, transparent), transparent 10rem),
+      color-mix(in oklab, var(--color-base-200) 30%, transparent);
+    box-shadow: 0 16px 46px color-mix(in oklab, var(--color-base-100) 52%, transparent);
+    backdrop-filter: blur(22px) saturate(130%);
+  }
+
+  .favn-mode-shell {
+    border: var(--border) solid color-mix(in oklab, var(--color-primary) 22%, color-mix(in oklab, var(--color-base-content) 7%, transparent));
+    background:
+      radial-gradient(circle at 0 45%, color-mix(in oklab, var(--color-primary) 16%, transparent), transparent 11rem),
+      color-mix(in oklab, var(--color-base-200) 32%, transparent);
+    box-shadow:
+      0 1px 0 color-mix(in oklab, var(--color-base-content) 10%, transparent) inset,
+      0 14px 46px color-mix(in oklab, var(--color-primary) 8%, transparent),
+      0 10px 32px color-mix(in oklab, var(--color-base-100) 46%, transparent);
+    backdrop-filter: blur(22px) saturate(132%);
+  }
+
+  .favn-mode-item {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: var(--border) solid transparent;
+    border-radius: var(--radius-box);
+    color: color-mix(in oklab, var(--color-base-content) 58%, transparent);
+    outline: none;
+    transition:
+      color 160ms ease,
+      background-color 160ms ease,
+      border-color 160ms ease,
+      box-shadow 160ms ease,
+      transform 160ms ease;
+  }
+
+  .favn-mode-item:hover,
+  .favn-mode-item:focus-visible {
+    color: color-mix(in oklab, var(--color-primary) 86%, var(--color-base-content));
+    background: color-mix(in oklab, var(--color-primary) 10%, transparent);
+    border-color: color-mix(in oklab, var(--color-primary) 24%, transparent);
+  }
+
+  .favn-mode-item-active {
+    color: var(--color-primary);
+    border-color: color-mix(in oklab, var(--color-primary) 38%, transparent);
+    background:
+      radial-gradient(circle at 50% 100%, color-mix(in oklab, var(--color-primary) 28%, transparent), transparent 70%),
+      color-mix(in oklab, var(--color-primary) 13%, transparent);
+    box-shadow:
+      0 0 0 1px color-mix(in oklab, var(--color-primary) 16%, transparent) inset,
+      0 0 24px color-mix(in oklab, var(--color-primary) 22%, transparent);
+  }
+
+  .favn-mode-item-active::after {
+    position: absolute;
+    content: "";
+    width: 0.25rem;
+    height: 0.25rem;
+    border-radius: 999rem;
+    background: var(--color-primary);
+    box-shadow: 0 0 12px color-mix(in oklab, var(--color-primary) 70%, transparent);
+  }
+
+  .favn-mode-rail-item {
+    width: 2.5rem;
+    height: 2.5rem;
+  }
+
+  .favn-mode-rail-item.favn-mode-item-active::after {
+    left: -0.45rem;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .favn-mode-dock-item {
+    min-width: 3rem;
+    height: 2.25rem;
+    flex: 1 1 0;
+    max-width: 4.25rem;
+  }
+
+  .favn-mode-dock-item.favn-mode-item-active::after {
+    bottom: -0.3rem;
+    left: 50%;
+    transform: translateX(-50%);
+  }
+
+  .favn-density-list-card {
+    padding: 0.75rem;
+  }
+
+  .favn-density-list-card-icon {
+    width: 2.25rem;
+    height: 2.25rem;
+  }
+
+  @media (min-width: 640px) {
+    .favn-density-list-card {
+      padding: 0.875rem;
+    }
+
+    .favn-density-list-card-icon {
+      width: 2.5rem;
+      height: 2.5rem;
+    }
   }
 
   .favn-icon-button {

--- a/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
@@ -1,0 +1,137 @@
+defmodule FavnView.AssetCatalogueLive do
+  @moduledoc false
+
+  use FavnView, :live_view
+
+  alias FavnView.Components.AssetCataloguePage
+
+  @default_filters %{search: "", connection: "all", catalogue: "all"}
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {assets, error} = load_assets()
+
+    socket =
+      assign(socket,
+        all_assets: assets,
+        assets: assets,
+        filters: @default_filters,
+        active_mode: :list,
+        loading: false,
+        error: error,
+        nav_items: AssetCataloguePage.nav_items(),
+        connection_options: connection_options(assets),
+        catalogue_options: catalogue_options(assets)
+      )
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("filter_assets", %{"filters" => params}, socket) do
+    filters = normalize_filters(params)
+
+    {:noreply,
+     assign(socket,
+       filters: filters,
+       assets: filter_assets(socket.assigns.all_assets, filters)
+     )}
+  end
+
+  def handle_event("set_mode", %{"mode" => mode}, socket) do
+    {:noreply, assign(socket, :active_mode, String.to_existing_atom(mode))}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <AssetCataloguePage.asset_catalogue_page
+      assets={@assets}
+      filters={@filters}
+      active_mode={@active_mode}
+      loading={@loading}
+      error={@error}
+      nav_items={@nav_items}
+      connection_options={@connection_options}
+      catalogue_options={@catalogue_options}
+    />
+    """
+  end
+
+  defp normalize_filters(params) do
+    %{
+      search: Map.get(params, "search", ""),
+      connection: Map.get(params, "connection", "all"),
+      catalogue: Map.get(params, "catalogue", "all")
+    }
+  end
+
+  defp filter_assets(assets, filters) do
+    search = filters.search |> String.downcase() |> String.trim()
+
+    Enum.filter(assets, fn asset ->
+      matches_search? = search == "" || String.contains?(String.downcase(asset.name), search)
+      matches_connection? = filters.connection == "all" || asset.connection == filters.connection
+      matches_catalogue? = filters.catalogue == "all" || asset.catalogue == filters.catalogue
+
+      matches_search? && matches_connection? && matches_catalogue?
+    end)
+  end
+
+  defp load_assets do
+    case FavnOrchestrator.active_manifest_targets() do
+      {:ok, %{assets: targets}} ->
+        {Enum.map(targets, &asset_from_target/1), nil}
+
+      {:error, reason} ->
+        {[], reason}
+    end
+  end
+
+  defp asset_from_target(target) do
+    relation = Map.get(target, :relation) || %{}
+
+    %{
+      id: Map.fetch!(target, :target_id),
+      name: relation_field(relation, :name) || asset_name(target),
+      connection: relation_field(relation, :connection) || "unknown",
+      catalogue: relation_field(relation, :catalog) || "uncatalogued",
+      type: target[:type] || "asset",
+      status: :unknown,
+      last_run_label: "No runs yet"
+    }
+  end
+
+  defp connection_options(assets), do: options_from_assets(assets, :connection, "Connection")
+  defp catalogue_options(assets), do: options_from_assets(assets, :catalogue, "Catalogue")
+
+  defp options_from_assets(assets, field, label) do
+    options =
+      assets
+      |> Enum.map(&Map.fetch!(&1, field))
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.uniq()
+      |> Enum.sort()
+      |> Enum.map(&{option_label(&1), &1})
+
+    [{label, "all"} | options]
+  end
+
+  defp relation_field(relation, field) do
+    Map.get(relation, field) || Map.get(relation, Atom.to_string(field))
+  end
+
+  defp asset_name(target) do
+    target
+    |> Map.get(:asset_ref, target[:label] || target[:target_id])
+    |> to_string()
+    |> String.split(":")
+    |> List.last()
+  end
+
+  defp option_label(value) do
+    value
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+end

--- a/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
@@ -6,6 +6,7 @@ defmodule FavnView.AssetCatalogueLive do
   alias FavnView.Components.AssetCataloguePage
 
   @default_filters %{search: "", connection: "all", catalogue: "all"}
+  @valid_modes ~w(list)
 
   @impl true
   def mount(_params, _session, socket) do
@@ -38,9 +39,11 @@ defmodule FavnView.AssetCatalogueLive do
      )}
   end
 
-  def handle_event("set_mode", %{"mode" => mode}, socket) do
+  def handle_event("set_mode", %{"mode" => mode}, socket) when mode in @valid_modes do
     {:noreply, assign(socket, :active_mode, String.to_existing_atom(mode))}
   end
+
+  def handle_event("set_mode", _params, socket), do: {:noreply, socket}
 
   @impl true
   def render(assigns) do
@@ -79,26 +82,26 @@ defmodule FavnView.AssetCatalogueLive do
   end
 
   defp load_assets do
-    case FavnOrchestrator.active_manifest_targets() do
-      {:ok, %{assets: targets}} ->
-        {Enum.map(targets, &asset_from_target/1), nil}
+    case FavnOrchestrator.active_asset_catalogue() do
+      {:ok, entries} ->
+        {Enum.map(entries, &asset_from_entry/1), nil}
 
       {:error, reason} ->
         {[], reason}
     end
   end
 
-  defp asset_from_target(target) do
-    relation = Map.get(target, :relation) || %{}
+  defp asset_from_entry(entry) do
+    relation = Map.get(entry, :relation) || %{}
 
     %{
-      id: Map.fetch!(target, :target_id),
-      name: relation_field(relation, :name) || asset_name(target),
+      id: Map.fetch!(entry, :target_id),
+      name: relation_field(relation, :name) || asset_name(entry),
       connection: relation_field(relation, :connection) || "unknown",
       catalogue: relation_field(relation, :catalog) || "uncatalogued",
-      type: target[:type] || "asset",
-      status: :unknown,
-      last_run_label: "No runs yet"
+      type: entry[:type] || "asset",
+      status: entry[:status] || :unknown,
+      last_run_label: last_run_label(entry[:latest_run_at])
     }
   end
 
@@ -134,4 +137,17 @@ defmodule FavnView.AssetCatalogueLive do
     |> String.replace("_", " ")
     |> String.capitalize()
   end
+
+  defp last_run_label(%DateTime{} = datetime) do
+    seconds = DateTime.diff(DateTime.utc_now(), datetime, :second)
+
+    cond do
+      seconds < 60 -> "just now"
+      seconds < 3_600 -> "#{div(seconds, 60)}m ago"
+      seconds < 86_400 -> "#{div(seconds, 3_600)}h ago"
+      true -> Calendar.strftime(datetime, "%b %-d %H:%M")
+    end
+  end
+
+  defp last_run_label(_value), do: "No runs yet"
 end

--- a/apps/favn_view/lib/favn_view/asset_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_detail_live.ex
@@ -1,0 +1,33 @@
+defmodule FavnView.AssetDetailLive do
+  @moduledoc false
+
+  use FavnView, :live_view
+
+  alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.GlassPanel
+
+  @impl true
+  def mount(%{"asset_id" => asset_id}, _session, socket) do
+    {:ok, assign(socket, asset_id: asset_id, nav_items: AssetCataloguePage.nav_items())}
+  end
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <AppShell.app_shell title={@asset_id} subtitle="Asset detail" nav_items={@nav_items}>
+      <div class="mx-auto w-full max-w-4xl">
+        <GlassPanel.glass_panel class="p-8 text-center" data-testid="asset-detail-placeholder">
+          <h2 class="text-xl font-medium">Asset detail coming soon</h2>
+          <p class="mt-2 text-base-content/60">
+            The catalogue can open assets now; detailed runs, lineage, docs, and code will follow.
+          </p>
+          <.link navigate={~p"/assets"} class="btn btn-primary btn-soft mt-6">
+            Back to catalogue
+          </.link>
+        </GlassPanel.glass_panel>
+      </div>
+    </AppShell.app_shell>
+    """
+  end
+end

--- a/apps/favn_view/lib/favn_view/components/app_shell.ex
+++ b/apps/favn_view/lib/favn_view/components/app_shell.ex
@@ -9,6 +9,7 @@ defmodule FavnView.Components.AppShell do
   alias FavnView.Components.ThemeToggle
 
   attr :title, :string, required: true
+  attr :subtitle, :string, default: nil
   attr :status, :string, default: nil
   attr :nav_items, :list, default: []
 
@@ -21,7 +22,7 @@ defmodule FavnView.Components.AppShell do
       <div class="favn-orbital-grid" aria-hidden="true"></div>
       <IconNav.icon_nav items={@nav_items} />
 
-      <div class="relative z-10 min-h-screen px-5 py-5 md:pl-32 md:pr-8 lg:pr-32">
+      <div class="relative z-10 min-h-screen px-5 py-4 md:py-5 md:pl-32 md:pr-8 lg:pr-32">
         <header class="mx-auto flex max-w-7xl items-center justify-between gap-3">
           <div class="flex items-center gap-2 md:hidden">
             <IconNav.mobile_icon_nav items={@nav_items} />
@@ -45,11 +46,16 @@ defmodule FavnView.Components.AppShell do
           </div>
         </header>
 
-        <main class="mx-auto flex min-h-[calc(100vh-5.5rem)] max-w-7xl flex-col justify-center py-12">
-          <section class="mb-8 flex flex-col gap-4 sm:flex-row sm:items-center">
-            <h1 class="text-4xl font-light tracking-tight text-base-content sm:text-5xl lg:text-6xl">
-              {@title}
-            </h1>
+        <main class="mx-auto flex min-h-[calc(100vh-5.5rem)] max-w-7xl flex-col justify-start py-8 md:justify-center md:py-12">
+          <section class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start md:mb-8 md:gap-4">
+            <div>
+              <h1 class="text-3xl font-light tracking-tight text-base-content sm:text-5xl lg:text-6xl">
+                {@title}
+              </h1>
+              <p :if={@subtitle} class="mt-2 text-base text-base-content/60 md:mt-3 md:text-lg">
+                {@subtitle}
+              </p>
+            </div>
             <span
               :if={@status}
               class="badge badge-success badge-soft favn-status-glow gap-2 px-4 py-4"

--- a/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
@@ -1,0 +1,480 @@
+defmodule FavnView.Components.AssetCataloguePage do
+  @moduledoc """
+  Asset catalogue page components for the first Favn operator catalogue screen.
+  """
+
+  use FavnView, :html
+
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.GlassPanel
+  alias FavnView.Components.ModeRail
+
+  attr :assets, :list, required: true
+  attr :filters, :map, required: true
+  attr :active_mode, :atom, required: true
+  attr :loading, :boolean, default: false
+  attr :error, :string, default: nil
+  attr :nav_items, :list, required: true
+  attr :connection_options, :list, required: true
+  attr :catalogue_options, :list, required: true
+
+  def asset_catalogue_page(assigns) do
+    ~H"""
+    <AppShell.app_shell
+      title="Asset catalogue"
+      subtitle="Browse and monitor all assets"
+      nav_items={@nav_items}
+    >
+      <div class="mx-auto w-full max-w-6xl pb-24 lg:pb-0" data-testid="asset-catalogue-page">
+        <.loading_state :if={@loading} />
+        <.error_state :if={!@loading && @error} />
+
+        <div :if={!@loading && !@error} class="space-y-3.5 lg:space-y-5">
+          <div id="asset-filters" data-testid="asset-filters">
+            <.asset_catalogue_filters
+              filters={@filters}
+              connection_options={@connection_options}
+              catalogue_options={@catalogue_options}
+            />
+          </div>
+
+          <.empty_state :if={@assets == []} />
+
+          <GlassPanel.glass_panel :if={@assets != []} class="hidden overflow-hidden lg:block">
+            <.asset_table assets={@assets} />
+          </GlassPanel.glass_panel>
+
+          <.asset_card_list :if={@assets != []} assets={@assets} />
+        </div>
+      </div>
+
+      <:mode_rail>
+        <ModeRail.mode_rail active={@active_mode} modes={catalogue_modes()} on_select="set_mode" />
+      </:mode_rail>
+    </AppShell.app_shell>
+    """
+  end
+
+  attr :filters, :map, required: true
+  attr :connection_options, :list, required: true
+  attr :catalogue_options, :list, required: true
+
+  def asset_catalogue_filters(assigns) do
+    ~H"""
+    <form
+      phx-change="filter_assets"
+      phx-submit="filter_assets"
+      class="grid grid-cols-2 gap-2.5 lg:grid-cols-[1fr_12rem_12rem] lg:gap-3"
+    >
+      <label class="input input-sm favn-surface-control col-span-2 w-full gap-3 px-4 focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-primary lg:col-span-1">
+        <.icon name="hero-magnifying-glass" class="size-5 shrink-0 text-base-content/60" />
+        <span class="sr-only">Search assets</span>
+        <input
+          id="asset-search"
+          type="search"
+          name="filters[search]"
+          value={@filters.search}
+          placeholder="Search assets"
+          autocomplete="off"
+          phx-debounce="200"
+        />
+      </label>
+
+      <label class="select select-sm favn-surface-control w-full gap-2 px-3 focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-primary">
+        <.icon name="hero-circle-stack" class="size-5 shrink-0 text-base-content/65" />
+        <span class="sr-only">Connection filter</span>
+        <select
+          name="filters[connection]"
+          id="connection-filter"
+          aria-label="Connection filter"
+          class="appearance-none"
+        >
+          <option
+            :for={{label, value} <- @connection_options}
+            value={value}
+            selected={@filters.connection == value}
+          >
+            {label}
+          </option>
+        </select>
+        <.icon name="hero-chevron-down" class="size-5 shrink-0 text-base-content/65" />
+      </label>
+
+      <label class="select select-sm favn-surface-control w-full gap-2 px-3 focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-primary">
+        <.icon name="hero-folder" class="size-5 shrink-0 text-base-content/65" />
+        <span class="sr-only">Catalogue filter</span>
+        <select
+          name="filters[catalogue]"
+          id="catalogue-filter"
+          aria-label="Catalogue filter"
+          class="appearance-none"
+        >
+          <option
+            :for={{label, value} <- @catalogue_options}
+            value={value}
+            selected={@filters.catalogue == value}
+          >
+            {label}
+          </option>
+        </select>
+        <.icon name="hero-chevron-down" class="size-5 shrink-0 text-base-content/65" />
+      </label>
+    </form>
+    """
+  end
+
+  attr :assets, :list, required: true
+
+  def asset_table(assigns) do
+    ~H"""
+    <div class="overflow-x-auto p-5 sm:p-6">
+      <table class="table table-lg" data-testid="asset-table">
+        <thead>
+          <tr class="border-base-content/10 text-base-content/65">
+            <th class="font-medium">Asset name</th>
+            <th class="font-medium">Connection</th>
+            <th class="font-medium">Catalogue</th>
+            <th class="font-medium">Type</th>
+            <th class="font-medium">Status</th>
+            <th class="font-medium">Last run</th>
+            <th class="sr-only">Open</th>
+          </tr>
+        </thead>
+        <tbody>
+          <.asset_table_row :for={asset <- @assets} asset={asset} />
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  attr :asset, :map, required: true
+
+  def asset_table_row(assigns) do
+    ~H"""
+    <tr
+      class="group border-base-content/10 transition hover:bg-primary/10 focus-within:bg-primary/10"
+      data-testid="asset-row"
+    >
+      <td>
+        <.link
+          navigate={~p"/assets/#{@asset.id}"}
+          class="flex items-center gap-3 font-medium text-base-content focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
+        >
+          <span class="flex size-8 items-center justify-center rounded-field border border-success/25 bg-success/10 text-success">
+            <.icon name={asset_type_icon(@asset.type)} class="size-4" />
+          </span>
+          {@asset.name}
+        </.link>
+      </td>
+      <td>
+        <span class="flex items-center gap-2 text-base-content/75">
+          <.connection_icon connection={@asset.connection} />
+          {connection_label(@asset.connection)}
+        </span>
+      </td>
+      <td class="text-base-content/70">{@asset.catalogue}</td>
+      <td class="text-base-content/70">{@asset.type}</td>
+      <td><.status_badge status={@asset.status} /></td>
+      <td class="text-base-content/70">{@asset.last_run_label}</td>
+      <td class="text-right">
+        <.icon_button
+          navigate={~p"/assets/#{@asset.id}"}
+          label={"Open #{@asset.name}"}
+          icon="hero-chevron-right"
+        />
+      </td>
+    </tr>
+    """
+  end
+
+  attr :assets, :list, required: true
+
+  def asset_card_list(assigns) do
+    ~H"""
+    <div class="space-y-2.5 lg:hidden" data-testid="asset-card-list">
+      <.asset_card :for={asset <- @assets} asset={asset} />
+    </div>
+    """
+  end
+
+  attr :asset, :map, required: true
+
+  def asset_card(assigns) do
+    ~H"""
+    <.link
+      navigate={~p"/assets/#{@asset.id}"}
+      class="card glass favn-surface-list favn-density-list-card block rounded-box transition hover:border-primary/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
+      data-testid="asset-card"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0 space-y-2">
+          <div class="flex items-center gap-3">
+            <span class="favn-density-list-card-icon flex shrink-0 items-center justify-center rounded-field border border-primary/30 bg-primary/10 text-primary">
+              <.connection_icon connection={@asset.connection} />
+            </span>
+            <div class="min-w-0">
+              <h2 class="truncate text-base font-medium leading-tight text-base-content">
+                {@asset.name}
+              </h2>
+              <p class="mt-0.5 truncate text-xs text-base-content/60">
+                {connection_label(@asset.connection)} · {@asset.catalogue} · {@asset.type}
+              </p>
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center gap-3 text-xs text-base-content/65">
+            <.status_badge status={@asset.status} />
+            <span>{@asset.last_run_label}</span>
+          </div>
+        </div>
+        <.icon name="hero-chevron-right" class="mt-2 size-5 shrink-0 text-base-content/55" />
+      </div>
+    </.link>
+    """
+  end
+
+  attr :status, :atom, required: true
+
+  def status_badge(assigns) do
+    ~H"""
+    <span class={["badge badge-sm badge-soft gap-2", status_badge_class(@status)]}>
+      <span class={["status", status_dot_class(@status)]}></span>
+      {status_label(@status)}
+    </span>
+    """
+  end
+
+  attr :connection, :string, required: true
+
+  def connection_icon(assigns) do
+    ~H"""
+    <.icon
+      name={connection_icon_name(@connection)}
+      class={["size-5", connection_icon_class(@connection)]}
+    />
+    """
+  end
+
+  attr :navigate, :string, required: true
+  attr :label, :string, required: true
+  attr :icon, :string, required: true
+
+  def icon_button(assigns) do
+    ~H"""
+    <.link
+      navigate={@navigate}
+      class="btn btn-ghost btn-circle favn-icon-button"
+      aria-label={@label}
+    >
+      <.icon name={@icon} class="size-5" />
+    </.link>
+    """
+  end
+
+  def loading_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto flex min-h-64 max-w-2xl items-center justify-center p-10">
+      <div class="text-center">
+        <span class="loading loading-ring loading-lg text-primary"></span>
+        <p class="mt-4 text-base-content/60">Loading assets</p>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def empty_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto max-w-2xl p-10 text-center" data-testid="asset-empty-state">
+      <h2 class="text-xl font-medium">No assets found</h2>
+      <p class="mt-2 text-base-content/60">Try changing the search or filters.</p>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def error_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto max-w-2xl p-10 text-center" data-testid="asset-error-state">
+      <h2 class="text-xl font-medium">Could not load assets</h2>
+      <p class="mt-2 text-base-content/60">Retry</p>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def catalogue_modes do
+    [
+      %{id: :list, label: "List", icon: "hero-list-bullet"},
+      %{id: :tree, label: "Tree", icon: "hero-share", disabled: true},
+      %{id: :filters, label: "Filters", icon: "hero-funnel"},
+      %{id: :more, label: "More", icon: "hero-ellipsis-vertical"}
+    ]
+  end
+
+  def nav_items(active \\ :assets) do
+    [
+      %{label: "Assets", icon: "hero-sparkles", href: "/assets", active: active == :assets},
+      %{label: "Lineage", icon: "hero-share", href: "#"},
+      %{label: "Storage", icon: "hero-circle-stack", href: "#"},
+      %{label: "Runs", icon: "hero-rocket-launch", href: "#"},
+      %{label: "Alerts", icon: "hero-bell", href: "#"},
+      %{label: "Settings", icon: "hero-cog-6-tooth", href: "#"}
+    ]
+  end
+
+  def sample_assets do
+    [
+      %{
+        id: "customer_orders_daily",
+        name: "customer_orders_daily",
+        connection: "snowflake",
+        catalogue: "sales",
+        type: "table",
+        status: :healthy,
+        last_run_label: "6m ago"
+      },
+      %{
+        id: "stg_orders",
+        name: "stg_orders",
+        connection: "snowflake",
+        catalogue: "sales",
+        type: "view",
+        status: :healthy,
+        last_run_label: "12m ago"
+      },
+      %{
+        id: "stg_customers",
+        name: "stg_customers",
+        connection: "snowflake",
+        catalogue: "sales",
+        type: "view",
+        status: :healthy,
+        last_run_label: "18m ago"
+      },
+      %{
+        id: "raw_payments",
+        name: "raw_payments",
+        connection: "s3",
+        catalogue: "finance",
+        type: "file",
+        status: :running,
+        last_run_label: "3m ago"
+      },
+      %{
+        id: "mart_daily_sales",
+        name: "mart_daily_sales",
+        connection: "snowflake",
+        catalogue: "sales",
+        type: "table",
+        status: :fresh,
+        last_run_label: "Today 06:00"
+      },
+      %{
+        id: "mart_customer_360",
+        name: "mart_customer_360",
+        connection: "duckdb",
+        catalogue: "marketing",
+        type: "table",
+        status: :fresh,
+        last_run_label: "Today 05:45"
+      },
+      %{
+        id: "dq_orders_nulls",
+        name: "dq_orders_nulls",
+        connection: "snowflake",
+        catalogue: "platform",
+        type: "metric",
+        status: :failed,
+        last_run_label: "Failed 12m ago"
+      },
+      %{
+        id: "alerts_revenue_drop",
+        name: "alerts_revenue_drop",
+        connection: "snowflake",
+        catalogue: "finance",
+        type: "metric",
+        status: :missed,
+        last_run_label: "Missed 1h ago"
+      },
+      %{
+        id: "stg_payments",
+        name: "stg_payments",
+        connection: "postgres",
+        catalogue: "finance",
+        type: "table",
+        status: :healthy,
+        last_run_label: "24m ago"
+      },
+      %{
+        id: "monthly_marketing_spend",
+        name: "monthly_marketing_spend",
+        connection: "s3",
+        catalogue: "marketing",
+        type: "file",
+        status: :fresh,
+        last_run_label: "Today 04:10"
+      }
+    ]
+  end
+
+  def connection_options do
+    [
+      {"Connection", "all"},
+      {"Snowflake", "snowflake"},
+      {"S3", "s3"},
+      {"Postgres", "postgres"},
+      {"DuckDB", "duckdb"}
+    ]
+  end
+
+  def catalogue_options do
+    [
+      {"Catalogue", "all"},
+      {"Sales", "sales"},
+      {"Finance", "finance"},
+      {"Platform", "platform"},
+      {"Marketing", "marketing"}
+    ]
+  end
+
+  defp status_badge_class(:healthy), do: "badge-success"
+  defp status_badge_class(:fresh), do: "badge-info"
+  defp status_badge_class(:running), do: "badge-warning"
+  defp status_badge_class(:failed), do: "badge-error"
+  defp status_badge_class(:missed), do: "badge-warning"
+  defp status_badge_class(:unknown), do: "badge-neutral"
+  defp status_badge_class(_status), do: "badge-neutral"
+
+  defp status_dot_class(:healthy), do: "status-success"
+  defp status_dot_class(:fresh), do: "status-info"
+  defp status_dot_class(:running), do: "status-warning"
+  defp status_dot_class(:failed), do: "status-error"
+  defp status_dot_class(:missed), do: "status-warning"
+  defp status_dot_class(:unknown), do: "status-neutral"
+  defp status_dot_class(_status), do: "status-neutral"
+
+  defp status_label(:healthy), do: "Healthy"
+  defp status_label(:fresh), do: "Fresh"
+  defp status_label(:running), do: "Running"
+  defp status_label(:failed), do: "Failed"
+  defp status_label(:missed), do: "Missed"
+  defp status_label(:unknown), do: "Unknown"
+  defp status_label(_status), do: "Unknown"
+
+  defp connection_label("s3"), do: "s3"
+  defp connection_label(connection), do: connection
+
+  defp connection_icon_name("snowflake"), do: "hero-sparkles"
+  defp connection_icon_name("s3"), do: "hero-circle-stack"
+  defp connection_icon_name("postgres"), do: "hero-circle-stack"
+  defp connection_icon_name("duckdb"), do: "hero-circle-stack"
+  defp connection_icon_name(_connection), do: "hero-circle-stack"
+
+  defp connection_icon_class("snowflake"), do: "text-info"
+  defp connection_icon_class("s3"), do: "text-success"
+  defp connection_icon_class("postgres"), do: "text-info"
+  defp connection_icon_class("duckdb"), do: "text-warning"
+  defp connection_icon_class(_connection), do: "text-base-content/60"
+
+  defp asset_type_icon("metric"), do: "hero-chart-bar"
+  defp asset_type_icon("file"), do: "hero-document"
+  defp asset_type_icon(_type), do: "hero-table-cells"
+end

--- a/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
@@ -304,8 +304,8 @@ defmodule FavnView.Components.AssetCataloguePage do
     [
       %{id: :list, label: "List", icon: "hero-list-bullet"},
       %{id: :tree, label: "Tree", icon: "hero-share", disabled: true},
-      %{id: :filters, label: "Filters", icon: "hero-funnel"},
-      %{id: :more, label: "More", icon: "hero-ellipsis-vertical"}
+      %{id: :filters, label: "Filters", icon: "hero-funnel", disabled: true},
+      %{id: :more, label: "More", icon: "hero-ellipsis-vertical", disabled: true}
     ]
   end
 

--- a/apps/favn_view/lib/favn_view/components/glass_panel.ex
+++ b/apps/favn_view/lib/favn_view/components/glass_panel.ex
@@ -13,7 +13,11 @@ defmodule FavnView.Components.GlassPanel do
 
   def glass_panel(assigns) do
     ~H"""
-    <section id={@id} class={["glass favn-glass-panel rounded-box", @class]} {@rest}>
+    <section
+      id={@id}
+      class={["glass favn-surface-panel favn-glass-panel rounded-box", @class]}
+      {@rest}
+    >
       {render_slot(@inner_block)}
     </section>
     """

--- a/apps/favn_view/lib/favn_view/components/mode_rail.ex
+++ b/apps/favn_view/lib/favn_view/components/mode_rail.ex
@@ -1,43 +1,110 @@
 defmodule FavnView.Components.ModeRail do
   @moduledoc """
-  Optional right-side icon rail for page modes.
+  Page-local mode controls that render as a right rail on desktop and a bottom
+  dock on mobile.
   """
 
   use FavnView, :html
 
+  attr :active, :atom, default: nil
+  attr :modes, :list, default: []
+  attr :on_select, :string, default: nil
   attr :class, :any, default: nil
 
   slot :item do
+    attr :id, :atom
     attr :label, :string, required: true
     attr :icon, :string, required: true
     attr :active, :boolean
+    attr :disabled, :boolean
+    attr :badge, :string
   end
 
   def mode_rail(assigns) do
+    assigns = assign(assigns, :mode_items, mode_items(assigns))
+
     ~H"""
     <nav
-      :if={@item != []}
+      :if={@mode_items != []}
       class={[
-        "favn-icon-rail fixed right-5 top-1/2 z-20 hidden -translate-y-1/2 flex-col items-center gap-3 rounded-box p-3 lg:flex",
+        "card glass favn-surface-list fixed right-5 top-1/2 z-20 hidden -translate-y-1/2 flex-col! items-center gap-2 rounded-box p-2 lg:flex",
         @class
       ]}
       aria-label="View modes"
     >
-      <div :for={item <- @item} class="tooltip tooltip-left" data-tip={item.label}>
-        <button
-          type="button"
-          class={[
-            "btn btn-ghost btn-square favn-icon-button rounded-box border border-base-content/10 text-base-content/70",
-            item[:active] && "bg-primary/15 text-primary favn-status-glow"
-          ]}
-          aria-label={item.label}
-          aria-pressed={item[:active] || false}
-        >
-          <.icon name={item.icon} class="size-5" />
-          <span class="sr-only">{render_slot(item)}</span>
-        </button>
+      <div :for={mode <- @mode_items} class="tooltip tooltip-left" data-tip={mode.label}>
+        <.mode_button mode={mode} active={mode_active?(mode, @active)} on_select={@on_select} />
       </div>
+    </nav>
+
+    <nav
+      :if={@mode_items != []}
+      class="favn-mobile-mode-dock card glass favn-surface-list fixed inset-x-6 bottom-3 z-30 mx-auto flex flex-row! max-w-md items-center justify-around gap-1 rounded-box p-1.5 pb-[max(0.375rem,env(safe-area-inset-bottom))] lg:hidden"
+      aria-label="View modes"
+    >
+      <.mode_button
+        :for={mode <- Enum.take(@mode_items, 5)}
+        mode={mode}
+        active={mode_active?(mode, @active)}
+        on_select={@on_select}
+        mobile
+      />
     </nav>
     """
   end
+
+  attr :mode, :map, required: true
+  attr :active, :boolean, required: true
+  attr :on_select, :string, default: nil
+  attr :mobile, :boolean, default: false
+
+  def mode_button(assigns) do
+    ~H"""
+    <button
+      type="button"
+      class={[
+        "favn-mode-item focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary",
+        @mobile && "favn-mode-dock-item",
+        !@mobile && "favn-mode-rail-item",
+        @active && "favn-mode-item-active",
+        @mode[:disabled] && "btn-disabled opacity-45"
+      ]}
+      aria-label={@mode.label}
+      aria-pressed={@active}
+      disabled={@mode[:disabled] || false}
+      phx-click={@on_select}
+      phx-value-mode={@mode.id}
+    >
+      <.icon name={@mode.icon} class="size-5" />
+      <span :if={@mode[:badge]} class="badge badge-primary badge-xs absolute right-1 top-1">
+        {@mode.badge}
+      </span>
+      <span class="sr-only">{@mode.label}</span>
+    </button>
+    """
+  end
+
+  defp mode_items(%{modes: modes}) when is_list(modes) and modes != [] do
+    Enum.map(modes, fn mode ->
+      mode
+      |> Map.put_new(:id, mode[:label] |> String.downcase() |> String.to_atom())
+      |> Map.put_new(:disabled, false)
+    end)
+  end
+
+  defp mode_items(%{item: items}) do
+    Enum.map(items, fn item ->
+      %{
+        id: item[:id] || item.label |> String.downcase() |> String.to_atom(),
+        label: item.label,
+        icon: item.icon,
+        active: item[:active] || false,
+        disabled: item[:disabled] || false,
+        badge: item[:badge]
+      }
+    end)
+  end
+
+  defp mode_active?(mode, nil), do: mode[:active] || false
+  defp mode_active?(mode, active), do: mode.id == active
 end

--- a/apps/favn_view/lib/favn_view/router.ex
+++ b/apps/favn_view/lib/favn_view/router.ex
@@ -18,6 +18,8 @@ defmodule FavnView.Router do
     pipe_through :browser
 
     live "/", PageLive, :home
+    live "/assets", AssetCatalogueLive, :index
+    live "/assets/:asset_id", AssetDetailLive, :show
   end
 
   # Other scopes may use custom stacks.

--- a/apps/favn_view/mix.exs
+++ b/apps/favn_view/mix.exs
@@ -59,6 +59,7 @@ defmodule FavnView.MixProject do
       {:telemetry_poller, "~> 1.0"},
       {:gettext, "~> 1.0"},
       {:jason, "~> 1.2"},
+      {:favn_orchestrator, in_umbrella: true},
       {:bandit, "~> 1.5"}
     ]
   end

--- a/apps/favn_view/storybook/components/asset_catalogue_page.story.exs
+++ b/apps/favn_view/storybook/components/asset_catalogue_page.story.exs
@@ -1,0 +1,76 @@
+defmodule FavnView.Storybook.Components.AssetCataloguePage do
+  alias FavnView.Components.AssetCataloguePage
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &AssetCataloguePage.asset_catalogue_page/1
+  def layout, do: :one_column
+  def render_source, do: :function
+
+  def container, do: {:iframe, style: "width: 100%; height: 980px; border: 0;"}
+
+  def template do
+    """
+    <div data-theme="favn-dark">
+      <.psb-variation/>
+    </div>
+    """
+  end
+
+  def variations do
+    [
+      %Variation{
+        id: :catalogue,
+        attributes: %{
+          assets: AssetCataloguePage.sample_assets(),
+          filters: %{search: "", connection: "all", catalogue: "all"},
+          active_mode: :list,
+          loading: false,
+          error: nil,
+          nav_items: AssetCataloguePage.nav_items(),
+          connection_options: AssetCataloguePage.connection_options(),
+          catalogue_options: AssetCataloguePage.catalogue_options()
+        }
+      },
+      %Variation{
+        id: :empty,
+        attributes: %{
+          assets: [],
+          filters: %{search: "orders", connection: "duckdb", catalogue: "marketing"},
+          active_mode: :filters,
+          loading: false,
+          error: nil,
+          nav_items: AssetCataloguePage.nav_items(),
+          connection_options: AssetCataloguePage.connection_options(),
+          catalogue_options: AssetCataloguePage.catalogue_options()
+        }
+      },
+      %Variation{
+        id: :loading,
+        attributes: %{
+          assets: [],
+          filters: %{search: "", connection: "all", catalogue: "all"},
+          active_mode: :list,
+          loading: true,
+          error: nil,
+          nav_items: AssetCataloguePage.nav_items(),
+          connection_options: AssetCataloguePage.connection_options(),
+          catalogue_options: AssetCataloguePage.catalogue_options()
+        }
+      },
+      %Variation{
+        id: :error,
+        attributes: %{
+          assets: [],
+          filters: %{search: "", connection: "all", catalogue: "all"},
+          active_mode: :list,
+          loading: false,
+          error: "load_failed",
+          nav_items: AssetCataloguePage.nav_items(),
+          connection_options: AssetCataloguePage.connection_options(),
+          catalogue_options: AssetCataloguePage.catalogue_options()
+        }
+      }
+    ]
+  end
+end

--- a/apps/favn_view/storybook/components/mode_rail.story.exs
+++ b/apps/favn_view/storybook/components/mode_rail.story.exs
@@ -26,8 +26,8 @@ defmodule FavnView.Storybook.Components.ModeRail do
           modes: [
             %{id: :list, label: "List", icon: "hero-list-bullet"},
             %{id: :tree, label: "Tree", icon: "hero-share", disabled: true},
-            %{id: :filters, label: "Filters", icon: "hero-funnel"},
-            %{id: :more, label: "More", icon: "hero-ellipsis-vertical"}
+            %{id: :filters, label: "Filters", icon: "hero-funnel", disabled: true},
+            %{id: :more, label: "More", icon: "hero-ellipsis-vertical", disabled: true}
           ]
         }
       }

--- a/apps/favn_view/storybook/components/mode_rail.story.exs
+++ b/apps/favn_view/storybook/components/mode_rail.story.exs
@@ -21,16 +21,15 @@ defmodule FavnView.Storybook.Components.ModeRail do
     [
       %Variation{
         id: :asset_modes,
-        slots: [
-          """
-          <:item label="Overview" icon="hero-play-circle" active>Overview</:item>
-          <:item label="Docs" icon="hero-book-open">Docs</:item>
-          <:item label="Definition" icon="hero-code-bracket">Definition</:item>
-          <:item label="Lineage" icon="hero-share">Lineage</:item>
-          <:item label="Notes" icon="hero-document-text">Notes</:item>
-          <:item label="Settings" icon="hero-cog-6-tooth">Settings</:item>
-          """
-        ]
+        attributes: %{
+          active: :list,
+          modes: [
+            %{id: :list, label: "List", icon: "hero-list-bullet"},
+            %{id: :tree, label: "Tree", icon: "hero-share", disabled: true},
+            %{id: :filters, label: "Filters", icon: "hero-funnel"},
+            %{id: :more, label: "More", icon: "hero-ellipsis-vertical"}
+          ]
+        }
       }
     ]
   end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -5,6 +5,9 @@ defmodule FavnView.PageLiveTest do
 
   alias Favn.Manifest
   alias Favn.Manifest.Version
+  alias Favn.Run.AssetResult
+  alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.Adapter.Memory
 
   setup do
@@ -13,6 +16,8 @@ defmodule FavnView.PageLiveTest do
     version = manifest_version()
     assert :ok = FavnOrchestrator.register_manifest(version)
     assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+    assert :ok = Storage.put_run(run_state(:customer_orders_daily, :ok, -600))
+    assert :ok = Storage.put_run(run_state(:raw_payments, :running, -30))
 
     :ok
   end
@@ -41,6 +46,10 @@ defmodule FavnView.PageLiveTest do
              ~s(a[href*="customer_orders_daily"]),
              "customer_orders_daily"
            )
+
+    assert html =~ "Healthy"
+    assert html =~ "10m ago"
+    assert html =~ "Running"
 
     assert has_element?(view, ~s([aria-label="View modes"]))
     assert has_element?(view, ~s([aria-label="Connection filter"]))
@@ -79,6 +88,12 @@ defmodule FavnView.PageLiveTest do
     assert html =~ "Asset detail coming soon"
   end
 
+  test "ignores invalid mode events", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/assets")
+
+    assert render_click(view, "set_mode", %{"mode" => "not_real"}) =~ "Asset catalogue"
+  end
+
   defp manifest_version do
     manifest = %Manifest{
       assets: [
@@ -100,5 +115,37 @@ defmodule FavnView.PageLiveTest do
       type: type,
       relation: %{connection: connection, catalog: catalog, name: Atom.to_string(name)}
     }
+  end
+
+  defp run_state(name, status, seconds_from_now) do
+    ref = {__MODULE__.Assets, name}
+    finished_at = DateTime.add(DateTime.utc_now(), seconds_from_now, :second)
+    started_at = DateTime.add(finished_at, -1, :second)
+
+    RunState.new(
+      id: "run_#{name}",
+      manifest_version_id: "mv_view_assets",
+      manifest_content_hash: "hash_view_assets",
+      asset_ref: ref,
+      target_refs: [ref]
+    )
+    |> RunState.transition(
+      status: status,
+      result: %{
+        asset_results: [
+          %AssetResult{
+            ref: ref,
+            stage: 0,
+            status: status,
+            started_at: started_at,
+            finished_at: if(status in [:pending, :running], do: nil, else: finished_at),
+            duration_ms: 1
+          }
+        ]
+      }
+    )
+    |> Map.put(:inserted_at, started_at)
+    |> Map.put(:updated_at, finished_at)
+    |> RunState.with_snapshot_hash()
   end
 end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -1,7 +1,21 @@
 defmodule FavnView.PageLiveTest do
-  use FavnView.ConnCase, async: true
+  use FavnView.ConnCase, async: false
 
   import Phoenix.LiveViewTest
+
+  alias Favn.Manifest
+  alias Favn.Manifest.Version
+  alias FavnOrchestrator.Storage.Adapter.Memory
+
+  setup do
+    Memory.reset()
+
+    version = manifest_version()
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    :ok
+  end
 
   test "renders the Favn HUD shell placeholder", %{conn: conn} do
     {:ok, view, html} = live(conn, ~p"/")
@@ -12,5 +26,79 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="window-timeline-panel"]))
     assert has_element?(view, ~s([aria-label="Primary navigation"]))
     assert has_element?(view, ~s([aria-label="View modes"]))
+  end
+
+  test "renders the asset catalogue", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/assets")
+
+    assert html =~ "Asset catalogue"
+    assert html =~ "Browse and monitor all assets"
+    assert has_element?(view, ~s([data-testid="asset-table"]))
+    assert has_element?(view, ~s([data-testid="asset-card-list"]))
+
+    assert has_element?(
+             view,
+             ~s(a[href*="customer_orders_daily"]),
+             "customer_orders_daily"
+           )
+
+    assert has_element?(view, ~s([aria-label="View modes"]))
+    assert has_element?(view, ~s([aria-label="Connection filter"]))
+    assert has_element?(view, ~s([aria-label="Catalogue filter"]))
+  end
+
+  test "filters assets by search, connection, and catalogue", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/assets")
+
+    view
+    |> element("form")
+    |> render_change(%{
+      "filters" => %{"search" => "payments", "connection" => "s3", "catalogue" => "finance"}
+    })
+
+    assert has_element?(view, ~s(a[href*="raw_payments"]), "raw_payments")
+    refute has_element?(view, ~s(a[href*="stg_payments"]), "stg_payments")
+  end
+
+  test "shows empty state when filters do not match", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/assets")
+
+    view
+    |> element("form")
+    |> render_change(%{
+      "filters" => %{"search" => "not_real", "connection" => "all", "catalogue" => "all"}
+    })
+
+    assert has_element?(view, ~s([data-testid="asset-empty-state"]), "No assets found")
+  end
+
+  test "opens the asset detail placeholder", %{conn: conn} do
+    {:ok, _view, html} = live(conn, ~p"/assets/customer_orders_daily")
+
+    assert html =~ "customer_orders_daily"
+    assert html =~ "Asset detail coming soon"
+  end
+
+  defp manifest_version do
+    manifest = %Manifest{
+      assets: [
+        asset(:customer_orders_daily, :snowflake, "sales", :sql),
+        asset(:raw_payments, :s3, "finance", :source),
+        asset(:stg_payments, :postgres, "finance", :sql)
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: "mv_view_assets")
+    version
+  end
+
+  defp asset(name, connection, catalog, type) do
+    %Favn.Manifest.Asset{
+      ref: {__MODULE__.Assets, name},
+      module: __MODULE__.Assets,
+      name: name,
+      type: type,
+      relation: %{connection: connection, catalog: catalog, name: Atom.to_string(name)}
+    }
   end
 end


### PR DESCRIPTION
## Summary
- Add an `/assets` LiveView catalogue backed by the public `FavnOrchestrator.active_manifest_targets/0` facade.
- Introduce reusable catalogue page components, responsive mode rail/dock behavior, and Storybook stories.
- Add Favn design-system surface classes and guidance for reusable Storybook-backed UI work.

## Verification
- `cd apps/favn_view && mix format && mix compile --warnings-as-errors && mix test`
- Storybook visual inspection with Playwright for the catalogue and mobile mode dock