### PR TITLE
Add Favn View log streaming UI

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -774,11 +774,12 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
 
   def handle_call({:list_logs, filter, opts}, _from, state) do
     page_opts = page_opts(opts)
+    order = log_order(opts)
 
     rows =
       log_entries(state)
       |> filter_logs(filter)
-      |> Enum.sort_by(&Map.get(&1, :global_sequence, 0))
+      |> Enum.sort_by(&Map.get(&1, :global_sequence, 0), order)
       |> Enum.drop(Keyword.fetch!(page_opts, :offset))
       |> Enum.take(Keyword.fetch!(page_opts, :limit) + 1)
 
@@ -1277,6 +1278,15 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   defp log_entries(state), do: Map.get(state, :log_entries, [])
+
+  defp log_order(opts) do
+    case Keyword.get(opts, :order, :asc) do
+      :desc -> :desc
+      "desc" -> :desc
+      _other -> :asc
+    end
+  end
+
   defp log_global_sequence(state), do: Map.get(state, :log_global_sequence, 0)
 
   defp find_idempotent_log_entry(entries, entry) do

--- a/apps/favn_orchestrator/test/logs_test.exs
+++ b/apps/favn_orchestrator/test/logs_test.exs
@@ -85,6 +85,29 @@ defmodule FavnOrchestrator.LogsTest do
     assert Enum.map(replayed, & &1.message) == ["second"]
   end
 
+  test "list logs supports descending order for latest pages" do
+    entries =
+      for sequence <- 1..5 do
+        %Entry{
+          run_id: "run_log_latest",
+          message: "log #{sequence}",
+          producer_id: "latest",
+          producer_sequence: sequence
+        }
+      end
+
+    assert {:ok, _persisted} = FavnOrchestrator.emit_logs(entries)
+
+    assert {:ok, page} =
+             FavnOrchestrator.list_logs(%Filter{run_id: "run_log_latest"},
+               limit: 2,
+               order: :desc
+             )
+
+    assert Enum.map(page.items, & &1.message) == ["log 5", "log 4"]
+    assert page.has_more?
+  end
+
   test "runner bridge merges step context so runner logs filter by asset step" do
     runner_opts = [
       runner_log_entries: %{

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -324,7 +324,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   def list_logs(filter, opts, adapter_opts) when is_list(opts) and is_list(adapter_opts) do
     with {:ok, page_opts} <- page_opts(opts),
          {:ok, repo} <- resolve_repo(adapter_opts),
-         {:ok, sql, params} <- list_logs_query(filter) do
+         {:ok, sql, params} <- list_logs_query(filter, opts) do
       query_and_decode_page(repo, sql, params, page_opts, &decode_log_entry_row/1)
     end
   end
@@ -1678,15 +1678,25 @@ defmodule Favn.Storage.Adapter.Postgres do
     end
   end
 
-  defp list_logs_query(filter) do
+  defp list_logs_query(filter, opts) do
     with {:ok, {where_sql, params}} <- build_log_filter_sql(filter) do
+      order = log_order_sql(opts)
+
       {:ok,
        """
        SELECT log_blob
        FROM favn_log_entries
        #{where_sql}
-       ORDER BY global_sequence ASC
+       ORDER BY global_sequence #{order}
        """, params}
+    end
+  end
+
+  defp log_order_sql(opts) do
+    case Keyword.get(opts, :order, :asc) do
+      :desc -> "DESC"
+      "desc" -> "DESC"
+      _other -> "ASC"
     end
   end
 

--- a/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
+++ b/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
@@ -116,6 +116,50 @@ defmodule FavnStoragePostgres.Integration.AdapterLiveTest do
     end
   end
 
+  test "lists logs in descending global sequence order", context do
+    case context[:opts] do
+      nil ->
+        :ok
+
+      opts ->
+        run_id = "run_pg_logs_#{System.unique_integer([:positive])}"
+        now = DateTime.utc_now() |> DateTime.truncate(:second)
+
+        entries =
+          for sequence <- 1..3 do
+            Favn.Log.Entry.normalize(%{
+              run_id: run_id,
+              asset_step_id: "step_a",
+              producer_id: "pg-test-#{run_id}",
+              producer_sequence: sequence,
+              occurred_at: DateTime.add(now, sequence, :second),
+              level: :info,
+              source: :runner,
+              stream: :stdout,
+              message: "postgres log #{sequence}"
+            })
+          end
+
+        assert {:ok, persisted} = Adapter.persist_log_entries(entries, opts)
+
+        assert {:ok, page} =
+                 Adapter.list_logs(
+                   %Favn.Log.Filter{run_id: run_id},
+                   [limit: 2, order: :desc],
+                   opts
+                 )
+
+        expected_sequences =
+          persisted
+          |> Enum.map(& &1.global_sequence)
+          |> Enum.sort(:desc)
+          |> Enum.take(2)
+
+        assert Enum.map(page.items, & &1.global_sequence) == expected_sequences
+        assert Enum.map(page.items, & &1.message) == ["postgres log 3", "postgres log 2"]
+    end
+  end
+
   test "run recovery accepts only consumer module atoms from the run manifest", context do
     case context[:opts] do
       nil ->

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -2124,19 +2124,28 @@ defmodule Favn.Storage.Adapter.SQLite do
     end
   end
 
-  defp list_logs_query(filter, _opts) do
+  defp list_logs_query(filter, opts) do
     with {:ok, {where_sql, params}} <- build_log_filter_sql(filter) do
       limit_placeholder = "?#{length(params) + 1}"
       offset_placeholder = "?#{length(params) + 2}"
+      order = log_order_sql(opts)
 
       {:ok,
        """
        SELECT log_blob
        FROM favn_log_entries
        #{where_sql}
-       ORDER BY global_sequence ASC
+       ORDER BY global_sequence #{order}
        LIMIT #{limit_placeholder} OFFSET #{offset_placeholder}
        """, params}
+    end
+  end
+
+  defp log_order_sql(opts) do
+    case Keyword.get(opts, :order, :asc) do
+      :desc -> "DESC"
+      "desc" -> "DESC"
+      _other -> "ASC"
     end
   end
 

--- a/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
@@ -166,6 +166,14 @@ defmodule Favn.SQLiteStorageTest do
 
     assert Enum.map(page.items, & &1.global_sequence) == [1, 2]
 
+    assert {:ok, latest_page} =
+             OrchestratorStorage.list_logs(%Favn.Log.Filter{run_id: "sqlite-log-run"},
+               limit: 1,
+               order: :desc
+             )
+
+    assert Enum.map(latest_page.items, & &1.global_sequence) == [2]
+
     assert {:ok, filtered} = OrchestratorStorage.list_logs(%Favn.Log.Filter{levels: [:error]})
     assert Enum.map(filtered.items, & &1.message) == ["failed"]
 

--- a/apps/favn_view/assets/js/app.js
+++ b/apps/favn_view/assets/js/app.js
@@ -25,11 +25,37 @@ import {LiveSocket} from "phoenix_live_view"
 import {hooks as colocatedHooks} from "phoenix-colocated/favn_view"
 import topbar from "../vendor/topbar"
 
+const Hooks = {
+  FavnLogViewer: {
+    mounted() {
+      this.scrollToBottom()
+      this.el.addEventListener("click", event => {
+        const button = event.target.closest("[data-copy-logs]")
+        if (!button) return
+
+        const source = document.getElementById(this.el.dataset.copySource)
+        if (!source) return
+
+        navigator.clipboard?.writeText(source.value)
+      })
+    },
+    updated() {
+      this.scrollToBottom()
+    },
+    scrollToBottom() {
+      if (this.el.dataset.liveTail !== "true") return
+
+      const terminal = this.el.querySelector("[data-testid='log-terminal-window']")
+      if (terminal) terminal.scrollTop = terminal.scrollHeight
+    }
+  }
+}
+
 const csrfToken = document.querySelector("meta[name='csrf-token']").getAttribute("content")
 const liveSocket = new LiveSocket("/live", Socket, {
   longPollFallbackMs: 2500,
   params: {_csrf_token: csrfToken},
-  hooks: {...colocatedHooks},
+  hooks: {...colocatedHooks, ...Hooks},
 })
 
 // Show progress bar on live navigation and form submits
@@ -80,4 +106,3 @@ if (process.env.NODE_ENV === "development") {
     window.liveReloader = reloader
   })
 }
-

--- a/apps/favn_view/lib/favn_view/asset_run_logs_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_run_logs_live.ex
@@ -3,9 +3,7 @@ defmodule FavnView.AssetRunLogsLive do
 
   use FavnView, :live_view
 
-  alias FavnView.Components.AppShell
-  alias FavnView.Components.LogViewer
-  alias FavnView.Components.ModeRail
+  alias FavnView.Components.LogPages
   alias FavnView.LogsLiveSupport
 
   @impl true
@@ -53,52 +51,7 @@ defmodule FavnView.AssetRunLogsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <AppShell.app_shell
-      title={@title}
-      subtitle={@subtitle}
-      status={@status}
-      status_tone={@status_tone}
-      nav_items={@nav_items}
-      back_href={@back_href}
-      back_label={@back_label}
-      facts={@facts}
-    >
-      <LogViewer.log_viewer
-        logs={@logs}
-        visible_logs={@visible_logs}
-        filter={@filter}
-        scope={@scope}
-        title="Logs"
-        subtitle="Asset-step scoped backend logs"
-        status={@logs_status}
-        live?={@live?}
-        live_tail?={@live_tail?}
-        wrap?={@wrap?}
-        search_query={@search_query}
-        selected_level={@selected_level}
-        selected_source={@selected_source}
-        next_cursor={@next_cursor}
-        empty_state={@empty_state}
-        warning={@stream_warning}
-        context_note={@context_note}
-        facts={@facts}
-      />
-
-      <:mode_rail>
-        <ModeRail.mode_rail active={:logs} modes={asset_log_modes()} on_select="set_mode" />
-      </:mode_rail>
-    </AppShell.app_shell>
+    <LogPages.asset_run_logs_page {assigns} />
     """
-  end
-
-  defp asset_log_modes do
-    [
-      %{id: :logs, label: "Logs", icon: "hero-calendar-days"},
-      %{id: :inputs, label: "Inputs", icon: "hero-rocket-launch", disabled: true},
-      %{id: :outputs, label: "Outputs", icon: "hero-share-nodes", disabled: true},
-      %{id: :error, label: "Error", icon: "hero-book-open", disabled: true},
-      %{id: :context, label: "Context", icon: "hero-code-bracket", disabled: true},
-      %{id: :debug, label: "Debug", icon: "hero-document-text", disabled: true}
-    ]
   end
 end

--- a/apps/favn_view/lib/favn_view/asset_run_logs_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_run_logs_live.ex
@@ -1,0 +1,104 @@
+defmodule FavnView.AssetRunLogsLive do
+  @moduledoc false
+
+  use FavnView, :live_view
+
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.LogViewer
+  alias FavnView.Components.ModeRail
+  alias FavnView.LogsLiveSupport
+
+  @impl true
+  def mount(%{"run_id" => run_id, "asset_step_id" => asset_step_id}, _session, socket) do
+    context = LogsLiveSupport.asset_context(run_id, asset_step_id)
+
+    socket =
+      LogsLiveSupport.mount_logs(socket, %{
+        filter: %Favn.Log.Filter{run_id: run_id, asset_step_id: asset_step_id},
+        scope: :asset,
+        nav_items: LogsLiveSupport.nav_items(:runs),
+        title: context.title,
+        subtitle: context.subtitle,
+        status: context.status,
+        status_tone: context.status_tone,
+        facts: context.facts,
+        back_href: ~p"/runs/#{run_id}",
+        back_label: "Back to run",
+        empty_state: "No logs recorded for this asset step yet.",
+        context_note: context.note
+      })
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_info({:favn_log_entry, entry}, socket),
+    do: {:noreply, LogsLiveSupport.add_live_log(socket, entry)}
+
+  @impl true
+  def handle_event("filter_logs", params, socket),
+    do: {:noreply, LogsLiveSupport.handle_filter(socket, params)}
+
+  def handle_event("toggle_wrap", _params, socket),
+    do: {:noreply, LogsLiveSupport.toggle(socket, :wrap?)}
+
+  def handle_event("toggle_live_tail", _params, socket),
+    do: {:noreply, LogsLiveSupport.toggle(socket, :live_tail?)}
+
+  def handle_event("set_mode", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def terminate(_reason, socket), do: LogsLiveSupport.unsubscribe(socket)
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <AppShell.app_shell
+      title={@title}
+      subtitle={@subtitle}
+      status={@status}
+      status_tone={@status_tone}
+      nav_items={@nav_items}
+      back_href={@back_href}
+      back_label={@back_label}
+      facts={@facts}
+    >
+      <LogViewer.log_viewer
+        logs={@logs}
+        visible_logs={@visible_logs}
+        filter={@filter}
+        scope={@scope}
+        title="Logs"
+        subtitle="Asset-step scoped backend logs"
+        status={@logs_status}
+        live?={@live?}
+        live_tail?={@live_tail?}
+        wrap?={@wrap?}
+        search_query={@search_query}
+        selected_level={@selected_level}
+        selected_source={@selected_source}
+        next_cursor={@next_cursor}
+        empty_state={@empty_state}
+        warning={@stream_warning}
+        context_note={@context_note}
+        facts={@facts}
+      />
+
+      <:mode_rail>
+        <ModeRail.mode_rail active={:logs} modes={asset_log_modes()} on_select="set_mode" />
+      </:mode_rail>
+    </AppShell.app_shell>
+    """
+  end
+
+  defp asset_log_modes do
+    [
+      %{id: :logs, label: "Logs", icon: "hero-calendar-days"},
+      %{id: :inputs, label: "Inputs", icon: "hero-rocket-launch", disabled: true},
+      %{id: :outputs, label: "Outputs", icon: "hero-share-nodes", disabled: true},
+      %{id: :error, label: "Error", icon: "hero-book-open", disabled: true},
+      %{id: :context, label: "Context", icon: "hero-code-bracket", disabled: true},
+      %{id: :debug, label: "Debug", icon: "hero-document-text", disabled: true}
+    ]
+  end
+end

--- a/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
@@ -315,6 +315,7 @@ defmodule FavnView.Components.AssetCataloguePage do
       %{label: "Lineage", icon: "hero-share", href: "#"},
       %{label: "Storage", icon: "hero-circle-stack", href: "#"},
       %{label: "Runs", icon: "hero-rocket-launch", href: "#", active: active == :runs},
+      %{label: "Logs", icon: "hero-document-text", href: "/logs", active: active == :logs},
       %{label: "Alerts", icon: "hero-bell", href: "#"},
       %{label: "Settings", icon: "hero-cog-6-tooth", href: "#"}
     ]

--- a/apps/favn_view/lib/favn_view/components/log_pages.ex
+++ b/apps/favn_view/lib/favn_view/components/log_pages.ex
@@ -1,0 +1,127 @@
+defmodule FavnView.Components.LogPages do
+  @moduledoc """
+  Page shells for the global, run, and asset-step log views.
+  """
+
+  use FavnView, :html
+
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.LogViewer
+  alias FavnView.Components.ModeRail
+
+  attr :nav_items, :list, default: []
+  attr :title, :string, required: true
+  attr :subtitle, :string, default: nil
+  attr :status, :string, default: nil
+  attr :status_tone, :atom, default: :neutral
+  attr :facts, :list, default: []
+  attr :back_href, :string, default: nil
+  attr :back_label, :string, default: nil
+  attr :logs, :list, default: []
+  attr :visible_logs, :list, default: []
+  attr :filter, :any, default: nil
+  attr :scope, :atom, default: :global
+  attr :logs_status, :atom, default: :ready
+  attr :live?, :boolean, default: false
+  attr :live_tail?, :boolean, default: true
+  attr :wrap?, :boolean, default: true
+  attr :search_query, :string, default: ""
+  attr :selected_level, :string, default: "all"
+  attr :selected_source, :string, default: "all"
+  attr :next_cursor, :any, default: nil
+  attr :empty_state, :string, default: "No logs yet."
+  attr :stream_warning, :string, default: nil
+  attr :context_note, :string, default: nil
+
+  def global_logs_page(assigns) do
+    ~H"""
+    <AppShell.app_shell title={@title} subtitle={@subtitle} nav_items={@nav_items}>
+      <.viewer assigns={assigns} viewer_title="Logs" viewer_subtitle={@subtitle} />
+    </AppShell.app_shell>
+    """
+  end
+
+  def run_logs_page(assigns) do
+    ~H"""
+    <AppShell.app_shell
+      title={@title}
+      subtitle={@subtitle}
+      status={@status}
+      status_tone={@status_tone}
+      nav_items={@nav_items}
+      back_href={@back_href}
+      back_label={@back_label}
+      facts={@facts}
+    >
+      <.viewer assigns={assigns} viewer_title="Logs" viewer_subtitle="Run-scoped backend logs" />
+    </AppShell.app_shell>
+    """
+  end
+
+  def asset_run_logs_page(assigns) do
+    ~H"""
+    <AppShell.app_shell
+      title={@title}
+      subtitle={@subtitle}
+      status={@status}
+      status_tone={@status_tone}
+      nav_items={@nav_items}
+      back_href={@back_href}
+      back_label={@back_label}
+      facts={@facts}
+    >
+      <.viewer
+        assigns={assigns}
+        viewer_title="Logs"
+        viewer_subtitle="Asset-step scoped backend logs"
+        facts={@facts}
+      />
+
+      <:mode_rail>
+        <ModeRail.mode_rail active={:logs} modes={asset_log_modes()} on_select="set_mode" />
+      </:mode_rail>
+    </AppShell.app_shell>
+    """
+  end
+
+  attr :assigns, :map, required: true
+  attr :viewer_title, :string, required: true
+  attr :viewer_subtitle, :string, default: nil
+  attr :facts, :list, default: []
+
+  def viewer(assigns) do
+    ~H"""
+    <LogViewer.log_viewer
+      logs={@assigns.logs}
+      visible_logs={@assigns.visible_logs}
+      filter={@assigns.filter}
+      scope={@assigns.scope}
+      title={@viewer_title}
+      subtitle={@viewer_subtitle}
+      status={@assigns.logs_status}
+      live?={@assigns.live?}
+      live_tail?={@assigns.live_tail?}
+      wrap?={@assigns.wrap?}
+      search_query={@assigns.search_query}
+      selected_level={@assigns.selected_level}
+      selected_source={@assigns.selected_source}
+      next_cursor={@assigns.next_cursor}
+      empty_state={@assigns.empty_state}
+      warning={@assigns.stream_warning}
+      context_note={@assigns.context_note}
+      facts={@facts}
+    />
+    """
+  end
+
+  def asset_log_modes do
+    [
+      %{id: :logs, label: "Logs", icon: "hero-calendar-days"},
+      %{id: :inputs, label: "Inputs", icon: "hero-rocket-launch", disabled: true},
+      %{id: :outputs, label: "Outputs", icon: "hero-share-nodes", disabled: true},
+      %{id: :error, label: "Error", icon: "hero-book-open", disabled: true},
+      %{id: :context, label: "Context", icon: "hero-code-bracket", disabled: true},
+      %{id: :debug, label: "Debug", icon: "hero-document-text", disabled: true}
+    ]
+  end
+end

--- a/apps/favn_view/lib/favn_view/components/log_viewer.ex
+++ b/apps/favn_view/lib/favn_view/components/log_viewer.ex
@@ -142,65 +142,135 @@ defmodule FavnView.Components.LogViewer do
     ~H"""
     <form
       phx-change="filter_logs"
-      class="grid gap-3 border-t border-base-content/10 p-4 sm:grid-cols-[minmax(14rem,1fr)_10rem_11rem_auto_auto_auto] sm:items-center sm:p-5"
+      class="border-t border-base-content/10 p-3 sm:grid sm:grid-cols-[minmax(14rem,1fr)_10rem_11rem_auto_auto_auto] sm:items-center sm:gap-3 sm:p-5"
     >
-      <label class="input favn-control-glass flex items-center gap-2 rounded-box">
-        <.icon name="hero-magnifying-glass" class="size-5 text-base-content/55" />
-        <input
-          type="search"
-          name="filters[search]"
-          value={@search_query}
-          placeholder="Search logs..."
-          class="grow"
-          data-testid="log-search-input"
+      <div class="flex items-center gap-2 sm:contents">
+        <label class="input favn-control-glass min-w-0 flex-1 items-center gap-2 rounded-box sm:flex">
+          <.icon name="hero-magnifying-glass" class="size-5 text-base-content/55" />
+          <input
+            type="search"
+            name="filters[search]"
+            value={@search_query}
+            placeholder="Search logs..."
+            class="grow"
+            data-testid="log-search-input"
+          />
+        </label>
+
+        <details class="dropdown dropdown-end sm:hidden">
+          <summary
+            class="btn btn-square favn-control-glass rounded-box"
+            aria-label="Log filters"
+            data-testid="log-filter-menu-toggle"
+          >
+            <.icon name="hero-funnel" class="size-5" />
+          </summary>
+          <div class="dropdown-content z-20 mt-2 w-[min(20rem,calc(100vw-2rem))] rounded-box border border-base-content/10 bg-base-200/95 p-3 shadow-2xl backdrop-blur">
+            <div class="grid gap-2">
+              <.level_select
+                selected_level={@selected_level}
+                levels={@levels}
+                testid="log-level-filter-mobile"
+              />
+              <.source_select
+                selected_source={@selected_source}
+                sources={@sources}
+                testid="log-source-filter-mobile"
+              />
+              <.toggle_button
+                event="toggle_wrap"
+                label="Wrap"
+                enabled?={@wrap?}
+                testid="log-wrap-toggle-mobile"
+              />
+              <.toggle_button
+                event="toggle_live_tail"
+                label="Live tail"
+                enabled?={@live_tail?}
+                testid="log-live-tail-toggle-mobile"
+              />
+              <.copy_button class="w-full justify-center" />
+            </div>
+          </div>
+        </details>
+      </div>
+
+      <div class="hidden sm:contents">
+        <.level_select selected_level={@selected_level} levels={@levels} testid="log-level-filter" />
+        <.source_select
+          selected_source={@selected_source}
+          sources={@sources}
+          testid="log-source-filter"
         />
-      </label>
-
-      <label class="select favn-control-glass rounded-box">
-        <span class="label">Level</span>
-        <select name="filters[level]" data-testid="log-level-filter">
-          <option value="all" selected={@selected_level == "all"}>All</option>
-          <option
-            :for={level <- @levels}
-            value={level}
-            selected={@selected_level == Atom.to_string(level)}
-          >
-            {level_label(level)}
-          </option>
-        </select>
-      </label>
-
-      <label class="select favn-control-glass rounded-box">
-        <span class="label">Source</span>
-        <select name="filters[source]" data-testid="log-source-filter">
-          <option value="all" selected={@selected_source == "all"}>All</option>
-          <option
-            :for={source <- @sources}
-            value={source}
-            selected={@selected_source == Atom.to_string(source)}
-          >
-            {source_label(source)}
-          </option>
-        </select>
-      </label>
-
-      <.toggle_button event="toggle_wrap" label="Wrap" enabled?={@wrap?} testid="log-wrap-toggle" />
-      <.toggle_button
-        event="toggle_live_tail"
-        label="Live tail"
-        enabled?={@live_tail?}
-        testid="log-live-tail-toggle"
-      />
-
-      <button
-        type="button"
-        class="btn favn-control-glass rounded-box"
-        data-copy-logs
-        data-testid="log-copy-button"
-      >
-        <.icon name="hero-clipboard-document" class="size-5" /> Copy
-      </button>
+        <.toggle_button event="toggle_wrap" label="Wrap" enabled?={@wrap?} testid="log-wrap-toggle" />
+        <.toggle_button
+          event="toggle_live_tail"
+          label="Live tail"
+          enabled?={@live_tail?}
+          testid="log-live-tail-toggle"
+        />
+        <.copy_button />
+      </div>
     </form>
+    """
+  end
+
+  attr :selected_level, :string, required: true
+  attr :levels, :list, required: true
+  attr :testid, :string, required: true
+
+  def level_select(assigns) do
+    ~H"""
+    <label class="select favn-control-glass rounded-box">
+      <span class="label">Level</span>
+      <select name="filters[level]" data-testid={@testid}>
+        <option value="all" selected={@selected_level == "all"}>All</option>
+        <option
+          :for={level <- @levels}
+          value={level}
+          selected={@selected_level == Atom.to_string(level)}
+        >
+          {level_label(level)}
+        </option>
+      </select>
+    </label>
+    """
+  end
+
+  attr :selected_source, :string, required: true
+  attr :sources, :list, required: true
+  attr :testid, :string, required: true
+
+  def source_select(assigns) do
+    ~H"""
+    <label class="select favn-control-glass rounded-box">
+      <span class="label">Source</span>
+      <select name="filters[source]" data-testid={@testid}>
+        <option value="all" selected={@selected_source == "all"}>All</option>
+        <option
+          :for={source <- @sources}
+          value={source}
+          selected={@selected_source == Atom.to_string(source)}
+        >
+          {source_label(source)}
+        </option>
+      </select>
+    </label>
+    """
+  end
+
+  attr :class, :any, default: nil
+
+  def copy_button(assigns) do
+    ~H"""
+    <button
+      type="button"
+      class={["btn favn-control-glass rounded-box", @class]}
+      data-copy-logs
+      data-testid="log-copy-button"
+    >
+      <.icon name="hero-clipboard-document" class="size-5" /> Copy
+    </button>
     """
   end
 

--- a/apps/favn_view/lib/favn_view/components/log_viewer.ex
+++ b/apps/favn_view/lib/favn_view/components/log_viewer.ex
@@ -36,32 +36,45 @@ defmodule FavnView.Components.LogViewer do
     ~H"""
     <section class="mx-auto w-full max-w-6xl" data-testid="log-viewer" data-log-scope={@scope}>
       <div class="card glass favn-glass-panel overflow-hidden rounded-box border border-primary/20 bg-base-200/35 shadow-2xl">
-        <div class="flex flex-col gap-5 border-b border-base-content/10 p-5 sm:p-6 lg:flex-row lg:items-start lg:justify-between">
+        <div class="flex flex-col gap-3 border-b border-base-content/10 p-4 sm:gap-5 sm:p-6 lg:flex-row lg:items-start lg:justify-between">
           <div class="min-w-0">
-            <div class="flex flex-wrap items-center gap-3">
-              <h2 class="text-2xl font-medium tracking-tight">{@title}</h2>
+            <div class="flex flex-wrap items-center gap-2 sm:gap-3">
+              <h2 class="text-xl font-medium tracking-tight sm:text-2xl">{@title}</h2>
               <span class={live_badge_class(@live?)} data-testid="log-live-status">
                 <span class={["status", @live? && "status-success", !@live? && "status-neutral"]}>
                 </span>
                 {if @live?, do: "Live streaming", else: "Loaded"}
               </span>
             </div>
-            <p :if={@subtitle} class="mt-2 text-sm text-base-content/55">{@subtitle}</p>
-            <p :if={@context_note} class="mt-3 text-sm text-warning/80" data-testid="log-context-note">
+            <p :if={@subtitle} class="mt-1 text-xs text-base-content/55 sm:mt-2 sm:text-sm">
+              {@subtitle}
+            </p>
+            <p
+              :if={@context_note}
+              class="mt-2 text-xs text-warning/80 sm:mt-3 sm:text-sm"
+              data-testid="log-context-note"
+            >
               {@context_note}
             </p>
-            <p :if={@warning} class="mt-3 text-sm text-warning/80" data-testid="log-stream-warning">
+            <p
+              :if={@warning}
+              class="mt-2 text-xs text-warning/80 sm:mt-3 sm:text-sm"
+              data-testid="log-stream-warning"
+            >
               {@warning}
             </p>
           </div>
 
-          <dl :if={@facts != []} class="grid gap-4 text-sm sm:grid-cols-3 lg:min-w-[24rem]">
+          <dl
+            :if={@facts != []}
+            class="grid grid-cols-3 gap-2 rounded-box border border-base-content/10 bg-base-content/[0.03] p-2 text-xs sm:gap-4 sm:border-0 sm:bg-transparent sm:p-0 sm:text-sm lg:min-w-[24rem]"
+          >
             <div
               :for={fact <- @facts}
-              class="border-base-content/20 sm:border-l sm:pl-5 first:border-l-0 first:pl-0"
+              class="min-w-0 border-base-content/10 px-2 first:pl-0 sm:border-l sm:border-base-content/20 sm:pl-5 sm:first:border-l-0 sm:first:pl-0"
             >
-              <dt class="text-base-content/55">{fact.label}</dt>
-              <dd class="mt-1 font-medium text-base-content">{fact.value}</dd>
+              <dt class="truncate text-base-content/55">{fact.label}</dt>
+              <dd class="mt-0.5 truncate font-medium text-base-content sm:mt-1">{fact.value}</dd>
             </div>
           </dl>
         </div>
@@ -332,8 +345,12 @@ defmodule FavnView.Components.LogViewer do
   defp level_class("error"), do: "text-error"
   defp level_class(_level), do: "text-info"
 
-  defp live_badge_class(true), do: "badge badge-success badge-soft gap-2 px-3 py-3"
-  defp live_badge_class(false), do: "badge badge-ghost gap-2 px-3 py-3"
+  defp live_badge_class(true),
+    do:
+      "badge badge-success badge-soft gap-1.5 px-2 py-2 text-xs sm:gap-2 sm:px-3 sm:py-3 sm:text-sm"
+
+  defp live_badge_class(false),
+    do: "badge badge-ghost gap-1.5 px-2 py-2 text-xs sm:gap-2 sm:px-3 sm:py-3 sm:text-sm"
 
   defp sequence_title(%{global_sequence: nil}), do: nil
   defp sequence_title(%{global_sequence: sequence}), do: "global sequence #{sequence}"

--- a/apps/favn_view/lib/favn_view/components/log_viewer.ex
+++ b/apps/favn_view/lib/favn_view/components/log_viewer.ex
@@ -1,0 +1,270 @@
+defmodule FavnView.Components.LogViewer do
+  @moduledoc """
+  Reusable terminal-style backend log viewer.
+  """
+
+  use FavnView, :html
+
+  alias FavnView.LogsViewModel
+
+  attr :logs, :list, default: []
+  attr :visible_logs, :list, default: []
+  attr :filter, :any, default: nil
+  attr :scope, :atom, default: :global
+  attr :title, :string, default: "Logs"
+  attr :subtitle, :string, default: nil
+  attr :status, :atom, default: :ready
+  attr :live?, :boolean, default: false
+  attr :live_tail?, :boolean, default: true
+  attr :wrap?, :boolean, default: true
+  attr :search_query, :string, default: ""
+  attr :selected_level, :string, default: "all"
+  attr :selected_source, :string, default: "all"
+  attr :next_cursor, :any, default: nil
+  attr :empty_state, :string, default: "No logs yet."
+  attr :facts, :list, default: []
+  attr :warning, :string, default: nil
+  attr :context_note, :string, default: nil
+
+  def log_viewer(assigns) do
+    assigns =
+      assigns
+      |> assign(:levels, LogsViewModel.levels())
+      |> assign(:sources, LogsViewModel.sources())
+      |> assign(:copy_text, LogsViewModel.plain_text(assigns.visible_logs))
+
+    ~H"""
+    <section class="mx-auto w-full max-w-6xl" data-testid="log-viewer" data-log-scope={@scope}>
+      <div class="card glass favn-glass-panel overflow-hidden rounded-box border border-primary/20 bg-base-200/35 shadow-2xl">
+        <div class="flex flex-col gap-5 border-b border-base-content/10 p-5 sm:p-6 lg:flex-row lg:items-start lg:justify-between">
+          <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-3">
+              <h2 class="text-2xl font-medium tracking-tight">{@title}</h2>
+              <span class={live_badge_class(@live?)} data-testid="log-live-status">
+                <span class={["status", @live? && "status-success", !@live? && "status-neutral"]}>
+                </span>
+                {if @live?, do: "Live streaming", else: "Loaded"}
+              </span>
+            </div>
+            <p :if={@subtitle} class="mt-2 text-sm text-base-content/55">{@subtitle}</p>
+            <p :if={@context_note} class="mt-3 text-sm text-warning/80" data-testid="log-context-note">
+              {@context_note}
+            </p>
+            <p :if={@warning} class="mt-3 text-sm text-warning/80" data-testid="log-stream-warning">
+              {@warning}
+            </p>
+          </div>
+
+          <dl :if={@facts != []} class="grid gap-4 text-sm sm:grid-cols-3 lg:min-w-[24rem]">
+            <div
+              :for={fact <- @facts}
+              class="border-base-content/20 sm:border-l sm:pl-5 first:border-l-0 first:pl-0"
+            >
+              <dt class="text-base-content/55">{fact.label}</dt>
+              <dd class="mt-1 font-medium text-base-content">{fact.value}</dd>
+            </div>
+          </dl>
+        </div>
+
+        <.toolbar
+          search_query={@search_query}
+          selected_level={@selected_level}
+          selected_source={@selected_source}
+          levels={@levels}
+          sources={@sources}
+          wrap?={@wrap?}
+          live_tail?={@live_tail?}
+        />
+
+        <div
+          id="log-terminal"
+          phx-hook="FavnLogViewer"
+          data-live-tail={to_string(@live_tail?)}
+          data-copy-source="log-copy-text"
+          class="relative border-t border-base-content/10 bg-base-100/55 p-4 sm:p-5"
+        >
+          <textarea id="log-copy-text" class="hidden" readonly>{@copy_text}</textarea>
+
+          <div
+            :if={@status == :loading}
+            class="rounded-box border border-dashed border-base-content/15 p-8 text-center text-sm text-base-content/55"
+            data-testid="log-loading-state"
+          >
+            Loading logs...
+          </div>
+
+          <div
+            :if={@status == :error}
+            class="rounded-box border border-error/25 bg-error/5 p-8 text-center text-sm text-error"
+            data-testid="log-error-state"
+          >
+            Unable to load logs.
+          </div>
+
+          <div
+            :if={@status != :loading and @status != :error and @visible_logs == []}
+            class="rounded-box border border-dashed border-base-content/15 p-8 text-center text-sm text-base-content/55"
+            data-testid="log-empty-state"
+          >
+            {@empty_state}
+            <span :if={@live?} class="mt-2 block text-xs text-base-content/45">
+              Listening for logs...
+            </span>
+          </div>
+
+          <div
+            :if={@status not in [:loading, :error] and @visible_logs != []}
+            class={[
+              "max-h-[34rem] overflow-auto rounded-box border border-base-content/10 bg-[#020817]/75 p-4 font-mono text-sm leading-6 shadow-inner",
+              !@wrap? && "whitespace-nowrap"
+            ]}
+            data-testid="log-terminal-window"
+          >
+            <div class="min-w-max space-y-5">
+              <.log_row :for={log <- @visible_logs} log={log} wrap?={@wrap?} />
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+    """
+  end
+
+  attr :search_query, :string, required: true
+  attr :selected_level, :string, required: true
+  attr :selected_source, :string, required: true
+  attr :levels, :list, required: true
+  attr :sources, :list, required: true
+  attr :wrap?, :boolean, required: true
+  attr :live_tail?, :boolean, required: true
+
+  def toolbar(assigns) do
+    ~H"""
+    <form
+      phx-change="filter_logs"
+      class="grid gap-3 border-t border-base-content/10 p-4 sm:grid-cols-[minmax(14rem,1fr)_10rem_11rem_auto_auto_auto] sm:items-center sm:p-5"
+    >
+      <label class="input favn-control-glass flex items-center gap-2 rounded-box">
+        <.icon name="hero-magnifying-glass" class="size-5 text-base-content/55" />
+        <input
+          type="search"
+          name="filters[search]"
+          value={@search_query}
+          placeholder="Search logs..."
+          class="grow"
+          data-testid="log-search-input"
+        />
+      </label>
+
+      <label class="select favn-control-glass rounded-box">
+        <span class="label">Level</span>
+        <select name="filters[level]" data-testid="log-level-filter">
+          <option value="all" selected={@selected_level == "all"}>All</option>
+          <option
+            :for={level <- @levels}
+            value={level}
+            selected={@selected_level == Atom.to_string(level)}
+          >
+            {level_label(level)}
+          </option>
+        </select>
+      </label>
+
+      <label class="select favn-control-glass rounded-box">
+        <span class="label">Source</span>
+        <select name="filters[source]" data-testid="log-source-filter">
+          <option value="all" selected={@selected_source == "all"}>All</option>
+          <option
+            :for={source <- @sources}
+            value={source}
+            selected={@selected_source == Atom.to_string(source)}
+          >
+            {source_label(source)}
+          </option>
+        </select>
+      </label>
+
+      <.toggle_button event="toggle_wrap" label="Wrap" enabled?={@wrap?} testid="log-wrap-toggle" />
+      <.toggle_button
+        event="toggle_live_tail"
+        label="Live tail"
+        enabled?={@live_tail?}
+        testid="log-live-tail-toggle"
+      />
+
+      <button
+        type="button"
+        class="btn favn-control-glass rounded-box"
+        data-copy-logs
+        data-testid="log-copy-button"
+      >
+        <.icon name="hero-clipboard-document" class="size-5" /> Copy
+      </button>
+    </form>
+    """
+  end
+
+  attr :event, :string, required: true
+  attr :label, :string, required: true
+  attr :enabled?, :boolean, required: true
+  attr :testid, :string, required: true
+
+  def toggle_button(assigns) do
+    ~H"""
+    <button
+      type="button"
+      phx-click={@event}
+      class="btn favn-control-glass rounded-box justify-between gap-3"
+      aria-pressed={to_string(@enabled?)}
+      data-testid={@testid}
+    >
+      <span>{@label}</span>
+      <span class={["toggle toggle-success toggle-sm", @enabled? && "toggle-checked"]}></span>
+    </button>
+    """
+  end
+
+  attr :log, :map, required: true
+  attr :wrap?, :boolean, required: true
+
+  def log_row(assigns) do
+    ~H"""
+    <article
+      class="grid gap-2 text-base-content/90 sm:grid-cols-[6.5rem_4.5rem_13rem_minmax(0,1fr)]"
+      data-testid="log-row"
+      title={sequence_title(@log)}
+    >
+      <time class="text-base-content/55">{@log.timestamp}</time>
+      <span class={["font-semibold", level_class(@log.level)]}>{@log.level_label}</span>
+      <span class="truncate text-base-content/55">{@log.source_label}</span>
+      <div class="min-w-0">
+        <pre class={[
+          "m-0 font-mono text-base-content/90",
+          @wrap? && "whitespace-pre-wrap break-words",
+          !@wrap? && "whitespace-pre"
+        ]}><code>{@log.message}</code></pre>
+        <span
+          :if={@log.truncated?}
+          class="mt-1 inline-flex rounded-full border border-warning/30 px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.16em] text-warning/80"
+        >
+          truncated
+        </span>
+      </div>
+    </article>
+    """
+  end
+
+  defp level_label(level), do: level |> Atom.to_string() |> String.upcase()
+  defp source_label(source), do: source |> Atom.to_string() |> String.replace("_", ":")
+
+  defp level_class("debug"), do: "text-base-content/45"
+  defp level_class("warning"), do: "text-warning"
+  defp level_class("error"), do: "text-error"
+  defp level_class(_level), do: "text-info"
+
+  defp live_badge_class(true), do: "badge badge-success badge-soft gap-2 px-3 py-3"
+  defp live_badge_class(false), do: "badge badge-ghost gap-2 px-3 py-3"
+
+  defp sequence_title(%{global_sequence: nil}), do: nil
+  defp sequence_title(%{global_sequence: sequence}), do: "global sequence #{sequence}"
+end

--- a/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
+++ b/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
@@ -86,49 +86,69 @@ defmodule FavnView.Components.RunOverviewHud do
 
   def asset_result_row(assigns) do
     ~H"""
-    <div
+    <.link
+      :if={@asset.inspectable?}
+      navigate={~p"/runs/#{@run_id}/assets/#{@asset.id}/logs"}
       class={[
-        "group grid gap-3 rounded-box border bg-base-content/[0.025] p-4 transition hover:border-primary/35 hover:bg-primary/[0.045] hover:shadow-lg hover:shadow-primary/10 lg:grid-cols-[1fr_10rem_8rem_10rem_2rem] lg:items-center",
+        "group grid gap-3 rounded-box border bg-base-content/[0.025] p-4 transition hover:border-primary/35 hover:bg-primary/[0.045] hover:shadow-lg hover:shadow-primary/10 lg:grid-cols-[1fr_10rem_8rem_10rem_2rem] lg:items-center no-underline",
         row_border_class(@asset.status_tone)
       ]}
       data-testid="run-asset-result-row"
       data-run-id={@run_id}
       data-asset-step-id={@asset.id}
-      role={if(@asset.inspectable?, do: "button", else: nil)}
-      tabindex={if(@asset.inspectable?, do: "0", else: nil)}
     >
-      <div class="flex min-w-0 items-center gap-3">
-        <span class={[
-          "flex size-9 shrink-0 items-center justify-center rounded-box",
-          icon_shell_class(@asset.status_tone)
-        ]}>
-          <.icon name="hero-table-cells" class="size-5" />
-        </span>
-        <div class="min-w-0">
-          <p class="truncate text-sm font-medium text-base-content">{@asset.display_name}</p>
-          <p class="truncate font-mono text-xs text-base-content/45">{@asset.asset_ref}</p>
-          <p :if={@asset.secondary} class="text-xs text-base-content/50">{@asset.secondary}</p>
-          <p :if={@asset.error} class="mt-1 text-xs text-error">{@asset.error}</p>
-        </div>
-      </div>
+      <.asset_result_row_content asset={@asset} />
+    </.link>
 
-      <div class="flex items-center gap-2 text-sm font-medium">
-        <.icon
-          name={status_icon(@asset.status_tone)}
-          class={["size-4", status_text_class(@asset.status_tone)]}
-        />
-        <span class={status_text_class(@asset.status_tone)}>{@asset.status}</span>
-      </div>
-
-      <p class="text-sm text-base-content/85">{@asset.duration}</p>
-      <p class="text-sm text-base-content/70">{@asset.started_at}</p>
-      <%!-- TODO: Attach /runs/:run_id/assets/:asset_step_id navigation here once that route and ID contract exist. --%>
-      <.icon
-        :if={@asset.inspectable?}
-        name="hero-chevron-right"
-        class="size-5 text-base-content/60 transition group-hover:text-primary"
-      />
+    <div
+      :if={!@asset.inspectable?}
+      class={[
+        "group grid gap-3 rounded-box border bg-base-content/[0.025] p-4 transition lg:grid-cols-[1fr_10rem_8rem_10rem_2rem] lg:items-center",
+        row_border_class(@asset.status_tone)
+      ]}
+      data-testid="run-asset-result-row"
+      data-run-id={@run_id}
+      data-asset-step-id={@asset.id}
+    >
+      <.asset_result_row_content asset={@asset} />
     </div>
+    """
+  end
+
+  attr :asset, :map, required: true
+
+  def asset_result_row_content(assigns) do
+    ~H"""
+    <div class="flex min-w-0 items-center gap-3">
+      <span class={[
+        "flex size-9 shrink-0 items-center justify-center rounded-box",
+        icon_shell_class(@asset.status_tone)
+      ]}>
+        <.icon name="hero-table-cells" class="size-5" />
+      </span>
+      <div class="min-w-0">
+        <p class="truncate text-sm font-medium text-base-content">{@asset.display_name}</p>
+        <p class="truncate font-mono text-xs text-base-content/45">{@asset.asset_ref}</p>
+        <p :if={@asset.secondary} class="text-xs text-base-content/50">{@asset.secondary}</p>
+        <p :if={@asset.error} class="mt-1 text-xs text-error">{@asset.error}</p>
+      </div>
+    </div>
+
+    <div class="flex items-center gap-2 text-sm font-medium">
+      <.icon
+        name={status_icon(@asset.status_tone)}
+        class={["size-4", status_text_class(@asset.status_tone)]}
+      />
+      <span class={status_text_class(@asset.status_tone)}>{@asset.status}</span>
+    </div>
+
+    <p class="text-sm text-base-content/85">{@asset.duration}</p>
+    <p class="text-sm text-base-content/70">{@asset.started_at}</p>
+    <.icon
+      :if={@asset.inspectable?}
+      name="hero-chevron-right"
+      class="size-5 text-base-content/60 transition group-hover:text-primary"
+    />
     """
   end
 

--- a/apps/favn_view/lib/favn_view/logs_live.ex
+++ b/apps/favn_view/lib/favn_view/logs_live.ex
@@ -1,0 +1,67 @@
+defmodule FavnView.LogsLive do
+  @moduledoc false
+
+  use FavnView, :live_view
+
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.LogViewer
+  alias FavnView.LogsLiveSupport
+
+  @impl true
+  def mount(_params, _session, socket) do
+    socket =
+      LogsLiveSupport.mount_logs(socket, %{
+        filter: %Favn.Log.Filter{},
+        scope: :global,
+        nav_items: LogsLiveSupport.nav_items(:logs),
+        title: "Logs",
+        subtitle: "Live system and run logs",
+        empty_state: "No logs yet."
+      })
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_info({:favn_log_entry, entry}, socket),
+    do: {:noreply, LogsLiveSupport.add_live_log(socket, entry)}
+
+  @impl true
+  def handle_event("filter_logs", params, socket),
+    do: {:noreply, LogsLiveSupport.handle_filter(socket, params)}
+
+  def handle_event("toggle_wrap", _params, socket),
+    do: {:noreply, LogsLiveSupport.toggle(socket, :wrap?)}
+
+  def handle_event("toggle_live_tail", _params, socket),
+    do: {:noreply, LogsLiveSupport.toggle(socket, :live_tail?)}
+
+  @impl true
+  def terminate(_reason, socket), do: LogsLiveSupport.unsubscribe(socket)
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <AppShell.app_shell title={@title} subtitle={@subtitle} nav_items={@nav_items}>
+      <LogViewer.log_viewer
+        logs={@logs}
+        visible_logs={@visible_logs}
+        filter={@filter}
+        scope={@scope}
+        title="Logs"
+        subtitle={@subtitle}
+        status={@logs_status}
+        live?={@live?}
+        live_tail?={@live_tail?}
+        wrap?={@wrap?}
+        search_query={@search_query}
+        selected_level={@selected_level}
+        selected_source={@selected_source}
+        next_cursor={@next_cursor}
+        empty_state={@empty_state}
+        warning={@stream_warning}
+      />
+    </AppShell.app_shell>
+    """
+  end
+end

--- a/apps/favn_view/lib/favn_view/logs_live.ex
+++ b/apps/favn_view/lib/favn_view/logs_live.ex
@@ -3,8 +3,7 @@ defmodule FavnView.LogsLive do
 
   use FavnView, :live_view
 
-  alias FavnView.Components.AppShell
-  alias FavnView.Components.LogViewer
+  alias FavnView.Components.LogPages
   alias FavnView.LogsLiveSupport
 
   @impl true
@@ -42,26 +41,7 @@ defmodule FavnView.LogsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <AppShell.app_shell title={@title} subtitle={@subtitle} nav_items={@nav_items}>
-      <LogViewer.log_viewer
-        logs={@logs}
-        visible_logs={@visible_logs}
-        filter={@filter}
-        scope={@scope}
-        title="Logs"
-        subtitle={@subtitle}
-        status={@logs_status}
-        live?={@live?}
-        live_tail?={@live_tail?}
-        wrap?={@wrap?}
-        search_query={@search_query}
-        selected_level={@selected_level}
-        selected_source={@selected_source}
-        next_cursor={@next_cursor}
-        empty_state={@empty_state}
-        warning={@stream_warning}
-      />
-    </AppShell.app_shell>
+    <LogPages.global_logs_page {assigns} />
     """
   end
 end

--- a/apps/favn_view/lib/favn_view/logs_live_support.ex
+++ b/apps/favn_view/lib/favn_view/logs_live_support.ex
@@ -7,6 +7,7 @@ defmodule FavnView.LogsLiveSupport do
   alias Favn.Log.Filter
   alias FavnView.Components.AssetCataloguePage
   alias FavnView.LogsViewModel
+  alias FavnView.RunStepViewModel
 
   @initial_limit 200
   @fetch_limit 500
@@ -131,7 +132,7 @@ defmodule FavnView.LogsLiveSupport do
   end
 
   defp load_initial_logs(filter) do
-    case FavnOrchestrator.list_logs(filter, limit: @fetch_limit) do
+    case FavnOrchestrator.list_logs(filter, limit: @fetch_limit, order: :desc) do
       {:ok, %{items: items}} ->
         %{status: :ready, logs: LogsViewModel.trim_latest(items, @initial_limit)}
 
@@ -213,7 +214,7 @@ defmodule FavnView.LogsLiveSupport do
     finished_at = Map.get(run, :finished_at)
     status = Map.get(run, :status)
     target = target_label(Map.get(run, :asset_ref), Map.get(run, :target_refs, []))
-    asset_results = run_step_results(run, run.id)
+    asset_results = RunStepViewModel.from_run(run)
 
     %{
       found?: true,
@@ -227,94 +228,6 @@ defmodule FavnView.LogsLiveSupport do
       asset_results: asset_results
     }
   end
-
-  defp run_step_results(run, run_id) do
-    node_results = node_results(Map.get(run, :node_results, %{}), run_id)
-
-    if node_results == [] do
-      asset_results(Map.get(run, :asset_results, %{}), run_id)
-    else
-      node_results
-    end
-  end
-
-  defp node_results(results, run_id) when is_map(results) do
-    results
-    |> Enum.map(fn {key, result} -> node_result(result, run_id, key) end)
-    |> Enum.sort_by(& &1.asset_ref)
-  end
-
-  defp node_results(results, run_id) when is_list(results) do
-    results |> Enum.map(&node_result(&1, run_id, node_key(&1))) |> Enum.sort_by(& &1.asset_ref)
-  end
-
-  defp node_results(_results, _run_id), do: []
-
-  defp node_result(result, run_id, node_key) do
-    asset_ref = LogsViewModel.ref_label(Map.get(result, :ref) || node_asset_ref(node_key))
-
-    %{
-      id: step_id(result, run_id, node_key, asset_ref),
-      asset_ref: asset_ref,
-      display_name: LogsViewModel.display_name(asset_ref),
-      status: LogsViewModel.status_label(Map.get(result, :status)),
-      status_tone: LogsViewModel.status_tone(Map.get(result, :status)),
-      duration: LogsViewModel.duration_ms_label(Map.get(result, :duration_ms)),
-      started_at: LogsViewModel.timestamp_label(Map.get(result, :started_at)),
-      attempt: Map.get(result, :attempt)
-    }
-  end
-
-  defp asset_results(results, run_id) when is_map(results) do
-    results
-    |> Enum.map(fn {key, result} -> asset_result(result, run_id, key) end)
-    |> Enum.sort_by(& &1.asset_ref)
-  end
-
-  defp asset_results(results, run_id) when is_list(results) do
-    results |> Enum.map(&asset_result(&1, run_id, nil)) |> Enum.sort_by(& &1.asset_ref)
-  end
-
-  defp asset_results(_results, _run_id), do: []
-
-  defp asset_result(result, run_id, key) do
-    asset_ref = LogsViewModel.ref_label(Map.get(result, :ref) || key)
-
-    %{
-      id: step_id(result, run_id, key, asset_ref),
-      asset_ref: asset_ref,
-      display_name: LogsViewModel.display_name(asset_ref),
-      status: LogsViewModel.status_label(Map.get(result, :status)),
-      status_tone: LogsViewModel.status_tone(Map.get(result, :status)),
-      duration: LogsViewModel.duration_ms_label(Map.get(result, :duration_ms)),
-      started_at: LogsViewModel.timestamp_label(Map.get(result, :started_at)),
-      attempt: Map.get(result, :attempt)
-    }
-  end
-
-  defp step_id(result, run_id, key, asset_ref) do
-    Map.get(result, :id) || Map.get(result, "id") || Map.get(result, :step_id) ||
-      Map.get(result, "step_id") || persisted_key_id(key, asset_ref) ||
-      LogsViewModel.deterministic_step_id(run_id, asset_ref)
-  end
-
-  defp persisted_key_id(nil, _asset_ref), do: nil
-
-  defp persisted_key_id(key, asset_ref) when is_binary(key) and key != asset_ref,
-    do: LogsViewModel.safe_id(key)
-
-  defp persisted_key_id(key, _asset_ref) when is_tuple(key),
-    do:
-      key
-      |> :erlang.term_to_binary()
-      |> Base.url_encode64(padding: false)
-      |> LogsViewModel.safe_id()
-
-  defp persisted_key_id(_key, _asset_ref), do: nil
-
-  defp node_key(result), do: Map.get(result, :node_key) || Map.get(result, "node_key")
-  defp node_asset_ref({ref, _window}) when is_tuple(ref), do: ref
-  defp node_asset_ref(_node_key), do: nil
 
   defp asset_facts(nil), do: []
 

--- a/apps/favn_view/lib/favn_view/logs_live_support.ex
+++ b/apps/favn_view/lib/favn_view/logs_live_support.ex
@@ -1,0 +1,335 @@
+defmodule FavnView.LogsLiveSupport do
+  @moduledoc false
+
+  import Phoenix.Component, only: [assign: 2, assign: 3]
+  import Phoenix.LiveView, only: [connected?: 1]
+
+  alias Favn.Log.Filter
+  alias FavnView.Components.AssetCataloguePage
+  alias FavnView.LogsViewModel
+
+  @initial_limit 200
+  @fetch_limit 500
+
+  def mount_logs(socket, attrs) do
+    filter = Filter.normalize(Map.fetch!(attrs, :filter))
+    scope = Map.fetch!(attrs, :scope)
+    load_result = load_initial_logs(filter)
+
+    socket =
+      socket
+      |> assign(Map.merge(default_assigns(), attrs))
+      |> assign(:filter, filter)
+      |> assign(:logs_status, load_result.status)
+      |> assign(:logs, load_result.logs)
+      |> assign(:next_cursor, LogsViewModel.latest_cursor(load_result.logs, scope, filter))
+      |> assign_visible_logs()
+
+    if connected?(socket) and load_result.status != :error do
+      subscribe_and_replay(socket)
+    else
+      socket
+    end
+  end
+
+  def handle_filter(socket, params) do
+    filters = Map.get(params, "filters", %{})
+
+    socket
+    |> assign(:search_query, Map.get(filters, "search", ""))
+    |> assign(:selected_level, normalize_choice(Map.get(filters, "level")))
+    |> assign(:selected_source, normalize_choice(Map.get(filters, "source")))
+    |> assign_visible_logs()
+  end
+
+  def toggle(socket, key) do
+    assign(socket, key, !Map.fetch!(socket.assigns, key))
+  end
+
+  def add_live_log(socket, entry) do
+    logs =
+      socket.assigns.logs
+      |> LogsViewModel.merge_entries([entry])
+      |> LogsViewModel.trim_latest(@initial_limit)
+
+    socket
+    |> assign(:logs, logs)
+    |> assign(
+      :next_cursor,
+      LogsViewModel.latest_cursor(logs, socket.assigns.scope, socket.assigns.filter)
+    )
+    |> assign_visible_logs()
+  end
+
+  def unsubscribe(%{assigns: %{log_subscription: subscription}}) when not is_nil(subscription) do
+    _ = FavnOrchestrator.unsubscribe_logs(subscription)
+    :ok
+  end
+
+  def unsubscribe(_socket), do: :ok
+
+  def run_context(run_id) do
+    case FavnOrchestrator.get_run(run_id) do
+      {:ok, run} ->
+        run_context_from_public(run)
+
+      {:error, reason} ->
+        %{
+          found?: false,
+          id: run_id,
+          title: LogsViewModel.short_id(run_id),
+          error: error_label(reason)
+        }
+    end
+  end
+
+  def asset_context(run_id, asset_step_id) do
+    run = run_context(run_id)
+
+    result =
+      if run[:found?], do: Enum.find(run.asset_results, &(&1.id == asset_step_id)), else: nil
+
+    %{
+      run: run,
+      result: result,
+      title: (result && result.display_name) || "Asset logs",
+      subtitle: "Run #{LogsViewModel.short_id(run_id)} · Asset step #{asset_step_id}",
+      status: result && result.status,
+      status_tone: (result && result.status_tone) || :neutral,
+      facts: asset_facts(result),
+      note:
+        if(run[:found?] && is_nil(result),
+          do: "Asset step context not found, showing matching logs."
+        )
+    }
+  end
+
+  def nav_items(active \\ :logs), do: AssetCataloguePage.nav_items(active)
+
+  defp default_assigns do
+    %{
+      nav_items: nav_items(),
+      title: "Logs",
+      subtitle: nil,
+      scope: :global,
+      status: nil,
+      status_tone: :neutral,
+      facts: [],
+      back_href: nil,
+      back_label: nil,
+      empty_state: "No logs yet.",
+      context_note: nil,
+      search_query: "",
+      selected_level: "all",
+      selected_source: "all",
+      wrap?: true,
+      live_tail?: true,
+      live?: false,
+      stream_warning: nil,
+      log_subscription: nil
+    }
+  end
+
+  defp load_initial_logs(filter) do
+    case FavnOrchestrator.list_logs(filter, limit: @fetch_limit) do
+      {:ok, %{items: items}} ->
+        %{status: :ready, logs: LogsViewModel.trim_latest(items, @initial_limit)}
+
+      {:error, _reason} ->
+        %{status: :error, logs: []}
+    end
+  end
+
+  defp subscribe_and_replay(socket) do
+    case subscribe_logs(socket.assigns.filter) do
+      {:ok, subscription} ->
+        socket
+        |> assign(:log_subscription, subscription)
+        |> assign(:live?, true)
+        |> replay_gap()
+
+      {:error, _reason} ->
+        assign(
+          socket,
+          :stream_warning,
+          "Loaded existing logs, but live streaming is unavailable."
+        )
+    end
+  end
+
+  defp replay_gap(%{assigns: %{next_cursor: nil}} = socket), do: socket
+
+  defp replay_gap(socket) do
+    # Initial load happens before subscription; replay closes that small handoff gap.
+    case FavnOrchestrator.replay_logs(socket.assigns.next_cursor, socket.assigns.filter,
+           limit: @initial_limit
+         ) do
+      {:ok, []} ->
+        socket
+
+      {:ok, entries} ->
+        logs =
+          socket.assigns.logs
+          |> LogsViewModel.merge_entries(entries)
+          |> LogsViewModel.trim_latest(@initial_limit)
+
+        socket
+        |> assign(:logs, logs)
+        |> assign(
+          :next_cursor,
+          LogsViewModel.latest_cursor(logs, socket.assigns.scope, socket.assigns.filter)
+        )
+        |> assign_visible_logs()
+
+      {:error, _reason} ->
+        socket
+    end
+  end
+
+  defp subscribe_logs(filter) do
+    Application.get_env(:favn_view, :log_subscribe_fun, &FavnOrchestrator.subscribe_logs/1).(
+      filter
+    )
+  end
+
+  defp assign_visible_logs(socket) do
+    visible_logs =
+      socket.assigns.logs
+      |> LogsViewModel.entries()
+      |> LogsViewModel.filter_entries(
+        socket.assigns.search_query,
+        socket.assigns.selected_level,
+        socket.assigns.selected_source
+      )
+
+    assign(socket, :visible_logs, visible_logs)
+  end
+
+  defp normalize_choice(value) when value in [nil, "", "all"], do: "all"
+  defp normalize_choice(value), do: to_string(value)
+
+  defp run_context_from_public(run) do
+    started_at = Map.get(run, :started_at)
+    finished_at = Map.get(run, :finished_at)
+    status = Map.get(run, :status)
+    target = target_label(Map.get(run, :asset_ref), Map.get(run, :target_refs, []))
+    asset_results = run_step_results(run, run.id)
+
+    %{
+      found?: true,
+      id: run.id,
+      title: LogsViewModel.short_id(run.id),
+      subtitle: Enum.reject([target], &is_nil/1) |> Enum.join(" · "),
+      status: LogsViewModel.status_label(status),
+      status_tone: LogsViewModel.status_tone(status),
+      started_at: LogsViewModel.timestamp_label(started_at),
+      duration: LogsViewModel.duration_label(started_at, finished_at),
+      asset_results: asset_results
+    }
+  end
+
+  defp run_step_results(run, run_id) do
+    node_results = node_results(Map.get(run, :node_results, %{}), run_id)
+
+    if node_results == [] do
+      asset_results(Map.get(run, :asset_results, %{}), run_id)
+    else
+      node_results
+    end
+  end
+
+  defp node_results(results, run_id) when is_map(results) do
+    results
+    |> Enum.map(fn {key, result} -> node_result(result, run_id, key) end)
+    |> Enum.sort_by(& &1.asset_ref)
+  end
+
+  defp node_results(results, run_id) when is_list(results) do
+    results |> Enum.map(&node_result(&1, run_id, node_key(&1))) |> Enum.sort_by(& &1.asset_ref)
+  end
+
+  defp node_results(_results, _run_id), do: []
+
+  defp node_result(result, run_id, node_key) do
+    asset_ref = LogsViewModel.ref_label(Map.get(result, :ref) || node_asset_ref(node_key))
+
+    %{
+      id: step_id(result, run_id, node_key, asset_ref),
+      asset_ref: asset_ref,
+      display_name: LogsViewModel.display_name(asset_ref),
+      status: LogsViewModel.status_label(Map.get(result, :status)),
+      status_tone: LogsViewModel.status_tone(Map.get(result, :status)),
+      duration: LogsViewModel.duration_ms_label(Map.get(result, :duration_ms)),
+      started_at: LogsViewModel.timestamp_label(Map.get(result, :started_at)),
+      attempt: Map.get(result, :attempt)
+    }
+  end
+
+  defp asset_results(results, run_id) when is_map(results) do
+    results
+    |> Enum.map(fn {key, result} -> asset_result(result, run_id, key) end)
+    |> Enum.sort_by(& &1.asset_ref)
+  end
+
+  defp asset_results(results, run_id) when is_list(results) do
+    results |> Enum.map(&asset_result(&1, run_id, nil)) |> Enum.sort_by(& &1.asset_ref)
+  end
+
+  defp asset_results(_results, _run_id), do: []
+
+  defp asset_result(result, run_id, key) do
+    asset_ref = LogsViewModel.ref_label(Map.get(result, :ref) || key)
+
+    %{
+      id: step_id(result, run_id, key, asset_ref),
+      asset_ref: asset_ref,
+      display_name: LogsViewModel.display_name(asset_ref),
+      status: LogsViewModel.status_label(Map.get(result, :status)),
+      status_tone: LogsViewModel.status_tone(Map.get(result, :status)),
+      duration: LogsViewModel.duration_ms_label(Map.get(result, :duration_ms)),
+      started_at: LogsViewModel.timestamp_label(Map.get(result, :started_at)),
+      attempt: Map.get(result, :attempt)
+    }
+  end
+
+  defp step_id(result, run_id, key, asset_ref) do
+    Map.get(result, :id) || Map.get(result, "id") || Map.get(result, :step_id) ||
+      Map.get(result, "step_id") || persisted_key_id(key, asset_ref) ||
+      LogsViewModel.deterministic_step_id(run_id, asset_ref)
+  end
+
+  defp persisted_key_id(nil, _asset_ref), do: nil
+
+  defp persisted_key_id(key, asset_ref) when is_binary(key) and key != asset_ref,
+    do: LogsViewModel.safe_id(key)
+
+  defp persisted_key_id(key, _asset_ref) when is_tuple(key),
+    do:
+      key
+      |> :erlang.term_to_binary()
+      |> Base.url_encode64(padding: false)
+      |> LogsViewModel.safe_id()
+
+  defp persisted_key_id(_key, _asset_ref), do: nil
+
+  defp node_key(result), do: Map.get(result, :node_key) || Map.get(result, "node_key")
+  defp node_asset_ref({ref, _window}) when is_tuple(ref), do: ref
+  defp node_asset_ref(_node_key), do: nil
+
+  defp asset_facts(nil), do: []
+
+  defp asset_facts(result) do
+    [
+      %{label: "Started", value: result.started_at},
+      %{label: "Duration", value: result.duration},
+      %{label: "Attempt", value: result.attempt || "-"}
+    ]
+  end
+
+  defp target_label(nil, []), do: nil
+  defp target_label(nil, [target | _rest]), do: LogsViewModel.ref_label(target)
+  defp target_label(target, _targets), do: LogsViewModel.ref_label(target)
+
+  defp error_label(:not_found), do: "Run not found"
+  defp error_label(reason), do: "Unable to load run: #{inspect(reason)}"
+end

--- a/apps/favn_view/lib/favn_view/logs_view_model.ex
+++ b/apps/favn_view/lib/favn_view/logs_view_model.ex
@@ -1,0 +1,190 @@
+defmodule FavnView.LogsViewModel do
+  @moduledoc false
+
+  alias Favn.Log.Entry
+
+  @levels Entry.levels()
+  @sources Entry.sources()
+
+  def levels, do: @levels
+  def sources, do: @sources
+
+  def entry(entry) do
+    %{
+      id: entry_id(entry),
+      global_sequence: Map.get(entry, :global_sequence),
+      occurred_at: Map.get(entry, :occurred_at),
+      timestamp: time_label(Map.get(entry, :occurred_at)),
+      level: normalize_atom(Map.get(entry, :level, :info)),
+      level_label: Map.get(entry, :level, :info) |> normalize_atom() |> String.upcase(),
+      source: normalize_atom(Map.get(entry, :source, :user_code)),
+      source_label: source_label(Map.get(entry, :source, :user_code)),
+      run_id: Map.get(entry, :run_id),
+      asset_step_id: Map.get(entry, :asset_step_id),
+      message: Map.get(entry, :message, "") || "",
+      metadata: Map.get(entry, :metadata, %{}) || %{},
+      metadata_text: metadata_text(Map.get(entry, :metadata, %{}) || %{}),
+      truncated?: Map.get(entry, :truncated, false) == true
+    }
+  end
+
+  def entries(entries) when is_list(entries), do: Enum.map(entries, &entry/1)
+
+  def filter_entries(entries, search_query, selected_level, selected_source) do
+    query = search_query |> to_string() |> String.trim() |> String.downcase()
+    selected_level = normalize_filter_value(selected_level)
+    selected_source = normalize_filter_value(selected_source)
+
+    Enum.filter(entries, fn entry ->
+      level_match?(entry, selected_level) and source_match?(entry, selected_source) and
+        search_match?(entry, query)
+    end)
+  end
+
+  def plain_text(entries) when is_list(entries) do
+    entries
+    |> Enum.map(fn entry ->
+      [entry.timestamp, entry.level_label, entry.source_label, entry.message]
+      |> Enum.reject(&(&1 in [nil, ""]))
+      |> Enum.join("  ")
+    end)
+    |> Enum.join("\n\n")
+  end
+
+  def latest_cursor(entries, scope, filter) do
+    entries
+    |> Enum.map(&Map.get(&1, :global_sequence))
+    |> Enum.reject(&is_nil/1)
+    |> Enum.max(fn -> nil end)
+    |> case do
+      nil ->
+        nil
+
+      sequence ->
+        %Favn.Log.Cursor{
+          scope: scope,
+          run_id: filter.run_id,
+          asset_step_id: filter.asset_step_id,
+          global_sequence: sequence
+        }
+    end
+  end
+
+  def merge_entries(existing, incoming) do
+    (existing ++ List.wrap(incoming))
+    |> Enum.uniq_by(&dedupe_key/1)
+    |> Enum.sort_by(&{Map.get(&1, :global_sequence) || 0, entry_id(&1)})
+  end
+
+  def trim_latest(entries, limit) do
+    entries
+    |> Enum.sort_by(&{Map.get(&1, :global_sequence) || 0, entry_id(&1)})
+    |> Enum.take(-limit)
+  end
+
+  def short_id(id) when is_binary(id) and byte_size(id) > 18, do: String.slice(id, 0, 18)
+  def short_id(id) when is_binary(id), do: id
+  def short_id(_id), do: "unknown"
+
+  def status_label(status) when status in [:ok, "ok"], do: "Succeeded"
+  def status_label(status) when status in [:running, "running"], do: "Running"
+  def status_label(status) when status in [:retrying, "retrying"], do: "Retrying"
+  def status_label(status) when status in [:pending, "pending"], do: "Pending"
+  def status_label(status) when status in [:partial, "partial"], do: "Partial"
+  def status_label(status) when status in [:error, "error"], do: "Failed"
+  def status_label(status) when status in [:blocked, "blocked"], do: "Blocked"
+  def status_label(status) when status in [:cancelled, "cancelled"], do: "Cancelled"
+  def status_label(status) when status in [:skipped_fresh, "skipped_fresh"], do: "Skipped fresh"
+  def status_label(status) when status in [:timed_out, "timed_out"], do: "Timed out"
+  def status_label(nil), do: "Unknown"
+  def status_label(status), do: humanize(status)
+
+  def status_tone(status) when status in [:ok, "ok"], do: :success
+
+  def status_tone(status)
+      when status in [:running, :pending, :retrying, "running", "pending", "retrying"], do: :info
+
+  def status_tone(status) when status in [:partial, "partial"], do: :warning
+
+  def status_tone(status)
+      when status in [:error, :timed_out, :blocked, "error", "timed_out", "blocked"], do: :error
+
+  def status_tone(_status), do: :neutral
+
+  def timestamp_label(%DateTime{} = value),
+    do: Calendar.strftime(value, "%b %-d, %Y %H:%M:%S UTC")
+
+  def timestamp_label(_value), do: "-"
+
+  def duration_label(%DateTime{} = started_at, %DateTime{} = finished_at) do
+    DateTime.diff(finished_at, started_at, :millisecond) |> duration_ms_label()
+  end
+
+  def duration_label(%DateTime{} = started_at, nil) do
+    DateTime.diff(DateTime.utc_now(), started_at, :millisecond) |> duration_ms_label()
+  end
+
+  def duration_label(_started_at, _finished_at), do: "-"
+  def duration_ms_label(value) when is_integer(value) and value < 1_000, do: "#{value} ms"
+  def duration_ms_label(value) when is_integer(value), do: "#{Float.round(value / 1_000, 1)} s"
+  def duration_ms_label(_value), do: "-"
+
+  def display_name(asset_ref) when is_binary(asset_ref),
+    do: asset_ref |> String.split(".") |> List.last()
+
+  def display_name(_asset_ref), do: nil
+
+  def ref_label({module, name}), do: "#{inspect(module)}.#{name}"
+  def ref_label(%{"module" => module, "name" => name}), do: "#{module}.#{name}"
+  def ref_label(ref) when is_atom(ref), do: Atom.to_string(ref)
+  def ref_label(ref) when is_binary(ref), do: ref
+  def ref_label(nil), do: nil
+  def ref_label(ref), do: inspect(ref)
+
+  def deterministic_step_id(run_id, asset_ref), do: safe_id("#{run_id}:#{asset_ref}")
+  def safe_id(value), do: value |> to_string() |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
+
+  defp entry_id(entry),
+    do:
+      Map.get(entry, :id) || "log-#{Map.get(entry, :global_sequence) || System.unique_integer()}"
+
+  defp dedupe_key(entry) do
+    Map.get(entry, :global_sequence) || Map.get(entry, :id) ||
+      {Map.get(entry, :producer_id), Map.get(entry, :producer_sequence)}
+  end
+
+  defp time_label(%DateTime{} = value), do: Calendar.strftime(value, "%H:%M:%S")
+  defp time_label(_value), do: "--:--:--"
+
+  defp source_label(source), do: source |> normalize_atom() |> String.replace("_", ":")
+  defp normalize_atom(value) when is_atom(value), do: Atom.to_string(value)
+  defp normalize_atom(value), do: to_string(value)
+
+  defp normalize_filter_value(value) when value in [nil, "", "all", :all], do: "all"
+  defp normalize_filter_value(value), do: normalize_atom(value)
+
+  defp level_match?(_entry, "all"), do: true
+  defp level_match?(entry, level), do: entry.level == level
+
+  defp source_match?(_entry, "all"), do: true
+  defp source_match?(entry, source), do: entry.source == source
+
+  defp search_match?(_entry, ""), do: true
+
+  defp search_match?(entry, query) do
+    [entry.message, entry.source_label, entry.level_label, entry.metadata_text]
+    |> Enum.join("\n")
+    |> String.downcase()
+    |> String.contains?(query)
+  end
+
+  defp metadata_text(metadata) when map_size(metadata) == 0, do: ""
+  defp metadata_text(metadata), do: inspect(metadata, pretty: true, limit: 50)
+
+  defp humanize(value) do
+    value
+    |> to_string()
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+end

--- a/apps/favn_view/lib/favn_view/router.ex
+++ b/apps/favn_view/lib/favn_view/router.ex
@@ -20,7 +20,10 @@ defmodule FavnView.Router do
     live "/", PageLive, :home
     live "/assets", AssetCatalogueLive, :index
     live "/assets/:asset_id", AssetDetailLive, :show
+    live "/logs", LogsLive, :index
     live "/runs/:run_id", RunDetailLive, :show
+    live "/runs/:run_id/logs", RunLogsLive, :show
+    live "/runs/:run_id/assets/:asset_step_id/logs", AssetRunLogsLive, :show
   end
 
   # Other scopes may use custom stacks.

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -6,6 +6,7 @@ defmodule FavnView.RunDetailLive do
   alias FavnView.Components.AssetCataloguePage
   alias FavnView.Components.RunDetailPage
   alias FavnView.AssetRoute
+  alias FavnView.RunStepViewModel
 
   @refresh_interval_ms 1_500
   @active_statuses [:pending, :running]
@@ -74,7 +75,7 @@ defmodule FavnView.RunDetailLive do
     target = target_label(Map.get(run, :asset_ref), Map.get(run, :target_refs, []))
     trigger = trigger_label(Map.get(run, :trigger, %{}), Map.get(run, :submit_kind))
     window = window_label(Map.get(run, :params, %{}), Map.get(run, :metadata, %{}))
-    asset_results = run_step_results(run, run.id)
+    asset_results = RunStepViewModel.from_run(run)
     event_items = event_items(events)
     back_asset_href = existing_back_asset_href || back_asset_href(Map.get(run, :asset_ref))
     failure_summary = failure_summary(status, asset_results, event_items)
@@ -121,80 +122,6 @@ defmodule FavnView.RunDetailLive do
 
   defp active_status?(status),
     do: status in @active_statuses or status in Enum.map(@active_statuses, &to_string/1)
-
-  defp run_step_results(run, run_id) do
-    node_results = node_results(Map.get(run, :node_results, %{}), run_id)
-
-    if node_results == [] do
-      asset_results(Map.get(run, :asset_results, %{}), run_id)
-    else
-      node_results
-    end
-  end
-
-  defp node_results(results, run_id) when is_map(results) do
-    results
-    |> Enum.map(fn {key, result} -> node_result(result, run_id, key) end)
-    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
-  end
-
-  defp node_results(results, run_id) when is_list(results) do
-    results
-    |> Enum.map(&node_result(&1, run_id, node_key(&1)))
-    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
-  end
-
-  defp node_results(_results, _run_id), do: []
-
-  defp node_result(result, run_id, node_key) do
-    asset_ref = ref_label(Map.get(result, :ref) || node_asset_ref(node_key))
-
-    %{
-      id: node_step_id(result, run_id, node_key, asset_ref),
-      asset_ref: asset_ref,
-      display_name: display_name(asset_ref),
-      secondary: node_secondary(result),
-      status: status_label(Map.get(result, :status)),
-      status_tone: status_tone(Map.get(result, :status)),
-      duration: duration_ms_label(Map.get(result, :duration_ms)),
-      started_at: timestamp_label(Map.get(result, :started_at)),
-      error: error_summary(Map.get(result, :error) || Map.get(result, :reason)),
-      output: output_metadata(result),
-      inspectable?: true
-    }
-  end
-
-  defp asset_results(results, run_id) when is_map(results) do
-    results
-    |> Enum.map(fn {key, result} -> asset_result(result, run_id, key) end)
-    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
-  end
-
-  defp asset_results(results, run_id) when is_list(results) do
-    results
-    |> Enum.map(&asset_result(&1, run_id, nil))
-    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
-  end
-
-  defp asset_results(_results, _run_id), do: []
-
-  defp asset_result(result, run_id, key) do
-    asset_ref = ref_label(Map.get(result, :ref) || key)
-
-    %{
-      id: asset_step_id(result, run_id, key, asset_ref),
-      asset_ref: asset_ref,
-      display_name: display_name(asset_ref),
-      secondary: asset_secondary(result),
-      status: status_label(Map.get(result, :status)),
-      status_tone: status_tone(Map.get(result, :status)),
-      duration: duration_ms_label(Map.get(result, :duration_ms)),
-      started_at: timestamp_label(Map.get(result, :started_at)),
-      error: error_summary(Map.get(result, :error)),
-      output: output_metadata(result),
-      inspectable?: true
-    }
-  end
 
   defp event_items(events) when is_list(events) do
     events
@@ -408,83 +335,6 @@ defmodule FavnView.RunDetailLive do
   defp asset_empty_message(_status, _failure_summary),
     do: "No asset results persisted for this run yet."
 
-  defp node_step_id(result, run_id, node_key, asset_ref) do
-    Map.get(result, :id) || Map.get(result, "id") || Map.get(result, :step_id) ||
-      Map.get(result, "step_id") || persisted_key_id(node_key, asset_ref) ||
-      deterministic_step_id(run_id, asset_ref)
-  end
-
-  defp asset_step_id(result, run_id, key, asset_ref) do
-    Map.get(result, :id) || Map.get(result, "id") || Map.get(result, :step_id) ||
-      Map.get(result, "step_id") || persisted_key_id(key, asset_ref) ||
-      deterministic_step_id(run_id, asset_ref)
-  end
-
-  defp persisted_key_id(nil, _asset_ref), do: nil
-  defp persisted_key_id(key, asset_ref) when is_binary(key) and key != asset_ref, do: safe_id(key)
-
-  defp persisted_key_id(key, _asset_ref) when is_tuple(key),
-    do: safe_id(:erlang.term_to_binary(key) |> Base.url_encode64(padding: false))
-
-  defp persisted_key_id(_key, _asset_ref), do: nil
-
-  defp deterministic_step_id(run_id, asset_ref), do: safe_id("#{run_id}:#{asset_ref}")
-
-  defp safe_id(value), do: value |> to_string() |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
-
-  defp display_name(asset_ref), do: asset_ref |> String.split(".") |> List.last()
-
-  defp asset_secondary(result) do
-    result
-    |> Map.get(:stage)
-    |> case do
-      nil -> nil
-      stage -> "Stage #{stage}"
-    end
-  end
-
-  defp node_secondary(result) do
-    [
-      window_secondary(Map.get(result, :window)),
-      freshness_secondary(Map.get(result, :freshness_key)),
-      reason_secondary(Map.get(result, :reason)),
-      asset_secondary(result)
-    ]
-    |> Enum.reject(&is_nil/1)
-    |> Enum.join(" · ")
-    |> case do
-      "" -> nil
-      secondary -> secondary
-    end
-  end
-
-  defp window_secondary(nil), do: nil
-  defp window_secondary(%{label: label}) when is_binary(label), do: label
-  defp window_secondary(%{"label" => label}) when is_binary(label), do: label
-  defp window_secondary(%{id: id}) when is_binary(id), do: id
-  defp window_secondary(%{"id" => id}) when is_binary(id), do: id
-  defp window_secondary(window), do: "Window #{inspect(window, limit: 5)}"
-
-  defp freshness_secondary(nil), do: nil
-  defp freshness_secondary(key), do: "Freshness #{key}"
-
-  defp reason_secondary(nil), do: nil
-  defp reason_secondary(reason) when reason in [:fresh, "fresh"], do: "Fresh"
-  defp reason_secondary(reason), do: humanize(reason)
-
-  defp node_key(result), do: Map.get(result, :node_key) || Map.get(result, "node_key")
-
-  defp node_asset_ref({ref, _window}) when is_tuple(ref), do: ref
-  defp node_asset_ref(_node_key), do: nil
-
-  defp output_metadata(result) do
-    meta = Map.get(result, :meta, %{}) || %{}
-
-    Map.get(meta, :output) || Map.get(meta, "output") || Map.get(meta, :outputs) ||
-      Map.get(meta, "outputs") || Map.get(meta, :materialization) ||
-      Map.get(meta, "materialization")
-  end
-
   defp outputs(asset_results) do
     asset_results
     |> Enum.filter(& &1.output)
@@ -512,19 +362,6 @@ defmodule FavnView.RunDetailLive do
 
   defp status_summary(nil), do: nil
   defp status_summary(status), do: "Status #{status_label(status)}"
-
-  defp error_summary(nil), do: nil
-  defp error_summary(%{message: message}) when is_binary(message), do: message
-  defp error_summary(%{"message" => message}) when is_binary(message), do: message
-  defp error_summary(%{reason: reason}), do: error_reason_summary(reason)
-  defp error_summary(%{"reason" => reason}), do: error_reason_summary(reason)
-  defp error_summary(reason) when is_binary(reason), do: reason
-  defp error_summary(reason) when is_atom(reason), do: humanize(reason)
-  defp error_summary(_error), do: "Execution error"
-
-  defp error_reason_summary(reason) when is_binary(reason), do: reason
-  defp error_reason_summary(reason) when is_atom(reason), do: humanize(reason)
-  defp error_reason_summary(reason), do: inspect(reason, limit: 5, printable_limit: 200)
 
   defp humanize(value) when is_atom(value), do: value |> Atom.to_string() |> humanize()
 

--- a/apps/favn_view/lib/favn_view/run_logs_live.ex
+++ b/apps/favn_view/lib/favn_view/run_logs_live.ex
@@ -1,0 +1,86 @@
+defmodule FavnView.RunLogsLive do
+  @moduledoc false
+
+  use FavnView, :live_view
+
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.LogViewer
+  alias FavnView.LogsLiveSupport
+
+  @impl true
+  def mount(%{"run_id" => run_id}, _session, socket) do
+    run = LogsLiveSupport.run_context(run_id)
+
+    socket =
+      LogsLiveSupport.mount_logs(socket, %{
+        filter: %Favn.Log.Filter{run_id: run_id},
+        scope: :run,
+        nav_items: LogsLiveSupport.nav_items(:runs),
+        title: "Run logs",
+        subtitle: run[:subtitle] || "Run #{run[:title]}",
+        status: run[:status],
+        status_tone: run[:status_tone] || :neutral,
+        facts: [
+          %{label: "Started", value: run[:started_at] || "-"},
+          %{label: "Duration", value: run[:duration] || "-"}
+        ],
+        back_href: ~p"/runs/#{run_id}",
+        back_label: "Back to run",
+        empty_state: "No logs recorded for this run yet."
+      })
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_info({:favn_log_entry, entry}, socket),
+    do: {:noreply, LogsLiveSupport.add_live_log(socket, entry)}
+
+  @impl true
+  def handle_event("filter_logs", params, socket),
+    do: {:noreply, LogsLiveSupport.handle_filter(socket, params)}
+
+  def handle_event("toggle_wrap", _params, socket),
+    do: {:noreply, LogsLiveSupport.toggle(socket, :wrap?)}
+
+  def handle_event("toggle_live_tail", _params, socket),
+    do: {:noreply, LogsLiveSupport.toggle(socket, :live_tail?)}
+
+  @impl true
+  def terminate(_reason, socket), do: LogsLiveSupport.unsubscribe(socket)
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <AppShell.app_shell
+      title={@title}
+      subtitle={@subtitle}
+      status={@status}
+      status_tone={@status_tone}
+      nav_items={@nav_items}
+      back_href={@back_href}
+      back_label={@back_label}
+      facts={@facts}
+    >
+      <LogViewer.log_viewer
+        logs={@logs}
+        visible_logs={@visible_logs}
+        filter={@filter}
+        scope={@scope}
+        title="Logs"
+        subtitle="Run-scoped backend logs"
+        status={@logs_status}
+        live?={@live?}
+        live_tail?={@live_tail?}
+        wrap?={@wrap?}
+        search_query={@search_query}
+        selected_level={@selected_level}
+        selected_source={@selected_source}
+        next_cursor={@next_cursor}
+        empty_state={@empty_state}
+        warning={@stream_warning}
+      />
+    </AppShell.app_shell>
+    """
+  end
+end

--- a/apps/favn_view/lib/favn_view/run_logs_live.ex
+++ b/apps/favn_view/lib/favn_view/run_logs_live.ex
@@ -3,8 +3,7 @@ defmodule FavnView.RunLogsLive do
 
   use FavnView, :live_view
 
-  alias FavnView.Components.AppShell
-  alias FavnView.Components.LogViewer
+  alias FavnView.Components.LogPages
   alias FavnView.LogsLiveSupport
 
   @impl true
@@ -52,35 +51,7 @@ defmodule FavnView.RunLogsLive do
   @impl true
   def render(assigns) do
     ~H"""
-    <AppShell.app_shell
-      title={@title}
-      subtitle={@subtitle}
-      status={@status}
-      status_tone={@status_tone}
-      nav_items={@nav_items}
-      back_href={@back_href}
-      back_label={@back_label}
-      facts={@facts}
-    >
-      <LogViewer.log_viewer
-        logs={@logs}
-        visible_logs={@visible_logs}
-        filter={@filter}
-        scope={@scope}
-        title="Logs"
-        subtitle="Run-scoped backend logs"
-        status={@logs_status}
-        live?={@live?}
-        live_tail?={@live_tail?}
-        wrap?={@wrap?}
-        search_query={@search_query}
-        selected_level={@selected_level}
-        selected_source={@selected_source}
-        next_cursor={@next_cursor}
-        empty_state={@empty_state}
-        warning={@stream_warning}
-      />
-    </AppShell.app_shell>
+    <LogPages.run_logs_page {assigns} />
     """
   end
 end

--- a/apps/favn_view/lib/favn_view/run_step_view_model.ex
+++ b/apps/favn_view/lib/favn_view/run_step_view_model.ex
@@ -1,0 +1,175 @@
+defmodule FavnView.RunStepViewModel do
+  @moduledoc false
+
+  alias FavnView.LogsViewModel
+
+  def from_run(run) do
+    run_id = Map.get(run, :id)
+    node_results = node_results(Map.get(run, :node_results, %{}), run_id)
+
+    if node_results == [] do
+      asset_results(Map.get(run, :asset_results, %{}), run_id)
+    else
+      node_results
+    end
+  end
+
+  def node_results(results, run_id) when is_map(results) do
+    results
+    |> Enum.map(fn {key, result} -> node_result(result, run_id, key) end)
+    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
+  end
+
+  def node_results(results, run_id) when is_list(results) do
+    results
+    |> Enum.map(&node_result(&1, run_id, node_key(&1)))
+    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
+  end
+
+  def node_results(_results, _run_id), do: []
+
+  def asset_results(results, run_id) when is_map(results) do
+    results
+    |> Enum.map(fn {key, result} -> asset_result(result, run_id, key) end)
+    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
+  end
+
+  def asset_results(results, run_id) when is_list(results) do
+    results
+    |> Enum.map(&asset_result(&1, run_id, nil))
+    |> Enum.sort_by(&{Map.get(&1, :secondary) || "", &1.asset_ref})
+  end
+
+  def asset_results(_results, _run_id), do: []
+
+  defp node_result(result, run_id, node_key) do
+    asset_ref = LogsViewModel.ref_label(Map.get(result, :ref) || node_asset_ref(node_key))
+
+    %{
+      id: step_id(result, run_id, node_key, asset_ref),
+      asset_ref: asset_ref,
+      display_name: LogsViewModel.display_name(asset_ref),
+      secondary: node_secondary(result),
+      status: LogsViewModel.status_label(Map.get(result, :status)),
+      status_tone: LogsViewModel.status_tone(Map.get(result, :status)),
+      duration: LogsViewModel.duration_ms_label(Map.get(result, :duration_ms)),
+      started_at: LogsViewModel.timestamp_label(Map.get(result, :started_at)),
+      attempt: Map.get(result, :attempt),
+      error: error_summary(Map.get(result, :error) || Map.get(result, :reason)),
+      output: output_metadata(result),
+      inspectable?: true
+    }
+  end
+
+  defp asset_result(result, run_id, key) do
+    asset_ref = LogsViewModel.ref_label(Map.get(result, :ref) || key)
+
+    %{
+      id: step_id(result, run_id, key, asset_ref),
+      asset_ref: asset_ref,
+      display_name: LogsViewModel.display_name(asset_ref),
+      secondary: asset_secondary(result),
+      status: LogsViewModel.status_label(Map.get(result, :status)),
+      status_tone: LogsViewModel.status_tone(Map.get(result, :status)),
+      duration: LogsViewModel.duration_ms_label(Map.get(result, :duration_ms)),
+      started_at: LogsViewModel.timestamp_label(Map.get(result, :started_at)),
+      attempt: Map.get(result, :attempt),
+      error: error_summary(Map.get(result, :error)),
+      output: output_metadata(result),
+      inspectable?: true
+    }
+  end
+
+  defp step_id(result, run_id, key, asset_ref) do
+    Map.get(result, :id) || Map.get(result, "id") || Map.get(result, :step_id) ||
+      Map.get(result, "step_id") || persisted_key_id(key, asset_ref) ||
+      LogsViewModel.deterministic_step_id(run_id, asset_ref)
+  end
+
+  defp persisted_key_id(nil, _asset_ref), do: nil
+
+  defp persisted_key_id(key, asset_ref) when is_binary(key) and key != asset_ref,
+    do: LogsViewModel.safe_id(key)
+
+  defp persisted_key_id(key, _asset_ref) when is_tuple(key),
+    do:
+      key
+      |> :erlang.term_to_binary()
+      |> Base.url_encode64(padding: false)
+      |> LogsViewModel.safe_id()
+
+  defp persisted_key_id(_key, _asset_ref), do: nil
+
+  defp asset_secondary(result) do
+    result
+    |> Map.get(:stage)
+    |> case do
+      nil -> nil
+      stage -> "Stage #{stage}"
+    end
+  end
+
+  defp node_secondary(result) do
+    [
+      window_secondary(Map.get(result, :window)),
+      freshness_secondary(Map.get(result, :freshness_key)),
+      reason_secondary(Map.get(result, :reason)),
+      asset_secondary(result)
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+    |> case do
+      "" -> nil
+      secondary -> secondary
+    end
+  end
+
+  defp window_secondary(nil), do: nil
+  defp window_secondary(%{label: label}) when is_binary(label), do: label
+  defp window_secondary(%{"label" => label}) when is_binary(label), do: label
+  defp window_secondary(%{id: id}) when is_binary(id), do: id
+  defp window_secondary(%{"id" => id}) when is_binary(id), do: id
+  defp window_secondary(window), do: "Window #{inspect(window, limit: 5)}"
+
+  defp freshness_secondary(nil), do: nil
+  defp freshness_secondary(key), do: "Freshness #{key}"
+
+  defp reason_secondary(nil), do: nil
+  defp reason_secondary(reason) when reason in [:fresh, "fresh"], do: "Fresh"
+  defp reason_secondary(reason), do: humanize(reason)
+
+  defp node_key(result), do: Map.get(result, :node_key) || Map.get(result, "node_key")
+  defp node_asset_ref({ref, _window}) when is_tuple(ref), do: ref
+  defp node_asset_ref(_node_key), do: nil
+
+  defp output_metadata(result) do
+    meta = Map.get(result, :meta, %{}) || %{}
+
+    Map.get(meta, :output) || Map.get(meta, "output") || Map.get(meta, :outputs) ||
+      Map.get(meta, "outputs") || Map.get(meta, :materialization) ||
+      Map.get(meta, "materialization")
+  end
+
+  defp error_summary(nil), do: nil
+  defp error_summary(%{message: message}) when is_binary(message), do: message
+  defp error_summary(%{"message" => message}) when is_binary(message), do: message
+  defp error_summary(%{reason: reason}), do: error_reason_summary(reason)
+  defp error_summary(%{"reason" => reason}), do: error_reason_summary(reason)
+  defp error_summary(reason) when is_binary(reason), do: reason
+  defp error_summary(reason) when is_atom(reason), do: humanize(reason)
+  defp error_summary(_error), do: "Execution error"
+
+  defp error_reason_summary(reason) when is_binary(reason), do: reason
+  defp error_reason_summary(reason) when is_atom(reason), do: humanize(reason)
+  defp error_reason_summary(reason), do: inspect(reason, limit: 5, printable_limit: 200)
+
+  defp humanize(value) when is_atom(value), do: value |> Atom.to_string() |> humanize()
+
+  defp humanize(value) when is_binary(value) do
+    value
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+
+  defp humanize(value), do: inspect(value)
+end

--- a/apps/favn_view/storybook/components/log_viewer.story.exs
+++ b/apps/favn_view/storybook/components/log_viewer.story.exs
@@ -1,0 +1,157 @@
+defmodule FavnView.Storybook.Components.LogViewer do
+  alias Favn.Log.Entry
+  alias FavnView.Components.LogViewer
+  alias FavnView.LogsViewModel
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &LogViewer.log_viewer/1
+  def layout, do: :one_column
+  def render_source, do: :function
+  def container, do: {:iframe, style: "width: 100%; height: 860px; border: 0;"}
+
+  def variations do
+    [
+      variation(:global_mixed, "Logs", "Live system and run logs", sample_logs(), true, true),
+      variation(
+        :running_live_stream,
+        "Logs",
+        "Listening to live backend logs",
+        sample_logs(:streaming),
+        true,
+        true
+      ),
+      variation(:empty_logs, "Logs", "Live system and run logs", [], true, true),
+      variation(:multi_line_sql, "Logs", "SQL runtime output", sample_logs(:sql), true, true),
+      variation(:long_stacktrace, "Logs", "Error output", sample_logs(:stacktrace), true, true),
+      variation(:wrap_on, "Logs", "Wrapped long messages", sample_logs(:long), true, true),
+      variation(
+        :wrap_off,
+        "Logs",
+        "Horizontal overflow for long messages",
+        sample_logs(:long),
+        true,
+        false
+      ),
+      variation(
+        :truncated_log,
+        "Logs",
+        "Persisted truncated output",
+        sample_logs(:truncated),
+        true,
+        true
+      ),
+      variation(
+        :asset_step_scoped,
+        "customer_orders_daily",
+        "Run r_2026_06_12 · Asset step 03",
+        sample_logs(:asset),
+        true,
+        true
+      )
+    ]
+  end
+
+  defp variation(id, title, subtitle, logs, live?, wrap?) do
+    view_logs = LogsViewModel.entries(logs)
+
+    %Variation{
+      id: id,
+      attributes: %{
+        logs: logs,
+        visible_logs: view_logs,
+        title: title,
+        subtitle: subtitle,
+        status: :ready,
+        live?: live?,
+        live_tail?: true,
+        wrap?: wrap?,
+        search_query: "",
+        selected_level: "all",
+        selected_source: "all",
+        empty_state: "No logs yet.",
+        facts: [
+          %{label: "Started", value: "09:41:12"},
+          %{label: "Duration", value: "02:14"},
+          %{label: "Attempt", value: "1/3"}
+        ]
+      }
+    }
+  end
+
+  defp sample_logs(kind \\ :mixed)
+  defp sample_logs(:mixed), do: base_logs()
+
+  defp sample_logs(:streaming),
+    do: base_logs() ++ [entry(5, :info, :runner, "Streaming new log lines...")]
+
+  defp sample_logs(:sql),
+    do: [
+      entry(
+        1,
+        :info,
+        :adapter,
+        "Running SQL:\nSELECT customer_id, order_id, total_amount\nFROM raw.orders\nWHERE order_date >= '2026-06-12'"
+      )
+    ]
+
+  defp sample_logs(:stacktrace),
+    do: [
+      entry(
+        1,
+        :error,
+        :user_code,
+        "Warehouse timeout\nquery_id=01bc...\n    at Favn.Asset.run/2\n    at FavnRunner.Worker.perform/1"
+      )
+    ]
+
+  defp sample_logs(:long),
+    do: [
+      entry(
+        1,
+        :info,
+        :runner,
+        String.duplicate(
+          "customer_orders_daily emitted a very long diagnostic message with many columns and partitions ",
+          4
+        )
+      )
+    ]
+
+  defp sample_logs(:truncated),
+    do: [
+      entry(1, :warning, :system, "Output exceeded maximum persisted log size\n[TRUNCATED]", true)
+    ]
+
+  defp sample_logs(:asset),
+    do: base_logs() |> Enum.map(&%{&1 | run_id: "r_2026_06_12", asset_step_id: "03"})
+
+  defp base_logs do
+    [
+      entry(1, :info, :runner, "Starting asset customer_orders_daily"),
+      entry(
+        2,
+        :info,
+        :adapter,
+        "Running SQL:\nSELECT customer_id, order_id, total_amount\nFROM raw.orders\nWHERE order_date >= '2026-06-12'"
+      ),
+      entry(3, :warning, :adapter, "Query exceeded warehouse threshold"),
+      entry(4, :error, :adapter, "Warehouse timeout\nquery_id=01bc...")
+    ]
+  end
+
+  defp entry(sequence, level, source, message, truncated \\ false) do
+    %Entry{
+      id: "story-log-#{sequence}",
+      global_sequence: sequence,
+      occurred_at:
+        DateTime.new!(~D[2026-06-12], ~T[09:41:12], "Etc/UTC")
+        |> DateTime.add(sequence * 8, :second),
+      level: level,
+      source: source,
+      message: message,
+      metadata: %{story: true},
+      truncated: truncated
+    }
+  end
+end

--- a/apps/favn_view/storybook/pages/asset_run_logs_page.story.exs
+++ b/apps/favn_view/storybook/pages/asset_run_logs_page.story.exs
@@ -1,0 +1,90 @@
+defmodule FavnView.Storybook.Pages.AssetRunLogsPage do
+  alias Favn.Log.Entry
+  alias Favn.Log.Filter
+  alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.LogPages
+  alias FavnView.LogsViewModel
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &LogPages.asset_run_logs_page/1
+  def layout, do: :one_column
+  def render_source, do: :function
+  def container, do: {:iframe, style: "width: 100%; height: 920px; border: 0;"}
+
+  def variations do
+    [
+      %Variation{
+        id: :asset_run_logs_page,
+        attributes:
+          page_attrs(%{
+            title: "customer_orders_daily",
+            subtitle: "Run run_2026_06_12 · Asset step 03",
+            status: "Running",
+            status_tone: :info,
+            nav_items: AssetCataloguePage.nav_items(:runs),
+            back_href: "/runs/run_2026_06_12",
+            back_label: "Back to run",
+            facts: [
+              %{label: "Started", value: "09:41:12"},
+              %{label: "Duration", value: "02:14"},
+              %{label: "Attempt", value: "1/3"}
+            ],
+            scope: :asset,
+            filter: %Filter{run_id: "run_2026_06_12", asset_step_id: "03"},
+            empty_state: "No logs recorded for this asset step yet."
+          })
+      }
+    ]
+  end
+
+  defp page_attrs(attrs) do
+    logs = sample_logs()
+
+    Map.merge(
+      %{
+        logs: logs,
+        visible_logs: LogsViewModel.entries(logs),
+        logs_status: :ready,
+        live?: true,
+        live_tail?: true,
+        wrap?: true,
+        search_query: "",
+        selected_level: "all",
+        selected_source: "all",
+        next_cursor: nil,
+        stream_warning: nil,
+        context_note: nil
+      },
+      attrs
+    )
+  end
+
+  defp sample_logs do
+    [
+      entry(1, :info, :runner, "Starting asset customer_orders_daily"),
+      entry(
+        2,
+        :info,
+        :adapter,
+        "Running SQL:\nSELECT customer_id, order_id, total_amount\nFROM raw.orders\nWHERE order_date >= '2026-06-12'"
+      ),
+      entry(3, :error, :adapter, "Warehouse timeout\nquery_id=01bc...")
+    ]
+  end
+
+  defp entry(sequence, level, source, message) do
+    %Entry{
+      id: "asset-page-log-#{sequence}",
+      global_sequence: sequence,
+      run_id: "run_2026_06_12",
+      asset_step_id: "03",
+      occurred_at:
+        DateTime.new!(~D[2026-06-12], ~T[09:41:12], "Etc/UTC")
+        |> DateTime.add(sequence * 8, :second),
+      level: level,
+      source: source,
+      message: message
+    }
+  end
+end

--- a/apps/favn_view/storybook/pages/logs_page.story.exs
+++ b/apps/favn_view/storybook/pages/logs_page.story.exs
@@ -1,0 +1,74 @@
+defmodule FavnView.Storybook.Pages.LogsPage do
+  alias Favn.Log.Entry
+  alias Favn.Log.Filter
+  alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.LogPages
+  alias FavnView.LogsViewModel
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &LogPages.global_logs_page/1
+  def layout, do: :one_column
+  def render_source, do: :function
+  def container, do: {:iframe, style: "width: 100%; height: 920px; border: 0;"}
+
+  def variations do
+    [
+      %Variation{
+        id: :global_logs_page,
+        attributes:
+          page_attrs(%{
+            title: "Logs",
+            subtitle: "Live system and run logs",
+            nav_items: AssetCataloguePage.nav_items(:logs),
+            scope: :global,
+            filter: %Filter{},
+            empty_state: "No logs yet."
+          })
+      }
+    ]
+  end
+
+  defp page_attrs(attrs) do
+    logs = sample_logs()
+
+    Map.merge(
+      %{
+        logs: logs,
+        visible_logs: LogsViewModel.entries(logs),
+        logs_status: :ready,
+        live?: true,
+        live_tail?: true,
+        wrap?: true,
+        search_query: "",
+        selected_level: "all",
+        selected_source: "all",
+        next_cursor: nil,
+        stream_warning: nil,
+        context_note: nil
+      },
+      attrs
+    )
+  end
+
+  defp sample_logs do
+    [
+      entry(1, :info, :orchestrator, "Run run_2026_06_12 accepted"),
+      entry(2, :info, :runner, "Starting asset customer_orders_daily"),
+      entry(3, :warning, :adapter, "Query exceeded warehouse threshold")
+    ]
+  end
+
+  defp entry(sequence, level, source, message) do
+    %Entry{
+      id: "global-page-log-#{sequence}",
+      global_sequence: sequence,
+      occurred_at:
+        DateTime.new!(~D[2026-06-12], ~T[09:41:12], "Etc/UTC")
+        |> DateTime.add(sequence * 8, :second),
+      level: level,
+      source: source,
+      message: message
+    }
+  end
+end

--- a/apps/favn_view/storybook/pages/run_logs_page.story.exs
+++ b/apps/favn_view/storybook/pages/run_logs_page.story.exs
@@ -1,0 +1,85 @@
+defmodule FavnView.Storybook.Pages.RunLogsPage do
+  alias Favn.Log.Entry
+  alias Favn.Log.Filter
+  alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.LogPages
+  alias FavnView.LogsViewModel
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &LogPages.run_logs_page/1
+  def layout, do: :one_column
+  def render_source, do: :function
+  def container, do: {:iframe, style: "width: 100%; height: 920px; border: 0;"}
+
+  def variations do
+    [
+      %Variation{
+        id: :run_logs_page,
+        attributes:
+          page_attrs(%{
+            title: "Run logs",
+            subtitle: "run_2026_06_12 · customer_orders_daily",
+            status: "Running",
+            status_tone: :info,
+            nav_items: AssetCataloguePage.nav_items(:runs),
+            back_href: "/runs/run_2026_06_12",
+            back_label: "Back to run",
+            facts: [%{label: "Started", value: "09:41:12"}, %{label: "Duration", value: "02:14"}],
+            scope: :run,
+            filter: %Filter{run_id: "run_2026_06_12"},
+            empty_state: "No logs recorded for this run yet."
+          })
+      }
+    ]
+  end
+
+  defp page_attrs(attrs) do
+    logs = sample_logs()
+
+    Map.merge(
+      %{
+        logs: logs,
+        visible_logs: LogsViewModel.entries(logs),
+        logs_status: :ready,
+        live?: true,
+        live_tail?: true,
+        wrap?: true,
+        search_query: "",
+        selected_level: "all",
+        selected_source: "all",
+        next_cursor: nil,
+        stream_warning: nil,
+        context_note: nil
+      },
+      attrs
+    )
+  end
+
+  defp sample_logs do
+    [
+      entry(1, :info, :runner, "Starting asset customer_orders_daily"),
+      entry(
+        2,
+        :info,
+        :adapter,
+        "Running SQL:\nSELECT customer_id, order_id, total_amount\nFROM raw.orders"
+      ),
+      entry(3, :warning, :adapter, "Query exceeded warehouse threshold")
+    ]
+  end
+
+  defp entry(sequence, level, source, message) do
+    %Entry{
+      id: "run-page-log-#{sequence}",
+      global_sequence: sequence,
+      run_id: "run_2026_06_12",
+      occurred_at:
+        DateTime.new!(~D[2026-06-12], ~T[09:41:12], "Etc/UTC")
+        |> DateTime.add(sequence * 8, :second),
+      level: level,
+      source: source,
+      message: message
+    }
+  end
+end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -210,10 +210,18 @@ defmodule FavnView.PageLiveTest do
 
   test "run detail renders asset results when present", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
+    asset_step_id = asset_step_id("run_customer_orders_daily", :customer_orders_daily)
 
     assert has_element?(view, ~s([data-testid="run-asset-results"]), "customer_orders_daily")
     assert has_element?(view, ~s([data-testid="run-asset-results"]), "Stage 0")
     assert has_element?(view, ~s([data-testid="run-asset-result-row"][data-asset-step-id]))
+
+    view
+    |> element(~s(a[data-testid="run-asset-result-row"][data-asset-step-id="#{asset_step_id}"]))
+    |> render_click()
+
+    assert {path, _flash} = assert_redirect(view)
+    assert path == ~p"/runs/run_customer_orders_daily/assets/#{asset_step_id}/logs"
   end
 
   test "run detail prefers node results for execution rows", %{conn: conn} do
@@ -347,6 +355,19 @@ defmodule FavnView.PageLiveTest do
     assert html =~ "Live system and run logs"
     assert has_element?(view, ~s([data-testid="log-viewer"][data-log-scope="global"]))
     assert has_element?(view, ~s([data-testid="log-row"]), "global boot")
+  end
+
+  test "/logs loads newest entries when more than one backend page exists", %{conn: conn} do
+    for index <- 1..510 do
+      seed_log!("paged log #{index}", producer_id: "paged", producer_sequence: index)
+    end
+
+    {:ok, view, _html} = live(conn, ~p"/logs")
+
+    assert has_element?(view, ~s([data-testid="log-row"]), "paged log 510")
+    assert has_element?(view, ~s([data-testid="log-row"]), "paged log 311")
+    refute has_element?(view, ~s([data-testid="log-row"]), "paged log 310")
+    refute has_element?(view, ~s([data-testid="log-row"]), "paged log 1")
   end
 
   test "/runs/:run_id/logs renders only run-scoped logs", %{conn: conn} do
@@ -735,6 +756,8 @@ defmodule FavnView.PageLiveTest do
       global_sequence: Keyword.get(opts, :global_sequence),
       run_id: Keyword.get(opts, :run_id),
       asset_step_id: Keyword.get(opts, :asset_step_id),
+      producer_id: Keyword.get(opts, :producer_id),
+      producer_sequence: Keyword.get(opts, :producer_sequence),
       occurred_at: Keyword.get(opts, :occurred_at, DateTime.utc_now()),
       level: Keyword.get(opts, :level, :info),
       source: Keyword.get(opts, :source, :runner),
@@ -744,8 +767,12 @@ defmodule FavnView.PageLiveTest do
   end
 
   defp asset_step_id(run_id, name) do
-    asset_ref = "#{inspect(__MODULE__.Assets)}.#{name}"
-    "#{run_id}:#{asset_ref}" |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
+    {:ok, run} = FavnOrchestrator.get_run(run_id)
+
+    run
+    |> FavnView.RunStepViewModel.from_run()
+    |> Enum.find(&(Map.get(&1, :display_name) == Atom.to_string(name)))
+    |> Map.fetch!(:id)
   end
 
   defp target_id(name) do

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -3,6 +3,7 @@ defmodule FavnView.PageLiveTest do
 
   import Phoenix.LiveViewTest
 
+  alias Favn.Log.Entry
   alias Favn.Manifest
   alias Favn.Manifest.Version
   alias Favn.Run.AssetResult
@@ -338,6 +339,142 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="run-not-found-state"]), "run_missing")
   end
 
+  test "/logs renders the global log viewer", %{conn: conn} do
+    seed_log!("global boot", source: :system)
+
+    {:ok, view, html} = live(conn, ~p"/logs")
+
+    assert html =~ "Live system and run logs"
+    assert has_element?(view, ~s([data-testid="log-viewer"][data-log-scope="global"]))
+    assert has_element?(view, ~s([data-testid="log-row"]), "global boot")
+  end
+
+  test "/runs/:run_id/logs renders only run-scoped logs", %{conn: conn} do
+    seed_log!("visible run log", run_id: "run_customer_orders_daily")
+    seed_log!("other run log", run_id: "run_failed_empty")
+
+    {:ok, view, html} = live(conn, ~p"/runs/run_customer_orders_daily/logs")
+
+    assert html =~ "Run logs"
+    assert has_element?(view, ~s([data-testid="log-viewer"][data-log-scope="run"]))
+    assert has_element?(view, ~s([data-testid="log-row"]), "visible run log")
+    refute has_element?(view, ~s([data-testid="log-row"]), "other run log")
+  end
+
+  test "/runs/:run_id/assets/:asset_step_id/logs renders only asset-scoped logs", %{conn: conn} do
+    asset_step_id = asset_step_id("run_customer_orders_daily", :customer_orders_daily)
+
+    seed_log!("visible asset log",
+      run_id: "run_customer_orders_daily",
+      asset_step_id: asset_step_id
+    )
+
+    seed_log!("run-only log", run_id: "run_customer_orders_daily")
+
+    {:ok, view, html} =
+      live(conn, ~p"/runs/run_customer_orders_daily/assets/#{asset_step_id}/logs")
+
+    assert html =~ "customer_orders_daily"
+    assert has_element?(view, ~s([data-testid="log-viewer"][data-log-scope="asset"]))
+    assert has_element?(view, ~s([data-testid="log-row"]), "visible asset log")
+    refute has_element?(view, ~s([data-testid="log-row"]), "run-only log")
+  end
+
+  test "asset logs show fallback when asset context is missing", %{conn: conn} do
+    seed_log!("orphan asset log",
+      run_id: "run_customer_orders_daily",
+      asset_step_id: "missing-step"
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily/assets/missing-step/logs")
+
+    assert has_element?(
+             view,
+             ~s([data-testid="log-context-note"]),
+             "Asset step context not found"
+           )
+
+    assert has_element?(view, ~s([data-testid="log-row"]), "orphan asset log")
+  end
+
+  test "multi-line log messages preserve newlines", %{conn: conn} do
+    seed_log!("Running SQL:\nSELECT customer_id\nFROM raw.orders",
+      run_id: "run_customer_orders_daily"
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily/logs")
+
+    assert render(view) =~ "Running SQL:\nSELECT customer_id\nFROM raw.orders"
+  end
+
+  test "level source and search filters affect rendered logs", %{conn: conn} do
+    seed_log!("warehouse threshold", level: :warning, source: :adapter)
+    seed_log!("runner heartbeat", level: :info, source: :runner)
+
+    {:ok, view, _html} = live(conn, ~p"/logs")
+
+    view
+    |> element("form")
+    |> render_change(%{
+      "filters" => %{"search" => "warehouse", "level" => "warning", "source" => "adapter"}
+    })
+
+    assert has_element?(view, ~s([data-testid="log-row"]), "warehouse threshold")
+    refute has_element?(view, ~s([data-testid="log-row"]), "runner heartbeat")
+  end
+
+  test "live log messages append and duplicate global sequences are ignored", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/logs")
+
+    entry = log_entry("live append", id: "manual-live", global_sequence: 4242)
+    send(view.pid, {:favn_log_entry, entry})
+    send(view.pid, {:favn_log_entry, entry})
+
+    html = render(view)
+    assert html =~ "live append"
+    assert Regex.scan(~r/data-testid="log-row"/, html) |> length() == 1
+  end
+
+  test "subscription failure shows non-fatal warning", %{conn: conn} do
+    original = Application.get_env(:favn_view, :log_subscribe_fun)
+    Application.put_env(:favn_view, :log_subscribe_fun, fn _filter -> {:error, :unavailable} end)
+
+    try do
+      {:ok, view, _html} = live(conn, ~p"/logs")
+
+      assert has_element?(
+               view,
+               ~s([data-testid="log-stream-warning"]),
+               "live streaming is unavailable"
+             )
+    after
+      if original do
+        Application.put_env(:favn_view, :log_subscribe_fun, original)
+      else
+        Application.delete_env(:favn_view, :log_subscribe_fun)
+      end
+    end
+  end
+
+  test "copy text formatting preserves multi-line logs" do
+    text =
+      [log_entry("first\nsecond", global_sequence: 1)]
+      |> FavnView.LogsViewModel.entries()
+      |> FavnView.LogsViewModel.plain_text()
+
+    assert text =~ "first\nsecond"
+  end
+
+  test "favn_view lib does not call storage adapters directly" do
+    files = Path.wildcard(Path.expand("../../lib/favn_view/**/*.ex", __DIR__))
+
+    for file <- files do
+      source = File.read!(file)
+      refute source =~ "Storage.Adapter"
+      refute source =~ "FavnOrchestrator.Storage"
+    end
+  end
+
   test "catalogue links open the detail route", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/assets")
     detail_path = detail_path(:customer_orders_daily)
@@ -586,6 +723,29 @@ defmodule FavnView.PageLiveTest do
                  message: if(status == :error, do: "Warehouse timeout", else: "Run finished")
                }
              })
+  end
+
+  defp seed_log!(message, opts) do
+    assert {:ok, [_entry]} = FavnOrchestrator.emit_log(log_entry(message, opts))
+  end
+
+  defp log_entry(message, opts) do
+    %Entry{
+      id: Keyword.get(opts, :id),
+      global_sequence: Keyword.get(opts, :global_sequence),
+      run_id: Keyword.get(opts, :run_id),
+      asset_step_id: Keyword.get(opts, :asset_step_id),
+      occurred_at: Keyword.get(opts, :occurred_at, DateTime.utc_now()),
+      level: Keyword.get(opts, :level, :info),
+      source: Keyword.get(opts, :source, :runner),
+      message: message,
+      metadata: Keyword.get(opts, :metadata, %{})
+    }
+  end
+
+  defp asset_step_id(run_id, name) do
+    asset_ref = "#{inspect(__MODULE__.Assets)}.#{name}"
+    "#{run_id}:#{asset_ref}" |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
   end
 
   defp target_id(name) do


### PR DESCRIPTION
## Summary
- Adds reusable terminal-style log viewer for global, run, and asset-step log routes.
- Streams live logs through public `FavnOrchestrator` log APIs with replay gap handling and dedupe.
- Adds Storybook states and LiveView coverage for filters, multiline logs, streaming, and boundary safety.

## Verification
- `mix format`
- `mix compile --warnings-as-errors` from `apps/favn_view`
- `mix test` from `apps/favn_view`