### PR TITLE
Add asset and run detail flows

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -13,6 +13,8 @@ defmodule FavnOrchestrator do
   alias Favn.Manifest.Version
   alias Favn.Window.Anchor
   alias Favn.Window.Policy
+  alias Favn.Window.Request, as: WindowRequest
+  alias Favn.Window.Spec, as: WindowSpec
   alias FavnOrchestrator.AssetFreshnessState
   alias FavnOrchestrator.Backfill.Repair, as: BackfillRepair
   alias FavnOrchestrator.BackfillManager
@@ -67,7 +69,37 @@ defmodule FavnOrchestrator do
           required(:status) => :healthy | :running | :failed | :unknown,
           required(:latest_run_id) => String.t() | nil,
           required(:latest_run_status) => atom() | nil,
+          required(:latest_run_at) => DateTime.t() | nil,
+          required(:run_enabled?) => boolean(),
+          required(:run_disabled_reason) => atom() | nil,
+          required(:run_label) => String.t()
+        }
+
+  @type asset_timeline_window :: %{
+          required(:id) => String.t(),
+          required(:label) => String.t(),
+          required(:date) => Date.t(),
+          required(:range) => String.t(),
+          required(:status) => :healthy | :running | :failed | :unknown,
+          required(:latest_run_id) => String.t() | nil,
+          required(:latest_run_status) => atom() | nil,
           required(:latest_run_at) => DateTime.t() | nil
+        }
+
+  @type asset_detail :: %{
+          required(:target_id) => String.t(),
+          required(:manifest_version_id) => String.t(),
+          required(:label) => String.t(),
+          required(:name) => String.t(),
+          required(:asset_ref) => String.t() | nil,
+          required(:relation) => map() | nil,
+          required(:type) => String.t() | nil,
+          required(:status) => :healthy | :running | :failed | :unknown,
+          required(:latest_run_id) => String.t() | nil,
+          required(:latest_run_status) => atom() | nil,
+          required(:latest_run_at) => DateTime.t() | nil,
+          required(:window) => map() | nil,
+          required(:timeline) => [asset_timeline_window()]
         }
 
   @doc """
@@ -205,6 +237,26 @@ defmodule FavnOrchestrator do
   end
 
   @doc """
+  Returns an operator-facing detail read model for one active asset target.
+
+  The detail is a DTO built at the orchestrator boundary. It includes manifest
+  target metadata, latest known freshness/run state, and a conservative 30-day
+  daily timeline. Missing runtime evidence is represented as `:unknown`.
+  """
+  @spec active_asset_detail(String.t(), keyword()) :: {:ok, asset_detail()} | {:error, term()}
+  def active_asset_detail(target_id, opts \\ []) when is_binary(target_id) and is_list(opts) do
+    with {:ok, manifest_version_id} <- active_manifest(),
+         {:ok, version} <- get_manifest(manifest_version_id),
+         {:ok, freshness_states} <- detail_freshness_states(manifest_version_id),
+         {:ok, runs} <- catalogue_runs(manifest_version_id) do
+      case asset_detail_entry(version, target_id, freshness_states, runs, opts) do
+        nil -> {:error, :not_found}
+        detail -> {:ok, detail}
+      end
+    end
+  end
+
+  @doc """
   Submits one asset run by manifest-scoped target id.
   """
   @spec submit_asset_run_for_manifest(String.t(), String.t(), keyword()) ::
@@ -214,6 +266,27 @@ defmodule FavnOrchestrator do
     with {:ok, version} <- get_manifest(manifest_version_id),
          {:ok, asset_ref} <- resolve_asset_target_ref(version, target_id) do
       submit_asset_run(asset_ref, Keyword.put(opts, :manifest_version_id, manifest_version_id))
+    end
+  end
+
+  @doc """
+  Submits a manifest-pinned asset run for one stable asset detail window id.
+  """
+  @spec submit_asset_window_run(String.t(), String.t(), String.t(), keyword()) ::
+          {:ok, run_id()} | {:error, term()}
+  def submit_asset_window_run(manifest_version_id, target_id, window_id, opts \\ [])
+      when is_binary(manifest_version_id) and is_binary(target_id) and is_binary(window_id) and
+             is_list(opts) do
+    with {:ok, version} <- get_manifest(manifest_version_id),
+         {:ok, asset} <- resolve_asset_target(version, target_id),
+         {:ok, window_request} <- window_request_from_id(window_id),
+         {:ok, anchor_window} <- resolve_asset_window(asset, window_request) do
+      submit_asset_run(
+        asset.ref,
+        opts
+        |> Keyword.put(:manifest_version_id, manifest_version_id)
+        |> Keyword.put(:anchor_window, anchor_window)
+      )
     end
   end
 
@@ -800,6 +873,14 @@ defmodule FavnOrchestrator do
     list_runs(manifest_version_id: manifest_version_id)
   end
 
+  defp detail_freshness_states(manifest_version_id) do
+    case list_asset_freshness(manifest_version_id: manifest_version_id, limit: Page.max_limit()) do
+      {:ok, page} -> {:ok, page.items}
+      {:error, :asset_freshness_state_not_supported} -> {:ok, []}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp asset_catalogue_entries(%Version{} = version, freshness_states, runs) do
     freshness_by_ref = Map.new(freshness_states, &{freshness_ref_string(&1), &1})
 
@@ -825,6 +906,232 @@ defmodule FavnOrchestrator do
     end)
     |> Enum.sort_by(& &1.label)
   end
+
+  defp asset_detail_entry(%Version{} = version, target_id, freshness_states, runs, opts) do
+    version.manifest.assets
+    |> List.wrap()
+    |> Enum.find(&(manifest_asset_target(&1).target_id == target_id))
+    |> case do
+      nil ->
+        nil
+
+      asset ->
+        target = manifest_asset_target(asset)
+        ref_string = ref_to_string(asset.ref)
+        latest_freshness = latest_freshness_for_ref(freshness_states, ref_string)
+        latest_run = latest_run_for_ref(runs, ref_string)
+
+        target
+        |> Map.take([:target_id, :label, :asset_ref, :relation, :type, :window])
+        |> Map.put(:manifest_version_id, version.manifest_version_id)
+        |> Map.put(:name, asset_detail_name(target))
+        |> Map.put(:status, catalogue_status(latest_freshness, latest_run))
+        |> Map.put(:latest_run_id, latest_run_id(latest_freshness, latest_run))
+        |> Map.put(:latest_run_status, latest_run_status(latest_freshness, latest_run))
+        |> Map.put(:latest_run_at, latest_run_at(latest_freshness, latest_run))
+        |> Map.put(
+          :timeline,
+          asset_detail_timeline(asset, latest_freshness, latest_run, freshness_states, opts)
+        )
+    end
+  end
+
+  defp latest_run_for_ref(runs, ref_string) do
+    runs
+    |> Enum.flat_map(&run_ref_entries/1)
+    |> Enum.filter(fn {run_ref_string, _run} -> run_ref_string == ref_string end)
+    |> Enum.map(fn {_run_ref_string, run} -> run end)
+    |> latest_run()
+  end
+
+  defp latest_freshness_for_ref(freshness_states, ref_string) do
+    Enum.find(freshness_states, fn state ->
+      freshness_ref_string(state) == ref_string &&
+        state.freshness_key == Favn.Freshness.Key.latest()
+    end)
+  end
+
+  defp asset_detail_timeline(asset, latest_freshness, latest_run, freshness_states, opts) do
+    selected_date = detail_timeline_selected_date(latest_freshness, latest_run, opts)
+    window_states = asset_window_freshness_by_date(asset, freshness_states)
+    latest_run_date = latest_run_at(latest_freshness, latest_run) |> detail_date_from_datetime()
+
+    for offset <- 0..29 do
+      date = Date.add(selected_date, offset - 29)
+      date_iso = Date.to_iso8601(date)
+      window_freshness = Map.get(window_states, date_iso)
+
+      %{
+        id: "window:day:#{date_iso}",
+        label: Calendar.strftime(date, "%b %-d"),
+        date: date,
+        range: Calendar.strftime(date, "%b %-d, %Y"),
+        status:
+          timeline_status(window_freshness, latest_freshness, latest_run, date, latest_run_date),
+        latest_run_id: latest_run_id(window_freshness, nil),
+        latest_run_status: latest_run_status(window_freshness, nil),
+        latest_run_at: latest_run_at(window_freshness, nil),
+        run_label: "Run this window"
+      }
+      |> put_window_run_state(asset)
+      |> maybe_put_latest_run(latest_freshness, latest_run, date, latest_run_date)
+    end
+  end
+
+  defp put_window_run_state(window, %{window: nil}) do
+    window
+    |> Map.put(:run_enabled?, false)
+    |> Map.put(:run_disabled_reason, :asset_has_no_window_policy)
+  end
+
+  defp put_window_run_state(%{id: window_id} = window, asset) do
+    with {:ok, window_request} <- window_request_from_id(window_id),
+         {:ok, _anchor_window} <- resolve_asset_window(asset, window_request) do
+      window
+      |> Map.put(:run_enabled?, true)
+      |> Map.put(:run_disabled_reason, nil)
+    else
+      {:error, reason} ->
+        window
+        |> Map.put(:run_enabled?, false)
+        |> Map.put(:run_disabled_reason, run_disabled_reason(reason))
+    end
+  end
+
+  defp run_disabled_reason({:window_request_without_policy, _kind}),
+    do: :asset_has_no_window_policy
+
+  defp run_disabled_reason(_reason), do: :invalid_window
+
+  defp detail_timeline_selected_date(latest_freshness, latest_run, opts) do
+    case {opts[:today], latest_run_at(latest_freshness, latest_run)} do
+      {%Date{} = date, _latest_run_at} -> date
+      {_today, %DateTime{} = datetime} -> DateTime.to_date(datetime)
+      _other -> Date.utc_today()
+    end
+  end
+
+  defp asset_window_freshness_by_date(asset, freshness_states) do
+    asset_ref_string = ref_to_string(asset.ref)
+
+    freshness_states
+    |> Enum.filter(&(freshness_ref_string(&1) == asset_ref_string))
+    |> Enum.flat_map(fn state ->
+      case window_date_from_freshness_key(state.freshness_key) do
+        nil -> []
+        date -> [{date, state}]
+      end
+    end)
+    |> Map.new(fn {date, state} -> {date, state} end)
+  end
+
+  defp window_date_from_freshness_key("calendar:day:" <> rest) do
+    rest
+    |> String.split(":")
+    |> List.last()
+    |> case do
+      <<_::binary-size(10)>> = date -> date
+      _other -> nil
+    end
+  end
+
+  defp window_date_from_freshness_key(_key), do: nil
+
+  defp window_request_from_id("window:day:" <> date) do
+    case WindowRequest.parse("day:#{date}") do
+      {:ok, request} -> {:ok, request}
+      {:error, reason} -> {:error, {:invalid_window_id, reason}}
+    end
+  end
+
+  defp window_request_from_id(window_id), do: {:error, {:invalid_window_id, window_id}}
+
+  defp resolve_asset_window(%{window: nil}, %WindowRequest{kind: kind}) do
+    {:error, {:window_request_without_policy, kind}}
+  end
+
+  defp resolve_asset_window(%{window: %WindowSpec{} = spec}, %WindowRequest{kind: kind} = request) do
+    if spec.kind == kind do
+      WindowRequest.to_anchor(request, spec.timezone)
+    else
+      {:error, {:window_kind_mismatch, spec.kind, kind}}
+    end
+  end
+
+  defp resolve_asset_window(asset, %WindowRequest{} = request) when is_atom(asset.window) do
+    with {:ok, spec} <- WindowSpec.new(asset.window) do
+      resolve_asset_window(%{asset | window: spec}, request)
+    end
+  end
+
+  defp resolve_asset_window(%{window: %{} = window}, %WindowRequest{} = request) do
+    case {Map.get(window, :kind) || Map.get(window, "kind"),
+          Map.get(window, :timezone) || Map.get(window, "timezone")} do
+      {kind, timezone} when not is_nil(kind) ->
+        with {:ok, normalized_kind} <- Policy.normalize_kind(kind),
+             {:ok, spec} <- WindowSpec.new(normalized_kind, timezone: timezone || "Etc/UTC") do
+          resolve_asset_window(%{window: spec}, request)
+        end
+
+      _other ->
+        {:error, :invalid_window_policy}
+    end
+  end
+
+  defp detail_date_from_datetime(%DateTime{} = datetime), do: DateTime.to_date(datetime)
+  defp detail_date_from_datetime(_datetime), do: nil
+
+  defp timeline_status(
+         %AssetFreshnessState{} = freshness,
+         _latest_freshness,
+         _latest_run,
+         _date,
+         _latest_run_date
+       ) do
+    catalogue_status(freshness, nil)
+  end
+
+  defp timeline_status(nil, latest_freshness, latest_run, date, date) do
+    catalogue_status(latest_freshness, latest_run)
+  end
+
+  defp timeline_status(nil, _latest_freshness, _latest_run, _date, _latest_run_date), do: :unknown
+
+  defp maybe_put_latest_run(window, latest_freshness, latest_run, date, date) do
+    window
+    |> Map.put_new(:latest_run_id, latest_run_id(latest_freshness, latest_run))
+    |> Map.put_new(:latest_run_status, latest_run_status(latest_freshness, latest_run))
+    |> Map.put_new(:latest_run_at, latest_run_at(latest_freshness, latest_run))
+    |> put_latest_run_if_missing(:latest_run_id, latest_run_id(latest_freshness, latest_run))
+    |> put_latest_run_if_missing(
+      :latest_run_status,
+      latest_run_status(latest_freshness, latest_run)
+    )
+    |> put_latest_run_if_missing(:latest_run_at, latest_run_at(latest_freshness, latest_run))
+  end
+
+  defp maybe_put_latest_run(window, _latest_freshness, _latest_run, _date, _latest_run_date),
+    do: window
+
+  defp put_latest_run_if_missing(window, key, value) do
+    if is_nil(window[key]), do: Map.put(window, key, value), else: window
+  end
+
+  defp asset_detail_name(%{relation: relation, asset_ref: asset_ref, label: label}) do
+    relation_name(relation) || asset_ref_name(asset_ref) || label
+  end
+
+  defp relation_name(%{name: name}) when is_binary(name), do: name
+  defp relation_name(%{"name" => name}) when is_binary(name), do: name
+  defp relation_name(_relation), do: nil
+
+  defp asset_ref_name(asset_ref) when is_binary(asset_ref) do
+    asset_ref
+    |> String.split(":")
+    |> List.last()
+  end
+
+  defp asset_ref_name(_asset_ref), do: nil
 
   defp manifest_asset_target(asset) do
     target_ref = asset.ref
@@ -1009,11 +1316,15 @@ defmodule FavnOrchestrator do
   defp normalize_data(value), do: value
 
   defp resolve_asset_target_ref(%Version{} = version, target_id) when is_binary(target_id) do
+    with {:ok, asset} <- resolve_asset_target(version, target_id), do: {:ok, asset.ref}
+  end
+
+  defp resolve_asset_target(%Version{} = version, target_id) when is_binary(target_id) do
     case Enum.find(
            List.wrap(version.manifest.assets),
            &(target_id_for_asset(&1.ref) == target_id)
          ) do
-      %{ref: target_ref} -> {:ok, target_ref}
+      %{ref: _target_ref} = asset -> {:ok, asset}
       _ -> {:error, :invalid_asset_target}
     end
   end

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -69,10 +69,7 @@ defmodule FavnOrchestrator do
           required(:status) => :healthy | :running | :failed | :unknown,
           required(:latest_run_id) => String.t() | nil,
           required(:latest_run_status) => atom() | nil,
-          required(:latest_run_at) => DateTime.t() | nil,
-          required(:run_enabled?) => boolean(),
-          required(:run_disabled_reason) => atom() | nil,
-          required(:run_label) => String.t()
+          required(:latest_run_at) => DateTime.t() | nil
         }
 
   @type asset_timeline_window :: %{
@@ -83,7 +80,10 @@ defmodule FavnOrchestrator do
           required(:status) => :healthy | :running | :failed | :unknown,
           required(:latest_run_id) => String.t() | nil,
           required(:latest_run_status) => atom() | nil,
-          required(:latest_run_at) => DateTime.t() | nil
+          required(:latest_run_at) => DateTime.t() | nil,
+          required(:run_enabled?) => boolean(),
+          required(:run_disabled_reason) => atom() | nil,
+          required(:run_label) => String.t()
         }
 
   @type asset_detail :: %{
@@ -286,8 +286,28 @@ defmodule FavnOrchestrator do
         opts
         |> Keyword.put(:manifest_version_id, manifest_version_id)
         |> Keyword.put(:anchor_window, anchor_window)
+        |> put_window_run_metadata(window_id, anchor_window)
       )
     end
+  end
+
+  defp put_window_run_metadata(opts, window_id, %Anchor{} = anchor_window) do
+    Keyword.update(opts, :metadata, window_run_metadata(window_id, anchor_window), fn metadata ->
+      Map.merge(Map.new(metadata), window_run_metadata(window_id, anchor_window))
+    end)
+  end
+
+  defp window_run_metadata(window_id, %Anchor{} = anchor_window) do
+    %{
+      selected_window: %{
+        id: window_id,
+        kind: anchor_window.kind,
+        key: anchor_window.key,
+        start_at: anchor_window.start_at,
+        end_at: anchor_window.end_at,
+        timezone: anchor_window.timezone
+      }
+    }
   end
 
   @doc """

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -292,9 +292,18 @@ defmodule FavnOrchestrator do
   end
 
   defp put_window_run_metadata(opts, window_id, %Anchor{} = anchor_window) do
-    Keyword.update(opts, :metadata, window_run_metadata(window_id, anchor_window), fn metadata ->
-      Map.merge(Map.new(metadata), window_run_metadata(window_id, anchor_window))
-    end)
+    selected_window_metadata = window_run_metadata(window_id, anchor_window)
+
+    case Keyword.fetch(opts, :metadata) do
+      :error ->
+        Keyword.put(opts, :metadata, selected_window_metadata)
+
+      {:ok, metadata} when is_map(metadata) ->
+        Keyword.put(opts, :metadata, Map.merge(metadata, selected_window_metadata))
+
+      {:ok, _invalid_metadata} ->
+        opts
+    end
   end
 
   defp window_run_metadata(window_id, %Anchor{} = anchor_window) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
@@ -290,6 +290,7 @@ defmodule FavnOrchestrator.RunManager do
     retry_backoff_ms = Keyword.get(opts, :retry_backoff_ms, 0)
     timeout_ms = Keyword.get(opts, :timeout_ms, RunState.default_timeout_ms())
     dependencies = Keyword.get(opts, :dependencies, :all)
+    anchor_window = Keyword.get(opts, :anchor_window)
 
     with :ok <- validate_params(params),
          :ok <- validate_trigger(trigger),
@@ -303,12 +304,17 @@ defmodule FavnOrchestrator.RunManager do
          :ok <- validate_max_attempts(max_attempts),
          :ok <- validate_retry_backoff_ms(retry_backoff_ms),
          :ok <- validate_timeout_ms(timeout_ms),
+         :ok <- validate_anchor_window(anchor_window),
          {:ok, manifest_version_id} <- resolve_manifest_version_id(opts),
          {:ok, version} <- ManifestStore.get_manifest(manifest_version_id),
          {:ok, index} <- Index.build_from_version(version),
          {:ok, _asset} <- Index.fetch_asset(index, asset_ref),
          {:ok, plan} <-
-           Planner.plan(asset_ref, graph_index: index.graph_index, dependencies: dependencies) do
+           Planner.plan(asset_ref,
+             graph_index: index.graph_index,
+             dependencies: dependencies,
+             anchor_window: anchor_window
+           ) do
       run_state =
         RunState.new(
           id: run_id,

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -97,8 +97,8 @@ defmodule FavnOrchestrator.ManifestStoreTest do
              allow_full_load: false
            }
 
-    finished_at = DateTime.add(DateTime.utc_now(), -300, :second)
-    old_finished_at = DateTime.add(finished_at, -3_600, :second)
+    finished_at = ~U[2026-05-10 12:00:00Z]
+    old_finished_at = ~U[2026-05-09 12:00:00Z]
 
     assert :ok =
              Storage.put_run(
@@ -153,6 +153,94 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert entry.latest_run_id == "run_asset_a"
     assert entry.latest_run_status == :ok
     assert entry.latest_run_at == finished_at
+
+    assert {:error, :not_found} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.AssetA:not_real")
+
+    assert {:ok, detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.AssetA:asset")
+
+    assert detail.target_id == "asset:Elixir.MyApp.AssetA:asset"
+    assert detail.name == "asset"
+    assert detail.asset_ref == "Elixir.MyApp.AssetA:asset"
+    assert detail.type == asset.type
+    assert detail.status == :healthy
+    assert detail.latest_run_id == "run_asset_a"
+    assert detail.latest_run_status == :ok
+    assert detail.latest_run_at == finished_at
+    assert detail.window == asset.window
+    assert length(detail.timeline) == 30
+
+    assert latest_window = Enum.find(detail.timeline, &(&1.date == ~D[2026-05-10]))
+    assert latest_window.id == "window:day:2026-05-10"
+    assert latest_window.label == "May 10"
+    assert latest_window.range == "May 10, 2026"
+    assert latest_window.status == :healthy
+    assert latest_window.latest_run_id == "run_asset_a"
+    assert latest_window.latest_run_status == :ok
+    assert latest_window.latest_run_at == finished_at
+    assert latest_window.run_enabled?
+    assert is_nil(latest_window.run_disabled_reason)
+    assert latest_window.run_label == "Run this window"
+
+    assert failed_window = Enum.find(detail.timeline, &(&1.date == ~D[2026-05-09]))
+    assert failed_window.status == :failed
+    assert failed_window.latest_run_id == "run_old_asset_a"
+    assert failed_window.latest_run_status == :error
+    assert failed_window.latest_run_at == old_finished_at
+
+    assert unknown_window = Enum.find(detail.timeline, &(&1.date == ~D[2026-04-11]))
+    assert unknown_window.status == :unknown
+    assert is_nil(unknown_window.latest_run_id)
+
+    assert {:error, {:invalid_window_id, "not-a-window"}} =
+             FavnOrchestrator.submit_asset_window_run(
+               "mv_a",
+               "asset:Elixir.MyApp.AssetA:asset",
+               "not-a-window"
+             )
+
+    assert {:error, :invalid_asset_target} =
+             FavnOrchestrator.submit_asset_window_run(
+               "mv_a",
+               "asset:Elixir.MyApp.AssetA:not_real",
+               "window:day:2026-05-10"
+             )
+
+    assert {:ok, run_id} =
+             FavnOrchestrator.submit_asset_window_run(
+               "mv_a",
+               "asset:Elixir.MyApp.AssetA:asset",
+               "window:day:2026-05-10",
+               dependencies: :none
+             )
+
+    assert {:ok, run} = Storage.get_run(run_id)
+    assert run.manifest_version_id == "mv_a"
+    assert run.asset_ref == {MyApp.AssetA, :asset}
+    target_start_us = DateTime.to_unix(~U[2026-05-10 00:00:00Z], :microsecond)
+
+    assert {{MyApp.AssetA, :asset}, target_window_key} =
+             Enum.find(run.plan.target_node_keys, fn
+               {{MyApp.AssetA, :asset}, %{start_at_us: ^target_start_us}} -> true
+               _other -> false
+             end)
+
+    assert target_window_key.kind == :day
+    assert target_window_key.start_at_us == target_start_us
+
+    assert target_node = run.plan.nodes[{{MyApp.AssetA, :asset}, target_window_key}]
+    assert target_node.window.kind == :day
+    assert target_node.window.start_at == ~U[2026-05-10 00:00:00Z]
+
+    assert :ok = ManifestStore.set_active_manifest("mv_b")
+
+    assert {:ok, no_window_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.AssetB:asset")
+
+    assert no_window = List.last(no_window_detail.timeline)
+    refute no_window.run_enabled?
+    assert no_window.run_disabled_reason == :asset_has_no_window_policy
   end
 
   test "publishes duplicate content under the existing canonical manifest version" do

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -207,6 +207,14 @@ defmodule FavnOrchestrator.ManifestStoreTest do
                "window:day:2026-05-10"
              )
 
+    assert {:error, :invalid_run_metadata} =
+             FavnOrchestrator.submit_asset_window_run(
+               "mv_a",
+               "asset:Elixir.MyApp.AssetA:asset",
+               "window:day:2026-05-10",
+               metadata: :invalid
+             )
+
     assert {:ok, run_id} =
              FavnOrchestrator.submit_asset_window_run(
                "mv_a",

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -218,6 +218,10 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert {:ok, run} = Storage.get_run(run_id)
     assert run.manifest_version_id == "mv_a"
     assert run.asset_ref == {MyApp.AssetA, :asset}
+    assert run.metadata.selected_window.id == "window:day:2026-05-10"
+    assert run.metadata.selected_window.kind == :day
+    assert run.metadata.selected_window.start_at == ~U[2026-05-10 00:00:00Z]
+
     target_start_us = DateTime.to_unix(~U[2026-05-10 00:00:00Z], :microsecond)
 
     assert {{MyApp.AssetA, :asset}, target_window_key} =

--- a/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
@@ -3,6 +3,7 @@ defmodule FavnView.AssetCatalogueLive do
 
   use FavnView, :live_view
 
+  alias FavnView.AssetRoute
   alias FavnView.Components.AssetCataloguePage
 
   @default_filters %{search: "", connection: "all", catalogue: "all"}
@@ -96,6 +97,7 @@ defmodule FavnView.AssetCatalogueLive do
 
     %{
       id: Map.fetch!(entry, :target_id),
+      route_id: entry |> Map.fetch!(:target_id) |> AssetRoute.to_param(),
       name: relation_field(relation, :name) || asset_name(entry),
       connection: relation_field(relation, :connection) || "unknown",
       catalogue: relation_field(relation, :catalog) || "uncatalogued",

--- a/apps/favn_view/lib/favn_view/asset_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_detail_live.ex
@@ -198,7 +198,7 @@ defmodule FavnView.AssetDetailLive do
 
   defp timeline_status(:healthy), do: :success
   defp timeline_status(:running), do: :warning
-  defp timeline_status(:failed), do: :warning
+  defp timeline_status(:failed), do: :error
   defp timeline_status(_status), do: :muted
 
   defp window_range([]), do: "No windows"

--- a/apps/favn_view/lib/favn_view/asset_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_detail_live.ex
@@ -3,24 +3,134 @@ defmodule FavnView.AssetDetailLive do
 
   use FavnView, :live_view
 
+  alias FavnView.AssetRoute
   alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.AssetDetailPage
   alias FavnView.Components.AppShell
   alias FavnView.Components.GlassPanel
 
+  @valid_modes ~w(timeline runs lineage docs code details)
+
   @impl true
   def mount(%{"asset_id" => asset_id}, _session, socket) do
-    {:ok, assign(socket, asset_id: asset_id, nav_items: AssetCataloguePage.nav_items())}
+    asset = load_asset(asset_id)
+
+    socket =
+      assign(socket,
+        asset_id: asset_id,
+        asset: asset,
+        active_mode: :timeline,
+        selected_window: default_selected_window(asset),
+        submitting_window_run?: false,
+        submitted_run_id: nil,
+        selected_window_error: nil,
+        nav_items: AssetCataloguePage.nav_items()
+      )
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("set_mode", %{"mode" => mode}, socket) when mode in @valid_modes do
+    {:noreply, assign(socket, :active_mode, String.to_existing_atom(mode))}
+  end
+
+  def handle_event("set_mode", _params, socket), do: {:noreply, socket}
+
+  def handle_event("select_window", %{"window-id" => window_id}, socket) do
+    selected_window =
+      socket.assigns
+      |> Map.get(:asset)
+      |> asset_timeline()
+      |> Enum.find(&(&1.id == window_id))
+
+    if selected_window do
+      {:noreply,
+       assign(socket,
+         selected_window: selected_window,
+         selected_window_error: nil,
+         submitted_run_id: nil
+       )}
+    else
+      {:noreply, socket}
+    end
+  end
+
+  def handle_event("select_window", _params, socket), do: {:noreply, socket}
+
+  def handle_event("run_selected_window", _params, socket) do
+    %{asset: asset, selected_window: selected_window} = socket.assigns
+
+    cond do
+      is_nil(asset) or is_nil(selected_window) ->
+        {:noreply, assign(socket, :selected_window_error, "Select a runnable window first.")}
+
+      !selected_window.run_enabled? ->
+        {:noreply,
+         assign(
+           socket,
+           :selected_window_error,
+           disabled_reason_label(selected_window.run_disabled_reason)
+         )}
+
+      true ->
+        socket =
+          assign(socket,
+            submitting_window_run?: true,
+            selected_window_error: nil,
+            submitted_run_id: nil
+          )
+
+        case FavnOrchestrator.submit_asset_window_run(
+               asset.manifest_version_id,
+               asset.target_id,
+               selected_window.id
+             ) do
+          {:ok, run_id} ->
+            {:noreply,
+             socket
+             |> put_flash(:info, "Run submitted")
+             |> push_navigate(to: ~p"/runs/#{run_id}")}
+
+          {:error, reason} ->
+            {:noreply,
+             assign(socket,
+               submitting_window_run?: false,
+               selected_window_error: submit_error_label(reason)
+             )}
+        end
+    end
   end
 
   @impl true
   def render(assigns) do
     ~H"""
-    <AppShell.app_shell title={@asset_id} subtitle="Asset detail" nav_items={@nav_items}>
+    <AssetDetailPage.asset_detail_page
+      :if={@asset}
+      title={@asset.title}
+      status={@asset.status}
+      status_tone={@asset.status_tone}
+      window_range={@asset.window_range}
+      nav_items={@nav_items}
+      timeline={@asset.timeline}
+      active_mode={@active_mode}
+      selected_window={@selected_window}
+      submitting_window_run?={@submitting_window_run?}
+      selected_window_error={@selected_window_error}
+      submitted_run_id={@submitted_run_id}
+    />
+
+    <AppShell.app_shell
+      :if={!@asset}
+      title="Asset not found"
+      subtitle={@asset_id}
+      nav_items={@nav_items}
+    >
       <div class="mx-auto w-full max-w-4xl">
-        <GlassPanel.glass_panel class="p-8 text-center" data-testid="asset-detail-placeholder">
-          <h2 class="text-xl font-medium">Asset detail coming soon</h2>
+        <GlassPanel.glass_panel class="p-8 text-center" data-testid="asset-not-found-state">
+          <h2 class="text-xl font-medium">Asset not found</h2>
           <p class="mt-2 text-base-content/60">
-            The catalogue can open assets now; detailed runs, lineage, docs, and code will follow.
+            No active catalogue entry matches this asset id.
           </p>
           <.link navigate={~p"/assets"} class="btn btn-primary btn-soft mt-6">
             Back to catalogue
@@ -30,4 +140,110 @@ defmodule FavnView.AssetDetailLive do
     </AppShell.app_shell>
     """
   end
+
+  defp load_asset(asset_id) do
+    target_id = AssetRoute.from_param(asset_id)
+
+    case FavnOrchestrator.active_asset_detail(target_id) do
+      {:ok, detail} -> asset_from_detail(detail)
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp asset_from_detail(detail) do
+    timeline = Enum.map(detail.timeline, &timeline_window/1)
+    selected_window = timeline_selected_window(timeline, detail)
+
+    timeline =
+      Enum.map(timeline, fn window ->
+        Map.put(window, :current, selected_window && window.id == selected_window.id)
+      end)
+
+    %{
+      manifest_version_id: detail.manifest_version_id,
+      target_id: detail.target_id,
+      title: detail.name || asset_name(detail),
+      status: status_label(Map.get(detail, :status)),
+      status_tone: status_tone(Map.get(detail, :status)),
+      window_range: window_range(timeline),
+      timeline: timeline
+    }
+  end
+
+  defp timeline_window(window) do
+    %{
+      id: window.id,
+      date: window.date,
+      day: Calendar.strftime(window.date, "%d") |> String.trim_leading("0"),
+      month: Calendar.strftime(window.date, "%b"),
+      date_label: window.range,
+      range_label: window.range,
+      status: timeline_status(window.status),
+      latest_run_id: window.latest_run_id,
+      latest_run_status: window.latest_run_status,
+      latest_run_at: window.latest_run_at,
+      run_enabled?: window.run_enabled?,
+      run_disabled_reason: window.run_disabled_reason,
+      run_label: window.run_label || "Run this window"
+    }
+  end
+
+  defp timeline_selected_window(timeline, detail) do
+    latest_run_date = detail.latest_run_at && DateTime.to_date(detail.latest_run_at)
+
+    Enum.find(timeline, fn window ->
+      latest_run_date && window.id == "window:day:#{Date.to_iso8601(latest_run_date)}"
+    end) || List.last(timeline)
+  end
+
+  defp timeline_status(:healthy), do: :success
+  defp timeline_status(:running), do: :warning
+  defp timeline_status(:failed), do: :warning
+  defp timeline_status(_status), do: :muted
+
+  defp window_range([]), do: "No windows"
+
+  defp window_range([first | _] = timeline) do
+    last = List.last(timeline)
+    "#{first.month} #{first.day} - #{last.month} #{last.day}, #{last.date.year}"
+  end
+
+  defp asset_name(detail) do
+    detail
+    |> Map.get(:asset_ref, detail[:label] || detail[:target_id])
+    |> to_string()
+    |> String.split(":")
+    |> List.last()
+  end
+
+  defp status_label(:healthy), do: "Healthy"
+  defp status_label(:running), do: "Running"
+  defp status_label(:failed), do: "Failed"
+  defp status_label(_status), do: "Unknown"
+
+  defp status_tone(:healthy), do: :success
+  defp status_tone(:running), do: :warning
+  defp status_tone(:failed), do: :error
+  defp status_tone(_status), do: :neutral
+
+  defp default_selected_window(nil), do: nil
+
+  defp default_selected_window(asset) do
+    Enum.find(asset.timeline, & &1.current) || List.last(asset.timeline)
+  end
+
+  defp asset_timeline(nil), do: []
+  defp asset_timeline(asset), do: Map.get(asset, :timeline, [])
+
+  defp disabled_reason_label(:asset_has_no_window_policy), do: "This asset has no window policy."
+  defp disabled_reason_label(:invalid_window), do: "This window cannot be run."
+  defp disabled_reason_label(_reason), do: "This window is not runnable."
+
+  defp submit_error_label(:invalid_asset_target), do: "Asset target is no longer available."
+  defp submit_error_label({:invalid_window_id, _reason}), do: "Window id is invalid."
+
+  defp submit_error_label({:window_request_without_policy, _kind}),
+    do: "This asset has no window policy."
+
+  defp submit_error_label(_reason), do: "Could not submit run."
 end

--- a/apps/favn_view/lib/favn_view/asset_route.ex
+++ b/apps/favn_view/lib/favn_view/asset_route.ex
@@ -1,0 +1,18 @@
+defmodule FavnView.AssetRoute do
+  @moduledoc false
+
+  @prefix "t-"
+
+  def to_param(target_id) when is_binary(target_id) do
+    @prefix <> Base.url_encode64(target_id, padding: false)
+  end
+
+  def from_param(@prefix <> encoded) do
+    case Base.url_decode64(encoded, padding: false) do
+      {:ok, target_id} -> target_id
+      :error -> @prefix <> encoded
+    end
+  end
+
+  def from_param(param), do: param
+end

--- a/apps/favn_view/lib/favn_view/components/app_shell.ex
+++ b/apps/favn_view/lib/favn_view/components/app_shell.ex
@@ -11,6 +11,7 @@ defmodule FavnView.Components.AppShell do
   attr :title, :string, required: true
   attr :subtitle, :string, default: nil
   attr :status, :string, default: nil
+  attr :status_tone, :atom, default: :success
   attr :nav_items, :list, default: []
 
   slot :inner_block, required: true
@@ -58,9 +59,12 @@ defmodule FavnView.Components.AppShell do
             </div>
             <span
               :if={@status}
-              class="badge badge-success badge-soft favn-status-glow gap-2 px-4 py-4"
+              class={[
+                "badge badge-soft favn-status-glow gap-2 px-4 py-4",
+                status_badge_class(@status_tone)
+              ]}
             >
-              <span class="status status-success"></span>
+              <span class={["status", status_dot_class(@status_tone)]}></span>
               {@status}
             </span>
           </section>
@@ -73,4 +77,16 @@ defmodule FavnView.Components.AppShell do
     </div>
     """
   end
+
+  defp status_badge_class(:info), do: "badge-info"
+  defp status_badge_class(:warning), do: "badge-warning"
+  defp status_badge_class(:error), do: "badge-error"
+  defp status_badge_class(:neutral), do: "badge-neutral"
+  defp status_badge_class(_tone), do: "badge-success"
+
+  defp status_dot_class(:info), do: "status-info"
+  defp status_dot_class(:warning), do: "status-warning"
+  defp status_dot_class(:error), do: "status-error"
+  defp status_dot_class(:neutral), do: "status-neutral"
+  defp status_dot_class(_tone), do: "status-success"
 end

--- a/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
@@ -158,7 +158,7 @@ defmodule FavnView.Components.AssetCataloguePage do
     >
       <td>
         <.link
-          navigate={~p"/assets/#{@asset.id}"}
+          navigate={~p"/assets/#{asset_route_id(@asset)}"}
           class="flex items-center gap-3 font-medium text-base-content focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
         >
           <span class="flex size-8 items-center justify-center rounded-field border border-success/25 bg-success/10 text-success">
@@ -179,7 +179,7 @@ defmodule FavnView.Components.AssetCataloguePage do
       <td class="text-base-content/70">{@asset.last_run_label}</td>
       <td class="text-right">
         <.icon_button
-          navigate={~p"/assets/#{@asset.id}"}
+          navigate={~p"/assets/#{asset_route_id(@asset)}"}
           label={"Open #{@asset.name}"}
           icon="hero-chevron-right"
         />
@@ -203,7 +203,7 @@ defmodule FavnView.Components.AssetCataloguePage do
   def asset_card(assigns) do
     ~H"""
     <.link
-      navigate={~p"/assets/#{@asset.id}"}
+      navigate={~p"/assets/#{asset_route_id(@asset)}"}
       class="card glass favn-surface-list favn-density-list-card block rounded-box transition hover:border-primary/40 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
       data-testid="asset-card"
     >
@@ -458,6 +458,8 @@ defmodule FavnView.Components.AssetCataloguePage do
   defp status_label(:missed), do: "Missed"
   defp status_label(:unknown), do: "Unknown"
   defp status_label(_status), do: "Unknown"
+
+  defp asset_route_id(asset), do: Map.get(asset, :route_id, asset.id)
 
   defp connection_label("s3"), do: "s3"
   defp connection_label(connection), do: connection

--- a/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
@@ -314,7 +314,7 @@ defmodule FavnView.Components.AssetCataloguePage do
       %{label: "Assets", icon: "hero-sparkles", href: "/assets", active: active == :assets},
       %{label: "Lineage", icon: "hero-share", href: "#"},
       %{label: "Storage", icon: "hero-circle-stack", href: "#"},
-      %{label: "Runs", icon: "hero-rocket-launch", href: "#"},
+      %{label: "Runs", icon: "hero-rocket-launch", href: "#", active: active == :runs},
       %{label: "Alerts", icon: "hero-bell", href: "#"},
       %{label: "Settings", icon: "hero-cog-6-tooth", href: "#"}
     ]

--- a/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
@@ -8,34 +8,79 @@ defmodule FavnView.Components.AssetDetailPage do
   alias FavnView.Components.AppShell
   alias FavnView.Components.GlassPanel
   alias FavnView.Components.ModeRail
+  alias FavnView.Components.SelectedWindowActions
 
   attr :title, :string, required: true
   attr :status, :string, required: true
+  attr :status_tone, :atom, default: :success
   attr :window_range, :string, required: true
   attr :nav_items, :list, required: true
   attr :timeline, :list, required: true
+  attr :active_mode, :atom, default: :timeline
+  attr :selected_window, :map, default: nil
+  attr :submitting_window_run?, :boolean, default: false
+  attr :selected_window_error, :string, default: nil
+  attr :submitted_run_id, :string, default: nil
 
   def asset_detail_page(assigns) do
     ~H"""
-    <AppShell.app_shell title={@title} status={@status} nav_items={@nav_items}>
-      <.window_timeline_panel window_range={@window_range} timeline={@timeline} />
+    <AppShell.app_shell
+      title={@title}
+      status={@status}
+      status_tone={@status_tone}
+      nav_items={@nav_items}
+    >
+      <.central_view
+        active_mode={@active_mode}
+        window_range={@window_range}
+        timeline={@timeline}
+        selected_window={@selected_window}
+        submitting_window_run?={@submitting_window_run?}
+        selected_window_error={@selected_window_error}
+        submitted_run_id={@submitted_run_id}
+      />
 
       <:mode_rail>
-        <ModeRail.mode_rail>
-          <:item label="Overview" icon="hero-play-circle" active>Overview</:item>
-          <:item label="Docs" icon="hero-book-open">Docs</:item>
-          <:item label="Definition" icon="hero-code-bracket">Definition</:item>
-          <:item label="Lineage" icon="hero-share">Lineage</:item>
-          <:item label="Notes" icon="hero-document-text">Notes</:item>
-          <:item label="Settings" icon="hero-cog-6-tooth">Settings</:item>
-        </ModeRail.mode_rail>
+        <ModeRail.mode_rail active={@active_mode} modes={detail_modes()} on_select="set_mode" />
       </:mode_rail>
     </AppShell.app_shell>
     """
   end
 
+  attr :active_mode, :atom, required: true
   attr :window_range, :string, required: true
   attr :timeline, :list, required: true
+  attr :selected_window, :map, default: nil
+  attr :submitting_window_run?, :boolean, default: false
+  attr :selected_window_error, :string, default: nil
+  attr :submitted_run_id, :string, default: nil
+
+  def central_view(assigns) do
+    ~H"""
+    <.window_timeline_panel
+      :if={@active_mode == :timeline}
+      window_range={@window_range}
+      timeline={@timeline}
+      selected_window={@selected_window}
+      submitting_window_run?={@submitting_window_run?}
+      selected_window_error={@selected_window_error}
+      submitted_run_id={@submitted_run_id}
+    />
+
+    <.placeholder_panel :if={@active_mode == :runs} title="Runs coming soon" />
+    <.placeholder_panel :if={@active_mode == :lineage} title="Lineage coming soon" />
+    <.placeholder_panel :if={@active_mode == :docs} title="Docs coming soon" />
+    <.placeholder_panel :if={@active_mode == :code} title="Code coming soon" />
+    <.placeholder_panel :if={@active_mode == :details} title="Details coming soon" />
+    """
+  end
+
+  attr :window_range, :string, required: true
+  attr :timeline, :list, required: true
+  attr :selected_window, :map, default: nil
+  attr :submitting_window_run?, :boolean, default: false
+  attr :selected_window_error, :string, default: nil
+  attr :submitted_run_id, :string, default: nil
 
   def window_timeline_panel(assigns) do
     ~H"""
@@ -81,45 +126,75 @@ defmodule FavnView.Components.AssetDetailPage do
 
         <div class="overflow-x-auto pb-2">
           <div class="flex min-w-[58rem] items-end justify-between gap-3 pt-3">
-            <.timeline_window :for={window <- @timeline} window={window} />
+            <.timeline_window
+              :for={window <- @timeline}
+              window={window}
+              selected={selected_window?(@selected_window, window)}
+            />
           </div>
         </div>
+
+        <SelectedWindowActions.selected_window_actions
+          selected_window={@selected_window}
+          submitting_window_run?={@submitting_window_run?}
+          selected_window_error={@selected_window_error}
+          submitted_run_id={@submitted_run_id}
+        />
       </div>
     </GlassPanel.glass_panel>
     """
   end
 
   attr :window, :map, required: true
+  attr :selected, :boolean, default: false
 
   def timeline_window(assigns) do
     ~H"""
     <div class="flex flex-col items-center gap-4">
-      <div
-        tabindex="0"
+      <button
+        type="button"
+        phx-click="select_window"
+        phx-value-window-id={@window.id}
+        data-testid={"timeline-window-#{@window.id}"}
         class={[
-          "flex h-32 w-9 items-center justify-center rounded-box border backdrop-blur-sm transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary",
+          "flex h-32 w-9 items-center justify-center rounded-box border backdrop-blur-sm transition hover:border-primary/50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary",
           timeline_window_class(@window),
-          @window[:current] && "ring-2 ring-primary shadow-primary/40 shadow-lg"
+          @selected && "ring-2 ring-primary shadow-primary/40 shadow-lg"
         ]}
-        aria-label={"#{@window.month} #{@window.day}: #{timeline_label(@window.status)}"}
+        aria-label={"#{@window.date_label}: #{timeline_label(@window.status)}"}
+        aria-pressed={to_string(@selected)}
       >
         <.icon name={timeline_icon(@window.status)} class="size-4" />
-      </div>
+      </button>
       <div class={[
         "text-center text-xs leading-tight text-base-content/60",
-        @window[:current] && "text-primary"
+        @selected && "text-primary"
       ]}>
         <div>{@window.day}</div>
         <div :if={@window.day in ["24", "1"]} class="uppercase tracking-wide">{@window.month}</div>
       </div>
-      <span :if={@window[:current]} class="status status-primary favn-status-glow"></span>
+      <span :if={@selected} class="status status-primary favn-status-glow"></span>
     </div>
+    """
+  end
+
+  attr :title, :string, required: true
+
+  def placeholder_panel(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel
+      class="mx-auto w-full max-w-3xl p-8 text-center"
+      data-testid="asset-mode-placeholder"
+    >
+      <h2 class="text-xl font-medium tracking-tight">{@title}</h2>
+      <p class="mt-2 text-sm text-base-content/60">This view will be wired in a later iteration.</p>
+    </GlassPanel.glass_panel>
     """
   end
 
   def sample_nav_items do
     [
-      %{label: "Assets", icon: "hero-sparkles", href: "/", active: true},
+      %{label: "Assets", icon: "hero-sparkles", href: "/assets", active: true},
       %{label: "Lineage", icon: "hero-share", href: "#"},
       %{label: "Storage", icon: "hero-circle-stack", href: "#"},
       %{label: "Runs", icon: "hero-rocket-launch", href: "#"},
@@ -161,6 +236,60 @@ defmodule FavnView.Components.AssetDetailPage do
       %{day: "21", month: "Jun", status: :muted},
       %{day: "22", month: "Jun", status: :success}
     ]
+    |> Enum.map(&sample_window/1)
+  end
+
+  def muted_timeline do
+    sample_timeline()
+    |> Enum.map(&(&1 |> Map.put(:status, :muted) |> Map.delete(:current)))
+    |> List.update_at(20, &Map.put(&1, :current, true))
+  end
+
+  def selected_sample_window do
+    Enum.find(sample_timeline(), & &1[:current])
+  end
+
+  def selected_muted_window do
+    Enum.find(muted_timeline(), & &1[:current])
+  end
+
+  def non_runnable_timeline do
+    Enum.map(sample_timeline(), fn window ->
+      window
+      |> Map.put(:run_enabled?, false)
+      |> Map.put(:run_disabled_reason, :asset_has_no_window_policy)
+    end)
+  end
+
+  def selected_non_runnable_window do
+    Enum.find(non_runnable_timeline(), & &1[:current])
+  end
+
+  def detail_modes do
+    [
+      %{id: :timeline, label: "Timeline", icon: "hero-calendar-days"},
+      %{id: :runs, label: "Runs", icon: "hero-rocket-launch"},
+      %{id: :lineage, label: "Lineage", icon: "hero-share"},
+      %{id: :docs, label: "Docs", icon: "hero-book-open"},
+      %{id: :code, label: "Code", icon: "hero-code-bracket"},
+      %{id: :details, label: "Details", icon: "hero-document-text"}
+    ]
+  end
+
+  defp selected_window?(nil, _window), do: false
+  defp selected_window?(selected_window, window), do: selected_window.id == window.id
+
+  defp sample_window(%{month: month, day: day} = window) do
+    year = if month == "May", do: 2026, else: 2026
+    date_label = "#{month} #{day}, #{year}"
+
+    window
+    |> Map.put(:id, "#{String.downcase(month)}-#{day}-#{year}")
+    |> Map.put(:date_label, date_label)
+    |> Map.put(:range_label, date_label)
+    |> Map.put(:run_enabled?, true)
+    |> Map.put(:run_disabled_reason, nil)
+    |> Map.put(:run_label, "Run this window")
   end
 
   defp timeline_window_class(%{status: :success}) do

--- a/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
@@ -300,15 +300,21 @@ defmodule FavnView.Components.AssetDetailPage do
     "border-warning/45 bg-warning/15 text-warning"
   end
 
+  defp timeline_window_class(%{status: :error}) do
+    "border-error/45 bg-error/15 text-error"
+  end
+
   defp timeline_window_class(%{status: :muted}) do
     "border-base-content/15 bg-base-content/10 text-base-content/45"
   end
 
   defp timeline_icon(:success), do: "hero-check-circle"
   defp timeline_icon(:warning), do: "hero-clock"
+  defp timeline_icon(:error), do: "hero-x-circle"
   defp timeline_icon(:muted), do: "hero-minus-circle"
 
   defp timeline_label(:success), do: "healthy"
   defp timeline_label(:warning), do: "late"
+  defp timeline_label(:error), do: "failed"
   defp timeline_label(:muted), do: "pending"
 end

--- a/apps/favn_view/lib/favn_view/components/mode_rail.ex
+++ b/apps/favn_view/lib/favn_view/components/mode_rail.ex
@@ -31,6 +31,7 @@ defmodule FavnView.Components.ModeRail do
         @class
       ]}
       aria-label="View modes"
+      data-testid="view-mode-rail"
     >
       <div :for={mode <- @mode_items} class="tooltip tooltip-left" data-tip={mode.label}>
         <.mode_button mode={mode} active={mode_active?(mode, @active)} on_select={@on_select} />
@@ -41,9 +42,10 @@ defmodule FavnView.Components.ModeRail do
       :if={@mode_items != []}
       class="favn-mobile-mode-dock card glass favn-surface-list fixed inset-x-6 bottom-3 z-30 mx-auto flex flex-row! max-w-md items-center justify-around gap-1 rounded-box p-1.5 pb-[max(0.375rem,env(safe-area-inset-bottom))] lg:hidden"
       aria-label="View modes"
+      data-testid="view-mode-dock"
     >
       <.mode_button
-        :for={mode <- Enum.take(@mode_items, 5)}
+        :for={mode <- @mode_items}
         mode={mode}
         active={mode_active?(mode, @active)}
         on_select={@on_select}
@@ -70,7 +72,7 @@ defmodule FavnView.Components.ModeRail do
         @mode[:disabled] && "btn-disabled opacity-45"
       ]}
       aria-label={@mode.label}
-      aria-pressed={@active}
+      aria-pressed={to_string(@active)}
       disabled={@mode[:disabled] || false}
       phx-click={@on_select}
       phx-value-mode={@mode.id}

--- a/apps/favn_view/lib/favn_view/components/run_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page.ex
@@ -1,0 +1,417 @@
+defmodule FavnView.Components.RunDetailPage do
+  @moduledoc """
+  Read-only run detail page for operator inspection.
+  """
+
+  use FavnView, :html
+
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.GlassPanel
+  alias FavnView.Components.ModeRail
+
+  attr :run, :map, required: true
+  attr :run_id, :string, required: true
+  attr :nav_items, :list, default: []
+  attr :active_mode, :atom, default: :overview
+
+  def run_detail_page(assigns) do
+    ~H"""
+    <AppShell.app_shell
+      title={page_title(@run, @run_id)}
+      subtitle={page_subtitle(@run)}
+      status={@run[:status]}
+      status_tone={@run[:status_tone] || :neutral}
+      nav_items={@nav_items}
+    >
+      <.not_found_panel :if={!@run[:found?]} run={@run} />
+      <.run_mode_panel :if={@run[:found?]} run={@run} active_mode={@active_mode} />
+
+      <:mode_rail>
+        <ModeRail.mode_rail active={@active_mode} modes={run_modes()} on_select="set_mode" />
+      </:mode_rail>
+    </AppShell.app_shell>
+    """
+  end
+
+  attr :run, :map, required: true
+  attr :active_mode, :atom, required: true
+
+  def run_mode_panel(assigns) do
+    ~H"""
+    <.overview_panel :if={@active_mode == :overview} run={@run} />
+    <.placeholder_panel
+      :if={@active_mode == :events}
+      title="Events"
+      copy="Detailed event filtering will follow."
+    />
+    <.placeholder_panel
+      :if={@active_mode == :assets}
+      title="Assets"
+      copy="Asset-level controls stay read-only for now."
+    />
+    <.placeholder_panel
+      :if={@active_mode == :output}
+      title="Output"
+      copy="Output previews are not available yet."
+    />
+    <.placeholder_panel
+      :if={@active_mode == :debug}
+      title="Debug"
+      copy="Debug data is intentionally hidden by default."
+    />
+    """
+  end
+
+  attr :run, :map, required: true
+
+  def overview_panel(assigns) do
+    ~H"""
+    <div class="mx-auto flex w-full max-w-6xl flex-col gap-5" data-testid="run-overview-panel">
+      <GlassPanel.glass_panel class="p-5 sm:p-6 lg:p-7">
+        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5" data-testid="run-summary-row">
+          <.summary_item label="Status" value={@run.status} tone={@run.status_tone} />
+          <.summary_item label="Target" value={@run.target} />
+          <.summary_item label="Started" value={@run.started_at} />
+          <.summary_item label="Duration" value={@run.duration} />
+          <.summary_item label="Manifest" value={@run.manifest_version_id} />
+        </div>
+      </GlassPanel.glass_panel>
+
+      <GlassPanel.glass_panel class="p-5 sm:p-6 lg:p-7" data-testid="run-asset-results">
+        <div class="mb-4 flex items-center justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-medium tracking-tight">Asset execution</h2>
+            <p class="text-sm text-base-content/55">
+              Stage grouped when execution stage data exists.
+            </p>
+          </div>
+          <span class="badge badge-ghost">{length(@run.asset_results)} assets</span>
+        </div>
+
+        <div
+          :if={@run.asset_results == []}
+          class="rounded-box border border-dashed border-base-content/15 p-5 text-sm text-base-content/55"
+        >
+          No asset results persisted for this run yet.
+        </div>
+
+        <div :if={@run.asset_results != []} class="flex flex-col gap-4">
+          <section
+            :for={group <- @run.asset_result_groups}
+            class="rounded-box border border-base-content/10 bg-base-content/[0.03] p-3"
+          >
+            <h3 class="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-base-content/45">
+              {stage_label(group.stage)}
+            </h3>
+            <div class="divide-y divide-base-content/10">
+              <.asset_result_row :for={asset <- group.items} asset={asset} />
+            </div>
+          </section>
+        </div>
+      </GlassPanel.glass_panel>
+
+      <GlassPanel.glass_panel class="p-5 sm:p-6 lg:p-7" data-testid="run-event-timeline">
+        <div class="mb-4 flex items-center justify-between gap-3">
+          <div>
+            <h2 class="text-lg font-medium tracking-tight">Event timeline</h2>
+            <p class="text-sm text-base-content/55">Latest persisted run events.</p>
+          </div>
+          <span class="badge badge-ghost">{length(@run.events)} events</span>
+        </div>
+
+        <div
+          :if={@run.latest_events == []}
+          class="rounded-box border border-dashed border-base-content/15 p-5 text-sm text-base-content/55"
+        >
+          No events persisted for this run yet.
+        </div>
+
+        <ol :if={@run.latest_events != []} class="space-y-3">
+          <.event_row :for={event <- @run.latest_events} event={event} />
+        </ol>
+      </GlassPanel.glass_panel>
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+  attr :tone, :atom, default: nil
+
+  def summary_item(assigns) do
+    ~H"""
+    <div class="rounded-box border border-base-content/10 bg-base-content/[0.035] p-3">
+      <p class="text-xs uppercase tracking-[0.16em] text-base-content/45">{@label}</p>
+      <p class="mt-1 truncate text-sm font-medium text-base-content" title={@value}>
+        <span :if={@tone} class={["badge badge-soft", badge_class(@tone)]}>{@value}</span>
+        <span :if={!@tone}>{@value}</span>
+      </p>
+    </div>
+    """
+  end
+
+  attr :asset, :map, required: true
+
+  def asset_result_row(assigns) do
+    ~H"""
+    <div class="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between">
+      <div class="min-w-0">
+        <p class="truncate text-sm font-medium text-base-content">{@asset.ref}</p>
+        <p class="text-xs text-base-content/50">Started {@asset.started_at} · {@asset.duration}</p>
+        <p :if={@asset.error} class="mt-1 text-xs text-error">{@asset.error}</p>
+      </div>
+      <span class={["badge badge-soft shrink-0", badge_class(@asset.status_tone)]}>
+        {@asset.status}
+      </span>
+    </div>
+    """
+  end
+
+  attr :event, :map, required: true
+
+  def event_row(assigns) do
+    ~H"""
+    <li class="grid gap-2 rounded-box border border-base-content/10 bg-base-content/[0.03] p-3 sm:grid-cols-[10rem_12rem_1fr] sm:items-start">
+      <time class="text-xs text-base-content/50">{@event.timestamp}</time>
+      <div class="flex items-center gap-2">
+        <span class="badge badge-ghost badge-sm">#{@event.sequence}</span>
+        <span class="text-sm font-medium text-base-content">{@event.event_type}</span>
+      </div>
+      <p class="text-sm text-base-content/65">{@event.summary}</p>
+    </li>
+    """
+  end
+
+  attr :run, :map, required: true
+
+  def not_found_panel(assigns) do
+    ~H"""
+    <div class="mx-auto w-full max-w-3xl">
+      <GlassPanel.glass_panel class="p-8 text-center" data-testid="run-not-found-state">
+        <h2 class="text-xl font-medium">{@run.error || "Run not found"}</h2>
+        <p class="mt-2 text-sm text-base-content/60">
+          No persisted run snapshot matches <span class="font-mono">{@run.id}</span>.
+        </p>
+        <.link navigate={~p"/assets"} class="btn btn-primary btn-soft mt-6">Back to assets</.link>
+      </GlassPanel.glass_panel>
+    </div>
+    """
+  end
+
+  attr :title, :string, required: true
+  attr :copy, :string, required: true
+
+  def placeholder_panel(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel
+      class="mx-auto w-full max-w-3xl p-8 text-center"
+      data-testid="run-mode-placeholder"
+    >
+      <h2 class="text-xl font-medium tracking-tight">{@title}</h2>
+      <p class="mt-2 text-sm text-base-content/60">{@copy}</p>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def sample_run(status \\ :running) do
+    %{
+      found?: true,
+      id: "run_01jrun_detail_sample",
+      short_id: "run_01jrun_detail",
+      title: "Run run_01jrun_detail",
+      subtitle: "FavnView.Assets.customer_orders_daily · Manual · window:day:2026-06-12",
+      status: status_label(status),
+      status_tone: status_tone(status),
+      target: "FavnView.Assets.customer_orders_daily",
+      trigger: "Manual",
+      window: "window:day:2026-06-12",
+      started_at: "Jun 12, 2026 14:00:00 UTC",
+      finished_at: if(status == :running, do: "-", else: "Jun 12, 2026 14:00:04 UTC"),
+      duration: if(status == :running, do: "4.2 s", else: "4.0 s"),
+      manifest_version_id: "mv_customer_orders",
+      asset_results: sample_asset_results(status),
+      asset_result_groups:
+        sample_asset_results(status)
+        |> Enum.group_by(& &1.stage)
+        |> Enum.map(fn {stage, items} -> %{stage: stage, items: items} end),
+      events: sample_events(status),
+      latest_events: sample_events(status)
+    }
+  end
+
+  def empty_run do
+    sample_run(:running)
+    |> Map.put(:asset_results, [])
+    |> Map.put(:asset_result_groups, [])
+    |> Map.put(:events, [])
+    |> Map.put(:latest_events, [])
+  end
+
+  def not_found_run do
+    %{
+      found?: false,
+      id: "run_missing",
+      error: "Run not found",
+      status: nil,
+      status_tone: :neutral
+    }
+  end
+
+  def sample_nav_items, do: FavnView.Components.AssetCataloguePage.nav_items()
+
+  defp sample_asset_results(:running) do
+    [
+      %{
+        ref: "FavnView.Assets.customer_orders_daily",
+        stage: 0,
+        status: "Running",
+        status_tone: :info,
+        started_at: "Jun 12, 2026 14:00:00 UTC",
+        duration: "4.2 s",
+        error: nil
+      }
+    ]
+  end
+
+  defp sample_asset_results(:error) do
+    [
+      %{
+        ref: "FavnView.Assets.raw_orders",
+        stage: 0,
+        status: "Succeeded",
+        status_tone: :success,
+        started_at: "Jun 12, 2026 14:00:00 UTC",
+        duration: "1.3 s",
+        error: nil
+      },
+      %{
+        ref: "FavnView.Assets.customer_orders_daily",
+        stage: 1,
+        status: "Failed",
+        status_tone: :error,
+        started_at: "Jun 12, 2026 14:00:02 UTC",
+        duration: "2.1 s",
+        error: "Warehouse timeout"
+      }
+    ]
+  end
+
+  defp sample_asset_results(_status) do
+    [
+      %{
+        ref: "FavnView.Assets.raw_orders",
+        stage: 0,
+        status: "Succeeded",
+        status_tone: :success,
+        started_at: "Jun 12, 2026 14:00:00 UTC",
+        duration: "1.3 s",
+        error: nil
+      },
+      %{
+        ref: "FavnView.Assets.customer_orders_daily",
+        stage: 1,
+        status: "Succeeded",
+        status_tone: :success,
+        started_at: "Jun 12, 2026 14:00:02 UTC",
+        duration: "1.8 s",
+        error: nil
+      }
+    ]
+  end
+
+  defp sample_events(:error) do
+    [
+      %{
+        sequence: 1,
+        timestamp: "Jun 12, 2026 14:00:00 UTC",
+        event_type: "Run started",
+        status: "Running",
+        status_tone: :info,
+        summary: "Run accepted by orchestrator"
+      },
+      %{
+        sequence: 2,
+        timestamp: "Jun 12, 2026 14:00:02 UTC",
+        event_type: "Step failed",
+        status: "Failed",
+        status_tone: :error,
+        summary: "Asset FavnView.Assets.customer_orders_daily"
+      },
+      %{
+        sequence: 3,
+        timestamp: "Jun 12, 2026 14:00:04 UTC",
+        event_type: "Run failed",
+        status: "Failed",
+        status_tone: :error,
+        summary: "Warehouse timeout"
+      }
+    ]
+  end
+
+  defp sample_events(status) do
+    [
+      %{
+        sequence: 1,
+        timestamp: "Jun 12, 2026 14:00:00 UTC",
+        event_type: "Run started",
+        status: "Running",
+        status_tone: :info,
+        summary: "Run accepted by orchestrator"
+      },
+      %{
+        sequence: 2,
+        timestamp: "Jun 12, 2026 14:00:04 UTC",
+        event_type: if(status == :running, do: "Step started", else: "Run finished"),
+        status: status_label(status),
+        status_tone: status_tone(status),
+        summary:
+          if(status == :running,
+            do: "Asset FavnView.Assets.customer_orders_daily",
+            else: "All selected assets completed"
+          )
+      }
+    ]
+  end
+
+  defp run_modes do
+    [
+      %{id: :overview, label: "Overview", icon: "hero-squares-2x2"},
+      %{id: :events, label: "Events", icon: "hero-clock"},
+      %{id: :assets, label: "Assets", icon: "hero-circle-stack"},
+      %{id: :output, label: "Output", icon: "hero-document-text"},
+      %{id: :debug, label: "Debug", icon: "hero-bug-ant"}
+    ]
+  end
+
+  defp page_title(%{found?: true, title: title}, _run_id), do: title
+  defp page_title(_run, run_id), do: "Run #{short_id(run_id)}"
+
+  defp page_subtitle(%{found?: true, subtitle: subtitle}), do: subtitle
+  defp page_subtitle(_run), do: "Run detail"
+
+  defp stage_label(nil), do: "Stage unknown"
+  defp stage_label(stage), do: "Stage #{stage}"
+
+  defp status_label(:ok), do: "Succeeded"
+  defp status_label(:running), do: "Running"
+  defp status_label(:error), do: "Failed"
+  defp status_label(:partial), do: "Partial"
+
+  defp status_label(status),
+    do: status |> to_string() |> String.replace("_", " ") |> String.capitalize()
+
+  defp status_tone(:ok), do: :success
+  defp status_tone(:running), do: :info
+  defp status_tone(:error), do: :error
+  defp status_tone(:partial), do: :warning
+  defp status_tone(_status), do: :neutral
+
+  defp badge_class(:success), do: "badge-success"
+  defp badge_class(:info), do: "badge-info"
+  defp badge_class(:warning), do: "badge-warning"
+  defp badge_class(:error), do: "badge-error"
+  defp badge_class(_tone), do: "badge-neutral"
+
+  defp short_id(id) when is_binary(id) and byte_size(id) > 18, do: String.slice(id, 0, 18)
+  defp short_id(id), do: to_string(id)
+end

--- a/apps/favn_view/lib/favn_view/components/selected_window_actions.ex
+++ b/apps/favn_view/lib/favn_view/components/selected_window_actions.ex
@@ -1,0 +1,64 @@
+defmodule FavnView.Components.SelectedWindowActions do
+  @moduledoc """
+  Compact action strip for the selected asset timeline window.
+  """
+
+  use FavnView, :html
+
+  attr :selected_window, :map, default: nil
+  attr :submitting_window_run?, :boolean, default: false
+  attr :selected_window_error, :string, default: nil
+  attr :submitted_run_id, :string, default: nil
+
+  def selected_window_actions(assigns) do
+    ~H"""
+    <div
+      :if={@selected_window}
+      class="flex flex-col gap-3 rounded-box border border-base-content/10 bg-base-content/[0.04] p-4 sm:flex-row sm:items-center sm:justify-between"
+      data-testid="selected-window-actions"
+    >
+      <div class="min-w-0">
+        <p class="text-xs uppercase tracking-[0.18em] text-base-content/45">Selected window</p>
+        <p class="mt-1 text-sm font-medium text-base-content">{@selected_window.range_label}</p>
+        <p class="mt-0.5 text-xs text-base-content/55">{status_label(@selected_window.status)}</p>
+        <p :if={!@selected_window.run_enabled?} class="mt-1 text-xs text-base-content/45">
+          {run_disabled_reason_label(@selected_window.run_disabled_reason)}
+        </p>
+        <p
+          :if={@selected_window_error}
+          class="mt-1 text-xs text-error"
+          data-testid="selected-window-error"
+        >
+          {@selected_window_error}
+        </p>
+        <p :if={@submitted_run_id} class="mt-1 text-xs text-success" data-testid="submitted-run-id">
+          Submitted {@submitted_run_id}
+        </p>
+      </div>
+
+      <div class="flex w-full shrink-0 justify-end gap-2 sm:w-auto">
+        <button
+          type="button"
+          class="btn btn-primary btn-soft btn-sm"
+          phx-click="run_selected_window"
+          phx-disable-with="Submitting..."
+          disabled={!@selected_window.run_enabled? || @submitting_window_run?}
+          data-testid="run-selected-window"
+        >
+          <span :if={@submitting_window_run?} class="loading loading-spinner loading-xs"></span>
+          {@selected_window.run_label || "Run this window"}
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  defp status_label(:success), do: "healthy"
+  defp status_label(:warning), do: "late"
+  defp status_label(:muted), do: "pending"
+  defp status_label(_status), do: "unknown"
+
+  defp run_disabled_reason_label(:asset_has_no_window_policy), do: "No window policy"
+  defp run_disabled_reason_label(:invalid_window), do: "Invalid window"
+  defp run_disabled_reason_label(_reason), do: "Not runnable"
+end

--- a/apps/favn_view/lib/favn_view/components/selected_window_actions.ex
+++ b/apps/favn_view/lib/favn_view/components/selected_window_actions.ex
@@ -55,6 +55,7 @@ defmodule FavnView.Components.SelectedWindowActions do
 
   defp status_label(:success), do: "healthy"
   defp status_label(:warning), do: "late"
+  defp status_label(:error), do: "failed"
   defp status_label(:muted), do: "pending"
   defp status_label(_status), do: "unknown"
 

--- a/apps/favn_view/lib/favn_view/page_live.ex
+++ b/apps/favn_view/lib/favn_view/page_live.ex
@@ -3,32 +3,8 @@ defmodule FavnView.PageLive do
 
   use FavnView, :live_view
 
-  alias FavnView.Components.AssetDetailPage
-
   @impl true
   def mount(_params, _session, socket) do
-    socket =
-      assign(socket,
-        title: "customer_orders_daily",
-        status: "Healthy",
-        window_range: "May 24 - Jun 22, 2026",
-        nav_items: AssetDetailPage.sample_nav_items(),
-        timeline: AssetDetailPage.sample_timeline()
-      )
-
-    {:ok, socket}
-  end
-
-  @impl true
-  def render(assigns) do
-    ~H"""
-    <AssetDetailPage.asset_detail_page
-      title={@title}
-      status={@status}
-      window_range={@window_range}
-      nav_items={@nav_items}
-      timeline={@timeline}
-    />
-    """
+    {:ok, redirect(socket, to: ~p"/assets")}
   end
 end

--- a/apps/favn_view/lib/favn_view/router.ex
+++ b/apps/favn_view/lib/favn_view/router.ex
@@ -20,6 +20,7 @@ defmodule FavnView.Router do
     live "/", PageLive, :home
     live "/assets", AssetCatalogueLive, :index
     live "/assets/:asset_id", AssetDetailLive, :show
+    live "/runs/:run_id", RunDetailLive, :show
   end
 
   # Other scopes may use custom stacks.

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -1,0 +1,245 @@
+defmodule FavnView.RunDetailLive do
+  @moduledoc false
+
+  use FavnView, :live_view
+
+  alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.RunDetailPage
+
+  @valid_modes ~w(overview events assets output debug)
+
+  @impl true
+  def mount(%{"run_id" => run_id}, _session, socket) do
+    socket =
+      assign(socket,
+        run_id: run_id,
+        run: load_run(run_id),
+        active_mode: :overview,
+        nav_items: AssetCataloguePage.nav_items()
+      )
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("set_mode", %{"mode" => mode}, socket) when mode in @valid_modes do
+    {:noreply, assign(socket, :active_mode, String.to_existing_atom(mode))}
+  end
+
+  def handle_event("set_mode", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <RunDetailPage.run_detail_page
+      run={@run}
+      run_id={@run_id}
+      nav_items={@nav_items}
+      active_mode={@active_mode}
+    />
+    """
+  end
+
+  defp load_run(run_id) do
+    with {:ok, run} <- FavnOrchestrator.get_run(run_id),
+         {:ok, events} <- FavnOrchestrator.list_run_events(run_id) do
+      run_from_public(run, events)
+    else
+      {:error, reason} -> %{id: run_id, found?: false, error: error_label(reason)}
+    end
+  end
+
+  defp run_from_public(run, events) do
+    started_at = Map.get(run, :started_at)
+    finished_at = Map.get(run, :finished_at)
+    status = Map.get(run, :status)
+    target = target_label(Map.get(run, :asset_ref), Map.get(run, :target_refs, []))
+    trigger = trigger_label(Map.get(run, :trigger, %{}), Map.get(run, :submit_kind))
+    window = window_label(Map.get(run, :params, %{}), Map.get(run, :metadata, %{}))
+    asset_results = asset_results(Map.get(run, :asset_results, %{}))
+    event_items = event_items(events)
+
+    %{
+      found?: true,
+      id: run.id,
+      short_id: short_id(run.id),
+      title: "Run #{short_id(run.id)}",
+      subtitle: subtitle([target, trigger, window]),
+      status: status_label(status),
+      status_tone: status_tone(status),
+      target: target || "No target",
+      trigger: trigger || "Manual",
+      window: window,
+      started_at: timestamp_label(started_at),
+      finished_at: timestamp_label(finished_at),
+      duration: duration_label(started_at, finished_at),
+      manifest_version_id: run.manifest_version_id || "Unknown",
+      asset_results: asset_results,
+      asset_result_groups: asset_result_groups(asset_results),
+      events: event_items,
+      latest_events: Enum.take(Enum.reverse(event_items), 8)
+    }
+  end
+
+  defp asset_results(results) when is_map(results) do
+    results
+    |> Map.values()
+    |> Enum.map(fn result ->
+      %{
+        ref: ref_label(Map.get(result, :ref)),
+        stage: Map.get(result, :stage),
+        status: status_label(Map.get(result, :status)),
+        status_tone: status_tone(Map.get(result, :status)),
+        started_at: timestamp_label(Map.get(result, :started_at)),
+        duration: duration_ms_label(Map.get(result, :duration_ms)),
+        error: error_summary(Map.get(result, :error))
+      }
+    end)
+    |> Enum.sort_by(&{&1.stage || 0, &1.ref})
+  end
+
+  defp asset_results(_results), do: []
+
+  defp asset_result_groups(results) do
+    results
+    |> Enum.group_by(& &1.stage)
+    |> Enum.sort_by(fn {stage, _items} -> stage || 0 end)
+    |> Enum.map(fn {stage, items} -> %{stage: stage, items: items} end)
+  end
+
+  defp event_items(events) when is_list(events) do
+    events
+    |> Enum.map(fn event ->
+      %{
+        sequence: Map.get(event, :sequence),
+        timestamp: timestamp_label(Map.get(event, :occurred_at)),
+        event_type: event_type_label(Map.get(event, :event_type)),
+        status: status_label(Map.get(event, :status)),
+        status_tone: status_tone(Map.get(event, :status)),
+        summary: event_summary(event)
+      }
+    end)
+  end
+
+  defp event_items(_events), do: []
+
+  defp subtitle(parts) do
+    parts
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+  end
+
+  defp target_label(nil, []), do: nil
+  defp target_label(nil, refs), do: refs |> Enum.map(&ref_label/1) |> Enum.join(", ")
+  defp target_label(ref, _refs), do: ref_label(ref)
+
+  defp trigger_label(%{kind: kind}, _submit_kind), do: humanize(kind)
+  defp trigger_label(%{"kind" => kind}, _submit_kind), do: humanize(kind)
+  defp trigger_label(_trigger, nil), do: nil
+  defp trigger_label(_trigger, submit_kind), do: humanize(submit_kind)
+
+  defp window_label(params, metadata) do
+    window = Map.get(params, :window) || Map.get(params, "window") || Map.get(metadata, :window)
+
+    cond do
+      is_binary(window) ->
+        window
+
+      is_map(window) ->
+        Map.get(window, :label) || Map.get(window, "label") || Map.get(window, :key)
+
+      true ->
+        nil
+    end
+  end
+
+  defp ref_label({module, name}), do: "#{inspect(module)}.#{name}"
+
+  defp ref_label(%{"module" => module, "name" => name}), do: "#{module}.#{name}"
+
+  defp ref_label(ref) when is_atom(ref), do: Atom.to_string(ref)
+  defp ref_label(ref) when is_binary(ref), do: ref
+  defp ref_label(ref), do: inspect(ref)
+
+  defp status_label(:ok), do: "Succeeded"
+  defp status_label(:running), do: "Running"
+  defp status_label(:pending), do: "Pending"
+  defp status_label(:partial), do: "Partial"
+  defp status_label(:error), do: "Failed"
+  defp status_label(:cancelled), do: "Cancelled"
+  defp status_label(:timed_out), do: "Timed out"
+  defp status_label(nil), do: "Unknown"
+  defp status_label(status), do: humanize(status)
+
+  defp status_tone(status) when status in [:ok, "ok"], do: :success
+  defp status_tone(status) when status in [:running, :pending, "running", "pending"], do: :info
+  defp status_tone(status) when status in [:partial, "partial"], do: :warning
+  defp status_tone(status) when status in [:error, :timed_out, "error", "timed_out"], do: :error
+  defp status_tone(status) when status in [:cancelled, "cancelled"], do: :neutral
+  defp status_tone(_status), do: :neutral
+
+  defp timestamp_label(%DateTime{} = value),
+    do: Calendar.strftime(value, "%b %-d, %Y %H:%M:%S UTC")
+
+  defp timestamp_label(_value), do: "-"
+
+  defp duration_label(%DateTime{} = started_at, %DateTime{} = finished_at) do
+    DateTime.diff(finished_at, started_at, :millisecond)
+    |> duration_ms_label()
+  end
+
+  defp duration_label(%DateTime{} = started_at, nil) do
+    DateTime.diff(DateTime.utc_now(), started_at, :millisecond)
+    |> duration_ms_label()
+  end
+
+  defp duration_label(_started_at, _finished_at), do: "-"
+
+  defp duration_ms_label(value) when is_integer(value) and value < 1_000, do: "#{value} ms"
+  defp duration_ms_label(value) when is_integer(value), do: "#{Float.round(value / 1_000, 1)} s"
+  defp duration_ms_label(_value), do: "-"
+
+  defp short_id(id) when is_binary(id) and byte_size(id) > 18, do: String.slice(id, 0, 18)
+  defp short_id(id) when is_binary(id), do: id
+  defp short_id(_id), do: "unknown"
+
+  defp event_type_label(type), do: humanize(type)
+
+  defp event_summary(event) do
+    data = Map.get(event, :data, %{}) || %{}
+
+    Map.get(data, :message) ||
+      Map.get(data, "message") ||
+      event_asset_summary(event) ||
+      status_summary(Map.get(event, :status)) ||
+      "Persisted event"
+  end
+
+  defp event_asset_summary(event) do
+    case Map.get(event, :asset_ref) do
+      nil -> nil
+      ref -> "Asset #{ref_label(ref)}"
+    end
+  end
+
+  defp status_summary(nil), do: nil
+  defp status_summary(status), do: "Status #{status_label(status)}"
+
+  defp error_summary(nil), do: nil
+  defp error_summary(%{message: message}) when is_binary(message), do: message
+  defp error_summary(%{"message" => message}) when is_binary(message), do: message
+  defp error_summary(error), do: inspect(error)
+
+  defp humanize(value) when is_atom(value), do: value |> Atom.to_string() |> humanize()
+
+  defp humanize(value) when is_binary(value) do
+    value
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp humanize(value), do: inspect(value)
+
+  defp error_label(:not_found), do: "Run not found"
+  defp error_label(_reason), do: "Run could not be loaded"
+end

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -15,7 +15,7 @@ defmodule FavnView.RunDetailLive do
         run_id: run_id,
         run: load_run(run_id),
         active_mode: :overview,
-        nav_items: AssetCataloguePage.nav_items()
+        nav_items: AssetCataloguePage.nav_items(:runs)
       )
 
     {:ok, socket}
@@ -139,14 +139,17 @@ defmodule FavnView.RunDetailLive do
   defp trigger_label(_trigger, submit_kind), do: humanize(submit_kind)
 
   defp window_label(params, metadata) do
-    window = Map.get(params, :window) || Map.get(params, "window") || Map.get(metadata, :window)
+    window =
+      Map.get(params, :window) || Map.get(params, "window") || Map.get(metadata, :selected_window) ||
+        Map.get(metadata, "selected_window") || Map.get(metadata, :window)
 
     cond do
       is_binary(window) ->
         window
 
       is_map(window) ->
-        Map.get(window, :label) || Map.get(window, "label") || Map.get(window, :key)
+        Map.get(window, :label) || Map.get(window, "label") || Map.get(window, :id) ||
+          Map.get(window, "id") || Map.get(window, :key)
 
       true ->
         nil

--- a/apps/favn_view/storybook/components/asset_detail_page.story.exs
+++ b/apps/favn_view/storybook/components/asset_detail_page.story.exs
@@ -12,13 +12,96 @@ defmodule FavnView.Storybook.Components.AssetDetailPage do
   def variations do
     [
       %Variation{
-        id: :healthy_asset,
+        id: :default_timeline,
         attributes: %{
           title: "customer_orders_daily",
           status: "Healthy",
+          status_tone: :success,
           window_range: "May 24 - Jun 22, 2026",
           nav_items: AssetDetailPage.sample_nav_items(),
-          timeline: AssetDetailPage.sample_timeline()
+          timeline: AssetDetailPage.sample_timeline(),
+          active_mode: :timeline,
+          selected_window: AssetDetailPage.selected_sample_window()
+        }
+      },
+      %Variation{
+        id: :selected_runnable_window,
+        attributes: %{
+          title: "customer_orders_daily",
+          status: "Healthy",
+          status_tone: :success,
+          window_range: "May 24 - Jun 22, 2026",
+          nav_items: AssetDetailPage.sample_nav_items(),
+          timeline: AssetDetailPage.sample_timeline(),
+          active_mode: :timeline,
+          selected_window: AssetDetailPage.selected_sample_window()
+        }
+      },
+      %Variation{
+        id: :selected_non_runnable_window,
+        attributes: %{
+          title: "raw_payments",
+          status: "Unknown",
+          status_tone: :neutral,
+          window_range: "May 24 - Jun 22, 2026",
+          nav_items: AssetDetailPage.sample_nav_items(),
+          timeline: AssetDetailPage.non_runnable_timeline(),
+          active_mode: :timeline,
+          selected_window: AssetDetailPage.selected_non_runnable_window()
+        }
+      },
+      %Variation{
+        id: :submit_success,
+        attributes: %{
+          title: "customer_orders_daily",
+          status: "Healthy",
+          status_tone: :success,
+          window_range: "May 24 - Jun 22, 2026",
+          nav_items: AssetDetailPage.sample_nav_items(),
+          timeline: AssetDetailPage.sample_timeline(),
+          active_mode: :timeline,
+          selected_window: AssetDetailPage.selected_sample_window(),
+          submitted_run_id: "run_01HZ"
+        }
+      },
+      %Variation{
+        id: :submit_error,
+        attributes: %{
+          title: "customer_orders_daily",
+          status: "Healthy",
+          status_tone: :success,
+          window_range: "May 24 - Jun 22, 2026",
+          nav_items: AssetDetailPage.sample_nav_items(),
+          timeline: AssetDetailPage.sample_timeline(),
+          active_mode: :timeline,
+          selected_window: AssetDetailPage.selected_sample_window(),
+          selected_window_error: "Could not submit run."
+        }
+      },
+      %Variation{
+        id: :selected_muted_window,
+        attributes: %{
+          title: "raw_payments",
+          status: "Unknown",
+          status_tone: :neutral,
+          window_range: "May 24 - Jun 22, 2026",
+          nav_items: AssetDetailPage.sample_nav_items(),
+          timeline: AssetDetailPage.muted_timeline(),
+          active_mode: :timeline,
+          selected_window: AssetDetailPage.selected_muted_window()
+        }
+      },
+      %Variation{
+        id: :placeholder_mode,
+        attributes: %{
+          title: "customer_orders_daily",
+          status: "Healthy",
+          status_tone: :success,
+          window_range: "May 24 - Jun 22, 2026",
+          nav_items: AssetDetailPage.sample_nav_items(),
+          timeline: AssetDetailPage.sample_timeline(),
+          active_mode: :runs,
+          selected_window: AssetDetailPage.selected_sample_window()
         }
       }
     ]

--- a/apps/favn_view/storybook/components/run_detail_page.story.exs
+++ b/apps/favn_view/storybook/components/run_detail_page.story.exs
@@ -1,0 +1,56 @@
+defmodule FavnView.Storybook.Components.RunDetailPage do
+  alias FavnView.Components.RunDetailPage
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &RunDetailPage.run_detail_page/1
+  def layout, do: :one_column
+  def render_source, do: :function
+
+  def container, do: {:iframe, style: "width: 100%; height: 920px; border: 0;"}
+
+  def variations do
+    [
+      %Variation{
+        id: :running_run,
+        attributes: %{
+          run: RunDetailPage.sample_run(:running),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :succeeded_with_asset_results,
+        attributes: %{
+          run: RunDetailPage.sample_run(:ok),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :failed_with_event_timeline,
+        attributes: %{
+          run: RunDetailPage.sample_run(:error),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :empty_no_events,
+        attributes: %{
+          run: RunDetailPage.empty_run(),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :not_found,
+        attributes: %{
+          run: RunDetailPage.not_found_run(),
+          run_id: "run_missing",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      }
+    ]
+  end
+end

--- a/apps/favn_view/storybook/components/selected_window_actions.story.exs
+++ b/apps/favn_view/storybook/components/selected_window_actions.story.exs
@@ -1,0 +1,60 @@
+defmodule FavnView.Storybook.Components.SelectedWindowActions do
+  alias FavnView.Components.AssetDetailPage
+  alias FavnView.Components.SelectedWindowActions
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &SelectedWindowActions.selected_window_actions/1
+  def layout, do: :one_column
+  def render_source, do: :function
+
+  def container, do: {:iframe, style: "width: 100%; height: 360px; border: 0;"}
+
+  def template do
+    """
+    <div data-theme="favn-dark" class="favn-shell-bg flex min-h-[22rem] items-center p-12 text-base-content">
+      <div class="w-full max-w-6xl">
+        <.psb-variation/>
+      </div>
+    </div>
+    """
+  end
+
+  def variations do
+    [
+      %Variation{
+        id: :runnable,
+        attributes: %{
+          selected_window: AssetDetailPage.selected_sample_window()
+        }
+      },
+      %Variation{
+        id: :submitting,
+        attributes: %{
+          selected_window: AssetDetailPage.selected_sample_window(),
+          submitting_window_run?: true
+        }
+      },
+      %Variation{
+        id: :success,
+        attributes: %{
+          selected_window: AssetDetailPage.selected_sample_window(),
+          submitted_run_id: "run_01HZ"
+        }
+      },
+      %Variation{
+        id: :error,
+        attributes: %{
+          selected_window: AssetDetailPage.selected_sample_window(),
+          selected_window_error: "Could not submit run."
+        }
+      },
+      %Variation{
+        id: :not_runnable,
+        attributes: %{
+          selected_window: AssetDetailPage.selected_non_runnable_window()
+        }
+      }
+    ]
+  end
+end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -6,6 +6,7 @@ defmodule FavnView.PageLiveTest do
   alias Favn.Manifest
   alias Favn.Manifest.Version
   alias Favn.Run.AssetResult
+  alias Favn.Window.Spec, as: WindowSpec
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.Adapter.Memory
@@ -18,19 +19,13 @@ defmodule FavnView.PageLiveTest do
     assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
     assert :ok = Storage.put_run(run_state(:customer_orders_daily, :ok, -600))
     assert :ok = Storage.put_run(run_state(:raw_payments, :running, -30))
+    seed_run_events!("run_customer_orders_daily")
 
     :ok
   end
 
-  test "renders the Favn HUD shell placeholder", %{conn: conn} do
-    {:ok, view, html} = live(conn, ~p"/")
-
-    assert html =~ "customer_orders_daily"
-    assert html =~ "Healthy"
-    assert html =~ "Window timeline"
-    assert has_element?(view, ~s([data-testid="window-timeline-panel"]))
-    assert has_element?(view, ~s([aria-label="Primary navigation"]))
-    assert has_element?(view, ~s([aria-label="View modes"]))
+  test "redirects home to the asset catalogue", %{conn: conn} do
+    assert {:error, {:redirect, %{to: "/assets"}}} = live(conn, ~p"/")
   end
 
   test "renders the asset catalogue", %{conn: conn} do
@@ -41,11 +36,7 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="asset-table"]))
     assert has_element?(view, ~s([data-testid="asset-card-list"]))
 
-    assert has_element?(
-             view,
-             ~s(a[href*="customer_orders_daily"]),
-             "customer_orders_daily"
-           )
+    assert has_element?(view, "a", "customer_orders_daily")
 
     assert html =~ "Healthy"
     assert html =~ "10m ago"
@@ -65,7 +56,7 @@ defmodule FavnView.PageLiveTest do
       "filters" => %{"search" => "payments", "connection" => "s3", "catalogue" => "finance"}
     })
 
-    assert has_element?(view, ~s(a[href*="raw_payments"]), "raw_payments")
+    assert has_element?(view, "a", "raw_payments")
     refute has_element?(view, ~s(a[href*="stg_payments"]), "stg_payments")
   end
 
@@ -81,11 +72,164 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="asset-empty-state"]), "No assets found")
   end
 
-  test "opens the asset detail placeholder", %{conn: conn} do
-    {:ok, _view, html} = live(conn, ~p"/assets/customer_orders_daily")
+  test "renders the selected asset detail page", %{conn: conn} do
+    {:ok, view, html} = live(conn, detail_path(:customer_orders_daily))
 
     assert html =~ "customer_orders_daily"
-    assert html =~ "Asset detail coming soon"
+    assert html =~ "Healthy"
+    assert html =~ "Window timeline"
+    assert has_element?(view, ~s([data-testid="window-timeline-panel"]))
+    assert has_element?(view, ~s([aria-label="View modes"]))
+  end
+
+  test "asset detail defaults to timeline mode", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+
+    assert has_element?(view, ~s([data-testid="window-timeline-panel"]), "Window timeline")
+    assert has_element?(view, ~s([data-testid="selected-window-actions"]), today_label())
+    assert has_element?(view, "[data-testid='run-selected-window']:not([disabled])")
+    refute has_element?(view, ~s([data-testid="create-backfill"]))
+    refute has_element?(view, ~s([data-testid="asset-mode-placeholder"]))
+  end
+
+  test "run selected window submits and navigates to run detail", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+
+    view
+    |> element(~s([data-testid="run-selected-window"]), "Run this window")
+    |> render_click()
+
+    assert {run_path, %{"info" => "Run submitted"}} = assert_redirect(view)
+    assert String.starts_with?(run_path, "/runs/run_")
+
+    {:ok, run_view, html} = live(conn, run_path)
+
+    assert html =~ "Run run_"
+    assert has_element?(run_view, ~s([data-testid="run-overview-panel"]))
+  end
+
+  test "non-runnable selected window keeps run disabled", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:stg_payments))
+
+    assert has_element?(view, ~s([data-testid="run-selected-window"][disabled]))
+    refute has_element?(view, ~s([data-testid="create-backfill"]))
+    assert has_element?(view, ~s([data-testid="selected-window-actions"]), "No window policy")
+  end
+
+  test "asset detail mode rail changes the central panel", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Runs"]))
+    |> render_click()
+
+    assert has_element?(view, ~s([data-testid="asset-mode-placeholder"]), "Runs coming soon")
+    refute has_element?(view, ~s([data-testid="window-timeline-panel"]))
+    assert has_element?(view, ~s(button[aria-label="Runs"][aria-pressed="true"]))
+  end
+
+  test "clicking a timeline window changes the selected window", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+    window_id = "window:day:#{Date.utc_today() |> Date.add(-29) |> Date.to_iso8601()}"
+    window_label = Date.utc_today() |> Date.add(-29) |> Calendar.strftime("%b %-d, %Y")
+
+    view
+    |> element(~s([data-testid="timeline-window-#{window_id}"]))
+    |> render_click()
+
+    assert has_element?(view, ~s([data-testid="selected-window-actions"]), window_label)
+
+    assert has_element?(
+             view,
+             ~s([data-testid="timeline-window-#{window_id}"][aria-pressed="true"])
+           )
+
+    assert has_element?(
+             view,
+             ~s([data-testid="timeline-window-#{window_id}"][aria-label*="pending"])
+           )
+  end
+
+  test "asset detail ignores invalid mode and window events", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+
+    assert render_click(view, "set_mode", %{"mode" => "not_real"}) =~ "Window timeline"
+    assert has_element?(view, ~s([data-testid="selected-window-actions"]), today_label())
+
+    assert render_click(view, "select_window", %{"window-id" => "not-real"}) =~ today_label()
+    assert has_element?(view, ~s([data-testid="window-timeline-panel"]))
+  end
+
+  test "shows not-found state for unknown asset ids", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/assets/not_real")
+
+    assert html =~ "Asset not found"
+    assert has_element?(view, ~s([data-testid="asset-not-found-state"]))
+  end
+
+  test "renders existing run detail overview", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/runs/run_customer_orders_daily")
+
+    assert html =~ "Run run_customer_order"
+    assert has_element?(view, ~s([data-testid="run-overview-panel"]))
+    assert has_element?(view, ~s([data-testid="run-summary-row"]), "Succeeded")
+    assert has_element?(view, ~s([data-testid="run-summary-row"]), "mv_view_assets")
+  end
+
+  test "run detail renders events when present", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
+
+    assert has_element?(view, ~s([data-testid="run-event-timeline"]), "Run started")
+    assert has_element?(view, ~s([data-testid="run-event-timeline"]), "Run finished")
+  end
+
+  test "run detail renders asset results when present", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
+
+    assert has_element?(view, ~s([data-testid="run-asset-results"]), "customer_orders_daily")
+    assert has_element?(view, ~s([data-testid="run-asset-results"]), "Stage 0")
+  end
+
+  test "run detail mode rail changes to placeholder modes", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Events"]))
+    |> render_click()
+
+    assert has_element?(view, ~s([data-testid="run-mode-placeholder"]), "Events")
+    refute has_element?(view, ~s([data-testid="run-overview-panel"]))
+  end
+
+  test "run detail ignores invalid mode events", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
+
+    assert render_click(view, "set_mode", %{"mode" => "not_real"}) =~ "Asset execution"
+    assert has_element?(view, ~s([data-testid="run-overview-panel"]))
+  end
+
+  test "shows not-found state for unknown run ids", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/runs/run_missing")
+
+    assert html =~ "Run not found"
+    assert has_element?(view, ~s([data-testid="run-not-found-state"]), "run_missing")
+  end
+
+  test "catalogue links open the detail route", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/assets")
+    detail_path = detail_path(:customer_orders_daily)
+
+    {:ok, detail_view, html} =
+      view
+      |> element(
+        ~s(tr[data-testid="asset-row"] a[href="#{detail_path}"]),
+        "customer_orders_daily"
+      )
+      |> render_click()
+      |> follow_redirect(conn, detail_path)
+
+    assert html =~ "customer_orders_daily"
+    assert has_element?(detail_view, ~s([data-testid="window-timeline-panel"]))
   end
 
   test "ignores invalid mode events", %{conn: conn} do
@@ -97,7 +241,7 @@ defmodule FavnView.PageLiveTest do
   defp manifest_version do
     manifest = %Manifest{
       assets: [
-        asset(:customer_orders_daily, :snowflake, "sales", :sql),
+        asset(:customer_orders_daily, :snowflake, "sales", :sql, WindowSpec.new!(:day)),
         asset(:raw_payments, :s3, "finance", :source),
         asset(:stg_payments, :postgres, "finance", :sql)
       ]
@@ -107,12 +251,13 @@ defmodule FavnView.PageLiveTest do
     version
   end
 
-  defp asset(name, connection, catalog, type) do
+  defp asset(name, connection, catalog, type, window \\ nil) do
     %Favn.Manifest.Asset{
       ref: {__MODULE__.Assets, name},
       module: __MODULE__.Assets,
       name: name,
       type: type,
+      window: window,
       relation: %{connection: connection, catalog: catalog, name: Atom.to_string(name)}
     }
   end
@@ -147,5 +292,45 @@ defmodule FavnView.PageLiveTest do
     |> Map.put(:inserted_at, started_at)
     |> Map.put(:updated_at, finished_at)
     |> RunState.with_snapshot_hash()
+  end
+
+  defp seed_run_events!(run_id) do
+    now = DateTime.utc_now()
+
+    assert :ok =
+             Storage.append_run_event(run_id, %{
+               run_id: run_id,
+               sequence: 1,
+               event_type: :run_started,
+               occurred_at: DateTime.add(now, -1, :second),
+               status: :running,
+               data: %{message: "Run started"}
+             })
+
+    assert :ok =
+             Storage.append_run_event(run_id, %{
+               run_id: run_id,
+               sequence: 2,
+               event_type: :run_finished,
+               occurred_at: now,
+               status: :ok,
+               data: %{message: "Run finished"}
+             })
+  end
+
+  defp target_id(name) do
+    {:ok, entries} = FavnOrchestrator.active_asset_catalogue()
+
+    entries
+    |> Enum.find(&(get_in(&1, [:relation, :name]) == Atom.to_string(name)))
+    |> Map.fetch!(:target_id)
+  end
+
+  defp detail_path(name) do
+    ~p"/assets/#{FavnView.AssetRoute.to_param(target_id(name))}"
+  end
+
+  defp today_label do
+    Date.utc_today() |> Calendar.strftime("%b %-d, %Y")
   end
 end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -105,6 +105,7 @@ defmodule FavnView.PageLiveTest do
     {:ok, run_view, html} = live(conn, run_path)
 
     assert html =~ "Run run_"
+    assert html =~ "window:day:#{Date.to_iso8601(Date.utc_today())}"
     assert has_element?(run_view, ~s([data-testid="run-overview-panel"]))
   end
 


### PR DESCRIPTION
## Summary
- Add orchestrator-backed asset detail timeline data and selected-window run submission.
- Add read-only run detail route with summary, asset results, events, mode rail placeholders, and Storybook coverage.
- Route asset catalogue/detail IDs safely and navigate submitted window runs to their run detail page.

## Verification
- mix format
- mix compile --warnings-as-errors (apps/favn_view)
- mix test (apps/favn_view)
- mix compile --warnings-as-errors (apps/favn_orchestrator)
- mix test (apps/favn_orchestrator)