### PR TITLE
Harden run detail HUD

### DIFF
--- a/apps/favn_view/lib/favn_view/components/app_shell.ex
+++ b/apps/favn_view/lib/favn_view/components/app_shell.ex
@@ -13,6 +13,9 @@ defmodule FavnView.Components.AppShell do
   attr :status, :string, default: nil
   attr :status_tone, :atom, default: :success
   attr :nav_items, :list, default: []
+  attr :back_href, :string, default: nil
+  attr :back_label, :string, default: nil
+  attr :facts, :list, default: []
 
   slot :inner_block, required: true
   slot :mode_rail
@@ -48,25 +51,47 @@ defmodule FavnView.Components.AppShell do
         </header>
 
         <main class="mx-auto flex min-h-[calc(100vh-5.5rem)] max-w-7xl flex-col justify-start py-8 md:justify-center md:py-12">
-          <section class="mb-6 flex flex-col gap-3 sm:flex-row sm:items-start md:mb-8 md:gap-4">
-            <div>
-              <h1 class="text-3xl font-light tracking-tight text-base-content sm:text-5xl lg:text-6xl">
-                {@title}
-              </h1>
+          <section class="mb-6 flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between md:mb-8">
+            <div class="min-w-0">
+              <.link
+                :if={@back_href && @back_label}
+                navigate={@back_href}
+                class="mb-6 inline-flex items-center gap-2 text-sm text-base-content/70 transition hover:text-primary"
+              >
+                <.icon name="hero-arrow-left" class="size-4" />
+                {@back_label}
+              </.link>
+
+              <div class="flex flex-col gap-3 sm:flex-row sm:items-center md:gap-4">
+                <h1 class="truncate text-3xl font-light tracking-tight text-base-content sm:text-5xl lg:text-6xl">
+                  {@title}
+                </h1>
+                <span
+                  :if={@status}
+                  class={[
+                    "badge badge-soft favn-status-glow gap-2 px-4 py-4",
+                    status_badge_class(@status_tone)
+                  ]}
+                >
+                  <span class={["status", status_dot_class(@status_tone)]}></span>
+                  {@status}
+                </span>
+              </div>
+
               <p :if={@subtitle} class="mt-2 text-base text-base-content/60 md:mt-3 md:text-lg">
                 {@subtitle}
               </p>
             </div>
-            <span
-              :if={@status}
-              class={[
-                "badge badge-soft favn-status-glow gap-2 px-4 py-4",
-                status_badge_class(@status_tone)
-              ]}
-            >
-              <span class={["status", status_dot_class(@status_tone)]}></span>
-              {@status}
-            </span>
+
+            <dl :if={@facts != []} class="grid gap-4 text-sm sm:grid-cols-3 lg:min-w-[28rem]">
+              <div
+                :for={fact <- @facts}
+                class="border-base-content/20 sm:border-l sm:pl-5 first:border-l-0 first:pl-0"
+              >
+                <dt class="text-base-content/55">{fact.label}</dt>
+                <dd class="mt-1 font-medium text-base-content">{fact.value}</dd>
+              </div>
+            </dl>
           </section>
 
           {render_slot(@inner_block)}

--- a/apps/favn_view/lib/favn_view/components/run_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page.ex
@@ -255,6 +255,48 @@ defmodule FavnView.Components.RunDetailPage do
     ])
   end
 
+  def sample_run_with_node_statuses do
+    sample_run(:partial)
+    |> Map.put(:asset_results, [
+      %{
+        id: "node-raw-orders-window-2026-06-12",
+        asset_ref: "FavnView.Assets.raw_orders",
+        display_name: "raw_orders",
+        secondary: "window:day:2026-06-12 · Fresh · Stage 0",
+        status: "Skipped fresh",
+        status_tone: :neutral,
+        started_at: "Jun 12, 2026 14:00:00 UTC",
+        duration: "1.0 s",
+        error: nil,
+        inspectable?: true
+      },
+      %{
+        id: "node-stg-orders-window-2026-06-12",
+        asset_ref: "FavnView.Assets.stg_orders",
+        display_name: "stg_orders",
+        secondary: "window:day:2026-06-12 · Stage 1",
+        status: "Retrying",
+        status_tone: :info,
+        started_at: "Jun 12, 2026 14:00:01 UTC",
+        duration: "500 ms",
+        error: nil,
+        inspectable?: true
+      },
+      %{
+        id: "node-customer-orders-window-2026-06-12",
+        asset_ref: "FavnView.Assets.customer_orders_daily",
+        display_name: "customer_orders_daily",
+        secondary: "window:day:2026-06-12 · Upstream failed · Stage 2",
+        status: "Blocked",
+        status_tone: :error,
+        started_at: "Jun 12, 2026 14:00:02 UTC",
+        duration: "1 ms",
+        error: "Upstream failed",
+        inspectable?: true
+      }
+    ])
+  end
+
   def not_found_run do
     %{
       found?: false,

--- a/apps/favn_view/lib/favn_view/components/run_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page.ex
@@ -8,6 +8,7 @@ defmodule FavnView.Components.RunDetailPage do
   alias FavnView.Components.AppShell
   alias FavnView.Components.GlassPanel
   alias FavnView.Components.ModeRail
+  alias FavnView.Components.RunOverviewHud
 
   attr :run, :map, required: true
   attr :run_id, :string, required: true
@@ -22,6 +23,9 @@ defmodule FavnView.Components.RunDetailPage do
       status={@run[:status]}
       status_tone={@run[:status_tone] || :neutral}
       nav_items={@nav_items}
+      back_href={@run[:back_asset_href]}
+      back_label={if(@run[:back_asset_href], do: "Back to asset", else: nil)}
+      facts={run_facts(@run)}
     >
       <.not_found_panel :if={!@run[:found?]} run={@run} />
       <.run_mode_panel :if={@run[:found?]} run={@run} active_mode={@active_mode} />
@@ -38,132 +42,41 @@ defmodule FavnView.Components.RunDetailPage do
 
   def run_mode_panel(assigns) do
     ~H"""
-    <.overview_panel :if={@active_mode == :overview} run={@run} />
-    <.placeholder_panel
-      :if={@active_mode == :events}
-      title="Events"
-      copy="Detailed event filtering will follow."
-    />
-    <.placeholder_panel
-      :if={@active_mode == :assets}
-      title="Assets"
-      copy="Asset-level controls stay read-only for now."
-    />
-    <.placeholder_panel
-      :if={@active_mode == :output}
-      title="Output"
-      copy="Output previews are not available yet."
-    />
-    <.placeholder_panel
-      :if={@active_mode == :debug}
-      title="Debug"
-      copy="Debug data is intentionally hidden by default."
-    />
+    <RunOverviewHud.run_overview_hud :if={@active_mode == :overview} run={@run} />
+    <.events_panel :if={@active_mode == :events} run={@run} />
+    <.outputs_panel :if={@active_mode == :outputs} run={@run} />
+    <.context_panel :if={@active_mode == :context} run={@run} />
+    <.debug_panel :if={@active_mode == :debug} run={@run} />
     """
   end
 
   attr :run, :map, required: true
 
-  def overview_panel(assigns) do
+  def events_panel(assigns) do
     ~H"""
-    <div class="mx-auto flex w-full max-w-6xl flex-col gap-5" data-testid="run-overview-panel">
-      <GlassPanel.glass_panel class="p-5 sm:p-6 lg:p-7">
-        <div class="grid gap-3 sm:grid-cols-2 lg:grid-cols-5" data-testid="run-summary-row">
-          <.summary_item label="Status" value={@run.status} tone={@run.status_tone} />
-          <.summary_item label="Target" value={@run.target} />
-          <.summary_item label="Started" value={@run.started_at} />
-          <.summary_item label="Duration" value={@run.duration} />
-          <.summary_item label="Manifest" value={@run.manifest_version_id} />
+    <GlassPanel.glass_panel
+      class="mx-auto w-full max-w-5xl p-5 sm:p-6 lg:p-7"
+      data-testid="run-event-timeline"
+    >
+      <div class="mb-4 flex items-center justify-between gap-3">
+        <div>
+          <h2 class="text-lg font-medium tracking-tight">Events</h2>
+          <p class="text-sm text-base-content/55">Chronological persisted run events.</p>
         </div>
-      </GlassPanel.glass_panel>
-
-      <GlassPanel.glass_panel class="p-5 sm:p-6 lg:p-7" data-testid="run-asset-results">
-        <div class="mb-4 flex items-center justify-between gap-3">
-          <div>
-            <h2 class="text-lg font-medium tracking-tight">Asset execution</h2>
-            <p class="text-sm text-base-content/55">
-              Stage grouped when execution stage data exists.
-            </p>
-          </div>
-          <span class="badge badge-ghost">{length(@run.asset_results)} assets</span>
-        </div>
-
-        <div
-          :if={@run.asset_results == []}
-          class="rounded-box border border-dashed border-base-content/15 p-5 text-sm text-base-content/55"
-        >
-          No asset results persisted for this run yet.
-        </div>
-
-        <div :if={@run.asset_results != []} class="flex flex-col gap-4">
-          <section
-            :for={group <- @run.asset_result_groups}
-            class="rounded-box border border-base-content/10 bg-base-content/[0.03] p-3"
-          >
-            <h3 class="mb-2 text-xs font-semibold uppercase tracking-[0.18em] text-base-content/45">
-              {stage_label(group.stage)}
-            </h3>
-            <div class="divide-y divide-base-content/10">
-              <.asset_result_row :for={asset <- group.items} asset={asset} />
-            </div>
-          </section>
-        </div>
-      </GlassPanel.glass_panel>
-
-      <GlassPanel.glass_panel class="p-5 sm:p-6 lg:p-7" data-testid="run-event-timeline">
-        <div class="mb-4 flex items-center justify-between gap-3">
-          <div>
-            <h2 class="text-lg font-medium tracking-tight">Event timeline</h2>
-            <p class="text-sm text-base-content/55">Latest persisted run events.</p>
-          </div>
-          <span class="badge badge-ghost">{length(@run.events)} events</span>
-        </div>
-
-        <div
-          :if={@run.latest_events == []}
-          class="rounded-box border border-dashed border-base-content/15 p-5 text-sm text-base-content/55"
-        >
-          No events persisted for this run yet.
-        </div>
-
-        <ol :if={@run.latest_events != []} class="space-y-3">
-          <.event_row :for={event <- @run.latest_events} event={event} />
-        </ol>
-      </GlassPanel.glass_panel>
-    </div>
-    """
-  end
-
-  attr :label, :string, required: true
-  attr :value, :string, required: true
-  attr :tone, :atom, default: nil
-
-  def summary_item(assigns) do
-    ~H"""
-    <div class="rounded-box border border-base-content/10 bg-base-content/[0.035] p-3">
-      <p class="text-xs uppercase tracking-[0.16em] text-base-content/45">{@label}</p>
-      <p class="mt-1 truncate text-sm font-medium text-base-content" title={@value}>
-        <span :if={@tone} class={["badge badge-soft", badge_class(@tone)]}>{@value}</span>
-        <span :if={!@tone}>{@value}</span>
-      </p>
-    </div>
-    """
-  end
-
-  attr :asset, :map, required: true
-
-  def asset_result_row(assigns) do
-    ~H"""
-    <div class="flex flex-col gap-2 py-3 sm:flex-row sm:items-center sm:justify-between">
-      <div class="min-w-0">
-        <p class="truncate text-sm font-medium text-base-content">{@asset.ref}</p>
-        <p class="text-xs text-base-content/50">Started {@asset.started_at} · {@asset.duration}</p>
-        <p :if={@asset.error} class="mt-1 text-xs text-error">{@asset.error}</p>
+        <span class="badge badge-ghost">{length(@run.events)} events</span>
       </div>
-      <span class={["badge badge-soft shrink-0", badge_class(@asset.status_tone)]}>
-        {@asset.status}
-      </span>
-    </div>
+
+      <div
+        :if={@run.events == []}
+        class="rounded-box border border-dashed border-base-content/15 p-5 text-sm text-base-content/55"
+      >
+        No events persisted for this run yet.
+      </div>
+
+      <ol :if={@run.events != []} class="space-y-3">
+        <.event_row :for={event <- @run.events} event={event} />
+      </ol>
+    </GlassPanel.glass_panel>
     """
   end
 
@@ -171,14 +84,90 @@ defmodule FavnView.Components.RunDetailPage do
 
   def event_row(assigns) do
     ~H"""
-    <li class="grid gap-2 rounded-box border border-base-content/10 bg-base-content/[0.03] p-3 sm:grid-cols-[10rem_12rem_1fr] sm:items-start">
+    <li class="grid gap-2 rounded-box border border-base-content/10 bg-base-content/[0.03] p-3 sm:grid-cols-[5rem_11rem_12rem_1fr] sm:items-start">
+      <span class="badge badge-ghost badge-sm">#{@event.sequence}</span>
       <time class="text-xs text-base-content/50">{@event.timestamp}</time>
-      <div class="flex items-center gap-2">
-        <span class="badge badge-ghost badge-sm">#{@event.sequence}</span>
-        <span class="text-sm font-medium text-base-content">{@event.event_type}</span>
-      </div>
-      <p class="text-sm text-base-content/65">{@event.summary}</p>
+      <span class="text-sm font-medium text-base-content">{@event.event_type}</span>
+      <p class="text-sm text-base-content/65">
+        <span :if={@event.asset} class="mr-2 font-mono text-xs text-base-content/45">
+          {@event.asset}
+        </span>
+        {@event.summary}
+      </p>
     </li>
+    """
+  end
+
+  attr :run, :map, required: true
+
+  def outputs_panel(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto w-full max-w-4xl p-6" data-testid="run-outputs-panel">
+      <h2 class="text-lg font-medium tracking-tight">Outputs</h2>
+      <p class="mt-2 text-sm text-base-content/55">Persisted output metadata, when available.</p>
+
+      <div
+        :if={@run.outputs == []}
+        class="mt-5 rounded-box border border-dashed border-base-content/15 p-5 text-sm text-base-content/55"
+      >
+        No output metadata persisted for this run yet.
+      </div>
+
+      <div :if={@run.outputs != []} class="mt-5 space-y-3">
+        <div
+          :for={output <- @run.outputs}
+          class="rounded-box border border-base-content/10 bg-base-content/[0.03] p-4"
+        >
+          <p class="font-mono text-xs text-base-content/55">{output.asset}</p>
+          <pre class="mt-2 overflow-auto text-xs text-base-content/75"><code>{output.output}</code></pre>
+        </div>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  attr :run, :map, required: true
+
+  def context_panel(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto w-full max-w-4xl p-6" data-testid="run-context-panel">
+      <h2 class="text-lg font-medium tracking-tight">Context</h2>
+      <dl class="mt-5 grid gap-3 sm:grid-cols-2">
+        <div
+          :for={item <- @run.context}
+          class="rounded-box border border-base-content/10 bg-base-content/[0.03] p-4"
+        >
+          <dt class="text-xs uppercase tracking-[0.16em] text-base-content/45">{item.label}</dt>
+          <dd class="mt-1 break-words text-sm font-medium text-base-content">{item.value}</dd>
+        </div>
+      </dl>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  attr :run, :map, required: true
+
+  def debug_panel(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto w-full max-w-5xl p-6" data-testid="run-debug-panel">
+      <h2 class="text-lg font-medium tracking-tight">Debug</h2>
+      <div class="mt-5 grid gap-4 lg:grid-cols-2">
+        <.debug_block title="Run" value={@run.raw_run} />
+        <.debug_block title="Events" value={@run.raw_events} />
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  attr :title, :string, required: true
+  attr :value, :string, required: true
+
+  def debug_block(assigns) do
+    ~H"""
+    <section class="min-w-0 rounded-box border border-base-content/10 bg-base-300/30 p-4">
+      <h3 class="text-sm font-medium">{@title}</h3>
+      <pre class="mt-3 max-h-[32rem] overflow-auto text-xs text-base-content/70"><code>{@value}</code></pre>
+    </section>
     """
   end
 
@@ -198,27 +187,14 @@ defmodule FavnView.Components.RunDetailPage do
     """
   end
 
-  attr :title, :string, required: true
-  attr :copy, :string, required: true
-
-  def placeholder_panel(assigns) do
-    ~H"""
-    <GlassPanel.glass_panel
-      class="mx-auto w-full max-w-3xl p-8 text-center"
-      data-testid="run-mode-placeholder"
-    >
-      <h2 class="text-xl font-medium tracking-tight">{@title}</h2>
-      <p class="mt-2 text-sm text-base-content/60">{@copy}</p>
-    </GlassPanel.glass_panel>
-    """
-  end
-
   def sample_run(status \\ :running) do
     %{
       found?: true,
       id: "run_01jrun_detail_sample",
+      raw_status: status,
+      active?: status in [:pending, :running],
       short_id: "run_01jrun_detail",
-      title: "Run run_01jrun_detail",
+      title: "run_01jrun_detail",
       subtitle: "FavnView.Assets.customer_orders_daily · Manual · window:day:2026-06-12",
       status: status_label(status),
       status_tone: status_tone(status),
@@ -230,21 +206,53 @@ defmodule FavnView.Components.RunDetailPage do
       duration: if(status == :running, do: "4.2 s", else: "4.0 s"),
       manifest_version_id: "mv_customer_orders",
       asset_results: sample_asset_results(status),
-      asset_result_groups:
-        sample_asset_results(status)
-        |> Enum.group_by(& &1.stage)
-        |> Enum.map(fn {stage, items} -> %{stage: stage, items: items} end),
       events: sample_events(status),
-      latest_events: sample_events(status)
+      latest_event_summary: "All selected assets completed successfully.",
+      current_activity: sample_current_activity(status),
+      failure_summary: sample_failure_summary(status),
+      asset_empty_message: sample_asset_empty_message(status),
+      outputs: [],
+      context: sample_context(),
+      back_asset_href: "/assets/t-sample",
+      raw_run: "%Favn.Run{...}",
+      raw_events: "[%Favn.RunEvent{...}]"
     }
   end
 
   def empty_run do
     sample_run(:running)
     |> Map.put(:asset_results, [])
-    |> Map.put(:asset_result_groups, [])
     |> Map.put(:events, [])
-    |> Map.put(:latest_events, [])
+    |> Map.put(:latest_event_summary, nil)
+    |> Map.put(:current_activity, "Waiting for first execution event...")
+    |> Map.put(:asset_empty_message, "Run accepted. Waiting for asset execution results...")
+  end
+
+  def sample_run_with_no_results(status) do
+    sample_run(status)
+    |> Map.put(:asset_results, [])
+    |> Map.put(:asset_empty_message, sample_asset_empty_message(status))
+    |> Map.put(:current_activity, sample_current_activity(status))
+    |> Map.put(:failure_summary, sample_no_result_failure_summary(status))
+  end
+
+  def sample_run_with_long_asset_names do
+    sample_run(:ok)
+    |> Map.put(:asset_results, [
+      %{
+        id: "long-asset-step",
+        asset_ref:
+          "FavnView.Assets.enterprise_revenue_operations.customer_orders_daily_with_extremely_long_asset_name_for_overflow_testing",
+        display_name: "customer_orders_daily_with_extremely_long_asset_name_for_overflow_testing",
+        secondary: "Stage 0",
+        status: "Succeeded",
+        status_tone: :success,
+        started_at: "Jun 12, 2026 14:00:00 UTC",
+        duration: "12.4 s",
+        error: nil,
+        inspectable?: true
+      }
+    ])
   end
 
   def not_found_run do
@@ -262,13 +270,45 @@ defmodule FavnView.Components.RunDetailPage do
   defp sample_asset_results(:running) do
     [
       %{
-        ref: "FavnView.Assets.customer_orders_daily",
-        stage: 0,
+        id: "run_01jrun_detail_sample-FavnView-Assets-customer_orders_daily",
+        asset_ref: "FavnView.Assets.customer_orders_daily",
+        display_name: "customer_orders_daily",
+        secondary: "Stage 0",
         status: "Running",
         status_tone: :info,
         started_at: "Jun 12, 2026 14:00:00 UTC",
         duration: "4.2 s",
-        error: nil
+        error: nil,
+        inspectable?: true
+      }
+    ]
+  end
+
+  defp sample_asset_results(:partial) do
+    [
+      %{
+        id: "run_01jrun_detail_sample-FavnView-Assets-raw_orders",
+        asset_ref: "FavnView.Assets.raw_orders",
+        display_name: "raw_orders",
+        secondary: "Stage 0",
+        status: "Succeeded",
+        status_tone: :success,
+        started_at: "Jun 12, 2026 14:00:00 UTC",
+        duration: "1.3 s",
+        error: nil,
+        inspectable?: true
+      },
+      %{
+        id: "run_01jrun_detail_sample-FavnView-Assets-customer_orders_daily",
+        asset_ref: "FavnView.Assets.customer_orders_daily",
+        display_name: "customer_orders_daily",
+        secondary: "Stage 1",
+        status: "Failed",
+        status_tone: :error,
+        started_at: "Jun 12, 2026 14:00:02 UTC",
+        duration: "2.1 s",
+        error: "Warehouse timeout",
+        inspectable?: true
       }
     ]
   end
@@ -276,22 +316,28 @@ defmodule FavnView.Components.RunDetailPage do
   defp sample_asset_results(:error) do
     [
       %{
-        ref: "FavnView.Assets.raw_orders",
-        stage: 0,
+        id: "run_01jrun_detail_sample-FavnView-Assets-raw_orders",
+        asset_ref: "FavnView.Assets.raw_orders",
+        display_name: "raw_orders",
+        secondary: "Stage 0",
         status: "Succeeded",
         status_tone: :success,
         started_at: "Jun 12, 2026 14:00:00 UTC",
         duration: "1.3 s",
-        error: nil
+        error: nil,
+        inspectable?: true
       },
       %{
-        ref: "FavnView.Assets.customer_orders_daily",
-        stage: 1,
+        id: "run_01jrun_detail_sample-FavnView-Assets-customer_orders_daily",
+        asset_ref: "FavnView.Assets.customer_orders_daily",
+        display_name: "customer_orders_daily",
+        secondary: "Stage 1",
         status: "Failed",
         status_tone: :error,
         started_at: "Jun 12, 2026 14:00:02 UTC",
         duration: "2.1 s",
-        error: "Warehouse timeout"
+        error: "Warehouse timeout",
+        inspectable?: true
       }
     ]
   end
@@ -299,22 +345,28 @@ defmodule FavnView.Components.RunDetailPage do
   defp sample_asset_results(_status) do
     [
       %{
-        ref: "FavnView.Assets.raw_orders",
-        stage: 0,
+        id: "run_01jrun_detail_sample-FavnView-Assets-raw_orders",
+        asset_ref: "FavnView.Assets.raw_orders",
+        display_name: "raw_orders",
+        secondary: "Stage 0",
         status: "Succeeded",
         status_tone: :success,
         started_at: "Jun 12, 2026 14:00:00 UTC",
         duration: "1.3 s",
-        error: nil
+        error: nil,
+        inspectable?: true
       },
       %{
-        ref: "FavnView.Assets.customer_orders_daily",
-        stage: 1,
+        id: "run_01jrun_detail_sample-FavnView-Assets-customer_orders_daily",
+        asset_ref: "FavnView.Assets.customer_orders_daily",
+        display_name: "customer_orders_daily",
+        secondary: "Stage 1",
         status: "Succeeded",
         status_tone: :success,
         started_at: "Jun 12, 2026 14:00:02 UTC",
         duration: "1.8 s",
-        error: nil
+        error: nil,
+        inspectable?: true
       }
     ]
   end
@@ -327,6 +379,7 @@ defmodule FavnView.Components.RunDetailPage do
         event_type: "Run started",
         status: "Running",
         status_tone: :info,
+        asset: nil,
         summary: "Run accepted by orchestrator"
       },
       %{
@@ -335,6 +388,7 @@ defmodule FavnView.Components.RunDetailPage do
         event_type: "Step failed",
         status: "Failed",
         status_tone: :error,
+        asset: "FavnView.Assets.customer_orders_daily",
         summary: "Asset FavnView.Assets.customer_orders_daily"
       },
       %{
@@ -343,6 +397,7 @@ defmodule FavnView.Components.RunDetailPage do
         event_type: "Run failed",
         status: "Failed",
         status_tone: :error,
+        asset: nil,
         summary: "Warehouse timeout"
       }
     ]
@@ -356,6 +411,7 @@ defmodule FavnView.Components.RunDetailPage do
         event_type: "Run started",
         status: "Running",
         status_tone: :info,
+        asset: nil,
         summary: "Run accepted by orchestrator"
       },
       %{
@@ -364,6 +420,7 @@ defmodule FavnView.Components.RunDetailPage do
         event_type: if(status == :running, do: "Step started", else: "Run finished"),
         status: status_label(status),
         status_tone: status_tone(status),
+        asset: if(status == :running, do: "FavnView.Assets.customer_orders_daily", else: nil),
         summary:
           if(status == :running,
             do: "Asset FavnView.Assets.customer_orders_daily",
@@ -375,13 +432,23 @@ defmodule FavnView.Components.RunDetailPage do
 
   defp run_modes do
     [
-      %{id: :overview, label: "Overview", icon: "hero-squares-2x2"},
-      %{id: :events, label: "Events", icon: "hero-clock"},
-      %{id: :assets, label: "Assets", icon: "hero-circle-stack"},
-      %{id: :output, label: "Output", icon: "hero-document-text"},
-      %{id: :debug, label: "Debug", icon: "hero-bug-ant"}
+      %{id: :overview, label: "Overview", icon: "hero-calendar-days"},
+      %{id: :events, label: "Events", icon: "hero-signal"},
+      %{id: :outputs, label: "Outputs", icon: "hero-circle-stack"},
+      %{id: :context, label: "Context", icon: "hero-book-open"},
+      %{id: :debug, label: "Debug", icon: "hero-code-bracket"}
     ]
   end
+
+  defp run_facts(%{found?: true} = run) do
+    [
+      %{label: "Started", value: run.started_at},
+      %{label: "Duration", value: run.duration},
+      %{label: "Triggered by", value: run.trigger}
+    ]
+  end
+
+  defp run_facts(_run), do: []
 
   defp page_title(%{found?: true, title: title}, _run_id), do: title
   defp page_title(_run, run_id), do: "Run #{short_id(run_id)}"
@@ -389,28 +456,68 @@ defmodule FavnView.Components.RunDetailPage do
   defp page_subtitle(%{found?: true, subtitle: subtitle}), do: subtitle
   defp page_subtitle(_run), do: "Run detail"
 
-  defp stage_label(nil), do: "Stage unknown"
-  defp stage_label(stage), do: "Stage #{stage}"
+  defp sample_context do
+    [
+      %{label: "Run ID", value: "run_01jrun_detail_sample"},
+      %{label: "Manifest version", value: "mv_customer_orders"},
+      %{label: "Trigger", value: "Manual"},
+      %{label: "Window", value: "window:day:2026-06-12"}
+    ]
+  end
+
+  defp sample_current_activity(status) when status in [:pending, :running],
+    do: "Currently executing FavnView.Assets.customer_orders_daily"
+
+  defp sample_current_activity(_status), do: nil
+
+  defp sample_failure_summary(status) when status in [:error, :timed_out] do
+    %{
+      count: 1,
+      total: 2,
+      asset: "FavnView.Assets.customer_orders_daily",
+      error: "Warehouse timeout"
+    }
+  end
+
+  defp sample_failure_summary(_status), do: nil
+
+  defp sample_no_result_failure_summary(status) when status in [:error, :timed_out] do
+    %{count: 0, total: 0, asset: nil, error: "Warehouse timeout"}
+  end
+
+  defp sample_no_result_failure_summary(_status), do: nil
+
+  defp sample_asset_empty_message(status) when status in [:pending, :running],
+    do: "Run accepted. Waiting for asset execution results..."
+
+  defp sample_asset_empty_message(:ok),
+    do: "Run completed, but no asset results were persisted."
+
+  defp sample_asset_empty_message(status) when status in [:error, :timed_out],
+    do: "Run failed before asset results were persisted. Latest error: Warehouse timeout"
+
+  defp sample_asset_empty_message(_status), do: "No asset results persisted for this run yet."
 
   defp status_label(:ok), do: "Succeeded"
+  defp status_label(:pending), do: "Pending"
   defp status_label(:running), do: "Running"
   defp status_label(:error), do: "Failed"
   defp status_label(:partial), do: "Partial"
+  defp status_label(:cancelled), do: "Cancelled"
+  defp status_label(:timed_out), do: "Timed out"
+  defp status_label(nil), do: "Unknown"
 
   defp status_label(status),
     do: status |> to_string() |> String.replace("_", " ") |> String.capitalize()
 
   defp status_tone(:ok), do: :success
+  defp status_tone(:pending), do: :info
   defp status_tone(:running), do: :info
   defp status_tone(:error), do: :error
+  defp status_tone(:timed_out), do: :error
   defp status_tone(:partial), do: :warning
+  defp status_tone(:cancelled), do: :neutral
   defp status_tone(_status), do: :neutral
-
-  defp badge_class(:success), do: "badge-success"
-  defp badge_class(:info), do: "badge-info"
-  defp badge_class(:warning), do: "badge-warning"
-  defp badge_class(:error), do: "badge-error"
-  defp badge_class(_tone), do: "badge-neutral"
 
   defp short_id(id) when is_binary(id) and byte_size(id) > 18, do: String.slice(id, 0, 18)
   defp short_id(id), do: to_string(id)

--- a/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
+++ b/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
@@ -1,0 +1,164 @@
+defmodule FavnView.Components.RunOverviewHud do
+  @moduledoc """
+  Calm operator-facing overview HUD for a single run.
+  """
+
+  use FavnView, :html
+
+  alias FavnView.Components.GlassPanel
+
+  attr :run, :map, required: true
+
+  def run_overview_hud(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel
+      class="mx-auto w-full max-w-6xl p-5 sm:p-6 lg:p-7"
+      data-testid="run-overview-panel"
+      data-run-active={to_string(@run.active?)}
+    >
+      <div class="flex flex-col gap-7">
+        <div class="flex flex-col gap-4 lg:flex-row lg:items-center">
+          <div class="min-w-[10rem]">
+            <p class="text-sm font-semibold text-base-content">Run status</p>
+            <div class={["mt-3 flex items-center gap-3", status_text_class(@run.status_tone)]}>
+              <.icon name={status_icon(@run.status_tone)} class="size-7" />
+              <p class="text-2xl font-medium tracking-tight">{@run.status}</p>
+            </div>
+          </div>
+          <p class="text-sm text-base-content/65">{status_sentence(@run.status)}</p>
+        </div>
+
+        <div
+          :if={@run.failure_summary}
+          class="rounded-box border border-error/25 bg-error/10 p-4 text-sm text-base-content/80"
+          data-testid="run-failure-summary"
+        >
+          <p
+            :if={@run.failure_summary.count > 0 && @run.failure_summary.total > 0}
+            class="font-medium text-error"
+          >
+            {@run.failure_summary.count} of {@run.failure_summary.total} assets failed.
+          </p>
+          <p :if={@run.failure_summary.asset} class="mt-1">
+            <span class="text-base-content/55">Failed asset:</span> {@run.failure_summary.asset}
+          </p>
+          <p :if={@run.failure_summary.error} class="mt-1">
+            <span class="text-base-content/55">Error:</span> {@run.failure_summary.error}
+          </p>
+        </div>
+
+        <div
+          :if={@run.current_activity}
+          class="rounded-box border border-info/20 bg-info/10 p-4 text-sm text-info-content/80"
+          data-testid="run-current-activity"
+        >
+          {@run.current_activity}
+        </div>
+
+        <div class="border-t border-base-content/10 pt-5" data-testid="run-asset-results">
+          <div class="grid grid-cols-[1fr_10rem_8rem_10rem_2rem] gap-4 px-4 pb-3 text-sm text-base-content/60 max-lg:hidden">
+            <span>Asset</span>
+            <span>Status</span>
+            <span>Duration</span>
+            <span>Started</span>
+            <span class="sr-only">Inspect</span>
+          </div>
+
+          <div
+            :if={@run.asset_results == []}
+            class="rounded-box border border-dashed border-base-content/15 p-5 text-sm text-base-content/55"
+            data-testid="run-asset-results-empty"
+          >
+            {@run.asset_empty_message}
+          </div>
+
+          <div :if={@run.asset_results != []} class="space-y-2">
+            <.asset_result_row :for={asset <- @run.asset_results} asset={asset} run_id={@run.id} />
+          </div>
+        </div>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  attr :asset, :map, required: true
+  attr :run_id, :string, required: true
+
+  def asset_result_row(assigns) do
+    ~H"""
+    <div
+      class={[
+        "group grid gap-3 rounded-box border bg-base-content/[0.025] p-4 transition hover:border-primary/35 hover:bg-primary/[0.045] hover:shadow-lg hover:shadow-primary/10 lg:grid-cols-[1fr_10rem_8rem_10rem_2rem] lg:items-center",
+        row_border_class(@asset.status_tone)
+      ]}
+      data-testid="run-asset-result-row"
+      data-run-id={@run_id}
+      data-asset-step-id={@asset.id}
+      role={if(@asset.inspectable?, do: "button", else: nil)}
+      tabindex={if(@asset.inspectable?, do: "0", else: nil)}
+    >
+      <div class="flex min-w-0 items-center gap-3">
+        <span class={[
+          "flex size-9 shrink-0 items-center justify-center rounded-box",
+          icon_shell_class(@asset.status_tone)
+        ]}>
+          <.icon name="hero-table-cells" class="size-5" />
+        </span>
+        <div class="min-w-0">
+          <p class="truncate text-sm font-medium text-base-content">{@asset.display_name}</p>
+          <p class="truncate font-mono text-xs text-base-content/45">{@asset.asset_ref}</p>
+          <p :if={@asset.secondary} class="text-xs text-base-content/50">{@asset.secondary}</p>
+          <p :if={@asset.error} class="mt-1 text-xs text-error">{@asset.error}</p>
+        </div>
+      </div>
+
+      <div class="flex items-center gap-2 text-sm font-medium">
+        <.icon
+          name={status_icon(@asset.status_tone)}
+          class={["size-4", status_text_class(@asset.status_tone)]}
+        />
+        <span class={status_text_class(@asset.status_tone)}>{@asset.status}</span>
+      </div>
+
+      <p class="text-sm text-base-content/85">{@asset.duration}</p>
+      <p class="text-sm text-base-content/70">{@asset.started_at}</p>
+      <%!-- TODO: Attach /runs/:run_id/assets/:asset_step_id navigation here once that route and ID contract exist. --%>
+      <.icon
+        :if={@asset.inspectable?}
+        name="hero-chevron-right"
+        class="size-5 text-base-content/60 transition group-hover:text-primary"
+      />
+    </div>
+    """
+  end
+
+  defp status_sentence("Succeeded"), do: "All selected assets completed successfully."
+  defp status_sentence("Running"), do: "Run is currently executing."
+  defp status_sentence("Pending"), do: "Run is queued for execution."
+  defp status_sentence("Failed"), do: "One or more assets failed."
+  defp status_sentence("Partial"), do: "Run completed with partial results."
+  defp status_sentence("Cancelled"), do: "Run was cancelled."
+  defp status_sentence("Timed out"), do: "One or more assets timed out."
+  defp status_sentence(_status), do: "Run status is not known yet."
+
+  defp status_icon(:success), do: "hero-check-circle"
+  defp status_icon(:info), do: "hero-arrow-path"
+  defp status_icon(:warning), do: "hero-exclamation-triangle"
+  defp status_icon(:error), do: "hero-x-circle"
+  defp status_icon(_tone), do: "hero-minus-circle"
+
+  defp status_text_class(:success), do: "text-success"
+  defp status_text_class(:info), do: "text-info"
+  defp status_text_class(:warning), do: "text-warning"
+  defp status_text_class(:error), do: "text-error"
+  defp status_text_class(_tone), do: "text-base-content/60"
+
+  defp icon_shell_class(:success), do: "bg-success/15 text-success"
+  defp icon_shell_class(:info), do: "bg-info/15 text-info"
+  defp icon_shell_class(:warning), do: "bg-warning/15 text-warning"
+  defp icon_shell_class(:error), do: "bg-error/15 text-error"
+  defp icon_shell_class(_tone), do: "bg-base-content/10 text-base-content/60"
+
+  defp row_border_class(:error), do: "border-error/40 shadow-error/10 shadow-lg"
+  defp row_border_class(_tone), do: "border-base-content/10"
+end

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -5,20 +5,38 @@ defmodule FavnView.RunDetailLive do
 
   alias FavnView.Components.AssetCataloguePage
   alias FavnView.Components.RunDetailPage
+  alias FavnView.AssetRoute
 
-  @valid_modes ~w(overview events assets output debug)
+  @refresh_interval_ms 1_500
+  @active_statuses [:pending, :running]
+  @valid_modes ~w(overview events outputs context debug)
 
   @impl true
   def mount(%{"run_id" => run_id}, _session, socket) do
+    run = load_run(run_id)
+
     socket =
       assign(socket,
         run_id: run_id,
-        run: load_run(run_id),
+        run: run,
         active_mode: :overview,
         nav_items: AssetCataloguePage.nav_items(:runs)
       )
+      |> maybe_schedule_refresh()
 
     {:ok, socket}
+  end
+
+  @impl true
+  def handle_info(:refresh_run, socket) do
+    run = load_run(socket.assigns.run_id)
+
+    socket =
+      socket
+      |> assign(:run, run)
+      |> maybe_schedule_refresh()
+
+    {:noreply, socket}
   end
 
   @impl true
@@ -56,15 +74,20 @@ defmodule FavnView.RunDetailLive do
     target = target_label(Map.get(run, :asset_ref), Map.get(run, :target_refs, []))
     trigger = trigger_label(Map.get(run, :trigger, %{}), Map.get(run, :submit_kind))
     window = window_label(Map.get(run, :params, %{}), Map.get(run, :metadata, %{}))
-    asset_results = asset_results(Map.get(run, :asset_results, %{}))
+    asset_results = asset_results(Map.get(run, :asset_results, %{}), run.id)
     event_items = event_items(events)
+    back_asset_href = back_asset_href(Map.get(run, :asset_ref))
+    failure_summary = failure_summary(status, asset_results, event_items)
+    current_activity = current_activity(status, asset_results, event_items)
 
     %{
       found?: true,
       id: run.id,
+      raw_status: status,
+      active?: active_status?(status),
       short_id: short_id(run.id),
-      title: "Run #{short_id(run.id)}",
-      subtitle: subtitle([target, trigger, window]),
+      title: short_id(run.id),
+      subtitle: subtitle([target, window]),
       status: status_label(status),
       status_tone: status_tone(status),
       target: target || "No target",
@@ -75,36 +98,60 @@ defmodule FavnView.RunDetailLive do
       duration: duration_label(started_at, finished_at),
       manifest_version_id: run.manifest_version_id || "Unknown",
       asset_results: asset_results,
-      asset_result_groups: asset_result_groups(asset_results),
       events: event_items,
-      latest_events: Enum.take(Enum.reverse(event_items), 8)
+      latest_event_summary: latest_event_summary(event_items),
+      current_activity: current_activity,
+      failure_summary: failure_summary,
+      asset_empty_message: asset_empty_message(status, failure_summary),
+      outputs: outputs(asset_results),
+      context: context_items(run, target, trigger, window),
+      back_asset_href: back_asset_href,
+      raw_run: inspect(run, pretty: true, limit: :infinity),
+      raw_events: inspect(events, pretty: true, limit: :infinity)
     }
   end
 
-  defp asset_results(results) when is_map(results) do
-    results
-    |> Map.values()
-    |> Enum.map(fn result ->
-      %{
-        ref: ref_label(Map.get(result, :ref)),
-        stage: Map.get(result, :stage),
-        status: status_label(Map.get(result, :status)),
-        status_tone: status_tone(Map.get(result, :status)),
-        started_at: timestamp_label(Map.get(result, :started_at)),
-        duration: duration_ms_label(Map.get(result, :duration_ms)),
-        error: error_summary(Map.get(result, :error))
-      }
-    end)
-    |> Enum.sort_by(&{&1.stage || 0, &1.ref})
+  defp maybe_schedule_refresh(%{assigns: %{run: %{active?: true}}} = socket) do
+    if connected?(socket), do: Process.send_after(self(), :refresh_run, @refresh_interval_ms)
+
+    socket
   end
 
-  defp asset_results(_results), do: []
+  defp maybe_schedule_refresh(socket), do: socket
 
-  defp asset_result_groups(results) do
+  defp active_status?(status),
+    do: status in @active_statuses or status in Enum.map(@active_statuses, &to_string/1)
+
+  defp asset_results(results, run_id) when is_map(results) do
     results
-    |> Enum.group_by(& &1.stage)
-    |> Enum.sort_by(fn {stage, _items} -> stage || 0 end)
-    |> Enum.map(fn {stage, items} -> %{stage: stage, items: items} end)
+    |> Enum.map(fn {key, result} -> asset_result(result, run_id, key) end)
+    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
+  end
+
+  defp asset_results(results, run_id) when is_list(results) do
+    results
+    |> Enum.map(&asset_result(&1, run_id, nil))
+    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
+  end
+
+  defp asset_results(_results, _run_id), do: []
+
+  defp asset_result(result, run_id, key) do
+    asset_ref = ref_label(Map.get(result, :ref) || key)
+
+    %{
+      id: asset_step_id(result, run_id, key, asset_ref),
+      asset_ref: asset_ref,
+      display_name: display_name(asset_ref),
+      secondary: asset_secondary(result),
+      status: status_label(Map.get(result, :status)),
+      status_tone: status_tone(Map.get(result, :status)),
+      duration: duration_ms_label(Map.get(result, :duration_ms)),
+      started_at: timestamp_label(Map.get(result, :started_at)),
+      error: error_summary(Map.get(result, :error)),
+      output: output_metadata(result),
+      inspectable?: true
+    }
   end
 
   defp event_items(events) when is_list(events) do
@@ -112,10 +159,12 @@ defmodule FavnView.RunDetailLive do
     |> Enum.map(fn event ->
       %{
         sequence: Map.get(event, :sequence),
+        raw_status: Map.get(event, :status),
         timestamp: timestamp_label(Map.get(event, :occurred_at)),
         event_type: event_type_label(Map.get(event, :event_type)),
         status: status_label(Map.get(event, :status)),
         status_tone: status_tone(Map.get(event, :status)),
+        asset: event_asset(event),
         summary: event_summary(event)
       }
     end)
@@ -132,6 +181,21 @@ defmodule FavnView.RunDetailLive do
   defp target_label(nil, []), do: nil
   defp target_label(nil, refs), do: refs |> Enum.map(&ref_label/1) |> Enum.join(", ")
   defp target_label(ref, _refs), do: ref_label(ref)
+
+  defp back_asset_href(nil), do: nil
+
+  defp back_asset_href(ref) do
+    ref_string = ref_label(ref)
+
+    with {:ok, entries} <- FavnOrchestrator.active_asset_catalogue(),
+         entry when not is_nil(entry) <-
+           Enum.find(entries, fn entry -> ref_label(Map.get(entry, :asset_ref)) == ref_string end),
+         target_id when is_binary(target_id) <- Map.get(entry, :target_id) do
+      "/assets/#{AssetRoute.to_param(target_id)}"
+    else
+      _other -> nil
+    end
+  end
 
   defp trigger_label(%{kind: kind}, _submit_kind), do: humanize(kind)
   defp trigger_label(%{"kind" => kind}, _submit_kind), do: humanize(kind)
@@ -164,13 +228,13 @@ defmodule FavnView.RunDetailLive do
   defp ref_label(ref) when is_binary(ref), do: ref
   defp ref_label(ref), do: inspect(ref)
 
-  defp status_label(:ok), do: "Succeeded"
-  defp status_label(:running), do: "Running"
-  defp status_label(:pending), do: "Pending"
-  defp status_label(:partial), do: "Partial"
-  defp status_label(:error), do: "Failed"
-  defp status_label(:cancelled), do: "Cancelled"
-  defp status_label(:timed_out), do: "Timed out"
+  defp status_label(status) when status in [:ok, "ok"], do: "Succeeded"
+  defp status_label(status) when status in [:running, "running"], do: "Running"
+  defp status_label(status) when status in [:pending, "pending"], do: "Pending"
+  defp status_label(status) when status in [:partial, "partial"], do: "Partial"
+  defp status_label(status) when status in [:error, "error"], do: "Failed"
+  defp status_label(status) when status in [:cancelled, "cancelled"], do: "Cancelled"
+  defp status_label(status) when status in [:timed_out, "timed_out"], do: "Timed out"
   defp status_label(nil), do: "Unknown"
   defp status_label(status), do: humanize(status)
 
@@ -224,6 +288,128 @@ defmodule FavnView.RunDetailLive do
       ref -> "Asset #{ref_label(ref)}"
     end
   end
+
+  defp event_asset(event) do
+    case Map.get(event, :asset_ref) do
+      nil -> nil
+      ref -> ref_label(ref)
+    end
+  end
+
+  defp latest_event_summary([]), do: nil
+  defp latest_event_summary(events), do: events |> List.last() |> Map.get(:summary)
+
+  defp failure_summary(status, asset_results, events)
+       when status in [:partial, :error, :timed_out, "partial", "error", "timed_out"] do
+    failed_assets = Enum.filter(asset_results, &(&1.status_tone == :error))
+    failed_asset = List.first(failed_assets)
+    error_event = latest_error_event(events)
+
+    %{
+      count: length(failed_assets),
+      total: length(asset_results),
+      asset: failed_asset && failed_asset.asset_ref,
+      error: (failed_asset && failed_asset.error) || (error_event && error_event.summary)
+    }
+  end
+
+  defp failure_summary(_status, _asset_results, _events), do: nil
+
+  defp latest_error_event(events) do
+    Enum.find(Enum.reverse(events), fn event ->
+      event.status_tone == :error or
+        event.raw_status in [:error, :timed_out, "error", "timed_out"]
+    end)
+  end
+
+  defp current_activity(status, asset_results, events)
+       when status in [:pending, :running, "pending", "running"] do
+    running_asset = Enum.find(asset_results, &(&1.status == "Running"))
+    latest_event = List.last(events)
+
+    cond do
+      running_asset -> "Currently executing #{running_asset.asset_ref}"
+      latest_event && latest_event.asset -> "Latest event: #{latest_event.asset}"
+      latest_event -> "Latest event: #{latest_event.summary}"
+      true -> "Waiting for first execution event..."
+    end
+  end
+
+  defp current_activity(_status, _asset_results, _events), do: nil
+
+  defp asset_empty_message(status, _failure_summary)
+       when status in [:pending, :running, "pending", "running"],
+       do: "Run accepted. Waiting for asset execution results..."
+
+  defp asset_empty_message(status, _failure_summary) when status in [:ok, "ok"],
+    do: "Run completed, but no asset results were persisted."
+
+  defp asset_empty_message(status, %{error: error})
+       when status in [:error, :timed_out, "error", "timed_out"] and is_binary(error),
+       do: "Run failed before asset results were persisted. Latest error: #{error}"
+
+  defp asset_empty_message(status, _failure_summary)
+       when status in [:error, :timed_out, "error", "timed_out"],
+       do: "Run failed before asset results were persisted."
+
+  defp asset_empty_message(_status, _failure_summary),
+    do: "No asset results persisted for this run yet."
+
+  defp asset_step_id(result, run_id, key, asset_ref) do
+    Map.get(result, :id) || Map.get(result, "id") || Map.get(result, :step_id) ||
+      Map.get(result, "step_id") || persisted_key_id(key, asset_ref) ||
+      deterministic_step_id(run_id, asset_ref)
+  end
+
+  defp persisted_key_id(nil, _asset_ref), do: nil
+  defp persisted_key_id(key, asset_ref) when is_binary(key) and key != asset_ref, do: safe_id(key)
+  defp persisted_key_id(_key, _asset_ref), do: nil
+
+  defp deterministic_step_id(run_id, asset_ref), do: safe_id("#{run_id}:#{asset_ref}")
+
+  defp safe_id(value), do: value |> to_string() |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
+
+  defp display_name(asset_ref), do: asset_ref |> String.split(".") |> List.last()
+
+  defp asset_secondary(result) do
+    result
+    |> Map.get(:stage)
+    |> case do
+      nil -> nil
+      stage -> "Stage #{stage}"
+    end
+  end
+
+  defp output_metadata(result) do
+    meta = Map.get(result, :meta, %{}) || %{}
+
+    Map.get(meta, :output) || Map.get(meta, "output") || Map.get(meta, :outputs) ||
+      Map.get(meta, "outputs") || Map.get(meta, :materialization) ||
+      Map.get(meta, "materialization")
+  end
+
+  defp outputs(asset_results) do
+    asset_results
+    |> Enum.filter(& &1.output)
+    |> Enum.map(fn asset ->
+      %{asset: asset.asset_ref, output: inspect(asset.output, pretty: true)}
+    end)
+  end
+
+  defp context_items(run, target, trigger, window) do
+    [
+      %{label: "Run ID", value: run.id},
+      %{label: "Manifest version", value: run.manifest_version_id || "Unknown"},
+      %{label: "Target", value: target || "No target"},
+      %{label: "Trigger", value: trigger || "Manual"},
+      %{label: "Window", value: window || "No window metadata"},
+      %{label: "Submit kind", value: submit_kind_label(Map.get(run, :submit_kind))},
+      %{label: "Replay mode", value: submit_kind_label(Map.get(run, :replay_mode))}
+    ]
+  end
+
+  defp submit_kind_label(nil), do: "Unknown"
+  defp submit_kind_label(value), do: humanize(value)
 
   defp status_summary(nil), do: nil
   defp status_summary(status), do: "Status #{status_label(status)}"

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -29,7 +29,7 @@ defmodule FavnView.RunDetailLive do
 
   @impl true
   def handle_info(:refresh_run, socket) do
-    run = load_run(socket.assigns.run_id)
+    run = load_run(socket.assigns.run_id, socket.assigns.run[:back_asset_href])
 
     socket =
       socket
@@ -58,25 +58,25 @@ defmodule FavnView.RunDetailLive do
     """
   end
 
-  defp load_run(run_id) do
+  defp load_run(run_id, back_asset_href \\ nil) do
     with {:ok, run} <- FavnOrchestrator.get_run(run_id),
          {:ok, events} <- FavnOrchestrator.list_run_events(run_id) do
-      run_from_public(run, events)
+      run_from_public(run, events, back_asset_href)
     else
       {:error, reason} -> %{id: run_id, found?: false, error: error_label(reason)}
     end
   end
 
-  defp run_from_public(run, events) do
+  defp run_from_public(run, events, existing_back_asset_href) do
     started_at = Map.get(run, :started_at)
     finished_at = Map.get(run, :finished_at)
     status = Map.get(run, :status)
     target = target_label(Map.get(run, :asset_ref), Map.get(run, :target_refs, []))
     trigger = trigger_label(Map.get(run, :trigger, %{}), Map.get(run, :submit_kind))
     window = window_label(Map.get(run, :params, %{}), Map.get(run, :metadata, %{}))
-    asset_results = asset_results(Map.get(run, :asset_results, %{}), run.id)
+    asset_results = run_step_results(run, run.id)
     event_items = event_items(events)
-    back_asset_href = back_asset_href(Map.get(run, :asset_ref))
+    back_asset_href = existing_back_asset_href || back_asset_href(Map.get(run, :asset_ref))
     failure_summary = failure_summary(status, asset_results, event_items)
     current_activity = current_activity(status, asset_results, event_items)
 
@@ -106,8 +106,8 @@ defmodule FavnView.RunDetailLive do
       outputs: outputs(asset_results),
       context: context_items(run, target, trigger, window),
       back_asset_href: back_asset_href,
-      raw_run: inspect(run, pretty: true, limit: :infinity),
-      raw_events: inspect(events, pretty: true, limit: :infinity)
+      raw_run: debug_inspect(run),
+      raw_events: debug_inspect(events)
     }
   end
 
@@ -121,6 +121,48 @@ defmodule FavnView.RunDetailLive do
 
   defp active_status?(status),
     do: status in @active_statuses or status in Enum.map(@active_statuses, &to_string/1)
+
+  defp run_step_results(run, run_id) do
+    node_results = node_results(Map.get(run, :node_results, %{}), run_id)
+
+    if node_results == [] do
+      asset_results(Map.get(run, :asset_results, %{}), run_id)
+    else
+      node_results
+    end
+  end
+
+  defp node_results(results, run_id) when is_map(results) do
+    results
+    |> Enum.map(fn {key, result} -> node_result(result, run_id, key) end)
+    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
+  end
+
+  defp node_results(results, run_id) when is_list(results) do
+    results
+    |> Enum.map(&node_result(&1, run_id, node_key(&1)))
+    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
+  end
+
+  defp node_results(_results, _run_id), do: []
+
+  defp node_result(result, run_id, node_key) do
+    asset_ref = ref_label(Map.get(result, :ref) || node_asset_ref(node_key))
+
+    %{
+      id: node_step_id(result, run_id, node_key, asset_ref),
+      asset_ref: asset_ref,
+      display_name: display_name(asset_ref),
+      secondary: node_secondary(result),
+      status: status_label(Map.get(result, :status)),
+      status_tone: status_tone(Map.get(result, :status)),
+      duration: duration_ms_label(Map.get(result, :duration_ms)),
+      started_at: timestamp_label(Map.get(result, :started_at)),
+      error: error_summary(Map.get(result, :error) || Map.get(result, :reason)),
+      output: output_metadata(result),
+      inspectable?: true
+    }
+  end
 
   defp asset_results(results, run_id) when is_map(results) do
     results
@@ -230,19 +272,30 @@ defmodule FavnView.RunDetailLive do
 
   defp status_label(status) when status in [:ok, "ok"], do: "Succeeded"
   defp status_label(status) when status in [:running, "running"], do: "Running"
+  defp status_label(status) when status in [:retrying, "retrying"], do: "Retrying"
   defp status_label(status) when status in [:pending, "pending"], do: "Pending"
   defp status_label(status) when status in [:partial, "partial"], do: "Partial"
   defp status_label(status) when status in [:error, "error"], do: "Failed"
+  defp status_label(status) when status in [:blocked, "blocked"], do: "Blocked"
   defp status_label(status) when status in [:cancelled, "cancelled"], do: "Cancelled"
+  defp status_label(status) when status in [:skipped_fresh, "skipped_fresh"], do: "Skipped fresh"
   defp status_label(status) when status in [:timed_out, "timed_out"], do: "Timed out"
   defp status_label(nil), do: "Unknown"
   defp status_label(status), do: humanize(status)
 
   defp status_tone(status) when status in [:ok, "ok"], do: :success
-  defp status_tone(status) when status in [:running, :pending, "running", "pending"], do: :info
+
+  defp status_tone(status)
+       when status in [:running, :pending, :retrying, "running", "pending", "retrying"], do: :info
+
   defp status_tone(status) when status in [:partial, "partial"], do: :warning
-  defp status_tone(status) when status in [:error, :timed_out, "error", "timed_out"], do: :error
-  defp status_tone(status) when status in [:cancelled, "cancelled"], do: :neutral
+
+  defp status_tone(status)
+       when status in [:error, :timed_out, :blocked, "error", "timed_out", "blocked"], do: :error
+
+  defp status_tone(status)
+       when status in [:cancelled, :skipped_fresh, "cancelled", "skipped_fresh"], do: :neutral
+
   defp status_tone(_status), do: :neutral
 
   defp timestamp_label(%DateTime{} = value),
@@ -355,6 +408,12 @@ defmodule FavnView.RunDetailLive do
   defp asset_empty_message(_status, _failure_summary),
     do: "No asset results persisted for this run yet."
 
+  defp node_step_id(result, run_id, node_key, asset_ref) do
+    Map.get(result, :id) || Map.get(result, "id") || Map.get(result, :step_id) ||
+      Map.get(result, "step_id") || persisted_key_id(node_key, asset_ref) ||
+      deterministic_step_id(run_id, asset_ref)
+  end
+
   defp asset_step_id(result, run_id, key, asset_ref) do
     Map.get(result, :id) || Map.get(result, "id") || Map.get(result, :step_id) ||
       Map.get(result, "step_id") || persisted_key_id(key, asset_ref) ||
@@ -363,6 +422,10 @@ defmodule FavnView.RunDetailLive do
 
   defp persisted_key_id(nil, _asset_ref), do: nil
   defp persisted_key_id(key, asset_ref) when is_binary(key) and key != asset_ref, do: safe_id(key)
+
+  defp persisted_key_id(key, _asset_ref) when is_tuple(key),
+    do: safe_id(:erlang.term_to_binary(key) |> Base.url_encode64(padding: false))
+
   defp persisted_key_id(_key, _asset_ref), do: nil
 
   defp deterministic_step_id(run_id, asset_ref), do: safe_id("#{run_id}:#{asset_ref}")
@@ -379,6 +442,40 @@ defmodule FavnView.RunDetailLive do
       stage -> "Stage #{stage}"
     end
   end
+
+  defp node_secondary(result) do
+    [
+      window_secondary(Map.get(result, :window)),
+      freshness_secondary(Map.get(result, :freshness_key)),
+      reason_secondary(Map.get(result, :reason)),
+      asset_secondary(result)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+    |> case do
+      "" -> nil
+      secondary -> secondary
+    end
+  end
+
+  defp window_secondary(nil), do: nil
+  defp window_secondary(%{label: label}) when is_binary(label), do: label
+  defp window_secondary(%{"label" => label}) when is_binary(label), do: label
+  defp window_secondary(%{id: id}) when is_binary(id), do: id
+  defp window_secondary(%{"id" => id}) when is_binary(id), do: id
+  defp window_secondary(window), do: "Window #{inspect(window, limit: 5)}"
+
+  defp freshness_secondary(nil), do: nil
+  defp freshness_secondary(key), do: "Freshness #{key}"
+
+  defp reason_secondary(nil), do: nil
+  defp reason_secondary(reason) when reason in [:fresh, "fresh"], do: "Fresh"
+  defp reason_secondary(reason), do: humanize(reason)
+
+  defp node_key(result), do: Map.get(result, :node_key) || Map.get(result, "node_key")
+
+  defp node_asset_ref({ref, _window}) when is_tuple(ref), do: ref
+  defp node_asset_ref(_node_key), do: nil
 
   defp output_metadata(result) do
     meta = Map.get(result, :meta, %{}) || %{}
@@ -411,13 +508,23 @@ defmodule FavnView.RunDetailLive do
   defp submit_kind_label(nil), do: "Unknown"
   defp submit_kind_label(value), do: humanize(value)
 
+  defp debug_inspect(value), do: inspect(value, pretty: true, limit: 50, printable_limit: 2_000)
+
   defp status_summary(nil), do: nil
   defp status_summary(status), do: "Status #{status_label(status)}"
 
   defp error_summary(nil), do: nil
   defp error_summary(%{message: message}) when is_binary(message), do: message
   defp error_summary(%{"message" => message}) when is_binary(message), do: message
-  defp error_summary(error), do: inspect(error)
+  defp error_summary(%{reason: reason}), do: error_reason_summary(reason)
+  defp error_summary(%{"reason" => reason}), do: error_reason_summary(reason)
+  defp error_summary(reason) when is_binary(reason), do: reason
+  defp error_summary(reason) when is_atom(reason), do: humanize(reason)
+  defp error_summary(_error), do: "Execution error"
+
+  defp error_reason_summary(reason) when is_binary(reason), do: reason
+  defp error_reason_summary(reason) when is_atom(reason), do: humanize(reason)
+  defp error_reason_summary(reason), do: inspect(reason, limit: 5, printable_limit: 200)
 
   defp humanize(value) when is_atom(value), do: value |> Atom.to_string() |> humanize()
 

--- a/apps/favn_view/storybook/components/run_detail_page.story.exs
+++ b/apps/favn_view/storybook/components/run_detail_page.story.exs
@@ -12,15 +12,7 @@ defmodule FavnView.Storybook.Components.RunDetailPage do
   def variations do
     [
       %Variation{
-        id: :running_run,
-        attributes: %{
-          run: RunDetailPage.sample_run(:running),
-          run_id: "run_01jrun_detail_sample",
-          nav_items: RunDetailPage.sample_nav_items()
-        }
-      },
-      %Variation{
-        id: :succeeded_with_asset_results,
+        id: :succeeded_with_asset_rows,
         attributes: %{
           run: RunDetailPage.sample_run(:ok),
           run_id: "run_01jrun_detail_sample",
@@ -28,7 +20,23 @@ defmodule FavnView.Storybook.Components.RunDetailPage do
         }
       },
       %Variation{
-        id: :failed_with_event_timeline,
+        id: :running_no_asset_results,
+        attributes: %{
+          run: RunDetailPage.empty_run(),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :running_with_partial_asset_results,
+        attributes: %{
+          run: RunDetailPage.sample_run(:running),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :failed_with_asset_error,
         attributes: %{
           run: RunDetailPage.sample_run(:error),
           run_id: "run_01jrun_detail_sample",
@@ -36,9 +44,41 @@ defmodule FavnView.Storybook.Components.RunDetailPage do
         }
       },
       %Variation{
-        id: :empty_no_events,
+        id: :failed_no_asset_results_error_event,
         attributes: %{
-          run: RunDetailPage.empty_run(),
+          run: RunDetailPage.sample_run_with_no_results(:error),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :partial_run,
+        attributes: %{
+          run: RunDetailPage.sample_run(:partial),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :cancelled_run,
+        attributes: %{
+          run: RunDetailPage.sample_run(:cancelled),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :timed_out_run,
+        attributes: %{
+          run: RunDetailPage.sample_run(:timed_out),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
+        id: :long_asset_names,
+        attributes: %{
+          run: RunDetailPage.sample_run_with_long_asset_names(),
           run_id: "run_01jrun_detail_sample",
           nav_items: RunDetailPage.sample_nav_items()
         }

--- a/apps/favn_view/storybook/components/run_detail_page.story.exs
+++ b/apps/favn_view/storybook/components/run_detail_page.story.exs
@@ -84,6 +84,14 @@ defmodule FavnView.Storybook.Components.RunDetailPage do
         }
       },
       %Variation{
+        id: :node_statuses,
+        attributes: %{
+          run: RunDetailPage.sample_run_with_node_statuses(),
+          run_id: "run_01jrun_detail_sample",
+          nav_items: RunDetailPage.sample_nav_items()
+        }
+      },
+      %Variation{
         id: :not_found,
         attributes: %{
           run: RunDetailPage.not_found_run(),

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -6,6 +6,7 @@ defmodule FavnView.PageLiveTest do
   alias Favn.Manifest
   alias Favn.Manifest.Version
   alias Favn.Run.AssetResult
+  alias Favn.Run.NodeResult
   alias Favn.Window.Spec, as: WindowSpec
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
@@ -28,6 +29,8 @@ defmodule FavnView.PageLiveTest do
 
     assert :ok =
              Storage.put_run(empty_run_state(:stg_payments, :error, "run_failed_empty"))
+
+    assert :ok = Storage.put_run(node_results_run_state())
 
     seed_run_events!("run_customer_orders_daily")
     seed_run_events!("run_failed_empty", :error)
@@ -210,6 +213,21 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="run-asset-results"]), "customer_orders_daily")
     assert has_element?(view, ~s([data-testid="run-asset-results"]), "Stage 0")
     assert has_element?(view, ~s([data-testid="run-asset-result-row"][data-asset-step-id]))
+  end
+
+  test "run detail prefers node results for execution rows", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_node_results")
+
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Skipped fresh")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Retrying")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Blocked")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"][data-asset-step-id]))
+
+    refute has_element?(
+             view,
+             ~s([data-testid="run-asset-result-row"]),
+             "asset aggregate fallback"
+           )
   end
 
   test "active run refreshes from running to terminal", %{conn: conn} do
@@ -419,7 +437,7 @@ defmodule FavnView.PageLiveTest do
   defp failed_run_state(name, run_id) do
     ref = {__MODULE__.Assets, name}
     upstream_ref = {__MODULE__.Assets, :raw_payments}
-    finished_at = DateTime.utc_now()
+    finished_at = DateTime.add(DateTime.utc_now(), -1_200, :second)
     started_at = DateTime.add(finished_at, -2, :second)
 
     RunState.new(
@@ -450,6 +468,75 @@ defmodule FavnView.PageLiveTest do
             duration_ms: 1_000,
             error: %{message: "Warehouse timeout"}
           }
+        ]
+      }
+    )
+    |> Map.put(:inserted_at, started_at)
+    |> Map.put(:updated_at, finished_at)
+    |> RunState.with_snapshot_hash()
+  end
+
+  defp node_results_run_state do
+    finished_at = DateTime.add(DateTime.utc_now(), -1_200, :second)
+    started_at = DateTime.add(finished_at, -2, :second)
+    raw_ref = {__MODULE__.Assets, :raw_payments}
+    stg_ref = {__MODULE__.Assets, :stg_payments}
+    customer_ref = {__MODULE__.Assets, :customer_orders_daily}
+
+    RunState.new(
+      id: "run_node_results",
+      manifest_version_id: "mv_view_assets",
+      manifest_content_hash: "hash_view_assets",
+      asset_ref: customer_ref,
+      target_refs: [raw_ref, stg_ref, customer_ref]
+    )
+    |> RunState.transition(
+      status: :partial,
+      result: %{
+        asset_results: [
+          %AssetResult{
+            ref: customer_ref,
+            stage: 99,
+            status: :ok,
+            started_at: started_at,
+            finished_at: finished_at,
+            duration_ms: 1,
+            meta: %{note: "asset aggregate fallback"}
+          }
+        ],
+        node_results: [
+          NodeResult.new(%{
+            node_key: {raw_ref, "window:day:2026-06-12"},
+            ref: raw_ref,
+            window: %{id: "window:day:2026-06-12"},
+            stage: 0,
+            status: :skipped_fresh,
+            reason: :fresh,
+            started_at: started_at,
+            finished_at: DateTime.add(started_at, 1, :second),
+            duration_ms: 1_000
+          }),
+          NodeResult.new(%{
+            node_key: {stg_ref, "window:day:2026-06-12"},
+            ref: stg_ref,
+            window: %{id: "window:day:2026-06-12"},
+            stage: 1,
+            status: :retrying,
+            started_at: DateTime.add(started_at, 1, :second),
+            duration_ms: 500
+          }),
+          NodeResult.new(%{
+            node_key: {customer_ref, "window:day:2026-06-12"},
+            ref: customer_ref,
+            window: %{id: "window:day:2026-06-12"},
+            stage: 2,
+            status: :blocked,
+            reason: :upstream_failed,
+            started_at: DateTime.add(started_at, 2, :second),
+            finished_at: finished_at,
+            duration_ms: 1,
+            error: %{reason: :upstream_failed}
+          })
         ]
       }
     )

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -19,7 +19,18 @@ defmodule FavnView.PageLiveTest do
     assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
     assert :ok = Storage.put_run(run_state(:customer_orders_daily, :ok, -600))
     assert :ok = Storage.put_run(run_state(:raw_payments, :running, -30))
+
+    assert :ok =
+             Storage.put_run(empty_run_state(:stg_payments, :running, "run_empty_running"))
+
+    assert :ok =
+             Storage.put_run(failed_run_state(:stg_payments, "run_failed_customer_orders"))
+
+    assert :ok =
+             Storage.put_run(empty_run_state(:stg_payments, :error, "run_failed_empty"))
+
     seed_run_events!("run_customer_orders_daily")
+    seed_run_events!("run_failed_empty", :error)
 
     :ok
   end
@@ -40,7 +51,6 @@ defmodule FavnView.PageLiveTest do
 
     assert html =~ "Healthy"
     assert html =~ "10m ago"
-    assert html =~ "Running"
 
     assert has_element?(view, ~s([aria-label="View modes"]))
     assert has_element?(view, ~s([aria-label="Connection filter"]))
@@ -104,7 +114,7 @@ defmodule FavnView.PageLiveTest do
 
     {:ok, run_view, html} = live(conn, run_path)
 
-    assert html =~ "Run run_"
+    assert html =~ "run_"
     assert html =~ "window:day:#{Date.to_iso8601(Date.utc_today())}"
     assert has_element?(run_view, ~s([data-testid="run-overview-panel"]))
   end
@@ -171,14 +181,24 @@ defmodule FavnView.PageLiveTest do
   test "renders existing run detail overview", %{conn: conn} do
     {:ok, view, html} = live(conn, ~p"/runs/run_customer_orders_daily")
 
-    assert html =~ "Run run_customer_order"
+    assert html =~ "run_customer_order"
     assert has_element?(view, ~s([data-testid="run-overview-panel"]))
-    assert has_element?(view, ~s([data-testid="run-summary-row"]), "Succeeded")
-    assert has_element?(view, ~s([data-testid="run-summary-row"]), "mv_view_assets")
+    assert has_element?(view, ~s([data-testid="run-overview-panel"]), "Succeeded")
+    refute html =~ "Healthy"
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Context"]))
+    |> render_click()
+
+    assert has_element?(view, ~s([data-testid="run-context-panel"]), "mv_view_assets")
   end
 
-  test "run detail renders events when present", %{conn: conn} do
+  test "run detail renders events mode when present", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Events"]))
+    |> render_click()
 
     assert has_element?(view, ~s([data-testid="run-event-timeline"]), "Run started")
     assert has_element?(view, ~s([data-testid="run-event-timeline"]), "Run finished")
@@ -189,23 +209,107 @@ defmodule FavnView.PageLiveTest do
 
     assert has_element?(view, ~s([data-testid="run-asset-results"]), "customer_orders_daily")
     assert has_element?(view, ~s([data-testid="run-asset-results"]), "Stage 0")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"][data-asset-step-id]))
   end
 
-  test "run detail mode rail changes to placeholder modes", %{conn: conn} do
+  test "active run refreshes from running to terminal", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
+
+    assert has_element?(view, ~s([data-testid="run-overview-panel"][data-run-active="true"]))
+    assert has_element?(view, ~s([data-testid="run-asset-results-empty"]), "Run accepted")
+
+    {:ok, active_run} = Storage.get_run("run_empty_running")
+
+    terminal_run =
+      RunState.transition(active_run,
+        status: :ok,
+        result: %{asset_results: terminal_asset_results(:stg_payments)}
+      )
+
+    assert :ok =
+             Storage.persist_run_transition(terminal_run, %{
+               run_id: terminal_run.id,
+               sequence: 3,
+               event_type: :run_finished,
+               occurred_at: DateTime.utc_now(),
+               status: :ok,
+               data: %{message: "Run finished"}
+             })
+
+    send(view.pid, :refresh_run)
+
+    assert render(view) =~ "Succeeded"
+    assert has_element?(view, ~s([data-testid="run-overview-panel"][data-run-active="false"]))
+  end
+
+  test "terminal run does not render as refreshing", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
+
+    assert has_element?(view, ~s([data-testid="run-overview-panel"][data-run-active="false"]))
+  end
+
+  test "running run with no asset results shows waiting state and no fake rows", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
+
+    assert has_element?(view, ~s([data-testid="run-asset-results-empty"]), "Run accepted")
+
+    assert has_element?(
+             view,
+             ~s([data-testid="run-current-activity"]),
+             "Waiting for first execution event"
+           )
+
+    refute has_element?(view, ~s([data-testid="run-asset-result-row"]))
+  end
+
+  test "failed run surfaces failed asset and error in overview", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_failed_customer_orders")
+
+    assert has_element?(view, ~s([data-testid="run-overview-panel"]), "Failed")
+    assert has_element?(view, ~s([data-testid="run-failure-summary"]), "1 of 2 assets failed")
+    assert has_element?(view, ~s([data-testid="run-failure-summary"]), "stg_payments")
+    assert has_element?(view, ~s([data-testid="run-failure-summary"]), "Warehouse timeout")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Failed")
+  end
+
+  test "failed run without asset results surfaces latest error event", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_failed_empty")
+
+    assert has_element?(
+             view,
+             ~s([data-testid="run-asset-results-empty"]),
+             "Run failed before asset results"
+           )
+
+    assert has_element?(view, ~s([data-testid="run-failure-summary"]), "Warehouse timeout")
+    refute has_element?(view, ~s([data-testid="run-asset-result-row"]))
+  end
+
+  test "run detail mode rail changes to events mode", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
 
     view
     |> element(~s([data-testid="view-mode-rail"] button[aria-label="Events"]))
     |> render_click()
 
-    assert has_element?(view, ~s([data-testid="run-mode-placeholder"]), "Events")
+    assert has_element?(view, ~s([data-testid="run-event-timeline"]), "Events")
     refute has_element?(view, ~s([data-testid="run-overview-panel"]))
+  end
+
+  test "run detail right rail exposes expected modes", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
+
+    for label <- ["Overview", "Events", "Outputs", "Context", "Debug"] do
+      assert has_element?(view, ~s([data-testid="view-mode-rail"] button[aria-label="#{label}"]))
+    end
+
+    refute has_element?(view, ~s([data-testid="view-mode-rail"] button[aria-label="Assets"]))
   end
 
   test "run detail ignores invalid mode events", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
 
-    assert render_click(view, "set_mode", %{"mode" => "not_real"}) =~ "Asset execution"
+    assert render_click(view, "set_mode", %{"mode" => "not_real"}) =~ "Run status"
     assert has_element?(view, ~s([data-testid="run-overview-panel"]))
   end
 
@@ -263,13 +367,13 @@ defmodule FavnView.PageLiveTest do
     }
   end
 
-  defp run_state(name, status, seconds_from_now) do
+  defp run_state(name, status, seconds_from_now, run_id \\ nil) do
     ref = {__MODULE__.Assets, name}
     finished_at = DateTime.add(DateTime.utc_now(), seconds_from_now, :second)
     started_at = DateTime.add(finished_at, -1, :second)
 
     RunState.new(
-      id: "run_#{name}",
+      id: run_id || "run_#{name}",
       manifest_version_id: "mv_view_assets",
       manifest_content_hash: "hash_view_assets",
       asset_ref: ref,
@@ -295,7 +399,83 @@ defmodule FavnView.PageLiveTest do
     |> RunState.with_snapshot_hash()
   end
 
-  defp seed_run_events!(run_id) do
+  defp empty_run_state(name, status, run_id) do
+    ref = {__MODULE__.Assets, name}
+    now = DateTime.utc_now()
+
+    RunState.new(
+      id: run_id,
+      manifest_version_id: "mv_view_assets",
+      manifest_content_hash: "hash_view_assets",
+      asset_ref: ref,
+      target_refs: [ref]
+    )
+    |> RunState.transition(status: status, result: %{asset_results: []})
+    |> Map.put(:inserted_at, now)
+    |> Map.put(:updated_at, now)
+    |> RunState.with_snapshot_hash()
+  end
+
+  defp failed_run_state(name, run_id) do
+    ref = {__MODULE__.Assets, name}
+    upstream_ref = {__MODULE__.Assets, :raw_payments}
+    finished_at = DateTime.utc_now()
+    started_at = DateTime.add(finished_at, -2, :second)
+
+    RunState.new(
+      id: run_id,
+      manifest_version_id: "mv_view_assets",
+      manifest_content_hash: "hash_view_assets",
+      asset_ref: ref,
+      target_refs: [upstream_ref, ref]
+    )
+    |> RunState.transition(
+      status: :error,
+      result: %{
+        asset_results: [
+          %AssetResult{
+            ref: upstream_ref,
+            stage: 0,
+            status: :ok,
+            started_at: started_at,
+            finished_at: DateTime.add(started_at, 1, :second),
+            duration_ms: 1_000
+          },
+          %AssetResult{
+            ref: ref,
+            stage: 1,
+            status: :error,
+            started_at: DateTime.add(started_at, 1, :second),
+            finished_at: finished_at,
+            duration_ms: 1_000,
+            error: %{message: "Warehouse timeout"}
+          }
+        ]
+      }
+    )
+    |> Map.put(:inserted_at, started_at)
+    |> Map.put(:updated_at, finished_at)
+    |> RunState.with_snapshot_hash()
+  end
+
+  defp terminal_asset_results(name) do
+    ref = {__MODULE__.Assets, name}
+    finished_at = DateTime.utc_now()
+    started_at = DateTime.add(finished_at, -1, :second)
+
+    [
+      %AssetResult{
+        ref: ref,
+        stage: 0,
+        status: :ok,
+        started_at: started_at,
+        finished_at: finished_at,
+        duration_ms: 1_000
+      }
+    ]
+  end
+
+  defp seed_run_events!(run_id, status \\ :ok) do
     now = DateTime.utc_now()
 
     assert :ok =
@@ -312,10 +492,12 @@ defmodule FavnView.PageLiveTest do
              Storage.append_run_event(run_id, %{
                run_id: run_id,
                sequence: 2,
-               event_type: :run_finished,
+               event_type: if(status == :error, do: :run_failed, else: :run_finished),
                occurred_at: now,
-               status: :ok,
-               data: %{message: "Run finished"}
+               status: status,
+               data: %{
+                 message: if(status == :error, do: "Warehouse timeout", else: "Run finished")
+               }
              })
   end
 


### PR DESCRIPTION
## Summary
- Adds a focused run detail HUD with run-status semantics, active-run polling, and status-aware Overview states.
- Surfaces failed assets/errors and current running activity from public orchestrator run/event DTOs only.
- Expands Storybook and LiveView coverage for running, failed, empty, terminal, and mode rail states.

## Verification
- mix format
- mix compile --warnings-as-errors (apps/favn_view)
- mix test (apps/favn_view)