### PR TITLE
Add runs list view

### DIFF
--- a/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
@@ -314,7 +314,7 @@ defmodule FavnView.Components.AssetCataloguePage do
       %{label: "Assets", icon: "hero-sparkles", href: "/assets", active: active == :assets},
       %{label: "Lineage", icon: "hero-share", href: "#"},
       %{label: "Storage", icon: "hero-circle-stack", href: "#"},
-      %{label: "Runs", icon: "hero-rocket-launch", href: "#", active: active == :runs},
+      %{label: "Runs", icon: "hero-rocket-launch", href: "/runs", active: active == :runs},
       %{label: "Logs", icon: "hero-document-text", href: "/logs", active: active == :logs},
       %{label: "Alerts", icon: "hero-bell", href: "#"},
       %{label: "Settings", icon: "hero-cog-6-tooth", href: "#"}

--- a/apps/favn_view/lib/favn_view/components/runs_list_page.ex
+++ b/apps/favn_view/lib/favn_view/components/runs_list_page.ex
@@ -1,0 +1,324 @@
+defmodule FavnView.Components.RunsListPage do
+  @moduledoc """
+  Runs list page components for scanning recent Favn runs.
+  """
+
+  use FavnView, :html
+
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.GlassPanel
+  alias FavnView.Components.ModeRail
+
+  attr :runs, :list, required: true
+  attr :active_mode, :atom, required: true
+  attr :loading, :boolean, default: false
+  attr :error, :string, default: nil
+  attr :nav_items, :list, required: true
+
+  def runs_list_page(assigns) do
+    ~H"""
+    <AppShell.app_shell title="Runs" subtitle="Recent orchestration activity" nav_items={@nav_items}>
+      <div class="mx-auto w-full max-w-6xl pb-24 lg:pb-0" data-testid="runs-list-page">
+        <.loading_state :if={@loading} />
+        <.error_state :if={!@loading && @error} />
+
+        <div :if={!@loading && !@error} class="space-y-3.5 lg:space-y-5">
+          <.empty_state :if={@runs == []} />
+
+          <GlassPanel.glass_panel :if={@runs != []} class="hidden overflow-visible lg:block">
+            <.runs_table runs={@runs} />
+          </GlassPanel.glass_panel>
+
+          <.run_card_list :if={@runs != []} runs={@runs} />
+        </div>
+      </div>
+
+      <:mode_rail>
+        <ModeRail.mode_rail active={@active_mode} modes={runs_modes()} on_select="set_mode" />
+      </:mode_rail>
+    </AppShell.app_shell>
+    """
+  end
+
+  attr :runs, :list, required: true
+
+  def runs_table(assigns) do
+    ~H"""
+    <div class="overflow-x-auto overflow-y-visible p-5 sm:p-6">
+      <table class="table table-lg" data-testid="runs-table">
+        <thead>
+          <tr class="border-base-content/10 text-base-content/65">
+            <th class="w-44 font-medium">Run</th>
+            <th class="font-medium">Target</th>
+            <th class="font-medium">Status</th>
+            <th class="font-medium">Trigger</th>
+            <th class="font-medium">Window</th>
+            <th class="font-medium">Progress</th>
+            <th class="font-medium">Started</th>
+            <th class="font-medium">Duration</th>
+          </tr>
+        </thead>
+        <tbody>
+          <.run_table_row :for={run <- @runs} run={run} />
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  attr :run, :map, required: true
+
+  def run_table_row(assigns) do
+    ~H"""
+    <tr
+      class="group border-base-content/10 transition hover:bg-primary/10 focus-within:bg-primary/10"
+      data-testid="run-row"
+    >
+      <td>
+        <.run_id_link run={@run} />
+      </td>
+      <td class="min-w-64 max-w-96">
+        <.target_cell run={@run} />
+      </td>
+      <td><.status_badge status={@run.raw_status} /></td>
+      <td class="text-base-content/70">{@run.trigger}</td>
+      <td class="max-w-40 truncate text-base-content/70" title={@run.window}>{@run.window}</td>
+      <td><.progress_label progress={@run.progress} /></td>
+      <td class="whitespace-nowrap text-base-content/70">{@run.started_at}</td>
+      <td class="whitespace-nowrap text-base-content/70">{@run.duration}</td>
+    </tr>
+    """
+  end
+
+  attr :runs, :list, required: true
+
+  def run_card_list(assigns) do
+    ~H"""
+    <div class="space-y-2.5 lg:hidden" data-testid="run-card-list">
+      <.run_card :for={run <- @runs} run={run} />
+    </div>
+    """
+  end
+
+  attr :run, :map, required: true
+
+  def run_card(assigns) do
+    ~H"""
+    <div
+      class="card glass favn-surface-list favn-density-list-card block rounded-box"
+      data-testid="run-card"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0 flex-1 space-y-2">
+          <div class="flex items-start gap-3">
+            <span class="favn-density-list-card-icon flex shrink-0 items-center justify-center rounded-field border border-primary/30 bg-primary/10 text-primary">
+              <.icon name="hero-rocket-launch" class="size-4" />
+            </span>
+            <div class="min-w-0 flex-1">
+              <.run_id_link run={@run} />
+              <div class="mt-1 min-w-0">
+                <.target_cell run={@run} />
+              </div>
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center gap-3 text-xs text-base-content/65">
+            <.status_badge status={@run.raw_status} />
+            <span>{@run.trigger}</span>
+            <span>{@run.window}</span>
+            <.progress_label progress={@run.progress} />
+          </div>
+          <p class="text-xs text-base-content/55">{@run.started_at} · {@run.duration}</p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :run, :map, required: true
+
+  def run_id_link(assigns) do
+    ~H"""
+    <.link
+      navigate={~p"/runs/#{@run.id}"}
+      class="block max-w-40 font-mono text-sm font-medium text-base-content hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-primary"
+      title={@run.id}
+      data-testid="run-id-link"
+    >
+      <span class="block truncate">{@run.short_id}</span>
+    </.link>
+    """
+  end
+
+  attr :run, :map, required: true
+
+  def target_cell(%{run: %{targets: [_single]}} = assigns) do
+    ~H"""
+    <p class="truncate text-sm font-medium text-base-content" title={@run.target}>{@run.target}</p>
+    """
+  end
+
+  def target_cell(assigns) do
+    ~H"""
+    <details class="dropdown dropdown-hover dropdown-bottom">
+      <summary class="list-none marker:content-none">
+        <span class="inline-flex max-w-full cursor-default items-center gap-2 align-middle">
+          <span class="truncate text-sm font-medium text-base-content" title={@run.target}>
+            {@run.target}
+          </span>
+          <span class="badge badge-xs badge-soft badge-info shrink-0">
+            +{length(@run.targets) - 1}
+          </span>
+        </span>
+      </summary>
+      <div class="dropdown-content z-20 mt-2 w-80 rounded-box border border-base-content/10 bg-base-100 p-3 shadow-xl">
+        <p class="mb-2 text-xs font-medium uppercase tracking-[0.2em] text-base-content/45">
+          Targets
+        </p>
+        <ul class="space-y-1 text-xs text-base-content/75">
+          <li :for={target <- @run.targets} class="truncate" title={target}>{target}</li>
+        </ul>
+      </div>
+    </details>
+    """
+  end
+
+  attr :status, :atom, required: true
+
+  def status_badge(assigns) do
+    ~H"""
+    <span class={["badge badge-sm badge-soft gap-2", status_badge_class(@status)]}>
+      <span class={["status", status_dot_class(@status)]}></span>
+      {status_label(@status)}
+    </span>
+    """
+  end
+
+  attr :progress, :map, required: true
+
+  def progress_label(assigns) do
+    ~H"""
+    <span class="whitespace-nowrap text-sm text-base-content/70" title={@progress.title}>
+      {@progress.label}
+    </span>
+    """
+  end
+
+  def loading_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto flex min-h-64 max-w-2xl items-center justify-center p-10">
+      <div class="text-center">
+        <span class="loading loading-ring loading-lg text-primary"></span>
+        <p class="mt-4 text-base-content/60">Loading runs</p>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def empty_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto max-w-2xl p-10 text-center" data-testid="runs-empty-state">
+      <h2 class="text-xl font-medium">No runs yet</h2>
+      <p class="mt-2 text-base-content/60">Submit an asset or pipeline to see run activity here.</p>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def error_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto max-w-2xl p-10 text-center" data-testid="runs-error-state">
+      <h2 class="text-xl font-medium">Could not load runs</h2>
+      <p class="mt-2 text-base-content/60">Retry</p>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def runs_modes do
+    [
+      %{id: :list, label: "List", icon: "hero-list-bullet"},
+      %{id: :filters, label: "Filters", icon: "hero-funnel", disabled: true},
+      %{id: :more, label: "More", icon: "hero-ellipsis-vertical", disabled: true}
+    ]
+  end
+
+  def sample_runs do
+    [
+      %{
+        id: "run_01jrun_catalogue_very_long_identifier_for_table_overflow_testing",
+        short_id: "run_01jr...esting",
+        target: "FavnView.Assets.customer_orders_daily",
+        targets: ["FavnView.Assets.customer_orders_daily"],
+        raw_status: :running,
+        trigger: "Asset",
+        window: "window:day:2026-06-12",
+        progress: %{label: "2/4 assets", title: "2 of 4 assets have reported results"},
+        started_at: "Jun 12 08:14",
+        duration: "31.2 s"
+      },
+      %{
+        id: "run_01jpipeline_multi_target_very_long_identifier",
+        short_id: "run_01jp...ifier",
+        target: "FavnView.Assets.raw_orders",
+        targets: [
+          "FavnView.Assets.raw_orders",
+          "FavnView.Assets.stg_orders",
+          "FavnView.Assets.customer_orders_daily"
+        ],
+        raw_status: :ok,
+        trigger: "Pipeline",
+        window: "Latest complete day",
+        progress: %{label: "3/3 assets", title: "3 of 3 assets have reported results"},
+        started_at: "Jun 12 07:45",
+        duration: "1.8 min"
+      },
+      %{
+        id: "run_01jfailed_backfill_target",
+        short_id: "run_01jf...arget",
+        target: "FavnView.Assets.revenue_by_region",
+        targets: ["FavnView.Assets.revenue_by_region"],
+        raw_status: :error,
+        trigger: "Backfill asset",
+        window: "2026-06-01..2026-06-12",
+        progress: %{label: "1/1 asset", title: "1 of 1 assets have reported results"},
+        started_at: "Jun 12 06:03",
+        duration: "9.4 s"
+      }
+    ]
+  end
+
+  def nav_items(active \\ :runs), do: AssetCataloguePage.nav_items(active)
+
+  defp status_badge_class(:ok), do: "badge-success"
+  defp status_badge_class(:running), do: "badge-info"
+  defp status_badge_class(:pending), do: "badge-info"
+  defp status_badge_class(:retrying), do: "badge-info"
+  defp status_badge_class(:partial), do: "badge-warning"
+  defp status_badge_class(:error), do: "badge-error"
+  defp status_badge_class(:blocked), do: "badge-error"
+  defp status_badge_class(:timed_out), do: "badge-error"
+  defp status_badge_class(:cancelled), do: "badge-neutral"
+  defp status_badge_class(:skipped_fresh), do: "badge-neutral"
+  defp status_badge_class(_status), do: "badge-neutral"
+
+  defp status_dot_class(:ok), do: "status-success"
+  defp status_dot_class(:running), do: "status-info"
+  defp status_dot_class(:pending), do: "status-info"
+  defp status_dot_class(:retrying), do: "status-info"
+  defp status_dot_class(:partial), do: "status-warning"
+  defp status_dot_class(:error), do: "status-error"
+  defp status_dot_class(:blocked), do: "status-error"
+  defp status_dot_class(:timed_out), do: "status-error"
+  defp status_dot_class(_status), do: "status-neutral"
+
+  defp status_label(:ok), do: "Succeeded"
+  defp status_label(:running), do: "Running"
+  defp status_label(:retrying), do: "Retrying"
+  defp status_label(:pending), do: "Pending"
+  defp status_label(:partial), do: "Partial"
+  defp status_label(:error), do: "Failed"
+  defp status_label(:blocked), do: "Blocked"
+  defp status_label(:cancelled), do: "Cancelled"
+  defp status_label(:skipped_fresh), do: "Skipped fresh"
+  defp status_label(:timed_out), do: "Timed out"
+  defp status_label(_status), do: "Unknown"
+end

--- a/apps/favn_view/lib/favn_view/components/runs_list_page.ex
+++ b/apps/favn_view/lib/favn_view/components/runs_list_page.ex
@@ -74,6 +74,7 @@ defmodule FavnView.Components.RunsListPage do
     <tr
       class="group border-base-content/10 transition hover:bg-primary/10 focus-within:bg-primary/10"
       data-testid="run-row"
+      data-run-id={@run.id}
     >
       <td>
         <.run_id_link run={@run} />
@@ -108,6 +109,7 @@ defmodule FavnView.Components.RunsListPage do
     <div
       class="card glass favn-surface-list favn-density-list-card block rounded-box"
       data-testid="run-card"
+      data-run-id={@run.id}
     >
       <div class="flex items-start justify-between gap-3">
         <div class="min-w-0 flex-1 space-y-2">

--- a/apps/favn_view/lib/favn_view/router.ex
+++ b/apps/favn_view/lib/favn_view/router.ex
@@ -21,6 +21,7 @@ defmodule FavnView.Router do
     live "/assets", AssetCatalogueLive, :index
     live "/assets/:asset_id", AssetDetailLive, :show
     live "/logs", LogsLive, :index
+    live "/runs", RunsListLive, :index
     live "/runs/:run_id", RunDetailLive, :show
     live "/runs/:run_id/logs", RunLogsLive, :show
     live "/runs/:run_id/assets/:asset_step_id/logs", AssetRunLogsLive, :show

--- a/apps/favn_view/lib/favn_view/runs_list_live.ex
+++ b/apps/favn_view/lib/favn_view/runs_list_live.ex
@@ -170,9 +170,6 @@ defmodule FavnView.RunsListLive do
       results == [] && active_status?(Map.get(run, :status)) ->
         %{label: "Waiting", title: "Run accepted. Waiting for #{fallback_title}."}
 
-      total == 0 && active_status?(Map.get(run, :status)) ->
-        %{label: "Waiting", title: "Run accepted. Waiting for #{fallback_title}."}
-
       total == 0 ->
         %{label: "-", title: "No #{fallback_title} available"}
 

--- a/apps/favn_view/lib/favn_view/runs_list_live.ex
+++ b/apps/favn_view/lib/favn_view/runs_list_live.ex
@@ -6,6 +6,7 @@ defmodule FavnView.RunsListLive do
   alias FavnView.Components.RunsListPage
   alias FavnView.LogsViewModel
 
+  @refresh_interval_ms 1_500
   @active_statuses [:pending, :running]
   @valid_modes ~w(list)
 
@@ -21,8 +22,21 @@ defmodule FavnView.RunsListLive do
         error: error,
         nav_items: RunsListPage.nav_items(:runs)
       )
+      |> maybe_schedule_refresh()
 
     {:ok, socket}
+  end
+
+  @impl true
+  def handle_info(:refresh_runs, socket) do
+    {runs, error} = load_runs()
+
+    socket =
+      socket
+      |> assign(runs: runs, error: error)
+      |> maybe_schedule_refresh()
+
+    {:noreply, socket}
   end
 
   @impl true
@@ -54,6 +68,16 @@ defmodule FavnView.RunsListLive do
         {[], inspect(reason)}
     end
   end
+
+  defp maybe_schedule_refresh(%{assigns: %{runs: runs}} = socket) do
+    if connected?(socket) and Enum.any?(runs, &active_status?(&1.raw_status)) do
+      Process.send_after(self(), :refresh_runs, @refresh_interval_ms)
+    end
+
+    socket
+  end
+
+  defp maybe_schedule_refresh(socket), do: socket
 
   defp run_from_public(run) do
     targets = targets(run)
@@ -119,42 +143,74 @@ defmodule FavnView.RunsListLive do
   end
 
   defp progress(run, targets) do
-    results = run_results(run)
+    node_results = raw_node_results(run)
+
+    if node_results == [] do
+      asset_progress(run, targets)
+    else
+      step_progress(run, node_results)
+    end
+  end
+
+  defp asset_progress(run, targets) do
+    results = Map.get(run, :asset_results, %{}) |> result_values()
+    progress_count(run, targets, results, "asset", "target progress")
+  end
+
+  defp step_progress(run, results) do
+    progress_count(run, [], results, "step", "execution progress")
+  end
+
+  defp progress_count(run, targets, results, unit, fallback_title) do
     total = max(length(targets), length(results))
     done = Enum.count(results, &terminal_result?/1)
-    unit = if total == 1, do: "asset", else: "assets"
+    units = pluralize(unit, total)
 
     cond do
-      total == 0 ->
-        %{label: "-", title: "No target progress available"}
-
       results == [] && active_status?(Map.get(run, :status)) ->
-        %{label: "Waiting", title: "Run accepted. Waiting for asset execution results."}
+        %{label: "Waiting", title: "Run accepted. Waiting for #{fallback_title}."}
+
+      total == 0 && active_status?(Map.get(run, :status)) ->
+        %{label: "Waiting", title: "Run accepted. Waiting for #{fallback_title}."}
+
+      total == 0 ->
+        %{label: "-", title: "No #{fallback_title} available"}
 
       true ->
         %{
-          label: "#{done}/#{total} #{unit}",
-          title: "#{done} of #{total} #{unit} have reported terminal results"
+          label: "#{done}/#{total} #{units}",
+          title: "#{done} of #{total} #{units} have reported terminal results"
         }
     end
   end
 
-  defp run_results(run) do
-    node_results = Map.get(run, :node_results, %{}) |> result_values()
-
-    if node_results == [] do
-      Map.get(run, :asset_results, %{}) |> result_values()
-    else
-      node_results
-    end
-  end
+  defp pluralize(unit, 1), do: unit
+  defp pluralize(unit, _total), do: unit <> "s"
 
   defp result_values(results) when is_map(results), do: Map.values(results)
   defp result_values(results) when is_list(results), do: results
   defp result_values(_results), do: []
 
+  defp raw_node_results(run) do
+    run
+    |> Map.get(:result, %{})
+    |> case do
+      %{node_results: results} -> result_values(results)
+      %{"node_results" => results} -> result_values(results)
+      _other -> []
+    end
+  end
+
   defp terminal_result?(result) do
-    Map.get(result, :status) in [:ok, :partial, :error, :cancelled, :timed_out, :skipped_fresh]
+    Map.get(result, :status) in [
+      :ok,
+      :partial,
+      :error,
+      :blocked,
+      :cancelled,
+      :timed_out,
+      :skipped_fresh
+    ]
   end
 
   defp active_status?(status), do: status in @active_statuses

--- a/apps/favn_view/lib/favn_view/runs_list_live.ex
+++ b/apps/favn_view/lib/favn_view/runs_list_live.ex
@@ -1,0 +1,185 @@
+defmodule FavnView.RunsListLive do
+  @moduledoc false
+
+  use FavnView, :live_view
+
+  alias FavnView.Components.RunsListPage
+  alias FavnView.LogsViewModel
+
+  @active_statuses [:pending, :running]
+  @valid_modes ~w(list)
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {runs, error} = load_runs()
+
+    socket =
+      assign(socket,
+        runs: runs,
+        active_mode: :list,
+        loading: false,
+        error: error,
+        nav_items: RunsListPage.nav_items(:runs)
+      )
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("set_mode", %{"mode" => mode}, socket) when mode in @valid_modes do
+    {:noreply, assign(socket, :active_mode, String.to_existing_atom(mode))}
+  end
+
+  def handle_event("set_mode", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <RunsListPage.runs_list_page
+      runs={@runs}
+      active_mode={@active_mode}
+      loading={@loading}
+      error={@error}
+      nav_items={@nav_items}
+    />
+    """
+  end
+
+  defp load_runs do
+    case FavnOrchestrator.list_runs(limit: 100) do
+      {:ok, runs} ->
+        {Enum.map(runs, &run_from_public/1), nil}
+
+      {:error, reason} ->
+        {[], inspect(reason)}
+    end
+  end
+
+  defp run_from_public(run) do
+    targets = targets(run)
+    progress = progress(run, targets)
+
+    %{
+      id: run.id,
+      short_id: short_id(run.id),
+      target: List.first(targets) || "No target",
+      targets: targets,
+      raw_status: Map.get(run, :status),
+      trigger: trigger_label(Map.get(run, :trigger, %{}), Map.get(run, :submit_kind)),
+      window: window_label(Map.get(run, :params, %{}), Map.get(run, :metadata, %{})) || "-",
+      progress: progress,
+      started_at: short_timestamp(Map.get(run, :started_at)),
+      duration:
+        duration_label(
+          Map.get(run, :started_at),
+          Map.get(run, :finished_at),
+          Map.get(run, :status)
+        )
+    }
+  end
+
+  defp targets(run) do
+    refs =
+      case Map.get(run, :target_refs, []) do
+        [] -> List.wrap(Map.get(run, :asset_ref))
+        refs -> refs
+      end
+
+    refs
+    |> Enum.map(&LogsViewModel.ref_label/1)
+    |> Enum.reject(&(&1 in [nil, "", "nil"]))
+    |> case do
+      [] -> ["No target"]
+      targets -> targets
+    end
+  end
+
+  defp trigger_label(%{kind: kind}, _submit_kind), do: humanize(kind)
+  defp trigger_label(%{"kind" => kind}, _submit_kind), do: humanize(kind)
+  defp trigger_label(_trigger, nil), do: "Unknown"
+  defp trigger_label(_trigger, submit_kind), do: humanize(submit_kind)
+
+  defp window_label(params, metadata) do
+    window =
+      Map.get(params, :window) || Map.get(params, "window") || Map.get(metadata, :selected_window) ||
+        Map.get(metadata, "selected_window") || Map.get(metadata, :window) ||
+        Map.get(metadata, "window")
+
+    cond do
+      is_binary(window) ->
+        window
+
+      is_map(window) ->
+        Map.get(window, :label) || Map.get(window, "label") || Map.get(window, :id) ||
+          Map.get(window, "id") || Map.get(window, :key) || Map.get(window, "key")
+
+      true ->
+        nil
+    end
+  end
+
+  defp progress(run, targets) do
+    results = run_results(run)
+    total = max(length(targets), length(results))
+    done = Enum.count(results, &terminal_result?/1)
+    unit = if total == 1, do: "asset", else: "assets"
+
+    cond do
+      total == 0 ->
+        %{label: "-", title: "No target progress available"}
+
+      results == [] && active_status?(Map.get(run, :status)) ->
+        %{label: "Waiting", title: "Run accepted. Waiting for asset execution results."}
+
+      true ->
+        %{
+          label: "#{done}/#{total} #{unit}",
+          title: "#{done} of #{total} #{unit} have reported terminal results"
+        }
+    end
+  end
+
+  defp run_results(run) do
+    node_results = Map.get(run, :node_results, %{}) |> result_values()
+
+    if node_results == [] do
+      Map.get(run, :asset_results, %{}) |> result_values()
+    else
+      node_results
+    end
+  end
+
+  defp result_values(results) when is_map(results), do: Map.values(results)
+  defp result_values(results) when is_list(results), do: results
+  defp result_values(_results), do: []
+
+  defp terminal_result?(result) do
+    Map.get(result, :status) in [:ok, :partial, :error, :cancelled, :timed_out, :skipped_fresh]
+  end
+
+  defp active_status?(status), do: status in @active_statuses
+
+  defp short_id(id) when is_binary(id) and byte_size(id) > 18 do
+    binary_part(id, 0, 9) <> "..." <> binary_part(id, byte_size(id) - 6, 6)
+  end
+
+  defp short_id(id) when is_binary(id), do: id
+  defp short_id(_id), do: "unknown"
+
+  defp short_timestamp(%DateTime{} = value), do: Calendar.strftime(value, "%b %-d %H:%M")
+  defp short_timestamp(_value), do: "-"
+
+  defp duration_label(started_at, nil, status) when status in @active_statuses do
+    LogsViewModel.duration_label(started_at, nil)
+  end
+
+  defp duration_label(started_at, finished_at, _status),
+    do: LogsViewModel.duration_label(started_at, finished_at)
+
+  defp humanize(value) do
+    value
+    |> to_string()
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+end

--- a/apps/favn_view/storybook/components/runs_list_page.story.exs
+++ b/apps/favn_view/storybook/components/runs_list_page.story.exs
@@ -1,0 +1,64 @@
+defmodule FavnView.Storybook.Components.RunsListPage do
+  alias FavnView.Components.RunsListPage
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &RunsListPage.runs_list_page/1
+  def layout, do: :one_column
+  def render_source, do: :function
+
+  def container, do: {:iframe, style: "width: 100%; height: 980px; border: 0;"}
+
+  def template do
+    """
+    <div data-theme="favn-dark">
+      <.psb-variation/>
+    </div>
+    """
+  end
+
+  def variations do
+    [
+      %Variation{
+        id: :runs,
+        attributes: %{
+          runs: RunsListPage.sample_runs(),
+          active_mode: :list,
+          loading: false,
+          error: nil,
+          nav_items: RunsListPage.nav_items()
+        }
+      },
+      %Variation{
+        id: :empty,
+        attributes: %{
+          runs: [],
+          active_mode: :list,
+          loading: false,
+          error: nil,
+          nav_items: RunsListPage.nav_items()
+        }
+      },
+      %Variation{
+        id: :loading,
+        attributes: %{
+          runs: [],
+          active_mode: :list,
+          loading: true,
+          error: nil,
+          nav_items: RunsListPage.nav_items()
+        }
+      },
+      %Variation{
+        id: :error,
+        attributes: %{
+          runs: [],
+          active_mode: :list,
+          loading: false,
+          error: "load_failed",
+          nav_items: RunsListPage.nav_items()
+        }
+      }
+    ]
+  end
+end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -61,6 +61,21 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([aria-label="Catalogue filter"]))
   end
 
+  test "renders the runs list", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/runs")
+
+    assert html =~ "Runs"
+    assert html =~ "Recent orchestration activity"
+    assert has_element?(view, ~s([data-testid="runs-table"]))
+    assert has_element?(view, ~s([data-testid="run-card-list"]))
+
+    assert has_element?(view, ~s(a[href="/runs/run_customer_orders_daily"]), "run_custo..._daily")
+    assert html =~ "customer_orders_daily"
+    assert html =~ "Succeeded"
+    assert html =~ "1/1 asset"
+    assert html =~ "+2"
+  end
+
   test "filters assets by search, connection, and catalogue", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/assets")
 

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -73,7 +73,50 @@ defmodule FavnView.PageLiveTest do
     assert html =~ "customer_orders_daily"
     assert html =~ "Succeeded"
     assert html =~ "1/1 asset"
+    assert html =~ "2/3 steps"
     assert html =~ "+2"
+  end
+
+  test "runs list refreshes active runs", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs")
+
+    assert has_element?(
+             view,
+             ~s([data-testid="run-row"][data-run-id="run_empty_running"]),
+             "Waiting"
+           )
+
+    {:ok, active_run} = Storage.get_run("run_empty_running")
+
+    terminal_run =
+      RunState.transition(active_run,
+        status: :ok,
+        result: %{asset_results: terminal_asset_results(:stg_payments)}
+      )
+
+    assert :ok =
+             Storage.persist_run_transition(terminal_run, %{
+               run_id: terminal_run.id,
+               sequence: 3,
+               event_type: :run_finished,
+               occurred_at: DateTime.utc_now(),
+               status: :ok,
+               data: %{message: "Run finished"}
+             })
+
+    send(view.pid, :refresh_runs)
+
+    assert has_element?(
+             view,
+             ~s([data-testid="run-row"][data-run-id="run_empty_running"]),
+             "Succeeded"
+           )
+
+    refute has_element?(
+             view,
+             ~s([data-testid="run-row"][data-run-id="run_empty_running"]),
+             "Waiting"
+           )
   end
 
   test "filters assets by search, connection, and catalogue", %{conn: conn} do


### PR DESCRIPTION
## Summary
- Add a `/runs` LiveView that lists recent orchestrator runs using the public `FavnOrchestrator.list_runs/1` facade.
- Render compact desktop/mobile run lists with shortened run IDs, multi-target hover disclosure, status, trigger, window, progress, started time, and duration.
- Add Storybook variations and LiveView coverage for the runs list.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `mix test`