### PR TITLE
Add backend log streaming foundation

### DIFF
--- a/apps/favn_core/lib/favn/contracts/runner_client.ex
+++ b/apps/favn_core/lib/favn/contracts/runner_client.ex
@@ -24,10 +24,16 @@ defmodule Favn.Contracts.RunnerClient do
 
   @callback cancel_work(execution_id(), map(), keyword()) :: :ok | {:error, term()}
 
+  @callback subscribe_execution_logs(execution_id(), pid(), keyword()) :: :ok | {:error, term()}
+
+  @callback unsubscribe_execution_logs(execution_id(), pid(), keyword()) :: :ok
+
   @callback inspect_relation(RelationInspectionRequest.t(), keyword()) ::
               {:ok, RelationInspectionResult.t()} | {:error, term()}
 
   @callback diagnostics(keyword()) :: {:ok, map()} | {:error, term()}
 
-  @optional_callbacks diagnostics: 1
+  @optional_callbacks diagnostics: 1,
+                      subscribe_execution_logs: 3,
+                      unsubscribe_execution_logs: 3
 end

--- a/apps/favn_core/lib/favn/log.ex
+++ b/apps/favn_core/lib/favn/log.ex
@@ -1,0 +1,68 @@
+defmodule Favn.Log do
+  @moduledoc """
+  Public helpers for constructing Favn log entries from user code.
+
+  The current execution context does not emit logs yet, so these helpers return
+  normalized `Favn.Log.Entry` structs for future runners/orchestrators to emit.
+  """
+
+  alias Favn.Log.Entry
+  alias Favn.Run.Context
+
+  @doc """
+  Builds a debug log entry.
+  """
+  @spec debug(Context.t() | map() | keyword(), String.t(), map()) :: Entry.t()
+  def debug(context_or_attrs, message, metadata \\ %{}),
+    do: build(:debug, context_or_attrs, message, metadata)
+
+  @doc """
+  Builds an info log entry.
+  """
+  @spec info(Context.t() | map() | keyword(), String.t(), map()) :: Entry.t()
+  def info(context_or_attrs, message, metadata \\ %{}),
+    do: build(:info, context_or_attrs, message, metadata)
+
+  @doc """
+  Builds a warning log entry.
+  """
+  @spec warning(Context.t() | map() | keyword(), String.t(), map()) :: Entry.t()
+  def warning(context_or_attrs, message, metadata \\ %{}),
+    do: build(:warning, context_or_attrs, message, metadata)
+
+  @doc """
+  Builds an error log entry.
+  """
+  @spec error(Context.t() | map() | keyword(), String.t(), map()) :: Entry.t()
+  def error(context_or_attrs, message, metadata \\ %{}),
+    do: build(:error, context_or_attrs, message, metadata)
+
+  @spec build(Entry.level(), Context.t() | map() | keyword(), String.t(), map()) :: Entry.t()
+  defp build(level, %Context{} = context, message, metadata) do
+    Entry.normalize(%{
+      run_id: context.run_id,
+      asset_ref: context.current_ref,
+      attempt: context.attempt,
+      occurred_at: DateTime.utc_now(),
+      level: level,
+      source: :user_code,
+      stream: :system,
+      message: message,
+      metadata: metadata
+    })
+  end
+
+  defp build(level, context_or_attrs, message, metadata) do
+    attrs =
+      context_or_attrs
+      |> Map.new()
+      |> Map.merge(%{
+        level: level,
+        occurred_at: context_or_attrs[:occurred_at] || DateTime.utc_now(),
+        message: message,
+        metadata: metadata
+      })
+
+    Entry.normalize(attrs)
+  end
+end

--- a/apps/favn_core/lib/favn/log/cursor.ex
+++ b/apps/favn_core/lib/favn/log/cursor.ex
@@ -1,0 +1,81 @@
+defmodule Favn.Log.Cursor do
+  @moduledoc """
+  Replay cursor for backend logs.
+
+  All cursor scopes carry the authoritative global sequence so replay ordering
+  does not depend on per-run or per-asset counters.
+  """
+
+  @type scope :: :global | :run | :asset
+
+  @type t :: %__MODULE__{
+          scope: scope(),
+          run_id: String.t() | nil,
+          asset_step_id: String.t() | nil,
+          global_sequence: non_neg_integer()
+        }
+
+  defstruct [:scope, :run_id, :asset_step_id, :global_sequence]
+
+  @doc """
+  Parses a cursor string.
+  """
+  @spec parse(String.t()) :: {:ok, t()} | {:error, :invalid_cursor}
+  def parse("global:" <> sequence), do: parse_global(sequence)
+
+  def parse("run:" <> rest) do
+    with [run_id, sequence] <- String.split(rest, ":", parts: 2),
+         {:ok, global_sequence} <- parse_sequence(sequence) do
+      {:ok, %__MODULE__{scope: :run, run_id: run_id, global_sequence: global_sequence}}
+    else
+      _error -> {:error, :invalid_cursor}
+    end
+  end
+
+  def parse("asset:" <> rest) do
+    with [run_id, asset_step_id, sequence] <- String.split(rest, ":", parts: 3),
+         {:ok, global_sequence} <- parse_sequence(sequence) do
+      {:ok,
+       %__MODULE__{
+         scope: :asset,
+         run_id: run_id,
+         asset_step_id: asset_step_id,
+         global_sequence: global_sequence
+       }}
+    else
+      _error -> {:error, :invalid_cursor}
+    end
+  end
+
+  def parse(_cursor), do: {:error, :invalid_cursor}
+
+  @doc """
+  Formats a cursor struct.
+  """
+  @spec format(t()) :: String.t()
+  def format(%__MODULE__{scope: :global, global_sequence: sequence}), do: "global:#{sequence}"
+
+  def format(%__MODULE__{scope: :run, run_id: run_id, global_sequence: sequence}),
+    do: "run:#{run_id}:#{sequence}"
+
+  def format(%__MODULE__{
+        scope: :asset,
+        run_id: run_id,
+        asset_step_id: asset_step_id,
+        global_sequence: sequence
+      }),
+      do: "asset:#{run_id}:#{asset_step_id}:#{sequence}"
+
+  defp parse_global(sequence) do
+    with {:ok, global_sequence} <- parse_sequence(sequence) do
+      {:ok, %__MODULE__{scope: :global, global_sequence: global_sequence}}
+    end
+  end
+
+  defp parse_sequence(value) do
+    case Integer.parse(value) do
+      {sequence, ""} when sequence >= 0 -> {:ok, sequence}
+      _other -> {:error, :invalid_cursor}
+    end
+  end
+end

--- a/apps/favn_core/lib/favn/log/entry.ex
+++ b/apps/favn_core/lib/favn/log/entry.ex
@@ -1,0 +1,177 @@
+defmodule Favn.Log.Entry do
+  @moduledoc """
+  Shared log entry contract for backend log streaming and persistence.
+
+  Runners provide producer identity and ordering for idempotency. Storage and
+  orchestrator layers assign the authoritative `global_sequence`.
+  """
+
+  alias Favn.Ref
+
+  @schema_version 1
+  @levels [:debug, :info, :warning, :error]
+  @sources [:orchestrator, :runner, :sql_runtime, :adapter, :user_code, :system]
+  @streams [:stdout, :stderr, :system]
+  @max_message_bytes 65_536
+
+  @type level :: :debug | :info | :warning | :error
+  @type source :: :orchestrator | :runner | :sql_runtime | :adapter | :user_code | :system
+  @type stream :: :stdout | :stderr | :system
+
+  @type t :: %__MODULE__{
+          schema_version: pos_integer(),
+          id: String.t() | nil,
+          global_sequence: non_neg_integer() | nil,
+          run_id: String.t() | nil,
+          asset_step_id: String.t() | nil,
+          node_key: term() | nil,
+          asset_ref: Ref.t() | nil,
+          runner_execution_id: String.t() | nil,
+          attempt: pos_integer() | nil,
+          producer_id: String.t() | nil,
+          producer_sequence: non_neg_integer() | nil,
+          occurred_at: DateTime.t() | nil,
+          level: level(),
+          source: source(),
+          stream: stream() | nil,
+          message: String.t(),
+          metadata: map(),
+          truncated: boolean()
+        }
+
+  defstruct schema_version: @schema_version,
+            id: nil,
+            global_sequence: nil,
+            run_id: nil,
+            asset_step_id: nil,
+            node_key: nil,
+            asset_ref: nil,
+            runner_execution_id: nil,
+            attempt: nil,
+            producer_id: nil,
+            producer_sequence: nil,
+            occurred_at: nil,
+            level: :info,
+            source: :user_code,
+            stream: :system,
+            message: "",
+            metadata: %{},
+            truncated: false
+
+  @doc """
+  Normalizes a map or keyword list into a log entry struct.
+  """
+  @spec normalize(map() | keyword() | t()) :: t()
+  def normalize(%__MODULE__{} = entry), do: normalize(Map.from_struct(entry))
+
+  def normalize(attrs) when is_list(attrs), do: attrs |> Map.new() |> normalize()
+
+  def normalize(attrs) when is_map(attrs) do
+    attrs = atomize_known_keys(attrs)
+
+    {message, message_truncated?} = normalize_message(Map.get(attrs, :message, ""))
+
+    struct!(__MODULE__, %{
+      schema_version: Map.get(attrs, :schema_version, @schema_version),
+      id: Map.get(attrs, :id),
+      global_sequence: Map.get(attrs, :global_sequence),
+      run_id: Map.get(attrs, :run_id),
+      asset_step_id: Map.get(attrs, :asset_step_id),
+      node_key: Map.get(attrs, :node_key),
+      asset_ref: Map.get(attrs, :asset_ref),
+      runner_execution_id: Map.get(attrs, :runner_execution_id),
+      attempt: Map.get(attrs, :attempt),
+      producer_id: Map.get(attrs, :producer_id),
+      producer_sequence: Map.get(attrs, :producer_sequence),
+      occurred_at: Map.get(attrs, :occurred_at),
+      level: normalize_enum(Map.get(attrs, :level), @levels, :level, :info),
+      source: normalize_enum(Map.get(attrs, :source), @sources, :source, :user_code),
+      stream: normalize_enum(Map.get(attrs, :stream), @streams, :stream, :system),
+      message: message,
+      metadata: Map.get(attrs, :metadata, %{}) || %{},
+      truncated: Map.get(attrs, :truncated, false) == true or message_truncated?
+    })
+  end
+
+  @doc """
+  Returns the maximum persisted message size in bytes before truncation.
+  """
+  @spec max_message_bytes() :: pos_integer()
+  def max_message_bytes, do: @max_message_bytes
+
+  @doc """
+  Returns supported log levels.
+  """
+  @spec levels() :: [level()]
+  def levels, do: @levels
+
+  @doc """
+  Returns supported log sources.
+  """
+  @spec sources() :: [source()]
+  def sources, do: @sources
+
+  @doc """
+  Returns supported log streams.
+  """
+  @spec streams() :: [stream()]
+  def streams, do: @streams
+
+  defp atomize_known_keys(attrs) do
+    known_keys = Map.keys(%__MODULE__{})
+
+    Enum.reduce(attrs, %{}, fn {key, value}, acc ->
+      normalized_key =
+        if key in known_keys, do: key, else: normalize_known_string_key(key, known_keys)
+
+      Map.put(acc, normalized_key, value)
+    end)
+  end
+
+  defp normalize_known_string_key(key, known_keys) when is_binary(key) do
+    Enum.find(known_keys, key, &(Atom.to_string(&1) == key))
+  end
+
+  defp normalize_known_string_key(key, _known_keys), do: key
+
+  defp normalize_enum(nil, _allowed, _field, default), do: default
+
+  defp normalize_enum(value, allowed, field, default) when is_binary(value) do
+    value
+    |> String.to_existing_atom()
+    |> normalize_enum(allowed, field, default)
+  rescue
+    ArgumentError -> raise ArgumentError, "invalid #{field}: #{inspect(value)}"
+  end
+
+  defp normalize_enum(value, allowed, field, _default) do
+    if value in allowed do
+      value
+    else
+      raise ArgumentError, "invalid #{field}: #{inspect(value)}"
+    end
+  end
+
+  defp normalize_message(value) when is_binary(value), do: truncate_message(value)
+  defp normalize_message(value), do: value |> inspect() |> truncate_message()
+
+  defp truncate_message(value) when byte_size(value) <= @max_message_bytes, do: {value, false}
+
+  defp truncate_message(value) do
+    suffix = "\n[TRUNCATED]"
+    prefix_size = @max_message_bytes - byte_size(suffix)
+    {valid_prefix(value, prefix_size) <> suffix, true}
+  end
+
+  defp valid_prefix(_value, size) when size <= 0, do: ""
+
+  defp valid_prefix(value, size) do
+    prefix = binary_part(value, 0, size)
+
+    if String.valid?(prefix) do
+      prefix
+    else
+      valid_prefix(value, size - 1)
+    end
+  end
+end

--- a/apps/favn_core/lib/favn/log/filter.ex
+++ b/apps/favn_core/lib/favn/log/filter.ex
@@ -1,0 +1,92 @@
+defmodule Favn.Log.Filter do
+  @moduledoc """
+  Query filter contract for backend logs.
+  """
+
+  alias Favn.Log.Entry
+  alias Favn.Ref
+
+  @type t :: %__MODULE__{
+          run_id: String.t() | nil,
+          asset_step_id: String.t() | nil,
+          node_key: String.t() | nil,
+          asset_ref: Ref.t() | nil,
+          levels: [Entry.level()],
+          sources: [Entry.source()],
+          since: DateTime.t() | nil,
+          until: DateTime.t() | nil
+        }
+
+  defstruct run_id: nil,
+            asset_step_id: nil,
+            node_key: nil,
+            asset_ref: nil,
+            levels: [],
+            sources: [],
+            since: nil,
+            until: nil
+
+  @doc """
+  Normalizes a map or keyword list into a log filter struct.
+  """
+  @spec normalize(map() | keyword() | t()) :: t()
+  def normalize(%__MODULE__{} = filter), do: normalize(Map.from_struct(filter))
+  def normalize(attrs) when is_list(attrs), do: attrs |> Map.new() |> normalize()
+
+  def normalize(attrs) when is_map(attrs) do
+    attrs = atomize_known_keys(attrs)
+
+    struct!(__MODULE__, %{
+      run_id: Map.get(attrs, :run_id),
+      asset_step_id: Map.get(attrs, :asset_step_id),
+      node_key: Map.get(attrs, :node_key),
+      asset_ref: Map.get(attrs, :asset_ref),
+      levels: normalize_list(Map.get(attrs, :levels, []), Entry.levels(), :level),
+      sources: normalize_list(Map.get(attrs, :sources, []), Entry.sources(), :source),
+      since: Map.get(attrs, :since),
+      until: Map.get(attrs, :until)
+    })
+  end
+
+  defp atomize_known_keys(attrs) do
+    known_keys = Map.keys(%__MODULE__{})
+
+    Enum.reduce(attrs, %{}, fn {key, value}, acc ->
+      normalized_key =
+        if key in known_keys, do: key, else: normalize_known_string_key(key, known_keys)
+
+      Map.put(acc, normalized_key, value)
+    end)
+  end
+
+  defp normalize_known_string_key(key, known_keys) when is_binary(key) do
+    Enum.find(known_keys, key, &(Atom.to_string(&1) == key))
+  end
+
+  defp normalize_known_string_key(key, _known_keys), do: key
+
+  defp normalize_list(nil, _allowed, _field), do: []
+
+  defp normalize_list(value, allowed, field) when not is_list(value),
+    do: normalize_list([value], allowed, field)
+
+  defp normalize_list(values, allowed, field) do
+    Enum.map(values, &normalize_enum(&1, allowed, field))
+  end
+
+  defp normalize_enum(value, allowed, field) when is_binary(value) do
+    value
+    |> String.to_existing_atom()
+    |> normalize_enum(allowed, field)
+  rescue
+    ArgumentError -> raise ArgumentError, "invalid #{field}: #{inspect(value)}"
+  end
+
+  defp normalize_enum(value, allowed, field) do
+    if value in allowed do
+      value
+    else
+      raise ArgumentError, "invalid #{field}: #{inspect(value)}"
+    end
+  end
+end

--- a/apps/favn_core/lib/favn/log/redaction_policy.ex
+++ b/apps/favn_core/lib/favn/log/redaction_policy.ex
@@ -1,0 +1,64 @@
+defmodule Favn.Log.RedactionPolicy do
+  @moduledoc """
+  Redaction settings for backend logs.
+
+  The default policy is declared-mode redaction with a conservative metadata key
+  list. Messages are preserved unless an explicit configured value or pattern
+  matches them.
+  """
+
+  @default_redact_keys [:password, :token, :secret, :api_key, :access_token, :refresh_token]
+
+  @type mode :: :none | :declared
+  @type t :: %__MODULE__{
+          mode: mode(),
+          redact_keys: [atom() | String.t()],
+          redact_key_patterns: [Regex.t()],
+          redact_values: [String.t()],
+          redact_patterns: [Regex.t()]
+        }
+
+  defstruct mode: :declared,
+            redact_keys: @default_redact_keys,
+            redact_key_patterns: [],
+            redact_values: [],
+            redact_patterns: []
+
+  @doc """
+  Normalizes a map, keyword list, mode atom, or policy struct.
+  """
+  @spec normalize(t() | map() | keyword() | mode() | nil) :: t()
+  def normalize(nil), do: %__MODULE__{}
+  def normalize(%__MODULE__{} = policy), do: policy
+  def normalize(mode) when mode in [:none, :declared], do: %__MODULE__{mode: mode}
+  def normalize(attrs) when is_list(attrs), do: attrs |> Map.new() |> normalize()
+
+  def normalize(attrs) when is_map(attrs) do
+    attrs = atomize_known_keys(attrs)
+
+    struct!(__MODULE__, %{
+      mode: Map.get(attrs, :mode, :declared),
+      redact_keys: Map.get(attrs, :redact_keys, @default_redact_keys),
+      redact_key_patterns: Map.get(attrs, :redact_key_patterns, []),
+      redact_values: Map.get(attrs, :redact_values, []),
+      redact_patterns: Map.get(attrs, :redact_patterns, [])
+    })
+  end
+
+  defp atomize_known_keys(attrs) do
+    known_keys = Map.keys(%__MODULE__{})
+
+    Enum.reduce(attrs, %{}, fn {key, value}, acc ->
+      normalized_key =
+        if key in known_keys, do: key, else: normalize_known_string_key(key, known_keys)
+
+      Map.put(acc, normalized_key, value)
+    end)
+  end
+
+  defp normalize_known_string_key(key, known_keys) when is_binary(key) do
+    Enum.find(known_keys, key, &(Atom.to_string(&1) == key))
+  end
+
+  defp normalize_known_string_key(key, _known_keys), do: key
+end

--- a/apps/favn_core/lib/favn/log/redactor.ex
+++ b/apps/favn_core/lib/favn/log/redactor.ex
@@ -1,0 +1,104 @@
+defmodule Favn.Log.Redactor do
+  @moduledoc """
+  Applies declared log redaction policy.
+  """
+
+  alias Favn.Log.Entry
+  alias Favn.Log.RedactionPolicy
+
+  @redacted "[REDACTED]"
+
+  @type result :: {Entry.t(), boolean()}
+
+  @doc """
+  Redacts an entry and returns whether any redaction occurred.
+  """
+  @spec redact(
+          Entry.t() | map() | keyword(),
+          RedactionPolicy.t() | map() | keyword() | RedactionPolicy.mode() | nil
+        ) ::
+          result()
+  def redact(entry, policy \\ nil) do
+    entry = Entry.normalize(entry)
+    policy = RedactionPolicy.normalize(policy)
+
+    if policy.mode == :none do
+      {entry, false}
+    else
+      {message, message_redacted?} = redact_message(entry.message, policy)
+      {metadata, metadata_redacted?} = redact_metadata(entry.metadata, policy)
+
+      {%{entry | message: message, metadata: metadata}, message_redacted? or metadata_redacted?}
+    end
+  end
+
+  defp redact_message(message, policy) do
+    message
+    |> redact_configured_values(policy.redact_values)
+    |> redact_patterns(policy.redact_patterns)
+  end
+
+  defp redact_metadata(value, policy), do: redact_metadata_value(value, policy)
+
+  defp redact_metadata_value(%DateTime{} = value, _policy), do: {value, false}
+
+  defp redact_metadata_value(value, policy) when is_map(value) do
+    Enum.reduce(value, {%{}, false}, fn {key, child}, {acc, redacted?} ->
+      if redact_key?(key, policy) do
+        {Map.put(acc, key, @redacted), true}
+      else
+        {redacted_child, child_redacted?} = redact_metadata_value(child, policy)
+        {Map.put(acc, key, redacted_child), redacted? or child_redacted?}
+      end
+    end)
+  end
+
+  defp redact_metadata_value(values, policy) when is_list(values) do
+    values
+    |> Enum.map_reduce(false, fn value, redacted? ->
+      {redacted_value, value_redacted?} = redact_metadata_value(value, policy)
+      {redacted_value, redacted? or value_redacted?}
+    end)
+  end
+
+  defp redact_metadata_value(value, policy) when is_tuple(value) do
+    {values, redacted?} = value |> Tuple.to_list() |> redact_metadata_value(policy)
+    {List.to_tuple(values), redacted?}
+  end
+
+  defp redact_metadata_value(value, policy) when is_binary(value) do
+    value
+    |> redact_configured_values(policy.redact_values)
+    |> redact_patterns(policy.redact_patterns)
+  end
+
+  defp redact_metadata_value(value, _policy), do: {value, false}
+
+  defp redact_key?(key, policy) do
+    normalized_key = normalize_key(key)
+
+    Enum.any?(policy.redact_keys, &(normalize_key(&1) == normalized_key)) or
+      Enum.any?(policy.redact_key_patterns, &Regex.match?(&1, normalized_key))
+  end
+
+  defp normalize_key(key) when is_atom(key), do: key |> Atom.to_string() |> String.downcase()
+  defp normalize_key(key) when is_binary(key), do: String.downcase(key)
+  defp normalize_key(key), do: key |> inspect() |> String.downcase()
+
+  defp redact_configured_values(value, redact_values) do
+    Enum.reduce(redact_values, {value, false}, fn secret, {acc, redacted?} ->
+      if is_binary(secret) and secret != "" and String.contains?(acc, secret) do
+        {String.replace(acc, secret, @redacted), true}
+      else
+        {acc, redacted?}
+      end
+    end)
+  end
+
+  defp redact_patterns({value, redacted?}, redact_patterns) do
+    Enum.reduce(redact_patterns, {value, redacted?}, fn pattern, {acc, acc_redacted?} ->
+      redacted = Regex.replace(pattern, acc, @redacted)
+      {redacted, acc_redacted? or redacted != acc}
+    end)
+  end
+end

--- a/apps/favn_core/test/contracts/runner_client_test.exs
+++ b/apps/favn_core/test/contracts/runner_client_test.exs
@@ -11,9 +11,12 @@ defmodule Favn.Contracts.RunnerClientTest do
                diagnostics: 1,
                inspect_relation: 2,
                register_manifest: 2,
-               submit_work: 2
+               submit_work: 2,
+               subscribe_execution_logs: 3,
+               unsubscribe_execution_logs: 3
              ]
 
-    assert RunnerClient.behaviour_info(:optional_callbacks) == [diagnostics: 1]
+    assert RunnerClient.behaviour_info(:optional_callbacks) |> Enum.sort() ==
+             [diagnostics: 1, subscribe_execution_logs: 3, unsubscribe_execution_logs: 3]
   end
 end

--- a/apps/favn_core/test/log_cursor_test.exs
+++ b/apps/favn_core/test/log_cursor_test.exs
@@ -1,0 +1,36 @@
+defmodule Favn.Log.CursorTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Log.Cursor
+
+  test "parses and formats global cursor" do
+    assert {:ok, cursor} = Cursor.parse("global:42")
+    assert cursor == %Cursor{scope: :global, global_sequence: 42}
+    assert Cursor.format(cursor) == "global:42"
+  end
+
+  test "parses and formats run cursor with global sequence" do
+    assert {:ok, cursor} = Cursor.parse("run:run_123:43")
+    assert cursor == %Cursor{scope: :run, run_id: "run_123", global_sequence: 43}
+    assert Cursor.format(cursor) == "run:run_123:43"
+  end
+
+  test "parses and formats asset cursor with global sequence" do
+    assert {:ok, cursor} = Cursor.parse("asset:run_123:asset_step_1:44")
+
+    assert cursor == %Cursor{
+             scope: :asset,
+             run_id: "run_123",
+             asset_step_id: "asset_step_1",
+             global_sequence: 44
+           }
+
+    assert Cursor.format(cursor) == "asset:run_123:asset_step_1:44"
+  end
+
+  test "rejects invalid cursors" do
+    assert Cursor.parse("run:run_123:not-int") == {:error, :invalid_cursor}
+    assert Cursor.parse("asset:run_123:asset_step_1:-1") == {:error, :invalid_cursor}
+    assert Cursor.parse("unknown:1") == {:error, :invalid_cursor}
+  end
+end

--- a/apps/favn_core/test/log_entry_test.exs
+++ b/apps/favn_core/test/log_entry_test.exs
@@ -1,0 +1,61 @@
+defmodule Favn.Log.EntryTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Log
+  alias Favn.Log.Entry
+  alias Favn.Run.Context
+
+  test "normalizes entry attrs" do
+    now = ~U[2026-05-01 12:00:00Z]
+
+    entry =
+      Entry.normalize(%{
+        "run_id" => "run_1",
+        "global_sequence" => 10,
+        "level" => "warning",
+        "source" => "runner",
+        "stream" => "stderr",
+        "message" => "hello",
+        "metadata" => %{rows: 3},
+        "occurred_at" => now
+      })
+
+    assert entry.schema_version == 1
+    assert entry.global_sequence == 10
+    assert entry.run_id == "run_1"
+    assert entry.level == :warning
+    assert entry.source == :runner
+    assert entry.stream == :stderr
+    assert entry.message == "hello"
+    assert entry.metadata == %{rows: 3}
+    assert entry.occurred_at == now
+    refute entry.truncated
+  end
+
+  test "user-code helpers infer run context fields" do
+    context = %Context{run_id: "run_1", current_ref: {MyApp.Asset, :daily}, attempt: 2}
+
+    entry = Log.info(context, "asset started", %{batch: 1})
+
+    assert %Entry{} = entry
+    assert entry.run_id == "run_1"
+    assert entry.asset_ref == {MyApp.Asset, :daily}
+    assert entry.attempt == 2
+    assert entry.level == :info
+    assert entry.source == :user_code
+    assert entry.stream == :system
+    assert entry.message == "asset started"
+    assert entry.metadata == %{batch: 1}
+    assert %DateTime{} = entry.occurred_at
+  end
+
+  test "user-code helpers accept attrs without runner or orchestrator dependencies" do
+    entry = Log.error([run_id: "run_2", producer_id: "runner-a"], "failed", %{reason: :boom})
+
+    assert entry.run_id == "run_2"
+    assert entry.producer_id == "runner-a"
+    assert entry.level == :error
+    assert entry.message == "failed"
+    assert entry.metadata == %{reason: :boom}
+  end
+end

--- a/apps/favn_core/test/log_filter_test.exs
+++ b/apps/favn_core/test/log_filter_test.exs
@@ -1,0 +1,40 @@
+defmodule Favn.Log.FilterTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Log.Filter
+
+  test "normalizes map and keyword filters" do
+    since = ~U[2026-05-01 00:00:00Z]
+    until_time = ~U[2026-05-01 01:00:00Z]
+
+    filter =
+      Filter.normalize(%{
+        "run_id" => "run_1",
+        "asset_step_id" => "asset_step_1",
+        "node_key" => "node-a",
+        "asset_ref" => {MyApp.Asset, :daily},
+        "levels" => ["info", :error],
+        "sources" => "runner",
+        "since" => since,
+        "until" => until_time
+      })
+
+    assert filter == %Filter{
+             run_id: "run_1",
+             asset_step_id: "asset_step_1",
+             node_key: "node-a",
+             asset_ref: {MyApp.Asset, :daily},
+             levels: [:info, :error],
+             sources: [:runner],
+             since: since,
+             until: until_time
+           }
+
+    assert %Filter{levels: [:warning]} = Filter.normalize(levels: :warning)
+  end
+
+  test "rejects unknown levels and sources" do
+    assert_raise ArgumentError, fn -> Filter.normalize(levels: [:notice]) end
+    assert_raise ArgumentError, fn -> Filter.normalize(sources: ["database"]) end
+  end
+end

--- a/apps/favn_core/test/log_redactor_test.exs
+++ b/apps/favn_core/test/log_redactor_test.exs
@@ -1,0 +1,56 @@
+defmodule Favn.Log.RedactorTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Log.Entry
+  alias Favn.Log.Redactor
+
+  test "preserves SQL and multiline messages by default" do
+    message = "SELECT *\nFROM users\nWHERE email = 'a@example.com'"
+    entry = %Entry{message: message, metadata: %{query: message, rows: 2}}
+
+    assert {redacted, false} = Redactor.redact(entry)
+    assert redacted.message == message
+    assert redacted.metadata.query == message
+    assert String.contains?(redacted.message, "\nFROM users\n")
+  end
+
+  test "redacts conservative metadata keys by default" do
+    entry = %Entry{
+      message: "connected to warehouse",
+      metadata: %{password: "secret", nested: %{"api_key" => "key", status: "ok"}}
+    }
+
+    assert {redacted, true} = Redactor.redact(entry)
+    assert redacted.message == "connected to warehouse"
+    assert redacted.metadata.password == "[REDACTED]"
+    assert redacted.metadata.nested["api_key"] == "[REDACTED]"
+    assert redacted.metadata.nested.status == "ok"
+  end
+
+  test "redacts explicit configured values in message and metadata" do
+    entry = %Entry{
+      message: "failed with token abc123\nretrying",
+      metadata: %{detail: "token abc123"}
+    }
+
+    assert {redacted, true} = Redactor.redact(entry, redact_values: ["abc123"])
+    assert redacted.message == "failed with token [REDACTED]\nretrying"
+    assert redacted.metadata.detail == "token [REDACTED]"
+  end
+
+  test "supports explicit patterns and none mode" do
+    entry = %Entry{message: "session id=s-123", metadata: %{private_id: "s-123"}}
+
+    assert {redacted, true} =
+             Redactor.redact(entry,
+               redact_key_patterns: [~r/private/],
+               redact_patterns: [~r/id=s-\d+/]
+             )
+
+    assert redacted.message == "session [REDACTED]"
+    assert redacted.metadata.private_id == "[REDACTED]"
+
+    assert {unchanged, false} = Redactor.redact(entry, :none)
+    assert unchanged == entry
+  end
+end

--- a/apps/favn_orchestrator/lib/favn/storage/adapter.ex
+++ b/apps/favn_orchestrator/lib/favn/storage/adapter.ex
@@ -71,6 +71,17 @@ defmodule Favn.Storage.Adapter do
   @callback list_global_run_events(filter_opts(), adapter_opts()) ::
               {:ok, [map()]} | {:error, error()}
 
+  @callback persist_log_entries([Favn.Log.Entry.t()], adapter_opts()) ::
+              {:ok, [Favn.Log.Entry.t()]} | {:error, error()}
+  @callback list_logs(Favn.Log.Filter.t() | map() | keyword(), keyword(), adapter_opts()) ::
+              {:ok, Page.t(Favn.Log.Entry.t())} | {:error, error()}
+  @callback replay_logs_after(
+              Favn.Log.Cursor.t() | String.t() | nil,
+              Favn.Log.Filter.t() | map() | keyword(),
+              keyword(),
+              adapter_opts()
+            ) :: {:ok, [Favn.Log.Entry.t()]} | {:error, error()}
+
   @callback put_scheduler_state(scheduler_key(), map(), adapter_opts()) ::
               :ok | {:error, error()}
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -21,6 +21,8 @@ defmodule FavnOrchestrator do
   alias FavnOrchestrator.Diagnostics
   alias FavnOrchestrator.Events
   alias FavnOrchestrator.Freshness.Query, as: FreshnessQuery
+  alias FavnOrchestrator.LogWriter
+  alias FavnOrchestrator.Logs
   alias FavnOrchestrator.ManifestStore
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.Projector
@@ -255,6 +257,46 @@ defmodule FavnOrchestrator do
       end
     end
   end
+
+  @doc """
+  Persists and publishes one trusted backend log entry.
+  """
+  @spec emit_log(term()) :: {:ok, [Favn.Log.Entry.t()]} | {:error, term()}
+  def emit_log(entry), do: LogWriter.write(entry)
+
+  @doc """
+  Persists and publishes trusted backend log entries as one batch.
+  """
+  @spec emit_logs([term()]) :: {:ok, [Favn.Log.Entry.t()]} | {:error, term()}
+  def emit_logs(entries) when is_list(entries), do: LogWriter.write(entries)
+
+  @doc """
+  Lists persisted backend logs matching the given filter.
+  """
+  @spec list_logs(term(), keyword()) :: {:ok, Page.t(Favn.Log.Entry.t())} | {:error, term()}
+  def list_logs(filter \\ default_log_filter(), opts \\ []) when is_list(opts) do
+    Storage.list_logs(filter, opts)
+  end
+
+  @doc """
+  Replays persisted backend logs after an authoritative log cursor.
+  """
+  @spec replay_logs(term(), term(), keyword()) :: {:ok, [Favn.Log.Entry.t()]} | {:error, term()}
+  def replay_logs(cursor, filter \\ default_log_filter(), opts \\ []) when is_list(opts) do
+    Storage.replay_logs_after(cursor, filter, opts)
+  end
+
+  @doc """
+  Subscribes the caller to live backend logs matching the given filter.
+  """
+  @spec subscribe_logs(term()) :: {:ok, term()} | {:error, term()}
+  def subscribe_logs(filter \\ default_log_filter()), do: Logs.subscribe_logs(filter)
+
+  @doc """
+  Unsubscribes the caller from a prior backend log subscription or equivalent filter.
+  """
+  @spec unsubscribe_logs(term()) :: :ok
+  def unsubscribe_logs(subscription_or_filter), do: Logs.unsubscribe_logs(subscription_or_filter)
 
   @doc """
   Submits one asset run by manifest-scoped target id.
@@ -1383,6 +1425,13 @@ defmodule FavnOrchestrator do
 
   defp configured_runner_opts do
     Application.get_env(:favn_orchestrator, :runner_client_opts, [])
+  end
+
+  defp default_log_filter do
+    case Code.ensure_loaded(Favn.Log.Filter) do
+      {:module, Favn.Log.Filter} -> struct(Favn.Log.Filter)
+      _other -> %{}
+    end
   end
 
   defp validate_runner_client(module) when is_atom(module) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -288,12 +288,16 @@ defmodule FavnOrchestrator do
 
   @doc """
   Subscribes the caller to live backend logs matching the given filter.
+
+  Run-scoped filters subscribe to the run topic. Filters with both `run_id` and
+  `asset_step_id` subscribe to the asset-step topic, then apply the remaining
+  `Favn.Log.Filter` fields before forwarding entries to the caller.
   """
   @spec subscribe_logs(term()) :: {:ok, term()} | {:error, term()}
   def subscribe_logs(filter \\ default_log_filter()), do: Logs.subscribe_logs(filter)
 
   @doc """
-  Unsubscribes the caller from a prior backend log subscription or equivalent filter.
+  Unsubscribes the caller from a prior backend log subscription.
   """
   @spec unsubscribe_logs(term()) :: :ok
   def unsubscribe_logs(subscription_or_filter), do: Logs.unsubscribe_logs(subscription_or_filter)

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -298,9 +298,12 @@ defmodule FavnOrchestrator do
 
   @doc """
   Unsubscribes the caller from a prior backend log subscription.
+
+  Callers must pass the subscription returned by `subscribe_logs/1`; equivalent
+  filters cannot stop the owned forwarding process.
   """
-  @spec unsubscribe_logs(term()) :: :ok
-  def unsubscribe_logs(subscription_or_filter), do: Logs.unsubscribe_logs(subscription_or_filter)
+  @spec unsubscribe_logs(term()) :: :ok | {:error, :invalid_log_subscription}
+  def unsubscribe_logs(subscription), do: Logs.unsubscribe_logs(subscription)
 
   @doc """
   Submits one asset run by manifest-scoped target id.

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
@@ -30,7 +30,7 @@ defmodule FavnOrchestrator.API.Router do
 
   plug(Plug.RequestId)
 
-  if Mix.env() == :dev do
+  if Mix.env() == :dev and Code.ensure_loaded?(Tidewave) do
     plug(Tidewave)
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/log_writer.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/log_writer.ex
@@ -8,46 +8,11 @@ defmodule FavnOrchestrator.LogWriter do
 
   @spec write(term() | [term()]) :: {:ok, [term()]} | {:error, term()}
   def write(entries) when is_list(entries) do
-    redacted_entries = Enum.map(entries, &redact_entry/1)
-
-    with {:ok, persisted_entries} <- Storage.persist_log_entries(redacted_entries) do
+    with {:ok, persisted_entries} <- Storage.persist_log_entries(entries) do
       Enum.each(persisted_entries, &Logs.broadcast_log_entry/1)
       {:ok, persisted_entries}
     end
   end
 
   def write(entry), do: write([entry])
-
-  defp redact_entry(entry) do
-    entry
-    |> normalize_entry()
-    |> apply_redaction_policy()
-  end
-
-  defp normalize_entry(%{__struct__: _struct} = entry), do: entry
-
-  defp normalize_entry(attrs) when is_map(attrs) do
-    case Code.ensure_loaded(Favn.Log.Entry) do
-      {:module, Favn.Log.Entry} -> Favn.Log.Entry.normalize(attrs)
-      _other -> attrs
-    end
-  end
-
-  defp normalize_entry(entry), do: entry
-
-  defp apply_redaction_policy(entry) do
-    with {:module, Favn.Log.Redactor} <- Code.ensure_loaded(Favn.Log.Redactor),
-         true <- function_exported?(Favn.Log.Redactor, :redact, 2) do
-      case Favn.Log.Redactor.redact(entry, redaction_policy()) do
-        {redacted_entry, _redacted?} -> redacted_entry
-        redacted_entry -> redacted_entry
-      end
-    else
-      _other -> entry
-    end
-  end
-
-  defp redaction_policy do
-    Application.get_env(:favn_orchestrator, :log_redaction_policy)
-  end
 end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/log_writer.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/log_writer.ex
@@ -1,0 +1,53 @@
+defmodule FavnOrchestrator.LogWriter do
+  @moduledoc """
+  Persists trusted backend logs and broadcasts them only after durable write.
+  """
+
+  alias FavnOrchestrator.Logs
+  alias FavnOrchestrator.Storage
+
+  @spec write(term() | [term()]) :: {:ok, [term()]} | {:error, term()}
+  def write(entries) when is_list(entries) do
+    redacted_entries = Enum.map(entries, &redact_entry/1)
+
+    with {:ok, persisted_entries} <- Storage.persist_log_entries(redacted_entries) do
+      Enum.each(persisted_entries, &Logs.broadcast_log_entry/1)
+      {:ok, persisted_entries}
+    end
+  end
+
+  def write(entry), do: write([entry])
+
+  defp redact_entry(entry) do
+    entry
+    |> normalize_entry()
+    |> apply_redaction_policy()
+  end
+
+  defp normalize_entry(%{__struct__: _struct} = entry), do: entry
+
+  defp normalize_entry(attrs) when is_map(attrs) do
+    case Code.ensure_loaded(Favn.Log.Entry) do
+      {:module, Favn.Log.Entry} -> Favn.Log.Entry.normalize(attrs)
+      _other -> attrs
+    end
+  end
+
+  defp normalize_entry(entry), do: entry
+
+  defp apply_redaction_policy(entry) do
+    with {:module, Favn.Log.Redactor} <- Code.ensure_loaded(Favn.Log.Redactor),
+         true <- function_exported?(Favn.Log.Redactor, :redact, 2) do
+      case Favn.Log.Redactor.redact(entry, redaction_policy()) do
+        {redacted_entry, _redacted?} -> redacted_entry
+        redacted_entry -> redacted_entry
+      end
+    else
+      _other -> entry
+    end
+  end
+
+  defp redaction_policy do
+    Application.get_env(:favn_orchestrator, :log_redaction_policy)
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/logs.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/logs.ex
@@ -7,25 +7,34 @@ defmodule FavnOrchestrator.Logs do
 
   @global_topic "favn:orchestrator:logs"
   @run_topic_prefix "favn:orchestrator:logs:run:"
+  @asset_topic_prefix "favn:orchestrator:logs:asset:"
 
   @spec subscribe_logs(term()) :: {:ok, term()} | {:error, term()}
   def subscribe_logs(filter \\ default_filter()) do
-    with {:ok, run_id} <- filter_run_id(filter),
-         topics <- subscription_topics(run_id),
-         :ok <- subscribe_topics(topics) do
-      {:ok, %{topics: topics, filter: filter}}
+    with {:ok, normalized_filter} <- normalize_filter(filter),
+         topics <- subscription_topics(normalized_filter),
+         {:ok, pid} <- start_subscription_forwarder(self(), topics, normalized_filter) do
+      {:ok, %{pid: pid, topics: topics, filter: normalized_filter}}
     end
   end
 
   @spec unsubscribe_logs(term()) :: :ok
+  def unsubscribe_logs(%{pid: pid}) when is_pid(pid) do
+    send(pid, :stop)
+    :ok
+  end
+
   def unsubscribe_logs(%{topics: topics}) when is_list(topics) do
     Enum.each(topics, &Phoenix.PubSub.unsubscribe(pubsub_name(), &1))
     :ok
   end
 
   def unsubscribe_logs(filter) do
-    with {:ok, run_id} <- filter_run_id(filter) do
-      Enum.each(subscription_topics(run_id), &Phoenix.PubSub.unsubscribe(pubsub_name(), &1))
+    with {:ok, normalized_filter} <- normalize_filter(filter) do
+      Enum.each(
+        subscription_topics(normalized_filter),
+        &Phoenix.PubSub.unsubscribe(pubsub_name(), &1)
+      )
     end
 
     :ok
@@ -40,6 +49,7 @@ defmodule FavnOrchestrator.Logs do
     case entry_run_id(entry) do
       run_id when is_binary(run_id) and run_id != "" ->
         _ = Phoenix.PubSub.broadcast(pubsub_name(), run_topic(run_id), message)
+        maybe_broadcast_asset_log_entry(entry, run_id, message)
 
       _other ->
         :ok
@@ -58,6 +68,12 @@ defmodule FavnOrchestrator.Logs do
   @spec run_topic(String.t()) :: String.t()
   def run_topic(run_id) when is_binary(run_id), do: @run_topic_prefix <> run_id
 
+  @spec asset_topic(String.t(), String.t()) :: String.t()
+  def asset_topic(run_id, asset_step_id)
+      when is_binary(run_id) and is_binary(asset_step_id) do
+    @asset_topic_prefix <> run_id <> ":" <> asset_step_id
+  end
+
   @spec pubsub_name() :: module()
   def pubsub_name do
     Application.get_env(:favn_orchestrator, :pubsub_name, FavnOrchestrator.PubSub)
@@ -72,10 +88,115 @@ defmodule FavnOrchestrator.Logs do
     end)
   end
 
-  defp subscription_topics(nil), do: [global_topic()]
-  defp subscription_topics(run_id), do: [run_topic(run_id)]
+  defp start_subscription_forwarder(owner, topics, filter) do
+    parent = self()
 
-  defp filter_run_id(filter), do: {:ok, field(filter, :run_id)}
+    pid =
+      spawn(fn ->
+        owner_ref = Process.monitor(owner)
+
+        case subscribe_topics(topics) do
+          :ok ->
+            send(parent, {__MODULE__, self(), :ready})
+            subscription_loop(owner, owner_ref, filter)
+
+          {:error, reason} ->
+            send(parent, {__MODULE__, self(), {:error, reason}})
+        end
+      end)
+
+    receive do
+      {__MODULE__, ^pid, :ready} -> {:ok, pid}
+      {__MODULE__, ^pid, {:error, reason}} -> {:error, reason}
+    after
+      1_000 -> {:error, :log_subscription_timeout}
+    end
+  end
+
+  defp subscription_loop(owner, owner_ref, filter) do
+    receive do
+      {:favn_log_entry, entry} = message ->
+        if matches_filter?(entry, filter), do: send(owner, message)
+        subscription_loop(owner, owner_ref, filter)
+
+      {:DOWN, ^owner_ref, :process, _pid, _reason} ->
+        :ok
+
+      :stop ->
+        :ok
+    end
+  end
+
+  defp maybe_broadcast_asset_log_entry(entry, run_id, message) do
+    case field(entry, :asset_step_id) do
+      asset_step_id when is_binary(asset_step_id) and asset_step_id != "" ->
+        _ = Phoenix.PubSub.broadcast(pubsub_name(), asset_topic(run_id, asset_step_id), message)
+        :ok
+
+      _other ->
+        :ok
+    end
+  end
+
+  defp subscription_topics(filter) do
+    run_id = Map.get(filter, :run_id)
+    asset_step_id = Map.get(filter, :asset_step_id)
+
+    cond do
+      is_binary(run_id) and run_id != "" and is_binary(asset_step_id) and asset_step_id != "" ->
+        [asset_topic(run_id, asset_step_id)]
+
+      is_binary(run_id) and run_id != "" ->
+        [run_topic(run_id)]
+
+      true ->
+        [global_topic()]
+    end
+  end
+
+  defp matches_filter?(entry, filter) do
+    Enum.all?(filter, fn
+      {:levels, []} -> true
+      {:levels, levels} when is_list(levels) -> field(entry, :level) in levels
+      {:sources, []} -> true
+      {:sources, sources} when is_list(sources) -> field(entry, :source) in sources
+      {:since, %DateTime{} = since} -> DateTime.compare(field(entry, :occurred_at), since) != :lt
+      {:until, %DateTime{} = until} -> DateTime.compare(field(entry, :occurred_at), until) != :gt
+      {_key, nil} -> true
+      {key, expected} -> field(entry, key) == expected
+    end)
+  end
+
+  defp normalize_filter(filter) do
+    case Code.ensure_loaded(Favn.Log.Filter) do
+      {:module, Favn.Log.Filter} -> {:ok, Favn.Log.Filter.normalize(filter) |> Map.from_struct()}
+      _other -> {:ok, normalize_filter_map(filter)}
+    end
+  rescue
+    error -> {:error, {:invalid_log_filter, error}}
+  end
+
+  defp normalize_filter_map(filter) when is_list(filter),
+    do: filter |> Map.new() |> normalize_filter_map()
+
+  defp normalize_filter_map(%_{} = filter),
+    do: filter |> Map.from_struct() |> normalize_filter_map()
+
+  defp normalize_filter_map(filter) when is_map(filter) do
+    filter
+    |> Enum.map(fn {key, value} -> {normalize_filter_key(key), value} end)
+    |> Map.new()
+  end
+
+  defp normalize_filter_map(_filter), do: %{}
+
+  defp normalize_filter_key(key) when is_atom(key), do: key
+
+  defp normalize_filter_key(key) when is_binary(key) do
+    String.to_existing_atom(key)
+  rescue
+    ArgumentError -> key
+  end
 
   defp entry_run_id(entry), do: field(entry, :run_id)
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/logs.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/logs.ex
@@ -18,27 +18,13 @@ defmodule FavnOrchestrator.Logs do
     end
   end
 
-  @spec unsubscribe_logs(term()) :: :ok
+  @spec unsubscribe_logs(term()) :: :ok | {:error, :invalid_log_subscription}
   def unsubscribe_logs(%{pid: pid}) when is_pid(pid) do
     send(pid, :stop)
     :ok
   end
 
-  def unsubscribe_logs(%{topics: topics}) when is_list(topics) do
-    Enum.each(topics, &Phoenix.PubSub.unsubscribe(pubsub_name(), &1))
-    :ok
-  end
-
-  def unsubscribe_logs(filter) do
-    with {:ok, normalized_filter} <- normalize_filter(filter) do
-      Enum.each(
-        subscription_topics(normalized_filter),
-        &Phoenix.PubSub.unsubscribe(pubsub_name(), &1)
-      )
-    end
-
-    :ok
-  end
+  def unsubscribe_logs(_subscription), do: {:error, :invalid_log_subscription}
 
   @spec broadcast_log_entry(term()) :: :ok
   def broadcast_log_entry(entry) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/logs.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/logs.ex
@@ -1,0 +1,95 @@
+defmodule FavnOrchestrator.Logs do
+  @moduledoc """
+  Operator-facing PubSub topics and helpers for persisted backend logs.
+  """
+
+  require Logger
+
+  @global_topic "favn:orchestrator:logs"
+  @run_topic_prefix "favn:orchestrator:logs:run:"
+
+  @spec subscribe_logs(term()) :: {:ok, term()} | {:error, term()}
+  def subscribe_logs(filter \\ default_filter()) do
+    with {:ok, run_id} <- filter_run_id(filter),
+         topics <- subscription_topics(run_id),
+         :ok <- subscribe_topics(topics) do
+      {:ok, %{topics: topics, filter: filter}}
+    end
+  end
+
+  @spec unsubscribe_logs(term()) :: :ok
+  def unsubscribe_logs(%{topics: topics}) when is_list(topics) do
+    Enum.each(topics, &Phoenix.PubSub.unsubscribe(pubsub_name(), &1))
+    :ok
+  end
+
+  def unsubscribe_logs(filter) do
+    with {:ok, run_id} <- filter_run_id(filter) do
+      Enum.each(subscription_topics(run_id), &Phoenix.PubSub.unsubscribe(pubsub_name(), &1))
+    end
+
+    :ok
+  end
+
+  @spec broadcast_log_entry(term()) :: :ok
+  def broadcast_log_entry(entry) do
+    message = {:favn_log_entry, entry}
+
+    _ = Phoenix.PubSub.broadcast(pubsub_name(), global_topic(), message)
+
+    case entry_run_id(entry) do
+      run_id when is_binary(run_id) and run_id != "" ->
+        _ = Phoenix.PubSub.broadcast(pubsub_name(), run_topic(run_id), message)
+
+      _other ->
+        :ok
+    end
+
+    :ok
+  rescue
+    error ->
+      Logger.warning("failed to broadcast log entry: #{inspect(error)}")
+      :ok
+  end
+
+  @spec global_topic() :: String.t()
+  def global_topic, do: @global_topic
+
+  @spec run_topic(String.t()) :: String.t()
+  def run_topic(run_id) when is_binary(run_id), do: @run_topic_prefix <> run_id
+
+  @spec pubsub_name() :: module()
+  def pubsub_name do
+    Application.get_env(:favn_orchestrator, :pubsub_name, FavnOrchestrator.PubSub)
+  end
+
+  defp subscribe_topics(topics) do
+    Enum.reduce_while(topics, :ok, fn topic, :ok ->
+      case Phoenix.PubSub.subscribe(pubsub_name(), topic) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp subscription_topics(nil), do: [global_topic()]
+  defp subscription_topics(run_id), do: [run_topic(run_id)]
+
+  defp filter_run_id(filter), do: {:ok, field(filter, :run_id)}
+
+  defp entry_run_id(entry), do: field(entry, :run_id)
+
+  defp field(%{__struct__: _struct} = value, key), do: Map.get(value, key)
+
+  defp field(value, key) when is_map(value),
+    do: Map.get(value, key) || Map.get(value, Atom.to_string(key))
+
+  defp field(_value, _key), do: nil
+
+  defp default_filter do
+    case Code.ensure_loaded(Favn.Log.Filter) do
+      {:module, Favn.Log.Filter} -> struct(Favn.Log.Filter)
+      _other -> %{}
+    end
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -437,10 +437,12 @@ defmodule FavnOrchestrator.RunServer.Execution do
       case runner_client.submit_work(work, runner_opts) do
         {:ok, execution_id} ->
           updated_run = with_inflight_execution(current_run, execution_id, work.metadata)
+          asset_step_id = Map.fetch!(work.metadata, :asset_step_id)
 
           case Persistence.persist_run_step(updated_run, :step_started, %{
                  asset_ref: asset_ref,
                  runner_execution_id: execution_id,
+                 asset_step_id: asset_step_id,
                  stage: stage,
                  attempt: attempt,
                  max_attempts: current_run.max_attempts,
@@ -448,9 +450,13 @@ defmodule FavnOrchestrator.RunServer.Execution do
                }) do
             :ok ->
               entry = %{
+                run_id: current_run.id,
+                asset_step_id: asset_step_id,
                 asset_ref: asset_ref,
                 node_key: node_key,
                 execution_id: execution_id,
+                runner_execution_id: execution_id,
+                attempt: attempt,
                 stage: stage,
                 freshness_key: decision_freshness_key(decisions, node_key)
               }
@@ -539,7 +545,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
   end
 
   defp await_runner_result(entry, timeout_ms, runner_client, runner_opts) do
-    bridge = start_runner_log_bridge(runner_client, entry.execution_id, runner_opts)
+    bridge = start_runner_log_bridge(runner_client, entry.execution_id, runner_opts, entry)
 
     try do
       runner_client.await_result(entry.execution_id, timeout_ms, runner_opts)
@@ -1073,6 +1079,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
   defp stage_work(%RunState{} = run_state, %Version{} = version, node_key, stage, attempt) do
     node = Map.fetch!(run_state.plan.nodes, node_key)
     asset_ref = node.ref
+    asset_step_id = asset_step_id(run_state.id, node_key, asset_ref)
 
     %RunnerWork{
       run_id: run_state.id,
@@ -1089,6 +1096,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
       metadata:
         Map.merge(work_metadata(run_state.metadata), %{
           attempt: attempt,
+          asset_step_id: asset_step_id,
           max_attempts: run_state.max_attempts,
           stage: stage,
           node_key: node_key
@@ -1593,6 +1601,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
         metadata:
           Map.merge(work_metadata(run_state.metadata), %{
             attempt: attempt,
+            asset_step_id: asset_step_id(run_state.id, {asset_ref, nil}, asset_ref),
             max_attempts: max_attempts,
             stage: stage,
             node_key: {asset_ref, nil}
@@ -1678,7 +1687,15 @@ defmodule FavnOrchestrator.RunServer.Execution do
          runner_client,
          runner_opts
        ) do
-    bridge = start_runner_log_bridge(runner_client, execution_id, runner_opts)
+    bridge =
+      start_runner_log_bridge(runner_client, execution_id, runner_opts, %{
+        run_id: running_with_execution.id,
+        asset_step_id: Map.get(running_with_execution.metadata, :asset_step_id),
+        node_key: Map.get(running_with_execution.metadata, :node_key),
+        asset_ref: asset_ref,
+        runner_execution_id: execution_id,
+        attempt: attempt
+      })
 
     await_result =
       try do
@@ -1794,12 +1811,26 @@ defmodule FavnOrchestrator.RunServer.Execution do
     end
   end
 
-  defp start_runner_log_bridge(runner_client, execution_id, runner_opts) do
-    case RunnerLogBridge.start_link(runner_client, execution_id, runner_opts) do
+  defp start_runner_log_bridge(runner_client, execution_id, runner_opts, context) do
+    case RunnerLogBridge.start(runner_client, execution_id, runner_opts, context) do
       {:ok, pid} -> pid
       {:error, _reason} -> nil
     end
   end
+
+  defp asset_step_id(run_id, node_key, asset_ref) do
+    persisted_key_id(node_key, asset_ref) || safe_id("#{run_id}:#{inspect(asset_ref)}")
+  end
+
+  defp persisted_key_id(nil, _asset_ref), do: nil
+  defp persisted_key_id(key, asset_ref) when is_binary(key) and key != asset_ref, do: safe_id(key)
+
+  defp persisted_key_id(key, _asset_ref) when is_tuple(key),
+    do: key |> :erlang.term_to_binary() |> Base.url_encode64(padding: false) |> safe_id()
+
+  defp persisted_key_id(_key, _asset_ref), do: nil
+
+  defp safe_id(value), do: value |> to_string() |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
 
   defp stop_runner_log_bridge(nil, _runner_client, _execution_id, _runner_opts), do: :ok
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -24,6 +24,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.Redaction
   alias FavnOrchestrator.RefreshPolicy
+  alias FavnOrchestrator.RunnerLogBridge
   alias FavnOrchestrator.RunServer.Persistence
   alias FavnOrchestrator.RunServer.Snapshots
   alias FavnOrchestrator.RunState
@@ -538,7 +539,13 @@ defmodule FavnOrchestrator.RunServer.Execution do
   end
 
   defp await_runner_result(entry, timeout_ms, runner_client, runner_opts) do
-    runner_client.await_result(entry.execution_id, timeout_ms, runner_opts)
+    bridge = start_runner_log_bridge(runner_client, entry.execution_id, runner_opts)
+
+    try do
+      runner_client.await_result(entry.execution_id, timeout_ms, runner_opts)
+    after
+      stop_runner_log_bridge(bridge, runner_client, entry.execution_id, runner_opts)
+    end
   rescue
     exception ->
       {:error,
@@ -1671,7 +1678,16 @@ defmodule FavnOrchestrator.RunServer.Execution do
          runner_client,
          runner_opts
        ) do
-    case runner_client.await_result(execution_id, running_with_execution.timeout_ms, runner_opts) do
+    bridge = start_runner_log_bridge(runner_client, execution_id, runner_opts)
+
+    await_result =
+      try do
+        runner_client.await_result(execution_id, running_with_execution.timeout_ms, runner_opts)
+      after
+        stop_runner_log_bridge(bridge, runner_client, execution_id, runner_opts)
+      end
+
+    case await_result do
       {:ok, %RunnerResult{} = result} ->
         result = sanitize_runner_result(result)
 
@@ -1776,6 +1792,19 @@ defmodule FavnOrchestrator.RunServer.Execution do
             Snapshots.cancelled_state(running_with_execution)
         end
     end
+  end
+
+  defp start_runner_log_bridge(runner_client, execution_id, runner_opts) do
+    case RunnerLogBridge.start_link(runner_client, execution_id, runner_opts) do
+      {:ok, pid} -> pid
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp stop_runner_log_bridge(nil, _runner_client, _execution_id, _runner_opts), do: :ok
+
+  defp stop_runner_log_bridge(pid, runner_client, execution_id, runner_opts) when is_pid(pid) do
+    RunnerLogBridge.stop(pid, runner_client, execution_id, runner_opts)
   end
 
   defp maybe_retry_step(

--- a/apps/favn_orchestrator/lib/favn_orchestrator/runner_client/local_node.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/runner_client/local_node.ex
@@ -50,6 +50,23 @@ defmodule FavnOrchestrator.RunnerClient.LocalNode do
   end
 
   @impl true
+  @spec subscribe_execution_logs(String.t(), pid(), [opt()]) :: :ok | {:error, term()}
+  def subscribe_execution_logs(execution_id, subscriber, opts \\ [])
+      when is_binary(execution_id) and is_pid(subscriber) and is_list(opts) do
+    dispatch(opts, :subscribe_execution_logs, [execution_id, subscriber, opts])
+  end
+
+  @impl true
+  @spec unsubscribe_execution_logs(String.t(), pid(), [opt()]) :: :ok
+  def unsubscribe_execution_logs(execution_id, subscriber, opts \\ [])
+      when is_binary(execution_id) and is_pid(subscriber) and is_list(opts) do
+    case dispatch(opts, :unsubscribe_execution_logs, [execution_id, subscriber, opts]) do
+      :ok -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+
+  @impl true
   @spec inspect_relation(RelationInspectionRequest.t(), [opt()]) ::
           {:ok, RelationInspectionResult.t()} | {:error, term()}
   def inspect_relation(%RelationInspectionRequest{} = request, opts \\ []) when is_list(opts) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/runner_log_bridge.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/runner_log_bridge.ex
@@ -1,0 +1,57 @@
+defmodule FavnOrchestrator.RunnerLogBridge do
+  @moduledoc false
+
+  alias FavnOrchestrator.LogWriter
+
+  @spec start_link(module(), String.t(), keyword()) :: {:ok, pid()} | {:error, term()}
+  def start_link(runner_client, execution_id, runner_opts)
+      when is_atom(runner_client) and is_binary(execution_id) and is_list(runner_opts) do
+    if function_exported?(runner_client, :subscribe_execution_logs, 3) do
+      parent = self()
+
+      pid =
+        spawn_link(fn ->
+          send(parent, {__MODULE__, self(), :ready})
+          loop()
+        end)
+
+      receive do
+        {__MODULE__, ^pid, :ready} -> :ok
+      end
+
+      case runner_client.subscribe_execution_logs(execution_id, pid, runner_opts) do
+        :ok ->
+          {:ok, pid}
+
+        {:error, reason} ->
+          send(pid, :stop)
+          {:error, reason}
+      end
+    else
+      {:error, :runner_log_subscription_not_supported}
+    end
+  end
+
+  @spec stop(pid(), module(), String.t(), keyword()) :: :ok
+  def stop(pid, runner_client, execution_id, runner_opts)
+      when is_pid(pid) and is_atom(runner_client) and is_binary(execution_id) and
+             is_list(runner_opts) do
+    if function_exported?(runner_client, :unsubscribe_execution_logs, 3) do
+      _ = runner_client.unsubscribe_execution_logs(execution_id, pid, runner_opts)
+    end
+
+    send(pid, :stop)
+    :ok
+  end
+
+  defp loop do
+    receive do
+      {:runner_log_entry, _execution_id, entry} ->
+        _ = LogWriter.write(entry)
+        loop()
+
+      :stop ->
+        :ok
+    end
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/runner_log_bridge.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/runner_log_bridge.ex
@@ -1,18 +1,32 @@
 defmodule FavnOrchestrator.RunnerLogBridge do
   @moduledoc false
 
+  require Logger
+
   alias FavnOrchestrator.LogWriter
 
-  @spec start_link(module(), String.t(), keyword()) :: {:ok, pid()} | {:error, term()}
-  def start_link(runner_client, execution_id, runner_opts)
+  @context_fields [
+    :run_id,
+    :asset_step_id,
+    :node_key,
+    :asset_ref,
+    :runner_execution_id,
+    :attempt
+  ]
+
+  @spec start(module(), String.t(), keyword(), map() | keyword()) ::
+          {:ok, pid()} | {:error, term()}
+  def start(runner_client, execution_id, runner_opts, context \\ %{})
       when is_atom(runner_client) and is_binary(execution_id) and is_list(runner_opts) do
     if function_exported?(runner_client, :subscribe_execution_logs, 3) do
       parent = self()
+      context = normalize_context(context, execution_id)
 
       pid =
-        spawn_link(fn ->
+        spawn(fn ->
+          parent_ref = Process.monitor(parent)
           send(parent, {__MODULE__, self(), :ready})
-          loop()
+          loop(execution_id, context, parent_ref)
         end)
 
       receive do
@@ -44,14 +58,89 @@ defmodule FavnOrchestrator.RunnerLogBridge do
     :ok
   end
 
-  defp loop do
+  defp loop(execution_id, context, parent_ref) do
     receive do
-      {:runner_log_entry, _execution_id, entry} ->
-        _ = LogWriter.write(entry)
-        loop()
+      {:runner_log_entry, ^execution_id, entry} ->
+        safe_handle_entry(entry, context)
+
+        loop(execution_id, context, parent_ref)
+
+      {:runner_log_entry, _other_execution_id, _entry} ->
+        loop(execution_id, context, parent_ref)
+
+      {:DOWN, ^parent_ref, :process, _pid, _reason} ->
+        :ok
 
       :stop ->
         :ok
     end
+  end
+
+  defp normalize_context(context, execution_id) when is_list(context) do
+    context |> Map.new() |> normalize_context(execution_id)
+  end
+
+  defp normalize_context(context, execution_id) when is_map(context) do
+    context
+    |> atomize_known_keys()
+    |> Map.put_new(:runner_execution_id, execution_id)
+    |> Map.take(@context_fields)
+  end
+
+  defp normalize_context(_context, execution_id), do: %{runner_execution_id: execution_id}
+
+  defp atomize_known_keys(map) do
+    Enum.reduce(map, %{}, fn {key, value}, acc ->
+      key = if is_binary(key), do: string_context_key(key), else: key
+      Map.put(acc, key, value)
+    end)
+  end
+
+  defp string_context_key(key),
+    do: Enum.find(@context_fields, key, &(Atom.to_string(&1) == key)) || key
+
+  defp merge_context(entry, context) do
+    entry
+    |> entry_to_map()
+    |> then(fn attrs ->
+      Enum.reduce(context, attrs, fn {key, value}, acc ->
+        if missing?(Map.get(acc, key)), do: Map.put(acc, key, value), else: acc
+      end)
+    end)
+  end
+
+  defp entry_to_map(%_{} = entry), do: Map.from_struct(entry)
+  defp entry_to_map(entry) when is_list(entry), do: Map.new(entry)
+  defp entry_to_map(entry) when is_map(entry), do: entry
+  defp entry_to_map(entry), do: %{message: inspect(entry), source: :runner, level: :warning}
+
+  defp missing?(nil), do: true
+  defp missing?(""), do: true
+  defp missing?(_value), do: false
+
+  defp safe_handle_entry(entry, context) do
+    entry
+    |> merge_context(context)
+    |> safe_write()
+  rescue
+    error -> log_ignored_entry(error)
+  catch
+    kind, reason -> log_ignored_entry({kind, reason})
+  end
+
+  defp safe_write(entry) do
+    case LogWriter.write(entry) do
+      {:ok, _entries} -> :ok
+      {:error, reason} -> log_ignored_entry(reason)
+    end
+  rescue
+    error -> log_ignored_entry(error)
+  catch
+    kind, reason -> log_ignored_entry({kind, reason})
+  end
+
+  defp log_ignored_entry(reason) do
+    Logger.warning("ignored malformed runner log entry: #{inspect(reason)}")
+    :ok
   end
 end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -129,7 +129,9 @@ defmodule FavnOrchestrator.Storage do
   @spec persist_log_entries([Favn.Log.Entry.t()]) ::
           {:ok, [Favn.Log.Entry.t()]} | {:error, term()}
   def persist_log_entries(entries) when is_list(entries) do
-    adapter_call(fn adapter, opts -> adapter.persist_log_entries(entries, opts) end)
+    with {:ok, redacted_entries} <- redact_log_entries(entries) do
+      adapter_call(fn adapter, opts -> adapter.persist_log_entries(redacted_entries, opts) end)
+    end
   end
 
   @spec list_logs(Favn.Log.Filter.t() | map() | keyword(), keyword()) ::
@@ -398,6 +400,40 @@ defmodule FavnOrchestrator.Storage do
   @spec adapter_opts() :: keyword()
   def adapter_opts do
     Application.get_env(:favn_orchestrator, :storage_adapter_opts, [])
+  end
+
+  defp redact_log_entries(entries) do
+    entries
+    |> Enum.reduce_while({:ok, []}, fn entry, {:ok, acc} ->
+      case redact_log_entry(entry) do
+        {:ok, redacted} -> {:cont, {:ok, [redacted | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, redacted} -> {:ok, Enum.reverse(redacted)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp redact_log_entry(entry) do
+    with {:module, Favn.Log.Redactor} <- Code.ensure_loaded(Favn.Log.Redactor),
+         true <- function_exported?(Favn.Log.Redactor, :redact, 2) do
+      case Favn.Log.Redactor.redact(entry, log_redaction_policy()) do
+        {redacted_entry, _redacted?} -> {:ok, redacted_entry}
+        redacted_entry -> {:ok, redacted_entry}
+      end
+    else
+      _other -> {:ok, entry}
+    end
+  rescue
+    error -> {:error, {:invalid_log_entry, error}}
+  catch
+    kind, reason -> {:error, {:invalid_log_entry, {kind, reason}}}
+  end
+
+  defp log_redaction_policy do
+    Application.get_env(:favn_orchestrator, :log_redaction_policy)
   end
 
   @spec validate_adapter(module()) :: :ok | {:error, term()}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -126,6 +126,33 @@ defmodule FavnOrchestrator.Storage do
     adapter_call(fn adapter, opts -> adapter.list_global_run_events(run_event_opts, opts) end)
   end
 
+  @spec persist_log_entries([Favn.Log.Entry.t()]) ::
+          {:ok, [Favn.Log.Entry.t()]} | {:error, term()}
+  def persist_log_entries(entries) when is_list(entries) do
+    adapter_call(fn adapter, opts -> adapter.persist_log_entries(entries, opts) end)
+  end
+
+  @spec list_logs(Favn.Log.Filter.t() | map() | keyword(), keyword()) ::
+          {:ok, Page.t(Favn.Log.Entry.t())} | {:error, term()}
+  def list_logs(filter \\ [], opts \\ []) when is_list(opts) do
+    with {:ok, page_opts} <- Page.normalize_opts(opts) do
+      adapter_call(fn adapter, adapter_opts ->
+        adapter.list_logs(filter, Keyword.merge(opts, page_opts), adapter_opts)
+      end)
+    end
+  end
+
+  @spec replay_logs_after(
+          Favn.Log.Cursor.t() | String.t() | nil,
+          Favn.Log.Filter.t() | map() | keyword(),
+          keyword()
+        ) :: {:ok, [Favn.Log.Entry.t()]} | {:error, term()}
+  def replay_logs_after(cursor, filter \\ [], opts \\ []) when is_list(opts) do
+    adapter_call(fn adapter, adapter_opts ->
+      adapter.replay_logs_after(cursor, filter, opts, adapter_opts)
+    end)
+  end
+
   @spec put_scheduler_state({module(), atom() | nil}, map()) :: :ok | {:error, term()}
   def put_scheduler_state({module, schedule_id} = key, state)
       when is_atom(module) and is_map(state) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -13,10 +13,27 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage.LogEntryCodec
   alias FavnOrchestrator.Storage.RunEventCodec
   alias FavnOrchestrator.Storage.RunStateCodec
   alias FavnOrchestrator.Storage.SchedulerStateCodec
   alias FavnOrchestrator.Storage.WriteSemantics
+
+  @log_filter_keys [
+    :run_id,
+    :asset_step_id,
+    :runner_execution_id,
+    :level,
+    :source,
+    :stream,
+    :levels,
+    :sources,
+    :since,
+    :until,
+    :asset_ref,
+    :node_key,
+    :after_global_sequence
+  ]
 
   @type state :: %{
           manifests: %{required(String.t()) => Version.t()},
@@ -24,6 +41,8 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
           runs: %{required(String.t()) => RunState.t()},
           run_events: %{required(String.t()) => [map()]},
           run_event_global_sequence: non_neg_integer(),
+          log_entries: [Favn.Log.Entry.t()],
+          log_global_sequence: non_neg_integer(),
           scheduler_states: %{required({module(), atom() | nil}) => map()},
           coverage_baselines: %{required(String.t()) => CoverageBaseline.t()},
           backfill_windows: %{required({String.t(), module(), String.t()}) => BackfillWindow.t()},
@@ -195,6 +214,27 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       when is_list(run_event_opts) and is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
     GenServer.call(server, {:list_global_run_events, run_event_opts})
+  end
+
+  @impl true
+  def persist_log_entries(entries, opts) when is_list(entries) and is_list(opts) do
+    with {:ok, normalized} <- normalize_log_entries(entries) do
+      server = Keyword.get(opts, :server, __MODULE__)
+      GenServer.call(server, {:persist_log_entries, normalized})
+    end
+  end
+
+  @impl true
+  def list_logs(filter, opts, adapter_opts) when is_list(opts) and is_list(adapter_opts) do
+    server = Keyword.get(adapter_opts, :server, __MODULE__)
+    GenServer.call(server, {:list_logs, filter, opts})
+  end
+
+  @impl true
+  def replay_logs_after(cursor, filter, opts, adapter_opts)
+      when is_list(opts) and is_list(adapter_opts) do
+    server = Keyword.get(adapter_opts, :server, __MODULE__)
+    GenServer.call(server, {:replay_logs_after, cursor, filter, opts})
   end
 
   @impl true
@@ -480,6 +520,8 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       runs: %{},
       run_events: %{},
       run_event_global_sequence: 0,
+      log_entries: [],
+      log_global_sequence: 0,
       scheduler_states: %{},
       coverage_baselines: %{},
       backfill_windows: %{},
@@ -704,6 +746,59 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
 
         true ->
           {:error, :cursor_invalid}
+      end
+
+    {:reply, reply, state}
+  end
+
+  def handle_call({:persist_log_entries, entries}, _from, state) do
+    {persisted, next_entries, next_sequence} =
+      Enum.reduce(entries, {[], log_entries(state), log_global_sequence(state)}, fn entry,
+                                                                                    {persisted,
+                                                                                     stored,
+                                                                                     sequence} ->
+        case find_idempotent_log_entry(stored, entry) do
+          nil ->
+            next_sequence = sequence + 1
+            persisted_entry = LogEntryCodec.assign_global_sequence(entry, next_sequence)
+            {[persisted_entry | persisted], stored ++ [persisted_entry], next_sequence}
+
+          existing ->
+            {[existing | persisted], stored, sequence}
+        end
+      end)
+
+    {:reply, {:ok, Enum.reverse(persisted)},
+     Map.merge(state, %{log_entries: next_entries, log_global_sequence: next_sequence})}
+  end
+
+  def handle_call({:list_logs, filter, opts}, _from, state) do
+    page_opts = page_opts(opts)
+
+    rows =
+      log_entries(state)
+      |> filter_logs(filter)
+      |> Enum.sort_by(&Map.get(&1, :global_sequence, 0))
+      |> Enum.drop(Keyword.fetch!(page_opts, :offset))
+      |> Enum.take(Keyword.fetch!(page_opts, :limit) + 1)
+
+    {:reply, {:ok, Page.from_fetched(rows, page_opts)}, state}
+  end
+
+  def handle_call({:replay_logs_after, cursor, filter, opts}, _from, state) do
+    limit = Keyword.get(opts, :limit, 200)
+
+    reply =
+      with {:ok, after_sequence} <- log_cursor_sequence(cursor),
+           :ok <- validate_replay_limit(limit) do
+        rows =
+          log_entries(state)
+          |> filter_logs(filter)
+          |> Enum.filter(&(Map.get(&1, :global_sequence, 0) > after_sequence))
+          |> Enum.sort_by(&Map.get(&1, :global_sequence, 0))
+          |> Enum.take(limit)
+
+        {:ok, rows}
       end
 
     {:reply, reply, state}
@@ -1167,6 +1262,125 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       if key in allowed_keys, do: false, else: {:error, {:unsupported_filter, key}}
     end)
   end
+
+  defp normalize_log_entries(entries) do
+    Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, acc} ->
+      case LogEntryCodec.normalize(entry) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp log_entries(state), do: Map.get(state, :log_entries, [])
+  defp log_global_sequence(state), do: Map.get(state, :log_global_sequence, 0)
+
+  defp find_idempotent_log_entry(entries, entry) do
+    producer_id = Map.get(entry, :producer_id)
+    producer_sequence = Map.get(entry, :producer_sequence)
+
+    if is_binary(producer_id) and is_integer(producer_sequence) do
+      Enum.find(entries, fn existing ->
+        Map.get(existing, :producer_id) == producer_id and
+          Map.get(existing, :producer_sequence) == producer_sequence
+      end)
+    end
+  end
+
+  defp filter_logs(entries, filter) do
+    filters = normalize_log_filter(filter)
+
+    Enum.filter(entries, fn entry ->
+      Enum.all?(filters, fn
+        {:after_global_sequence, sequence} ->
+          Map.get(entry, :global_sequence, 0) > sequence
+
+        {:levels, []} ->
+          true
+
+        {:levels, levels} when is_list(levels) ->
+          Map.get(entry, :level) in levels
+
+        {:sources, []} ->
+          true
+
+        {:sources, sources} when is_list(sources) ->
+          Map.get(entry, :source) in sources
+
+        {:since, %DateTime{} = since} ->
+          DateTime.compare(Map.get(entry, :occurred_at), since) != :lt
+
+        {:until, %DateTime{} = until} ->
+          DateTime.compare(Map.get(entry, :occurred_at), until) != :gt
+
+        {:asset_ref, expected} ->
+          Map.get(entry, :asset_ref) == expected
+
+        {:node_key, expected} ->
+          Map.get(entry, :node_key) == expected
+
+        {key, expected} ->
+          Map.get(entry, key) == expected
+      end)
+    end)
+  end
+
+  defp normalize_log_filter(filter) when is_list(filter),
+    do: Keyword.drop(filter, [:limit, :offset])
+
+  defp normalize_log_filter(%_{} = filter),
+    do: filter |> Map.from_struct() |> normalize_log_filter()
+
+  defp normalize_log_filter(filter) when is_map(filter) do
+    filter
+    |> Enum.map(fn {key, value} -> {normalize_filter_key(key), value} end)
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp normalize_log_filter(_filter), do: []
+
+  defp normalize_filter_key(key) when is_atom(key), do: key
+
+  defp normalize_filter_key(key) when is_binary(key) do
+    Enum.find(@log_filter_keys, key, &(Atom.to_string(&1) == key)) || key
+  end
+
+  defp log_cursor_sequence(nil), do: {:ok, 0}
+  defp log_cursor_sequence(value) when is_integer(value) and value >= 0, do: {:ok, value}
+
+  defp log_cursor_sequence(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {sequence, ""} when sequence >= 0 ->
+        {:ok, sequence}
+
+      _ ->
+        case Favn.Log.Cursor.parse(value) do
+          {:ok, cursor} -> log_cursor_sequence(cursor)
+          {:error, _reason} -> {:error, :cursor_invalid}
+        end
+    end
+  end
+
+  defp log_cursor_sequence(%_{} = cursor),
+    do: cursor |> Map.from_struct() |> log_cursor_sequence()
+
+  defp log_cursor_sequence(%{} = cursor) do
+    cursor
+    |> Map.get(
+      :global_sequence,
+      Map.get(cursor, :after_global_sequence, Map.get(cursor, "global_sequence"))
+    )
+    |> log_cursor_sequence()
+  end
+
+  defp log_cursor_sequence(_cursor), do: {:error, :cursor_invalid}
+
+  defp validate_replay_limit(limit) when is_integer(limit) and limit > 0, do: :ok
+  defp validate_replay_limit(_limit), do: {:error, :cursor_invalid}
 
   defp reject_scoped(_values, []), do: %{}
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/log_entry_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/log_entry_codec.ex
@@ -47,6 +47,10 @@ defmodule FavnOrchestrator.Storage.LogEntryCodec do
 
       {:ok, Favn.Log.Entry.normalize(attrs)}
     end
+  rescue
+    error -> {:error, {:invalid_log_entry, error}}
+  catch
+    kind, reason -> {:error, {:invalid_log_entry, {kind, reason}}}
   end
 
   defp entry_to_map(%_{} = entry), do: Map.from_struct(entry)

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/log_entry_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/log_entry_codec.ex
@@ -1,0 +1,263 @@
+defmodule FavnOrchestrator.Storage.LogEntryCodec do
+  @moduledoc false
+
+  alias FavnOrchestrator.Storage.JsonSafe
+  alias FavnOrchestrator.Storage.PayloadCodec
+
+  @format "favn.log_entry.storage.v1"
+  @fields [
+    :schema_version,
+    :id,
+    :global_sequence,
+    :run_id,
+    :asset_step_id,
+    :node_key,
+    :asset_ref,
+    :runner_execution_id,
+    :attempt,
+    :producer_id,
+    :producer_sequence,
+    :occurred_at,
+    :level,
+    :source,
+    :stream,
+    :message,
+    :metadata,
+    :truncated
+  ]
+
+  @spec normalize(term()) :: {:ok, Favn.Log.Entry.t()} | {:error, term()}
+  def normalize(entry) do
+    attrs = entry |> entry_to_map() |> Map.take(@fields)
+
+    with {:ok, occurred_at} <- normalize_datetime(Map.get(attrs, :occurred_at)),
+         {:ok, message} <- normalize_message(Map.get(attrs, :message)) do
+      attrs =
+        attrs
+        |> Map.put(:schema_version, normalize_schema_version(Map.get(attrs, :schema_version)))
+        |> Map.put(:id, normalize_id(Map.get(attrs, :id)))
+        |> Map.put(:global_sequence, normalize_positive_integer(Map.get(attrs, :global_sequence)))
+        |> Map.put(:occurred_at, occurred_at)
+        |> Map.put(:level, normalize_atom_or_string(Map.get(attrs, :level)))
+        |> Map.put(:source, normalize_atom_or_string(Map.get(attrs, :source)))
+        |> Map.put(:stream, normalize_atom_or_string(Map.get(attrs, :stream)))
+        |> Map.put(:message, message)
+        |> Map.put(:metadata, normalize_metadata(Map.get(attrs, :metadata)))
+        |> Map.put(:truncated, Map.get(attrs, :truncated) == true)
+
+      {:ok, Favn.Log.Entry.normalize(attrs)}
+    end
+  end
+
+  defp entry_to_map(%_{} = entry), do: Map.from_struct(entry)
+  defp entry_to_map(entry) when is_list(entry), do: Map.new(entry)
+  defp entry_to_map(entry) when is_map(entry), do: entry
+
+  @spec assign_global_sequence(Favn.Log.Entry.t(), pos_integer()) :: Favn.Log.Entry.t()
+  def assign_global_sequence(entry, global_sequence)
+      when is_integer(global_sequence) and global_sequence > 0 do
+    struct(entry, global_sequence: global_sequence)
+  end
+
+  @spec encode(Favn.Log.Entry.t()) :: {:ok, String.t()} | {:error, term()}
+  def encode(entry) do
+    {:ok, Jason.encode!(to_dto(entry))}
+  rescue
+    error -> {:error, {:log_entry_encode_failed, error}}
+  end
+
+  @spec decode(String.t()) :: {:ok, Favn.Log.Entry.t()} | {:error, term()}
+  def decode(payload) when is_binary(payload) do
+    with {:ok, %{"format" => @format, "schema_version" => 1} = dto} <- Jason.decode(payload),
+         {:ok, occurred_at} <- normalize_datetime(Map.get(dto, "occurred_at")),
+         {:ok, metadata} <- normalize_decoded_metadata(Map.get(dto, "metadata")) do
+      attrs = %{
+        schema_version: 1,
+        id: Map.get(dto, "id"),
+        global_sequence: normalize_positive_integer(Map.get(dto, "global_sequence")),
+        run_id: normalize_optional_binary(Map.get(dto, "run_id")),
+        asset_step_id: normalize_optional_binary(Map.get(dto, "asset_step_id")),
+        node_key:
+          decode_payload_or_value(Map.get(dto, "node_key_payload"), Map.get(dto, "node_key")),
+        asset_ref:
+          decode_payload_or_value(Map.get(dto, "asset_ref_payload"), Map.get(dto, "asset_ref")),
+        runner_execution_id: normalize_optional_binary(Map.get(dto, "runner_execution_id")),
+        attempt: normalize_non_negative_integer(Map.get(dto, "attempt")),
+        producer_id: normalize_optional_binary(Map.get(dto, "producer_id")),
+        producer_sequence: normalize_positive_integer(Map.get(dto, "producer_sequence")),
+        occurred_at: occurred_at,
+        level: existing_atom_or_string(Map.get(dto, "level")),
+        source: existing_atom_or_string(Map.get(dto, "source")),
+        stream: existing_atom_or_string(Map.get(dto, "stream")),
+        message: Map.get(dto, "message") || "",
+        metadata: metadata,
+        truncated: Map.get(dto, "truncated") == true
+      }
+
+      {:ok, Favn.Log.Entry.normalize(attrs)}
+    else
+      {:ok, other} -> {:error, {:invalid_log_entry_dto, other}}
+      {:error, reason} -> {:error, {:invalid_log_entry_json, reason}}
+    end
+  end
+
+  @spec node_key_storage(term()) :: {String.t() | nil, String.t() | nil}
+  def node_key_storage(nil), do: {nil, nil}
+
+  def node_key_storage(node_key) do
+    with {:ok, blob} <- PayloadCodec.encode(node_key) do
+      {:crypto.hash(:sha256, blob) |> Base.encode16(case: :lower), blob}
+    else
+      _ ->
+        inspected = inspect(node_key)
+        {:crypto.hash(:sha256, inspected) |> Base.encode16(case: :lower), nil}
+    end
+  end
+
+  @spec asset_ref_storage(term()) :: {String.t() | nil, String.t() | nil}
+  def asset_ref_storage(nil), do: {nil, nil}
+
+  def asset_ref_storage(asset_ref) do
+    with {:ok, blob} <- PayloadCodec.encode(asset_ref) do
+      {asset_ref_key(asset_ref), blob}
+    else
+      _ -> {asset_ref_key(asset_ref), nil}
+    end
+  end
+
+  defp to_dto(entry) do
+    attrs = Map.from_struct(entry)
+
+    %{
+      "format" => @format,
+      "schema_version" => 1,
+      "id" => Map.get(attrs, :id),
+      "global_sequence" => Map.get(attrs, :global_sequence),
+      "run_id" => Map.get(attrs, :run_id),
+      "asset_step_id" => Map.get(attrs, :asset_step_id),
+      "node_key" => JsonSafe.data(Map.get(attrs, :node_key)),
+      "node_key_payload" => payload_to_dto(Map.get(attrs, :node_key)),
+      "asset_ref" => JsonSafe.data(Map.get(attrs, :asset_ref)),
+      "asset_ref_payload" => payload_to_dto(Map.get(attrs, :asset_ref)),
+      "runner_execution_id" => Map.get(attrs, :runner_execution_id),
+      "attempt" => Map.get(attrs, :attempt),
+      "producer_id" => Map.get(attrs, :producer_id),
+      "producer_sequence" => Map.get(attrs, :producer_sequence),
+      "occurred_at" => datetime_to_dto(Map.get(attrs, :occurred_at)),
+      "level" => stringify(Map.get(attrs, :level)),
+      "source" => stringify(Map.get(attrs, :source)),
+      "stream" => stringify(Map.get(attrs, :stream)),
+      "message" => Map.get(attrs, :message) || "",
+      "metadata" => JsonSafe.data(Map.get(attrs, :metadata) || %{}),
+      "truncated" => Map.get(attrs, :truncated) == true
+    }
+  end
+
+  defp normalize_schema_version(value) when is_integer(value) and value > 0, do: value
+  defp normalize_schema_version(_value), do: 1
+
+  defp normalize_id(value) when is_binary(value) and value != "", do: value
+  defp normalize_id(_value), do: random_uuid()
+
+  defp random_uuid do
+    <<a::32, b::16, c::16, d::16, e::48>> = :crypto.strong_rand_bytes(16)
+
+    c = Bitwise.bor(Bitwise.band(c, 0x0FFF), 0x4000)
+    d = Bitwise.bor(Bitwise.band(d, 0x3FFF), 0x8000)
+
+    [
+      Base.encode16(<<a::32>>, case: :lower),
+      Base.encode16(<<b::16>>, case: :lower),
+      Base.encode16(<<c::16>>, case: :lower),
+      Base.encode16(<<d::16>>, case: :lower),
+      Base.encode16(<<e::48>>, case: :lower)
+    ]
+    |> Enum.join("-")
+  end
+
+  defp normalize_message(value) when is_binary(value), do: {:ok, value}
+  defp normalize_message(nil), do: {:ok, ""}
+  defp normalize_message(value), do: {:error, {:invalid_log_entry_field, :message, value}}
+
+  defp normalize_datetime(nil), do: {:ok, DateTime.utc_now()}
+  defp normalize_datetime(%DateTime{} = value), do: {:ok, value}
+
+  defp normalize_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> {:ok, datetime}
+      _ -> {:error, {:invalid_log_entry_field, :occurred_at, value}}
+    end
+  end
+
+  defp normalize_datetime(value), do: {:error, {:invalid_log_entry_field, :occurred_at, value}}
+
+  defp normalize_positive_integer(value) when is_integer(value) and value > 0, do: value
+  defp normalize_positive_integer(_value), do: nil
+
+  defp normalize_non_negative_integer(value) when is_integer(value) and value >= 0, do: value
+  defp normalize_non_negative_integer(_value), do: nil
+
+  defp normalize_atom_or_string(nil), do: nil
+  defp normalize_atom_or_string(value) when is_atom(value), do: value
+  defp normalize_atom_or_string(value) when is_binary(value) and value != "", do: value
+  defp normalize_atom_or_string(_value), do: nil
+
+  defp normalize_optional_binary(value) when is_binary(value) and value != "", do: value
+  defp normalize_optional_binary(_value), do: nil
+
+  defp normalize_metadata(value) when is_map(value), do: JsonSafe.data(value)
+  defp normalize_metadata(_value), do: %{}
+
+  defp normalize_decoded_metadata(value) when is_map(value), do: {:ok, value}
+  defp normalize_decoded_metadata(nil), do: {:ok, %{}}
+
+  defp normalize_decoded_metadata(value),
+    do: {:error, {:invalid_log_entry_field, :metadata, value}}
+
+  defp existing_atom_or_string(nil), do: nil
+
+  defp existing_atom_or_string(value) when is_binary(value) do
+    String.to_existing_atom(value)
+  rescue
+    ArgumentError -> value
+  end
+
+  defp existing_atom_or_string(value), do: value
+
+  defp stringify(nil), do: nil
+  defp stringify(value) when is_atom(value), do: Atom.to_string(value)
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(value), do: inspect(value)
+
+  defp datetime_to_dto(nil), do: nil
+  defp datetime_to_dto(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+  defp datetime_to_dto(value) when is_binary(value), do: value
+
+  defp payload_to_dto(nil), do: nil
+
+  defp payload_to_dto(value) do
+    case PayloadCodec.encode(value) do
+      {:ok, payload} -> payload
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp decode_payload_or_value(payload, fallback) when is_binary(payload) do
+    case PayloadCodec.decode(payload) do
+      {:ok, value} -> value
+      {:error, _reason} -> fallback
+    end
+  end
+
+  defp decode_payload_or_value(_payload, fallback), do: fallback
+
+  defp asset_ref_key({module, name}) when is_atom(module) and is_atom(name),
+    do: Atom.to_string(module) <> "." <> Atom.to_string(name)
+
+  defp asset_ref_key(%{"module" => module, "name" => name})
+       when is_binary(module) and is_binary(name),
+       do: module <> "." <> name
+
+  defp asset_ref_key(value),
+    do: :crypto.hash(:sha256, inspect(value)) |> Base.encode16(case: :lower)
+end

--- a/apps/favn_orchestrator/test/diagnostics_test.exs
+++ b/apps/favn_orchestrator/test/diagnostics_test.exs
@@ -87,6 +87,24 @@ defmodule FavnOrchestrator.DiagnosticsTest do
     def list_global_run_events(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def persist_log_entries(entries, _opts), do: {:ok, entries}
+
+    @impl true
+    def list_logs(_filter, _opts, _adapter_opts),
+      do:
+        {:ok,
+         %FavnOrchestrator.Page{
+           items: [],
+           limit: 100,
+           offset: 0,
+           has_more?: false,
+           next_offset: nil
+         }}
+
+    @impl true
+    def replay_logs_after(_cursor, _filter, _opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
     def put_scheduler_state(_key, _state, _opts), do: :ok
 
     @impl true

--- a/apps/favn_orchestrator/test/logs_test.exs
+++ b/apps/favn_orchestrator/test/logs_test.exs
@@ -1,0 +1,85 @@
+defmodule FavnOrchestrator.LogsTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Log.Entry
+  alias Favn.Log.Filter
+  alias FavnOrchestrator.Storage.Adapter.Memory
+
+  setup do
+    previous_adapter = Application.get_env(:favn_orchestrator, :storage_adapter)
+    previous_opts = Application.get_env(:favn_orchestrator, :storage_adapter_opts)
+
+    Application.put_env(:favn_orchestrator, :storage_adapter, Memory)
+    Application.put_env(:favn_orchestrator, :storage_adapter_opts, [])
+
+    Memory.reset()
+
+    on_exit(fn ->
+      restore_env(:favn_orchestrator, :storage_adapter, previous_adapter)
+      restore_env(:favn_orchestrator, :storage_adapter_opts, previous_opts)
+      Memory.reset()
+    end)
+
+    :ok
+  end
+
+  test "log writer broadcasts persisted entries" do
+    assert {:ok, subscription} = FavnOrchestrator.subscribe_logs(%Filter{run_id: "run_log_live"})
+
+    assert {:ok, [persisted]} =
+             FavnOrchestrator.emit_log(%Entry{
+               run_id: "run_log_live",
+               source: :runner,
+               level: :info,
+               message: "asset execution started",
+               producer_id: "runner:exec-log-live",
+               producer_sequence: 1
+             })
+
+    assert persisted.global_sequence == 1
+    assert {:ok, received} = receive_log_entry("run_log_live")
+    assert received.global_sequence == persisted.global_sequence
+
+    assert :ok = FavnOrchestrator.unsubscribe_logs(subscription)
+  end
+
+  test "list and replay APIs delegate to storage" do
+    assert {:ok, [_first, second]} =
+             FavnOrchestrator.emit_logs([
+               %Entry{
+                 run_id: "run_log_read",
+                 message: "first",
+                 producer_id: "p",
+                 producer_sequence: 1
+               },
+               %Entry{
+                 run_id: "run_log_read",
+                 message: "second",
+                 producer_id: "p",
+                 producer_sequence: 2
+               }
+             ])
+
+    assert {:ok, page} = FavnOrchestrator.list_logs(%Filter{run_id: "run_log_read"})
+    assert Enum.map(page.items, & &1.message) == ["first", "second"]
+
+    assert {:ok, replayed} =
+             FavnOrchestrator.replay_logs(second.global_sequence - 1, %Filter{
+               run_id: "run_log_read"
+             })
+
+    assert Enum.map(replayed, & &1.message) == ["second"]
+  end
+
+  defp receive_log_entry(run_id, timeout \\ 1_000) do
+    receive do
+      {:favn_log_entry, %Entry{run_id: ^run_id} = entry} -> {:ok, entry}
+      {:favn_log_entry, %Entry{}} -> receive_log_entry(run_id, timeout)
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_env(app, key, value), do: Application.put_env(app, key, value)
+end

--- a/apps/favn_orchestrator/test/logs_test.exs
+++ b/apps/favn_orchestrator/test/logs_test.exs
@@ -3,7 +3,21 @@ defmodule FavnOrchestrator.LogsTest do
 
   alias Favn.Log.Entry
   alias Favn.Log.Filter
+  alias FavnOrchestrator.RunnerLogBridge
   alias FavnOrchestrator.Storage.Adapter.Memory
+
+  defmodule RunnerClientLogStub do
+    def subscribe_execution_logs(execution_id, subscriber, opts) do
+      opts
+      |> Keyword.fetch!(:runner_log_entries)
+      |> Map.fetch!(execution_id)
+      |> Enum.each(fn entry -> send(subscriber, {:runner_log_entry, execution_id, entry}) end)
+
+      :ok
+    end
+
+    def unsubscribe_execution_logs(_execution_id, _subscriber, _opts), do: :ok
+  end
 
   setup do
     previous_adapter = Application.get_env(:favn_orchestrator, :storage_adapter)
@@ -71,6 +85,168 @@ defmodule FavnOrchestrator.LogsTest do
     assert Enum.map(replayed, & &1.message) == ["second"]
   end
 
+  test "runner bridge merges step context so runner logs filter by asset step" do
+    runner_opts = [
+      runner_log_entries: %{
+        "exec_step_a" => [
+          %{
+            level: :info,
+            source: :runner,
+            message: "from runner step a",
+            producer_id: "runner:exec_step_a",
+            producer_sequence: 1,
+            metadata: %{password: "secret", keep: "visible"}
+          }
+        ],
+        "exec_step_b" => [
+          %{
+            level: :info,
+            source: :runner,
+            message: "from runner step b",
+            producer_id: "runner:exec_step_b",
+            producer_sequence: 1
+          }
+        ]
+      }
+    ]
+
+    assert {:ok, bridge_a} =
+             RunnerLogBridge.start(RunnerClientLogStub, "exec_step_a", runner_opts, %{
+               run_id: "run_bridge_filter",
+               asset_step_id: "step_a",
+               node_key: {:node, :a},
+               asset_ref: {__MODULE__, :asset_a},
+               runner_execution_id: "exec_step_a",
+               attempt: 2
+             })
+
+    assert {:ok, bridge_b} =
+             RunnerLogBridge.start(RunnerClientLogStub, "exec_step_b", runner_opts, %{
+               run_id: "run_bridge_filter",
+               asset_step_id: "step_b",
+               node_key: {:node, :b},
+               asset_ref: {__MODULE__, :asset_b},
+               runner_execution_id: "exec_step_b",
+               attempt: 1
+             })
+
+    eventually(fn ->
+      assert {:ok, page} =
+               FavnOrchestrator.list_logs(%Filter{
+                 run_id: "run_bridge_filter",
+                 asset_step_id: "step_a"
+               })
+
+      assert [%Entry{} = entry] = page.items
+      assert entry.message == "from runner step a"
+      assert entry.run_id == "run_bridge_filter"
+      assert entry.asset_step_id == "step_a"
+      assert entry.node_key == {:node, :a}
+      assert entry.asset_ref == {__MODULE__, :asset_a}
+      assert entry.runner_execution_id == "exec_step_a"
+      assert entry.attempt == 2
+      assert entry.metadata["password"] == "[REDACTED]"
+    end)
+
+    assert {:ok, replayed} =
+             FavnOrchestrator.replay_logs(0, %Filter{
+               run_id: "run_bridge_filter",
+               asset_step_id: "step_a"
+             })
+
+    assert Enum.map(replayed, & &1.message) == ["from runner step a"]
+
+    RunnerLogBridge.stop(bridge_a, RunnerClientLogStub, "exec_step_a", runner_opts)
+    RunnerLogBridge.stop(bridge_b, RunnerClientLogStub, "exec_step_b", runner_opts)
+  end
+
+  test "runner bridge ignores malformed runner log entries without crashing" do
+    runner_opts = [
+      runner_log_entries: %{
+        "exec_bad_log" => [
+          %{
+            level: :fatal,
+            source: :alien,
+            message: "bad runner log",
+            producer_id: "runner:exec_bad_log",
+            producer_sequence: 1
+          }
+        ]
+      }
+    ]
+
+    assert {:ok, bridge} =
+             RunnerLogBridge.start(RunnerClientLogStub, "exec_bad_log", runner_opts, %{
+               run_id: "run_bad_log",
+               asset_step_id: "step_bad"
+             })
+
+    Process.sleep(50)
+    assert Process.alive?(bridge)
+
+    assert {:ok, page} = FavnOrchestrator.list_logs(%Filter{run_id: "run_bad_log"})
+    assert page.items == []
+
+    RunnerLogBridge.stop(bridge, RunnerClientLogStub, "exec_bad_log", runner_opts)
+  end
+
+  test "live run subscriptions deliver only matching run entries" do
+    assert {:ok, subscription} = FavnOrchestrator.subscribe_logs(%Filter{run_id: "run_live_a"})
+
+    assert {:ok, _} =
+             FavnOrchestrator.emit_log(%Entry{run_id: "run_live_b", message: "other run"})
+
+    assert {:ok, [persisted]} =
+             FavnOrchestrator.emit_log(%Entry{run_id: "run_live_a", message: "wanted run"})
+
+    assert {:ok, received} = receive_log_entry("run_live_a")
+    assert received.global_sequence == persisted.global_sequence
+    refute_receive {:favn_log_entry, %Entry{run_id: "run_live_b"}}, 100
+
+    assert :ok = FavnOrchestrator.unsubscribe_logs(subscription)
+  end
+
+  test "live asset-step subscriptions use asset topics and honor remaining filters" do
+    assert {:ok, subscription} =
+             FavnOrchestrator.subscribe_logs(%Filter{
+               run_id: "run_live_asset",
+               asset_step_id: "step_a",
+               levels: [:error]
+             })
+
+    assert {:ok, _} =
+             FavnOrchestrator.emit_log(%Entry{
+               run_id: "run_live_asset",
+               asset_step_id: "step_b",
+               level: :error,
+               message: "other step"
+             })
+
+    assert {:ok, _} =
+             FavnOrchestrator.emit_log(%Entry{
+               run_id: "run_live_asset",
+               asset_step_id: "step_a",
+               level: :info,
+               message: "filtered level"
+             })
+
+    assert {:ok, [persisted]} =
+             FavnOrchestrator.emit_log(%Entry{
+               run_id: "run_live_asset",
+               asset_step_id: "step_a",
+               level: :error,
+               message: "wanted step"
+             })
+
+    assert {:ok, received} = receive_log_entry("run_live_asset")
+    assert received.global_sequence == persisted.global_sequence
+    assert received.asset_step_id == "step_a"
+    assert received.level == :error
+    refute_receive {:favn_log_entry, %Entry{}}, 100
+
+    assert :ok = FavnOrchestrator.unsubscribe_logs(subscription)
+  end
+
   defp receive_log_entry(run_id, timeout \\ 1_000) do
     receive do
       {:favn_log_entry, %Entry{run_id: ^run_id} = entry} -> {:ok, entry}
@@ -79,6 +255,18 @@ defmodule FavnOrchestrator.LogsTest do
       timeout -> {:error, :timeout}
     end
   end
+
+  defp eventually(fun, attempts \\ 20)
+
+  defp eventually(fun, attempts) when attempts > 0 do
+    fun.()
+  rescue
+    ExUnit.AssertionError ->
+      Process.sleep(25)
+      eventually(fun, attempts - 1)
+  end
+
+  defp eventually(fun, 0), do: fun.()
 
   defp restore_env(app, key, nil), do: Application.delete_env(app, key)
   defp restore_env(app, key, value), do: Application.put_env(app, key, value)

--- a/apps/favn_orchestrator/test/logs_test.exs
+++ b/apps/favn_orchestrator/test/logs_test.exs
@@ -206,6 +206,11 @@ defmodule FavnOrchestrator.LogsTest do
     assert :ok = FavnOrchestrator.unsubscribe_logs(subscription)
   end
 
+  test "unsubscribe requires the returned subscription handle" do
+    assert {:error, :invalid_log_subscription} =
+             FavnOrchestrator.unsubscribe_logs(%Filter{run_id: "run_unsubscribe_filter"})
+  end
+
   test "live asset-step subscriptions use asset topics and honor remaining filters" do
     assert {:ok, subscription} =
              FavnOrchestrator.subscribe_logs(%Filter{

--- a/apps/favn_orchestrator/test/readiness_test.exs
+++ b/apps/favn_orchestrator/test/readiness_test.exs
@@ -87,6 +87,24 @@ defmodule FavnOrchestrator.ReadinessTest do
     def list_global_run_events(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def persist_log_entries(entries, _opts), do: {:ok, entries}
+
+    @impl true
+    def list_logs(_filter, _opts, _adapter_opts),
+      do:
+        {:ok,
+         %FavnOrchestrator.Page{
+           items: [],
+           limit: 100,
+           offset: 0,
+           has_more?: false,
+           next_offset: nil
+         }}
+
+    @impl true
+    def replay_logs_after(_cursor, _filter, _opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
     def put_scheduler_state(_key, _state, _opts), do: :ok
 
     @impl true

--- a/apps/favn_orchestrator/test/run_manager_test.exs
+++ b/apps/favn_orchestrator/test/run_manager_test.exs
@@ -736,6 +736,72 @@ defmodule FavnOrchestrator.RunManagerTest do
     end
   end
 
+  defmodule RunnerClientMalformedLogStub do
+    @behaviour Favn.Contracts.RunnerClient
+
+    @impl true
+    def register_manifest(_version, _opts), do: :ok
+
+    @impl true
+    def submit_work(work, _opts), do: {:ok, execution_id(work)}
+
+    @impl true
+    def await_result(execution_id, _timeout, _opts) do
+      {:ok,
+       %RunnerResult{
+         status: :ok,
+         asset_results: [asset_result(execution_id)],
+         metadata: %{stub: :malformed_log}
+       }}
+    end
+
+    @impl true
+    def cancel_work(_execution_id, _reason, _opts), do: :ok
+
+    @impl true
+    def inspect_relation(_request, _opts), do: {:error, :not_supported}
+
+    @impl true
+    def subscribe_execution_logs(execution_id, subscriber, _opts) do
+      send(subscriber, {
+        :runner_log_entry,
+        execution_id,
+        %{level: :fatal, source: :alien, message: "bad runner log"}
+      })
+
+      :ok
+    end
+
+    @impl true
+    def unsubscribe_execution_logs(_execution_id, _subscriber, _opts), do: :ok
+
+    defp asset_result(execution_id) do
+      %Favn.Run.AssetResult{
+        ref: execution_ref(execution_id),
+        stage: 0,
+        status: :ok,
+        started_at: DateTime.utc_now(),
+        finished_at: DateTime.utc_now(),
+        duration_ms: 0,
+        meta: %{},
+        error: nil,
+        attempt_count: 1,
+        max_attempts: 1,
+        attempts: []
+      }
+    end
+
+    defp execution_id(work) do
+      {module, name} = work.asset_ref
+      "exec_#{work.run_id}_#{Atom.to_string(module)}_#{Atom.to_string(name)}"
+    end
+
+    defp execution_ref(execution_id) do
+      [module, name] = execution_id |> String.split("_") |> Enum.take(-2)
+      {String.to_atom(module), String.to_atom(name)}
+    end
+  end
+
   defmodule RunnerClientRetryMetadataLeakStub do
     @behaviour Favn.Contracts.RunnerClient
 
@@ -857,6 +923,26 @@ defmodule FavnOrchestrator.RunManagerTest do
            ]
 
     assert Enum.map(events, & &1.sequence) == [1, 2, 3, 4, 5]
+  end
+
+  test "malformed runner log entries do not fail active runs" do
+    Application.put_env(:favn_orchestrator, :runner_client, RunnerClientMalformedLogStub)
+
+    version = manifest_version("mv_malformed_runner_log")
+
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    assert {:ok, run_id} =
+             FavnOrchestrator.submit_asset_run({MyApp.Assets.Gold, :asset},
+               manifest_version_id: version.manifest_version_id
+             )
+
+    assert {:ok, run} = await_terminal_run(run_id)
+    assert run.status == :ok
+
+    assert {:ok, page} = FavnOrchestrator.list_logs(%Favn.Log.Filter{run_id: run_id})
+    assert page.items == []
   end
 
   test "accepted success transitions broadcast on both run and global topics in storage order" do

--- a/apps/favn_orchestrator/test/storage_facade_test.exs
+++ b/apps/favn_orchestrator/test/storage_facade_test.exs
@@ -56,6 +56,24 @@ defmodule Favn.StorageFacadeTest do
     def list_global_run_events(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def persist_log_entries(entries, _opts), do: {:ok, entries}
+
+    @impl true
+    def list_logs(_filter, _opts, _adapter_opts),
+      do:
+        {:ok,
+         %FavnOrchestrator.Page{
+           items: [],
+           limit: 100,
+           offset: 0,
+           has_more?: false,
+           next_offset: nil
+         }}
+
+    @impl true
+    def replay_logs_after(_cursor, _filter, _opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
     def put_scheduler_state(_key, _state, _opts), do: :ok
 
     @impl true
@@ -178,6 +196,24 @@ defmodule Favn.StorageFacadeTest do
     def list_global_run_events(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def persist_log_entries(entries, _opts), do: {:ok, entries}
+
+    @impl true
+    def list_logs(_filter, _opts, _adapter_opts),
+      do:
+        {:ok,
+         %FavnOrchestrator.Page{
+           items: [],
+           limit: 100,
+           offset: 0,
+           has_more?: false,
+           next_offset: nil
+         }}
+
+    @impl true
+    def replay_logs_after(_cursor, _filter, _opts, _adapter_opts), do: {:ok, []}
+
+    @impl true
     def put_scheduler_state(_key, _state, _opts), do: :ok
 
     @impl true
@@ -287,6 +323,62 @@ defmodule Favn.StorageFacadeTest do
     assert {:ok, run_state} = OrchestratorStorage.get_run("run_storage_facade")
     assert run_state.id == "run_storage_facade"
     assert run_state.manifest_version_id == "mv_storage_facade"
+  end
+
+  test "memory storage persists paginates filters and replays log entries" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    first =
+      Favn.Log.Entry.normalize(%{
+        run_id: "run_logs",
+        asset_step_id: "step_a",
+        asset_ref: {MyApp.Assets.Gold, :asset},
+        producer_id: "runner-1",
+        producer_sequence: 1,
+        occurred_at: now,
+        level: :info,
+        source: :runner,
+        stream: :stdout,
+        message: "hello\nworld",
+        metadata: %{password: "secret", visible: "yes"}
+      })
+
+    second =
+      Favn.Log.Entry.normalize(%{
+        run_id: "run_logs",
+        asset_step_id: "step_b",
+        producer_id: "runner-1",
+        producer_sequence: 2,
+        occurred_at: DateTime.add(now, 1, :second),
+        level: :error,
+        source: :runner,
+        stream: :stderr,
+        message: "boom"
+      })
+
+    assert {:ok, [persisted_first, persisted_second]} =
+             OrchestratorStorage.persist_log_entries([first, second])
+
+    assert persisted_first.global_sequence == 1
+    assert persisted_second.global_sequence == 2
+    assert persisted_first.message == "hello\nworld"
+    assert persisted_first.metadata["password"] == "[REDACTED]"
+
+    assert {:ok, [^persisted_first]} = OrchestratorStorage.persist_log_entries([first])
+
+    assert {:ok, page} =
+             OrchestratorStorage.list_logs(%Favn.Log.Filter{run_id: "run_logs"}, limit: 1)
+
+    assert Enum.map(page.items, & &1.global_sequence) == [1]
+    assert page.has_more? == true
+
+    assert {:ok, filtered} = OrchestratorStorage.list_logs(%Favn.Log.Filter{levels: [:error]})
+    assert Enum.map(filtered.items, & &1.message) == ["boom"]
+
+    cursor = %Favn.Log.Cursor{scope: :run, run_id: "run_logs", global_sequence: 1}
+
+    assert {:ok, [^persisted_second]} =
+             OrchestratorStorage.replay_logs_after(cursor, [run_id: "run_logs"], limit: 10)
   end
 
   test "always delegates child spec setup to orchestrator storage" do

--- a/apps/favn_runner/lib/favn_runner.ex
+++ b/apps/favn_runner/lib/favn_runner.ex
@@ -84,6 +84,33 @@ defmodule FavnRunner do
   def cancel_work(_execution_id, _reason, _opts), do: {:error, :invalid_cancel_args}
 
   @doc """
+  Subscribes a process to live logs for one runner execution.
+  """
+  @spec subscribe_execution_logs(execution_id(), pid(), keyword()) :: :ok | {:error, term()}
+  def subscribe_execution_logs(execution_id, subscriber, opts \\ [])
+
+  def subscribe_execution_logs(execution_id, subscriber, opts)
+      when is_binary(execution_id) and is_pid(subscriber) and is_list(opts) do
+    Server.subscribe_execution_logs(execution_id, subscriber, opts)
+  end
+
+  def subscribe_execution_logs(_execution_id, _subscriber, _opts),
+    do: {:error, :invalid_log_subscription_args}
+
+  @doc """
+  Unsubscribes a process from live logs for one runner execution.
+  """
+  @spec unsubscribe_execution_logs(execution_id(), pid(), keyword()) :: :ok
+  def unsubscribe_execution_logs(execution_id, subscriber, opts \\ [])
+
+  def unsubscribe_execution_logs(execution_id, subscriber, opts)
+      when is_binary(execution_id) and is_pid(subscriber) and is_list(opts) do
+    Server.unsubscribe_execution_logs(execution_id, subscriber, opts)
+  end
+
+  def unsubscribe_execution_logs(_execution_id, _subscriber, _opts), do: :ok
+
+  @doc """
   Runs one safe read-only relation inspection request through the runner boundary.
   """
   @spec inspect_relation(RelationInspectionRequest.t(), keyword()) ::

--- a/apps/favn_runner/lib/favn_runner/log_sink.ex
+++ b/apps/favn_runner/lib/favn_runner/log_sink.ex
@@ -1,0 +1,17 @@
+defmodule FavnRunner.LogSink do
+  @moduledoc false
+
+  @spec emit(pid(), String.t(), map()) :: :ok
+  def emit(server_pid, execution_id, attrs)
+      when is_pid(server_pid) and is_binary(execution_id) and is_map(attrs) do
+    send(server_pid, {:runner_log_entry, execution_id, build_entry(attrs)})
+    :ok
+  end
+
+  defp build_entry(attrs) do
+    case Code.ensure_loaded(Favn.Log.Entry) do
+      {:module, Favn.Log.Entry} -> struct(Favn.Log.Entry, attrs)
+      _other -> attrs
+    end
+  end
+end

--- a/apps/favn_runner/lib/favn_runner/server.ex
+++ b/apps/favn_runner/lib/favn_runner/server.ex
@@ -30,13 +30,15 @@ defmodule FavnRunner.Server do
           optional(:pid) => pid(),
           optional(:monitor_ref) => reference(),
           optional(:result) => RunnerResult.t(),
-          optional(:events) => [term()]
+          optional(:events) => [term()],
+          optional(:logs) => [term()]
         }
 
   @type state :: %{
           executions: %{required(execution_id()) => execution_state()},
           monitor_to_execution: %{required(reference()) => execution_id()},
-          waiters: %{required(execution_id()) => [waiter()]}
+          waiters: %{required(execution_id()) => [waiter()]},
+          log_subscribers: %{required(execution_id()) => MapSet.t(pid())}
         }
 
   @spec start_link(keyword()) :: GenServer.on_start()
@@ -80,6 +82,29 @@ defmodule FavnRunner.Server do
 
   def cancel_work(_execution_id, _reason, _opts), do: {:error, :invalid_cancel_args}
 
+  @spec subscribe_execution_logs(execution_id(), pid(), keyword()) :: :ok | {:error, term()}
+  def subscribe_execution_logs(execution_id, subscriber, opts \\ [])
+
+  def subscribe_execution_logs(execution_id, subscriber, opts)
+      when is_binary(execution_id) and is_pid(subscriber) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:subscribe_execution_logs, execution_id, subscriber})
+  end
+
+  def subscribe_execution_logs(_execution_id, _subscriber, _opts),
+    do: {:error, :invalid_log_subscription_args}
+
+  @spec unsubscribe_execution_logs(execution_id(), pid(), keyword()) :: :ok
+  def unsubscribe_execution_logs(execution_id, subscriber, opts \\ [])
+
+  def unsubscribe_execution_logs(execution_id, subscriber, opts)
+      when is_binary(execution_id) and is_pid(subscriber) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:unsubscribe_execution_logs, execution_id, subscriber})
+  end
+
+  def unsubscribe_execution_logs(_execution_id, _subscriber, _opts), do: :ok
+
   @spec inspect_relation(RelationInspectionRequest.t(), keyword()) ::
           {:ok, term()} | {:error, term()}
   def inspect_relation(%RelationInspectionRequest{} = request, opts \\ []) when is_list(opts) do
@@ -99,7 +124,7 @@ defmodule FavnRunner.Server do
 
   @impl true
   def init(_args) do
-    {:ok, %{executions: %{}, monitor_to_execution: %{}, waiters: %{}}}
+    {:ok, %{executions: %{}, monitor_to_execution: %{}, waiters: %{}, log_subscribers: %{}}}
   end
 
   @impl true
@@ -127,7 +152,8 @@ defmodule FavnRunner.Server do
                 status: :running,
                 pid: pid,
                 monitor_ref: monitor_ref,
-                events: []
+                events: [],
+                logs: []
               }
 
               next_state =
@@ -143,7 +169,8 @@ defmodule FavnRunner.Server do
               work: work,
               status: :completed,
               result: preflight_failed_result(work, version, diagnostic),
-              events: []
+              events: [],
+              logs: []
             }
 
             next_state = put_in(state, [:executions, execution_id], execution)
@@ -195,6 +222,42 @@ defmodule FavnRunner.Server do
     end
   end
 
+  def handle_call({:subscribe_execution_logs, execution_id, subscriber}, _from, state) do
+    case Map.fetch(state.executions, execution_id) do
+      {:ok, %{status: status} = execution} when status in [:running, :completed] ->
+        subscribers =
+          state.log_subscribers
+          |> Map.get(execution_id, MapSet.new())
+          |> MapSet.put(subscriber)
+
+        execution
+        |> Map.get(:logs, [])
+        |> Enum.reverse()
+        |> Enum.each(fn entry -> send(subscriber, {:runner_log_entry, execution_id, entry}) end)
+
+        {:reply, :ok, put_in(state, [:log_subscribers, execution_id], subscribers)}
+
+      :error ->
+        {:reply, {:error, :execution_not_found}, state}
+    end
+  end
+
+  def handle_call({:unsubscribe_execution_logs, execution_id, subscriber}, _from, state) do
+    subscribers =
+      state.log_subscribers
+      |> Map.get(execution_id, MapSet.new())
+      |> MapSet.delete(subscriber)
+
+    log_subscribers =
+      if MapSet.size(subscribers) == 0 do
+        Map.delete(state.log_subscribers, execution_id)
+      else
+        Map.put(state.log_subscribers, execution_id, subscribers)
+      end
+
+    {:reply, :ok, %{state | log_subscribers: log_subscribers}}
+  end
+
   def handle_call({:inspect_relation, %RelationInspectionRequest{} = request}, _from, state) do
     reply =
       with {:ok, version} <-
@@ -230,6 +293,24 @@ defmodule FavnRunner.Server do
         nil -> [event]
         events -> [event | events]
       end)
+
+    {:noreply, next_state}
+  end
+
+  def handle_info({:runner_log_entry, execution_id, entry}, state) do
+    state.log_subscribers
+    |> Map.get(execution_id, MapSet.new())
+    |> Enum.each(fn subscriber -> send(subscriber, {:runner_log_entry, execution_id, entry}) end)
+
+    next_state =
+      if Map.has_key?(state.executions, execution_id) do
+        update_in(state, [:executions, execution_id, :logs], fn
+          nil -> [entry]
+          logs -> [entry | logs]
+        end)
+      else
+        state
+      end
 
     {:noreply, next_state}
   end
@@ -306,8 +387,14 @@ defmodule FavnRunner.Server do
         work: execution[:work],
         status: :completed,
         result: result,
-        events: execution[:events] || []
+        events: execution[:events] || [],
+        logs: execution[:logs] || []
       })
+
+    next_state = %{
+      next_state
+      | log_subscribers: Map.delete(next_state.log_subscribers, execution_id)
+    }
 
     {waiters, remaining_waiters} = Map.pop(next_state.waiters, execution_id, [])
 

--- a/apps/favn_runner/lib/favn_runner/worker.ex
+++ b/apps/favn_runner/lib/favn_runner/worker.ex
@@ -14,6 +14,7 @@ defmodule FavnRunner.Worker do
   alias Favn.SQLAsset.Runtime, as: SQLAssetRuntime
   alias FavnRunner.ContextBuilder
   alias FavnRunner.EventSink
+  alias FavnRunner.LogSink
   alias FavnRunner.RuntimeConfigDiagnostic
 
   @type init_arg :: %{
@@ -49,6 +50,7 @@ defmodule FavnRunner.Worker do
     started_at = DateTime.utc_now()
 
     emit_event(server, execution_id, work, :asset_started, %{asset_ref: asset.ref})
+    emit_log(server, execution_id, work, asset, 1, :info, "asset execution started")
 
     result =
       case asset.type do
@@ -78,6 +80,7 @@ defmodule FavnRunner.Worker do
     case result do
       {:ok, meta} ->
         emit_event(server, execution_id, work, :asset_succeeded, %{asset_ref: asset.ref})
+        emit_log(server, execution_id, work, asset, 2, :info, "asset execution finished")
 
         build_runner_result(
           work,
@@ -91,6 +94,8 @@ defmodule FavnRunner.Worker do
           asset_ref: asset.ref,
           error: error
         })
+
+        emit_log(server, execution_id, work, asset, 2, :error, "asset execution failed")
 
         build_runner_result(
           work,
@@ -228,6 +233,34 @@ defmodule FavnRunner.Worker do
     }
 
     EventSink.emit(server, execution_id, event)
+  end
+
+  defp emit_log(
+         server,
+         execution_id,
+         %RunnerWork{} = work,
+         %Asset{} = asset,
+         sequence,
+         level,
+         message
+       ) do
+    producer_id = "runner:" <> execution_id
+
+    LogSink.emit(server, execution_id, %{
+      source: :runner,
+      level: level,
+      message: message,
+      run_id: work.run_id,
+      manifest_version_id: work.manifest_version_id,
+      manifest_content_hash: work.manifest_content_hash,
+      asset_ref: asset.ref,
+      runner_execution_id: execution_id,
+      attempt: Map.get(work.metadata, :attempt),
+      metadata: Map.put(work.metadata, :runner_execution_id, execution_id),
+      occurred_at: DateTime.utc_now(),
+      producer_id: producer_id,
+      producer_sequence: sequence
+    })
   end
 
   defp execute_sql_asset(%Asset{} = asset, %Version{} = version, %RunnerWork{} = work) do

--- a/apps/favn_runner/test/favn_runner_test.exs
+++ b/apps/favn_runner/test/favn_runner_test.exs
@@ -168,6 +168,49 @@ defmodule FavnRunnerTest do
     assert asset_result.meta[:observed] == true
   end
 
+  test "server forwards subscribed execution logs" do
+    fixture_ref = {FavnRunnerTest.SleepLogAsset, :asset}
+
+    fixture_manifest =
+      build_manifest([
+        %Asset{
+          ref: fixture_ref,
+          module: elem(fixture_ref, 0),
+          name: :asset,
+          type: :elixir,
+          execution: %{entrypoint: :asset, arity: 1}
+        }
+      ])
+
+    {:ok, fixture_version} =
+      Version.new(fixture_manifest,
+        manifest_version_id:
+          "mv_log_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)
+      )
+
+    assert :ok = FavnRunner.register_manifest(fixture_version)
+
+    work = %RunnerWork{
+      run_id: "run_log_forward",
+      manifest_version_id: fixture_version.manifest_version_id,
+      manifest_content_hash: fixture_version.content_hash,
+      asset_ref: fixture_ref,
+      metadata: %{attempt: 1}
+    }
+
+    assert {:ok, execution_id} = FavnRunner.submit_work(work)
+    assert :ok = FavnRunner.subscribe_execution_logs(execution_id, self())
+    assert {:ok, entry} = receive_runner_log(execution_id)
+
+    assert entry.run_id == "run_log_forward"
+    assert entry.source == :runner
+    assert entry.runner_execution_id == execution_id
+    assert entry.producer_id == "runner:" <> execution_id
+    assert is_integer(entry.producer_sequence)
+
+    assert {:ok, _result} = FavnRunner.await_result(execution_id, 1_000)
+  end
+
   test "rejects unknown manifest version" do
     work =
       %RunnerWork{
@@ -178,6 +221,18 @@ defmodule FavnRunnerTest do
       }
 
     assert {:error, :manifest_not_found} = FavnRunner.submit_work(work)
+  end
+
+  defp receive_runner_log(execution_id, timeout \\ 1_000) do
+    receive do
+      {:runner_log_entry, ^execution_id, entry} ->
+        {:ok, entry}
+
+      {:runner_log_entry, _other_execution_id, _entry} ->
+        receive_runner_log(execution_id, timeout)
+    after
+      timeout -> {:error, :timeout}
+    end
   end
 
   defp build_manifest(assets) do
@@ -212,6 +267,16 @@ defmodule FavnRunnerTest.ElixirAsset do
 end
 
 defmodule FavnRunnerTest.SourceAsset do
+end
+
+defmodule FavnRunnerTest.SleepLogAsset do
+  alias Favn.Run.Context
+
+  @spec asset(Context.t()) :: :ok
+  def asset(%Context{}) do
+    Process.sleep(100)
+    :ok
+  end
 end
 
 defmodule FavnRunnerTest.ConnectionModule do

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -17,6 +17,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   alias FavnOrchestrator.Storage.Backfill.BackfillWindowCodec
   alias FavnOrchestrator.Storage.Backfill.CoverageBaselineCodec
   alias FavnOrchestrator.Storage.Freshness.AssetFreshnessStateCodec
+  alias FavnOrchestrator.Storage.LogEntryCodec
   alias FavnOrchestrator.Storage.ManifestCodec
   alias FavnOrchestrator.Storage.RunEventCodec
   alias FavnOrchestrator.Storage.RunSnapshotCodec
@@ -30,6 +31,20 @@ defmodule Favn.Storage.Adapter.Postgres do
   @active_manifest_key "active_manifest_version_id"
   @nil_schedule_id "__nil__"
   @schema_ready_cache_key {__MODULE__, :external_schema_ready}
+  @log_filter_keys [
+    :run_id,
+    :asset_step_id,
+    :runner_execution_id,
+    :level,
+    :source,
+    :stream,
+    :levels,
+    :sources,
+    :since,
+    :until,
+    :asset_ref,
+    :node_key
+  ]
 
   @impl true
   def child_spec(opts) when is_list(opts) do
@@ -289,6 +304,39 @@ defmodule Favn.Storage.Adapter.Postgres do
         {:error, reason} ->
           {:error, reason}
       end
+    end
+  end
+
+  @impl true
+  def persist_log_entries(entries, opts) when is_list(entries) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, normalized} <- normalize_log_entries(entries) do
+      repo.transact(fn ->
+        case persist_log_entries_in_transaction(repo, normalized) do
+          {:ok, persisted} -> {:ok, persisted}
+          {:error, reason} -> repo.rollback(reason)
+        end
+      end)
+    end
+  end
+
+  @impl true
+  def list_logs(filter, opts, adapter_opts) when is_list(opts) and is_list(adapter_opts) do
+    with {:ok, page_opts} <- page_opts(opts),
+         {:ok, repo} <- resolve_repo(adapter_opts),
+         {:ok, sql, params} <- list_logs_query(filter) do
+      query_and_decode_page(repo, sql, params, page_opts, &decode_log_entry_row/1)
+    end
+  end
+
+  @impl true
+  def replay_logs_after(cursor, filter, opts, adapter_opts)
+      when is_list(opts) and is_list(adapter_opts) do
+    with {:ok, after_sequence} <- log_cursor_sequence(cursor),
+         :ok <- validate_log_replay_limit(Keyword.get(opts, :limit, 200)),
+         {:ok, repo} <- resolve_repo(adapter_opts),
+         {:ok, sql, params} <- replay_logs_query(filter, after_sequence, opts) do
+      query_and_decode_rows(repo, sql, params, &decode_log_entry_row/1)
     end
   end
 
@@ -975,6 +1023,8 @@ defmodule Favn.Storage.Adapter.Postgres do
   defp decode_asset_freshness_state_row([record_payload]),
     do: AssetFreshnessStateCodec.decode(record_payload)
 
+  defp decode_log_entry_row([payload]), do: LogEntryCodec.decode(payload)
+
   defp persist_run(repo, run) do
     repo.transact(fn ->
       case guarded_put_run(repo, run) do
@@ -1191,6 +1241,135 @@ defmodule Favn.Storage.Adapter.Postgres do
     sql = "SELECT nextval('favn_run_event_global_seq')"
 
     case SQL.query(repo, sql, []) do
+      {:ok, %{rows: [[value]]}} when is_integer(value) -> {:ok, value}
+      {:ok, _} -> {:error, :invalid_counter_value}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp normalize_log_entries(entries) do
+    Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, acc} ->
+      case LogEntryCodec.normalize(entry) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp persist_log_entries_in_transaction(repo, entries) do
+    Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, acc} ->
+      case persist_log_entry(repo, entry) do
+        {:ok, persisted} -> {:cont, {:ok, [persisted | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, persisted} -> {:ok, Enum.reverse(persisted)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp persist_log_entry(repo, entry) do
+    with {:ok, existing} <- fetch_log_entry_by_producer(repo, entry),
+         nil <- existing,
+         {:ok, global_sequence} <- next_log_global_sequence(repo) do
+      entry = LogEntryCodec.assign_global_sequence(entry, global_sequence)
+      {node_key_hash, node_key_blob} = LogEntryCodec.node_key_storage(Map.get(entry, :node_key))
+
+      {asset_ref_key, asset_ref_blob} =
+        LogEntryCodec.asset_ref_storage(Map.get(entry, :asset_ref))
+
+      now = DateTime.utc_now()
+
+      sql =
+        """
+        INSERT INTO favn_log_entries (
+          id, global_sequence, run_id, asset_step_id, node_key_hash, node_key_blob,
+          asset_ref_key, asset_ref_blob, runner_execution_id, attempt, producer_id,
+          producer_sequence, occurred_at, level, source, stream, message, metadata_blob,
+          log_blob, truncated, inserted_at
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19, $20, $21)
+        """
+
+      params = [
+        entry.id,
+        entry.global_sequence,
+        entry.run_id,
+        entry.asset_step_id,
+        node_key_hash,
+        node_key_blob,
+        asset_ref_key,
+        asset_ref_blob,
+        entry.runner_execution_id,
+        entry.attempt,
+        entry.producer_id,
+        entry.producer_sequence,
+        entry.occurred_at,
+        optional_atom_to_string(entry.level),
+        optional_atom_to_string(entry.source),
+        optional_atom_to_string(entry.stream),
+        entry.message,
+        Jason.encode!(entry.metadata || %{}),
+        encode_log_entry(entry),
+        entry.truncated == true,
+        now
+      ]
+
+      case SQL.query(repo, sql, params) do
+        {:ok, _} ->
+          {:ok, entry}
+
+        {:error, %{postgres: %{code: :unique_violation}}} ->
+          resolve_log_entry_conflict(repo, entry)
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      %_{} = existing -> {:ok, existing}
+      {:error, reason} -> {:error, reason}
+      other -> {:error, {:invalid_log_entry_insert, other}}
+    end
+  end
+
+  defp fetch_log_entry_by_producer(_repo, %{
+         producer_id: producer_id,
+         producer_sequence: producer_sequence
+       })
+       when not is_binary(producer_id) or not is_integer(producer_sequence),
+       do: {:ok, nil}
+
+  defp fetch_log_entry_by_producer(repo, entry) do
+    sql =
+      """
+      SELECT log_blob
+      FROM favn_log_entries
+      WHERE producer_id = $1 AND producer_sequence = $2
+      LIMIT 1
+      """
+
+    case SQL.query(repo, sql, [entry.producer_id, entry.producer_sequence]) do
+      {:ok, %{rows: [[blob]]}} -> LogEntryCodec.decode(blob)
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_log_entry_conflict(repo, entry) do
+    with {:ok, existing} <- fetch_log_entry_by_producer(repo, entry) do
+      case existing do
+        nil -> {:error, :log_entry_conflict}
+        existing -> {:ok, existing}
+      end
+    end
+  end
+
+  defp next_log_global_sequence(repo) do
+    case SQL.query(repo, "SELECT nextval('favn_log_global_seq')", []) do
       {:ok, %{rows: [[value]]}} when is_integer(value) -> {:ok, value}
       {:ok, _} -> {:error, :invalid_counter_value}
       {:error, reason} -> {:error, reason}
@@ -1499,6 +1678,165 @@ defmodule Favn.Storage.Adapter.Postgres do
     end
   end
 
+  defp list_logs_query(filter) do
+    with {:ok, {where_sql, params}} <- build_log_filter_sql(filter) do
+      {:ok,
+       """
+       SELECT log_blob
+       FROM favn_log_entries
+       #{where_sql}
+       ORDER BY global_sequence ASC
+       """, params}
+    end
+  end
+
+  defp replay_logs_query(filter, after_sequence, opts) do
+    with {:ok, {where_sql, params}} <- build_log_filter_sql(filter) do
+      limit = Keyword.get(opts, :limit, 200)
+      prefix = if where_sql == "", do: " WHERE ", else: where_sql <> " AND "
+      after_placeholder = "$#{length(params) + 1}"
+      limit_placeholder = "$#{length(params) + 2}"
+
+      {:ok,
+       """
+       SELECT log_blob
+       FROM favn_log_entries
+       #{prefix}global_sequence > #{after_placeholder}
+       ORDER BY global_sequence ASC
+       LIMIT #{limit_placeholder}
+       """, params ++ [after_sequence, limit]}
+    end
+  end
+
+  defp build_log_filter_sql(filter) do
+    filter
+    |> normalize_log_filter()
+    |> Enum.reduce_while({:ok, [], []}, fn {key, value}, {:ok, clauses, params} ->
+      case log_filter_clause(key, value, length(params) + 1) do
+        {:ok, clause, encoded} ->
+          {:cont, {:ok, [clause | clauses], params ++ List.wrap(encoded)}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, [], []} ->
+        {:ok, {"", []}}
+
+      {:ok, clauses, params} ->
+        {:ok, {"WHERE " <> Enum.join(Enum.reverse(clauses), " AND "), params}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp normalize_log_filter(filter) when is_list(filter),
+    do: Keyword.drop(filter, [:limit, :offset])
+
+  defp normalize_log_filter(%_{} = filter),
+    do: filter |> Map.from_struct() |> normalize_log_filter()
+
+  defp normalize_log_filter(filter) when is_map(filter) do
+    filter
+    |> Enum.map(fn {key, value} -> {normalize_log_filter_key(key), value} end)
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp normalize_log_filter(_filter), do: []
+
+  defp normalize_log_filter_key(key) when is_atom(key), do: key
+
+  defp normalize_log_filter_key(key) when is_binary(key) do
+    Enum.find(@log_filter_keys, key, &(Atom.to_string(&1) == key)) || key
+  end
+
+  defp log_filter_clause(:run_id, value, next), do: {:ok, "run_id = $#{next}", value}
+
+  defp log_filter_clause(:asset_step_id, value, next),
+    do: {:ok, "asset_step_id = $#{next}", value}
+
+  defp log_filter_clause(:runner_execution_id, value, next),
+    do: {:ok, "runner_execution_id = $#{next}", value}
+
+  defp log_filter_clause(:level, value, next),
+    do: {:ok, "level = $#{next}", encode_log_filter_atom(value)}
+
+  defp log_filter_clause(:source, value, next),
+    do: {:ok, "source = $#{next}", encode_log_filter_atom(value)}
+
+  defp log_filter_clause(:stream, value, next),
+    do: {:ok, "stream = $#{next}", encode_log_filter_atom(value)}
+
+  defp log_filter_clause(:levels, [], next), do: {:ok, "1 = $#{next}", 1}
+
+  defp log_filter_clause(:levels, values, next) when is_list(values) do
+    placeholders = Enum.map_join(0..(length(values) - 1), ",", &"$#{next + &1}")
+    {:ok, "level IN (#{placeholders})", Enum.map(values, &encode_log_filter_atom/1)}
+  end
+
+  defp log_filter_clause(:sources, [], next), do: {:ok, "1 = $#{next}", 1}
+
+  defp log_filter_clause(:sources, values, next) when is_list(values) do
+    placeholders = Enum.map_join(0..(length(values) - 1), ",", &"$#{next + &1}")
+    {:ok, "source IN (#{placeholders})", Enum.map(values, &encode_log_filter_atom/1)}
+  end
+
+  defp log_filter_clause(:since, %DateTime{} = value, next),
+    do: {:ok, "occurred_at >= $#{next}", value}
+
+  defp log_filter_clause(:until, %DateTime{} = value, next),
+    do: {:ok, "occurred_at <= $#{next}", value}
+
+  defp log_filter_clause(:asset_ref, value, next) do
+    {key, _blob} = LogEntryCodec.asset_ref_storage(value)
+    {:ok, "asset_ref_key = $#{next}", key}
+  end
+
+  defp log_filter_clause(:node_key, value, next) do
+    {hash, _blob} = LogEntryCodec.node_key_storage(value)
+    {:ok, "node_key_hash = $#{next}", hash}
+  end
+
+  defp log_filter_clause(key, _value, _next), do: {:error, {:unsupported_filter, key}}
+
+  defp encode_log_filter_atom(value) when is_atom(value), do: Atom.to_string(value)
+  defp encode_log_filter_atom(value), do: value
+
+  defp log_cursor_sequence(nil), do: {:ok, 0}
+  defp log_cursor_sequence(value) when is_integer(value) and value >= 0, do: {:ok, value}
+
+  defp log_cursor_sequence(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {sequence, ""} when sequence >= 0 ->
+        {:ok, sequence}
+
+      _ ->
+        case Favn.Log.Cursor.parse(value) do
+          {:ok, cursor} -> log_cursor_sequence(cursor)
+          {:error, _reason} -> {:error, :cursor_invalid}
+        end
+    end
+  end
+
+  defp log_cursor_sequence(%_{} = cursor),
+    do: cursor |> Map.from_struct() |> log_cursor_sequence()
+
+  defp log_cursor_sequence(%{} = cursor) do
+    cursor
+    |> Map.get(
+      :global_sequence,
+      Map.get(cursor, :after_global_sequence, Map.get(cursor, "global_sequence"))
+    )
+    |> log_cursor_sequence()
+  end
+
+  defp log_cursor_sequence(_cursor), do: {:error, :cursor_invalid}
+
+  defp validate_log_replay_limit(limit) when is_integer(limit) and limit > 0, do: :ok
+  defp validate_log_replay_limit(_limit), do: {:error, :cursor_invalid}
+
   defp run_snapshot_select do
     """
     SELECT r.run_blob, r.manifest_version_id, m.manifest_version_id, m.content_hash, m.schema_version, m.runner_contract_version, m.serialization_format, m.manifest_json, m.inserted_at
@@ -1627,6 +1965,13 @@ defmodule Favn.Storage.Adapter.Postgres do
     case RunEventCodec.encode(event) do
       {:ok, payload} -> payload
       {:error, reason} -> raise ArgumentError, "invalid run event payload: #{inspect(reason)}"
+    end
+  end
+
+  defp encode_log_entry(entry) do
+    case LogEntryCodec.encode(entry) do
+      {:ok, payload} -> payload
+      {:error, reason} -> raise ArgumentError, "invalid log entry payload: #{inspect(reason)}"
     end
   end
 

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
@@ -3,6 +3,7 @@ defmodule FavnStoragePostgres.Migrations do
 
   alias Ecto.Adapters.SQL
   alias FavnStoragePostgres.Migrations.AddAssetFreshnessState
+  alias FavnStoragePostgres.Migrations.AddLogEntries
   alias FavnStoragePostgres.Migrations.AddBackfillState
   alias FavnStoragePostgres.Migrations.AddRunEventGlobalSequence
   alias FavnStoragePostgres.Migrations.CreateFoundation
@@ -13,7 +14,8 @@ defmodule FavnStoragePostgres.Migrations do
     {20_260_428_100_000, AddBackfillState},
     {20_260_503_120_000, AddRunEventGlobalSequence},
     {20_260_505_100_000, RebuildBackfillReadModelsForDtos},
-    {20_260_509_100_000, AddAssetFreshnessState}
+    {20_260_509_100_000, AddAssetFreshnessState},
+    {20_260_510_100_000, AddLogEntries}
   ]
   @required_tables [
     "public.favn_manifest_versions",
@@ -26,7 +28,9 @@ defmodule FavnStoragePostgres.Migrations do
     "public.favn_asset_window_states",
     "public.favn_asset_freshness_states",
     "public.favn_run_write_seq",
-    "public.favn_run_event_global_seq"
+    "public.favn_run_event_global_seq",
+    "public.favn_log_entries",
+    "public.favn_log_global_seq"
   ]
   @expected_versions Enum.map(@migrations, fn {version, _module} -> to_string(version) end)
 

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_log_entries.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_log_entries.ex
@@ -1,0 +1,47 @@
+defmodule FavnStoragePostgres.Migrations.AddLogEntries do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up do
+    execute("CREATE SEQUENCE IF NOT EXISTS favn_log_global_seq")
+
+    create_if_not_exists table(:favn_log_entries, primary_key: false) do
+      add(:id, :string, primary_key: true)
+      add(:global_sequence, :bigint, null: false)
+      add(:run_id, :string)
+      add(:asset_step_id, :string)
+      add(:node_key_hash, :string)
+      add(:node_key_blob, :text)
+      add(:asset_ref_key, :string)
+      add(:asset_ref_blob, :text)
+      add(:runner_execution_id, :string)
+      add(:attempt, :integer)
+      add(:producer_id, :string)
+      add(:producer_sequence, :bigint)
+      add(:occurred_at, :utc_datetime_usec, null: false)
+      add(:level, :string)
+      add(:source, :string)
+      add(:stream, :string)
+      add(:message, :text, null: false)
+      add(:metadata_blob, :text, null: false)
+      add(:log_blob, :text, null: false)
+      add(:truncated, :boolean, null: false, default: false)
+      add(:inserted_at, :utc_datetime_usec, null: false)
+    end
+
+    create_if_not_exists(unique_index(:favn_log_entries, [:global_sequence]))
+    create_if_not_exists(unique_index(:favn_log_entries, [:producer_id, :producer_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:run_id, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:run_id, :asset_step_id, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:asset_ref_key, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:level, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:source, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:occurred_at]))
+  end
+
+  def down do
+    drop_if_exists(table(:favn_log_entries))
+    execute("DROP SEQUENCE IF EXISTS favn_log_global_seq")
+  end
+end

--- a/apps/favn_storage_postgres/test/adapter_test.exs
+++ b/apps/favn_storage_postgres/test/adapter_test.exs
@@ -68,6 +68,14 @@ defmodule FavnStoragePostgres.AdapterTest do
     assert {:error, :invalid_pagination} = Adapter.list_asset_window_states(filters, opts)
   end
 
+  test "log read APIs validate pagination and cursors before database access" do
+    opts = [repo_mode: :managed, repo_config: repo_config()]
+
+    assert {:error, :invalid_pagination} = Adapter.list_logs([], [limit: 0], opts)
+    assert {:error, :cursor_invalid} = Adapter.replay_logs_after("bad", [], [limit: 10], opts)
+    assert {:error, :cursor_invalid} = Adapter.replay_logs_after(nil, [], [limit: 0], opts)
+  end
+
   defp repo_config do
     [
       hostname: "localhost",

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -19,6 +19,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   alias FavnOrchestrator.Storage.Backfill.CoverageBaselineCodec
   alias FavnOrchestrator.Storage.Freshness.AssetFreshnessStateCodec
   alias FavnOrchestrator.Storage.IdempotencyResponseCodec
+  alias FavnOrchestrator.Storage.LogEntryCodec
   alias FavnOrchestrator.Storage.ManifestCodec
   alias FavnOrchestrator.Storage.RunEventCodec
   alias FavnOrchestrator.Storage.RunSnapshotCodec
@@ -33,7 +34,22 @@ defmodule Favn.Storage.Adapter.SQLite do
   @active_manifest_key "active_manifest_version_id"
   @write_counter_key "run_write_order"
   @run_event_global_sequence_key "run_event_global_sequence"
+  @log_global_sequence_key "log_global_sequence"
   @nil_schedule_id "__nil__"
+  @log_filter_keys [
+    :run_id,
+    :asset_step_id,
+    :runner_execution_id,
+    :level,
+    :source,
+    :stream,
+    :levels,
+    :sources,
+    :since,
+    :until,
+    :asset_ref,
+    :node_key
+  ]
 
   @impl true
   def child_spec(opts) when is_list(opts) do
@@ -292,6 +308,42 @@ defmodule Favn.Storage.Adapter.SQLite do
 
         {:error, reason} ->
           {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def persist_log_entries(entries, opts) when is_list(entries) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, normalized} <- normalize_log_entries(entries) do
+      repo.transact(fn ->
+        case persist_log_entries_in_transaction(repo, normalized) do
+          {:ok, persisted} -> {:ok, persisted}
+          {:error, reason} -> repo.rollback(reason)
+        end
+      end)
+    end
+  end
+
+  @impl true
+  def list_logs(filter, opts, adapter_opts) when is_list(opts) and is_list(adapter_opts) do
+    with {:ok, repo} <- repo_name(adapter_opts),
+         {:ok, page_opts} <- page_opts(opts),
+         {:ok, sql, params} <- list_logs_query(filter, opts) do
+      decode_page(repo, sql, params, page_opts, &decode_log_entry_row/1)
+    end
+  end
+
+  @impl true
+  def replay_logs_after(cursor, filter, opts, adapter_opts)
+      when is_list(opts) and is_list(adapter_opts) do
+    with {:ok, repo} <- repo_name(adapter_opts),
+         {:ok, after_sequence} <- log_cursor_sequence(cursor),
+         :ok <- validate_log_replay_limit(Keyword.get(opts, :limit, 200)),
+         {:ok, sql, params} <- replay_logs_query(filter, after_sequence, opts) do
+      case SQL.query(repo, sql, params) do
+        {:ok, %{rows: rows}} -> decode_log_entry_rows(rows)
+        {:error, reason} -> {:error, reason}
       end
     end
   end
@@ -1728,6 +1780,150 @@ defmodule Favn.Storage.Adapter.SQLite do
     end
   end
 
+  defp next_log_global_sequence(repo) do
+    sql =
+      """
+      INSERT INTO favn_counters (name, value)
+      VALUES (?1, 1)
+      ON CONFLICT(name) DO UPDATE SET value = value + 1
+      RETURNING value
+      """
+
+    case SQL.query(repo, sql, [@log_global_sequence_key]) do
+      {:ok, %{rows: [[value]]}} when is_integer(value) -> {:ok, value}
+      {:ok, _} -> {:error, :invalid_counter_value}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp normalize_log_entries(entries) do
+    Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, acc} ->
+      case LogEntryCodec.normalize(entry) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, normalized} -> {:ok, Enum.reverse(normalized)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp persist_log_entries_in_transaction(repo, entries) do
+    Enum.reduce_while(entries, {:ok, []}, fn entry, {:ok, acc} ->
+      case persist_log_entry(repo, entry) do
+        {:ok, persisted} -> {:cont, {:ok, [persisted | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, persisted} -> {:ok, Enum.reverse(persisted)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp persist_log_entry(repo, entry) do
+    with {:ok, existing} <- fetch_log_entry_by_producer(repo, entry),
+         nil <- existing,
+         {:ok, global_sequence} <- next_log_global_sequence(repo) do
+      entry = LogEntryCodec.assign_global_sequence(entry, global_sequence)
+      {node_key_hash, node_key_blob} = LogEntryCodec.node_key_storage(Map.get(entry, :node_key))
+
+      {asset_ref_key, asset_ref_blob} =
+        LogEntryCodec.asset_ref_storage(Map.get(entry, :asset_ref))
+
+      now = DateTime.utc_now()
+
+      sql =
+        """
+        INSERT INTO favn_log_entries (
+          id, global_sequence, run_id, asset_step_id, node_key_hash, node_key_blob,
+          asset_ref_key, asset_ref_blob, runner_execution_id, attempt, producer_id,
+          producer_sequence, occurred_at, level, source, stream, message, metadata_blob,
+          log_blob, truncated, inserted_at
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19, ?20, ?21)
+        """
+
+      params = [
+        entry.id,
+        entry.global_sequence,
+        entry.run_id,
+        entry.asset_step_id,
+        node_key_hash,
+        node_key_blob,
+        asset_ref_key,
+        asset_ref_blob,
+        entry.runner_execution_id,
+        entry.attempt,
+        entry.producer_id,
+        entry.producer_sequence,
+        entry.occurred_at,
+        encode_optional_atom(entry.level),
+        encode_optional_atom(entry.source),
+        encode_optional_atom(entry.stream),
+        entry.message,
+        Jason.encode!(entry.metadata || %{}),
+        encode_log_entry(entry),
+        entry.truncated == true,
+        now
+      ]
+
+      case SQL.query(repo, sql, params) do
+        {:ok, _} ->
+          {:ok, entry}
+
+        {:error, %{sqlite: %{code: :constraint_failed}}} ->
+          resolve_log_entry_conflict(repo, entry)
+
+        {:error, %Exqlite.Error{message: message} = reason} when is_binary(message) ->
+          if String.contains?(message, "UNIQUE constraint failed") do
+            resolve_log_entry_conflict(repo, entry)
+          else
+            {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    else
+      %_{} = existing -> {:ok, existing}
+      {:error, reason} -> {:error, reason}
+      other -> {:error, {:invalid_log_entry_insert, other}}
+    end
+  end
+
+  defp fetch_log_entry_by_producer(_repo, %{
+         producer_id: producer_id,
+         producer_sequence: producer_sequence
+       })
+       when not is_binary(producer_id) or not is_integer(producer_sequence),
+       do: {:ok, nil}
+
+  defp fetch_log_entry_by_producer(repo, entry) do
+    sql =
+      """
+      SELECT log_blob
+      FROM favn_log_entries
+      WHERE producer_id = ?1 AND producer_sequence = ?2
+      LIMIT 1
+      """
+
+    case SQL.query(repo, sql, [entry.producer_id, entry.producer_sequence]) do
+      {:ok, %{rows: [[blob]]}} -> LogEntryCodec.decode(blob)
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp resolve_log_entry_conflict(repo, entry) do
+    with {:ok, existing} <- fetch_log_entry_by_producer(repo, entry) do
+      case existing do
+        nil -> {:error, :log_entry_conflict}
+        existing -> {:ok, existing}
+      end
+    end
+  end
+
   defp fetch_manifest_hash(repo, manifest_version_id) do
     sql = "SELECT content_hash FROM favn_manifest_versions WHERE manifest_version_id = ?1 LIMIT 1"
 
@@ -1927,6 +2123,184 @@ defmodule Favn.Storage.Adapter.SQLite do
       {:error, reason} -> {:error, reason}
     end
   end
+
+  defp list_logs_query(filter, _opts) do
+    with {:ok, {where_sql, params}} <- build_log_filter_sql(filter) do
+      limit_placeholder = "?#{length(params) + 1}"
+      offset_placeholder = "?#{length(params) + 2}"
+
+      {:ok,
+       """
+       SELECT log_blob
+       FROM favn_log_entries
+       #{where_sql}
+       ORDER BY global_sequence ASC
+       LIMIT #{limit_placeholder} OFFSET #{offset_placeholder}
+       """, params}
+    end
+  end
+
+  defp replay_logs_query(filter, after_sequence, opts) do
+    with {:ok, {where_sql, params}} <- build_log_filter_sql(filter) do
+      limit = Keyword.get(opts, :limit, 200)
+      prefix = if where_sql == "", do: " WHERE ", else: where_sql <> " AND "
+      after_placeholder = "?#{length(params) + 1}"
+      limit_placeholder = "?#{length(params) + 2}"
+
+      {:ok,
+       """
+       SELECT log_blob
+       FROM favn_log_entries
+       #{prefix}global_sequence > #{after_placeholder}
+       ORDER BY global_sequence ASC
+       LIMIT #{limit_placeholder}
+       """, params ++ [after_sequence, limit]}
+    end
+  end
+
+  defp build_log_filter_sql(filter) do
+    filter
+    |> normalize_log_filter()
+    |> Enum.reduce_while({:ok, [], []}, fn {key, value}, {:ok, clauses, params} ->
+      case log_filter_clause(key, value, length(params) + 1) do
+        {:ok, clause, encoded} ->
+          {:cont, {:ok, [clause | clauses], params ++ List.wrap(encoded)}}
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, [], []} ->
+        {:ok, {"", []}}
+
+      {:ok, clauses, params} ->
+        {:ok, {"WHERE " <> Enum.join(Enum.reverse(clauses), " AND "), params}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp normalize_log_filter(filter) when is_list(filter),
+    do: Keyword.drop(filter, [:limit, :offset])
+
+  defp normalize_log_filter(%_{} = filter),
+    do: filter |> Map.from_struct() |> normalize_log_filter()
+
+  defp normalize_log_filter(filter) when is_map(filter) do
+    filter
+    |> Enum.map(fn {key, value} -> {normalize_log_filter_key(key), value} end)
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+  end
+
+  defp normalize_log_filter(_filter), do: []
+
+  defp normalize_log_filter_key(key) when is_atom(key), do: key
+
+  defp normalize_log_filter_key(key) when is_binary(key) do
+    Enum.find(@log_filter_keys, key, &(Atom.to_string(&1) == key)) || key
+  end
+
+  defp log_filter_clause(:run_id, value, next), do: {:ok, "run_id = ?#{next}", value}
+
+  defp log_filter_clause(:asset_step_id, value, next),
+    do: {:ok, "asset_step_id = ?#{next}", value}
+
+  defp log_filter_clause(:runner_execution_id, value, next),
+    do: {:ok, "runner_execution_id = ?#{next}", value}
+
+  defp log_filter_clause(:level, value, next),
+    do: {:ok, "level = ?#{next}", encode_log_filter_atom(value)}
+
+  defp log_filter_clause(:source, value, next),
+    do: {:ok, "source = ?#{next}", encode_log_filter_atom(value)}
+
+  defp log_filter_clause(:stream, value, next),
+    do: {:ok, "stream = ?#{next}", encode_log_filter_atom(value)}
+
+  defp log_filter_clause(:levels, [], next), do: {:ok, "1 = ?#{next}", 1}
+
+  defp log_filter_clause(:levels, values, next) when is_list(values) do
+    placeholders = Enum.map_join(0..(length(values) - 1), ",", &"?#{next + &1}")
+    {:ok, "level IN (#{placeholders})", Enum.map(values, &encode_log_filter_atom/1)}
+  end
+
+  defp log_filter_clause(:sources, [], next), do: {:ok, "1 = ?#{next}", 1}
+
+  defp log_filter_clause(:sources, values, next) when is_list(values) do
+    placeholders = Enum.map_join(0..(length(values) - 1), ",", &"?#{next + &1}")
+    {:ok, "source IN (#{placeholders})", Enum.map(values, &encode_log_filter_atom/1)}
+  end
+
+  defp log_filter_clause(:since, %DateTime{} = value, next),
+    do: {:ok, "occurred_at >= ?#{next}", value}
+
+  defp log_filter_clause(:until, %DateTime{} = value, next),
+    do: {:ok, "occurred_at <= ?#{next}", value}
+
+  defp log_filter_clause(:asset_ref, value, next) do
+    {key, _blob} = LogEntryCodec.asset_ref_storage(value)
+    {:ok, "asset_ref_key = ?#{next}", key}
+  end
+
+  defp log_filter_clause(:node_key, value, next) do
+    {hash, _blob} = LogEntryCodec.node_key_storage(value)
+    {:ok, "node_key_hash = ?#{next}", hash}
+  end
+
+  defp log_filter_clause(key, _value, _next), do: {:error, {:unsupported_filter, key}}
+
+  defp encode_log_filter_atom(value) when is_atom(value), do: Atom.to_string(value)
+  defp encode_log_filter_atom(value), do: value
+
+  defp log_cursor_sequence(nil), do: {:ok, 0}
+  defp log_cursor_sequence(value) when is_integer(value) and value >= 0, do: {:ok, value}
+
+  defp log_cursor_sequence(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {sequence, ""} when sequence >= 0 ->
+        {:ok, sequence}
+
+      _ ->
+        case Favn.Log.Cursor.parse(value) do
+          {:ok, cursor} -> log_cursor_sequence(cursor)
+          {:error, _reason} -> {:error, :cursor_invalid}
+        end
+    end
+  end
+
+  defp log_cursor_sequence(%_{} = cursor),
+    do: cursor |> Map.from_struct() |> log_cursor_sequence()
+
+  defp log_cursor_sequence(%{} = cursor) do
+    cursor
+    |> Map.get(
+      :global_sequence,
+      Map.get(cursor, :after_global_sequence, Map.get(cursor, "global_sequence"))
+    )
+    |> log_cursor_sequence()
+  end
+
+  defp log_cursor_sequence(_cursor), do: {:error, :cursor_invalid}
+
+  defp validate_log_replay_limit(limit) when is_integer(limit) and limit > 0, do: :ok
+  defp validate_log_replay_limit(_limit), do: {:error, :cursor_invalid}
+
+  defp decode_log_entry_rows(rows) do
+    Enum.reduce_while(rows, {:ok, []}, fn row, {:ok, acc} ->
+      case decode_log_entry_row(row) do
+        {:ok, entry} -> {:cont, {:ok, [entry | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, entries} -> {:ok, Enum.reverse(entries)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp decode_log_entry_row([payload]), do: LogEntryCodec.decode(payload)
 
   defp decode_event_rows(rows) do
     Enum.reduce_while(rows, {:ok, []}, fn [global_sequence, payload], {:ok, acc} ->
@@ -2155,6 +2529,13 @@ defmodule Favn.Storage.Adapter.SQLite do
     case RunEventCodec.encode(event) do
       {:ok, payload} -> payload
       {:error, reason} -> raise ArgumentError, "invalid run event payload: #{inspect(reason)}"
+    end
+  end
+
+  defp encode_log_entry(entry) do
+    case LogEntryCodec.encode(entry) do
+      {:ok, payload} -> payload
+      {:error, reason} -> raise ArgumentError, "failed to encode log entry: #{inspect(reason)}"
     end
   end
 

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
@@ -6,6 +6,7 @@ defmodule FavnStorageSqlite.Migrations do
   alias FavnStorageSqlite.Migrations.AddAssetFreshnessState
   alias FavnStorageSqlite.Migrations.AddBackfillState
   alias FavnStorageSqlite.Migrations.AddIdempotencyRecords
+  alias FavnStorageSqlite.Migrations.AddLogEntries
   alias FavnStorageSqlite.Migrations.AddRunEventGlobalSequence
   alias FavnStorageSqlite.Migrations.CreateFoundation
   alias FavnStorageSqlite.Migrations.RebuildBackfillReadModelsForDtos
@@ -17,7 +18,8 @@ defmodule FavnStorageSqlite.Migrations do
     {20_260_503_100_000, AddIdempotencyRecords},
     {20_260_503_120_000, AddRunEventGlobalSequence},
     {20_260_505_100_000, RebuildBackfillReadModelsForDtos},
-    {20_260_509_100_000, AddAssetFreshnessState}
+    {20_260_509_100_000, AddAssetFreshnessState},
+    {20_260_510_100_000, AddLogEntries}
   ]
   @required_tables [
     "favn_manifest_versions",
@@ -34,7 +36,8 @@ defmodule FavnStorageSqlite.Migrations do
     "favn_auth_sessions",
     "favn_auth_audits",
     "favn_idempotency_records",
-    "favn_counters"
+    "favn_counters",
+    "favn_log_entries"
   ]
   @expected_versions Enum.map(@migrations, fn {version, _module} -> to_string(version) end)
 

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_log_entries.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_log_entries.ex
@@ -1,0 +1,40 @@
+defmodule FavnStorageSqlite.Migrations.AddLogEntries do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists table(:favn_log_entries, primary_key: false) do
+      add(:id, :string, primary_key: true)
+      add(:global_sequence, :integer, null: false)
+      add(:run_id, :string)
+      add(:asset_step_id, :string)
+      add(:node_key_hash, :string)
+      add(:node_key_blob, :text)
+      add(:asset_ref_key, :string)
+      add(:asset_ref_blob, :text)
+      add(:runner_execution_id, :string)
+      add(:attempt, :integer)
+      add(:producer_id, :string)
+      add(:producer_sequence, :integer)
+      add(:occurred_at, :text, null: false)
+      add(:level, :string)
+      add(:source, :string)
+      add(:stream, :string)
+      add(:message, :text, null: false)
+      add(:metadata_blob, :text, null: false)
+      add(:log_blob, :text, null: false)
+      add(:truncated, :boolean, null: false, default: false)
+      add(:inserted_at, :text, null: false)
+    end
+
+    create_if_not_exists(unique_index(:favn_log_entries, [:global_sequence]))
+    create_if_not_exists(unique_index(:favn_log_entries, [:producer_id, :producer_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:run_id, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:run_id, :asset_step_id, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:asset_ref_key, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:level, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:source, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:occurred_at]))
+  end
+end

--- a/apps/favn_storage_sqlite/test/sqlite_readiness_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_readiness_test.exs
@@ -235,7 +235,8 @@ defmodule FavnStorageSqlite.ReadinessTest do
              "20260503100000",
              "20260503120000",
              "20260505100000",
-             "20260509100000"
+             "20260509100000",
+             "20260510100000"
            ]
 
     refute Migrations.schema_ready?(Repo)

--- a/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
@@ -147,6 +147,18 @@ defmodule Favn.SQLiteStorageTest do
     assert persisted_first.message == "line one\nline two"
     assert persisted_first.metadata["password"] == "[REDACTED]"
 
+    assert {:ok, %{rows: [[metadata_blob, log_blob]]}} =
+             SQL.query(
+               Repo,
+               "SELECT metadata_blob, log_blob FROM favn_log_entries WHERE global_sequence = ?1",
+               [persisted_first.global_sequence]
+             )
+
+    assert Jason.decode!(metadata_blob)["password"] == "[REDACTED]"
+    assert Jason.decode!(log_blob)["metadata"]["password"] == "[REDACTED]"
+    refute metadata_blob =~ "secret"
+    refute log_blob =~ "secret"
+
     assert {:ok, [^persisted_first]} = OrchestratorStorage.persist_log_entries([first])
 
     assert {:ok, page} =

--- a/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
@@ -107,6 +107,64 @@ defmodule Favn.SQLiteStorageTest do
     assert {:error, :not_found} = Storage.get_run("missing-sqlite-run")
   end
 
+  test "persists lists replays and deduplicates log entries" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+    first =
+      Favn.Log.Entry.normalize(%{
+        run_id: "sqlite-log-run",
+        asset_step_id: "step_a",
+        asset_ref: {Favn.SQLiteStorageTest, :sample_asset},
+        node_key: "node-a",
+        producer_id: "sqlite-runner",
+        producer_sequence: 1,
+        occurred_at: now,
+        level: :info,
+        source: :runner,
+        stream: :stdout,
+        message: "line one\nline two",
+        metadata: %{password: "secret", keep: "visible"}
+      })
+
+    second =
+      Favn.Log.Entry.normalize(%{
+        run_id: "sqlite-log-run",
+        asset_step_id: "step_b",
+        producer_id: "sqlite-runner",
+        producer_sequence: 2,
+        occurred_at: DateTime.add(now, 1, :second),
+        level: :error,
+        source: :runner,
+        stream: :stderr,
+        message: "failed"
+      })
+
+    assert {:ok, [persisted_first, persisted_second]} =
+             OrchestratorStorage.persist_log_entries([first, second])
+
+    assert persisted_first.global_sequence == 1
+    assert persisted_second.global_sequence == 2
+    assert persisted_first.message == "line one\nline two"
+    assert persisted_first.metadata["password"] == "[REDACTED]"
+
+    assert {:ok, [^persisted_first]} = OrchestratorStorage.persist_log_entries([first])
+
+    assert {:ok, page} =
+             OrchestratorStorage.list_logs(%Favn.Log.Filter{run_id: "sqlite-log-run"}, limit: 10)
+
+    assert Enum.map(page.items, & &1.global_sequence) == [1, 2]
+
+    assert {:ok, filtered} = OrchestratorStorage.list_logs(%Favn.Log.Filter{levels: [:error]})
+    assert Enum.map(filtered.items, & &1.message) == ["failed"]
+
+    assert {:ok, [^persisted_second]} =
+             OrchestratorStorage.replay_logs_after(
+               "run:sqlite-log-run:1",
+               [run_id: "sqlite-log-run"],
+               limit: 10
+             )
+  end
+
   test "run recovery accepts consumer module atoms from the run manifest" do
     run = sample_run("sqlite-run-manifest-atom", :running)
     existing_module = Atom.to_string(Favn.SQLiteStorageTest)

--- a/apps/favn_test_support/priv/fixtures/assets/runner_assets.ex
+++ b/apps/favn_test_support/priv/fixtures/assets/runner_assets.ex
@@ -294,6 +294,15 @@ defmodule Favn.Test.Fixtures.Assets.Runner.TerminalFailingStore do
   def list_global_run_events(_filters, _opts), do: {:ok, []}
 
   @impl true
+  def persist_log_entries(entries, _opts), do: {:ok, entries}
+
+  @impl true
+  def list_logs(_filter, opts, _adapter_opts), do: {:ok, empty_page(opts)}
+
+  @impl true
+  def replay_logs_after(_cursor, _filter, _opts, _adapter_opts), do: {:ok, []}
+
+  @impl true
   def put_scheduler_state(_scheduler_key, _state, _opts), do: :ok
 
   @impl true

--- a/opencode.json
+++ b/opencode.json
@@ -1,14 +1,9 @@
 {
   "$schema": "https://opencode.ai/config.json",
   "mcp": {
-    "tidewave_view": {
+    "tidewave": {
       "type": "remote",
       "url": "http://127.0.0.1:4173/tidewave/mcp",
-      "enabled": true
-    },
-    "tidewave_orchestrator": {
-      "type": "remote",
-      "url": "http://127.0.0.1:4101/tidewave/mcp",
       "enabled": true
     },
     "playwright": {


### PR DESCRIPTION
## Summary
- Add shared log entry/filter/cursor/redaction contracts and public orchestrator log APIs.
- Persist logs through memory, SQLite, and Postgres adapters with storage-assigned global cursors for replay.
- Wire runner lifecycle log emission into orchestrator persistence and PubSub streaming.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test` app-scoped suites for favn_core, favn_runner, favn_orchestrator, favn_storage_sqlite, favn_storage_postgres, favn_test_support, and favn_local
- `git diff --check`
- Tidewave runtime checks for emit/list/replay/subscribe and multiline messages