### PR TITLE
Add asset run window configuration

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -7,6 +7,7 @@ defmodule FavnOrchestrator do
   most application code should build against.
   """
 
+  alias Favn.Assets.Planner
   alias Favn.Contracts.RelationInspectionRequest
   alias Favn.Contracts.RunnerClient
   alias Favn.Manifest.Index
@@ -20,6 +21,7 @@ defmodule FavnOrchestrator do
   alias FavnOrchestrator.BackfillManager
   alias FavnOrchestrator.Diagnostics
   alias FavnOrchestrator.Events
+  alias FavnOrchestrator.Freshness.Decider, as: FreshnessDecider
   alias FavnOrchestrator.Freshness.Query, as: FreshnessQuery
   alias FavnOrchestrator.LogWriter
   alias FavnOrchestrator.Logs
@@ -1027,7 +1029,7 @@ defmodule FavnOrchestrator do
         |> Map.put(:latest_run_id, latest_run_id(latest_freshness, latest_run))
         |> Map.put(:latest_run_status, latest_run_status(latest_freshness, latest_run))
         |> Map.put(:latest_run_at, latest_run_at(latest_freshness, latest_run))
-        |> Map.put(:freshness, asset_freshness_detail(asset, latest_freshness))
+        |> Map.put(:freshness, asset_freshness_detail(asset, version, freshness_states, opts))
         |> Map.put(
           :timeline,
           asset_detail_timeline(asset, latest_freshness, latest_run, freshness_states, opts)
@@ -1035,8 +1037,9 @@ defmodule FavnOrchestrator do
     end
   end
 
-  defp asset_freshness_detail(asset, latest_freshness) do
+  defp asset_freshness_detail(asset, version, freshness_states, opts) do
     policy = asset_freshness_policy(asset)
+    now = Keyword.get(opts, :now, DateTime.utc_now())
 
     cond do
       policy.kind == :always ->
@@ -1061,62 +1064,33 @@ defmodule FavnOrchestrator do
           ]
         )
 
-      is_nil(latest_freshness) or is_nil(latest_freshness.latest_success_run_id) ->
-        freshness_detail(
-          :unknown,
-          policy,
-          latest_success_detail(latest_freshness),
-          "No successful freshness evidence exists for this asset yet.",
-          [
-            %{
-              kind: :never_run,
-              message: "No successful freshness-producing run has been recorded."
-            }
-          ]
-        )
-
       true ->
-        explain_asset_freshness(asset, latest_freshness, policy)
+        classify_asset_freshness(asset, version, freshness_states, policy, now)
     end
   end
 
-  defp explain_asset_freshness(asset, latest_freshness, policy) do
-    upstream_node_keys = Enum.map(asset.depends_on, &{&1, nil})
+  defp classify_asset_freshness(asset, version, freshness_states, policy, now) do
+    with {:ok, plan} <- asset_freshness_plan(asset, version, now),
+         {:ok, target_node_key} <- asset_freshness_target_node_key(plan, asset.ref) do
+      states = freshness_state_lookup(freshness_states)
+      assets_by_ref = Map.new(version.manifest.assets, &{&1.ref, &1})
 
-    case explain_asset_staleness(asset.ref,
-           freshness_key: Favn.Freshness.Key.latest(),
-           upstream_node_keys: upstream_node_keys
-         ) do
-      {:ok, %{status: :fresh}} ->
-        freshness_detail(
-          :fresh,
-          policy,
-          latest_success_detail(latest_freshness),
-          "Backend freshness state currently satisfies this asset's policy.",
-          [
-            %{
-              kind: :policy_fresh,
-              message: "Backend freshness state satisfies the declared policy."
-            }
-          ]
+      decision =
+        FreshnessDecider.decide(plan, target_node_key,
+          assets_by_ref: assets_by_ref,
+          prior_states: states,
+          current_states: states,
+          now: now
         )
 
-      {:ok, %{status: :stale, stale_reasons: reasons}} ->
-        reasons = Enum.map(reasons, &asset_freshness_reason/1)
-
-        freshness_detail(
-          :stale,
-          policy,
-          latest_success_detail(latest_freshness),
-          stale_explanation(asset, reasons),
-          reasons
-        )
-
+      state = Map.get(states, {asset.ref, Map.fetch!(decision, :freshness_key)})
+      freshness_detail_from_decision(asset, policy, state, decision)
+    else
       {:error, _reason} ->
         freshness_detail(
           :unknown,
           policy,
-          latest_success_detail(latest_freshness),
+          nil,
           "Freshness state exists, but backend could not explain whether it is stale.",
           [
             %{
@@ -1126,6 +1100,126 @@ defmodule FavnOrchestrator do
           ]
         )
     end
+  end
+
+  defp freshness_detail_from_decision(_asset, policy, state, %{decision: :skipped_fresh}) do
+    freshness_detail(
+      :fresh,
+      policy,
+      latest_success_detail(state),
+      "Backend freshness state currently satisfies this asset's policy.",
+      [
+        %{
+          kind: :policy_fresh,
+          message: "Backend freshness state satisfies the declared policy."
+        }
+      ]
+    )
+  end
+
+  defp freshness_detail_from_decision(asset, policy, state, %{
+         decision: :run,
+         reason: :upstream_version_changed,
+         stale_reasons: stale_reasons
+       }) do
+    reasons = Enum.map(stale_reasons, &asset_freshness_reason/1)
+
+    freshness_detail(
+      :stale,
+      policy,
+      latest_success_detail(state),
+      stale_explanation(asset, reasons),
+      reasons
+    )
+  end
+
+  defp freshness_detail_from_decision(_asset, policy, nil, %{decision: :run}) do
+    freshness_detail(
+      :unknown,
+      policy,
+      nil,
+      "No successful freshness evidence exists for this asset yet.",
+      [
+        %{
+          kind: :never_run,
+          message: "No successful freshness-producing run has been recorded."
+        }
+      ]
+    )
+  end
+
+  defp freshness_detail_from_decision(_asset, policy, state, %{
+         decision: :run,
+         reason: :freshness_expired
+       }) do
+    freshness_detail(
+      :stale,
+      policy,
+      latest_success_detail(state),
+      "Stored freshness evidence no longer satisfies this asset's policy.",
+      [
+        %{
+          kind: :freshness_expired,
+          message: "Stored freshness evidence no longer satisfies the declared policy."
+        }
+      ]
+    )
+  end
+
+  defp freshness_detail_from_decision(_asset, policy, state, %{decision: :run, reason: reason}) do
+    freshness_detail(
+      :stale,
+      policy,
+      latest_success_detail(state),
+      "Backend freshness policy requires this asset to run.",
+      [
+        %{
+          kind: reason,
+          message: "Backend freshness policy requires this asset to run."
+        }
+      ]
+    )
+  end
+
+  defp asset_freshness_plan(asset, version, now) do
+    with {:ok, index} <- Index.build_from_version(version) do
+      opts = [dependencies: :all, graph_index: index.graph_index]
+
+      opts =
+        case asset_current_anchor_window(asset, now) do
+          {:ok, anchor_window} -> Keyword.put(opts, :anchor_window, anchor_window)
+          :error -> opts
+        end
+
+      Planner.plan(asset.ref, opts)
+    end
+  end
+
+  defp asset_current_anchor_window(%{window: %WindowSpec{} = spec}, now) do
+    with {:ok, period} <- Favn.TimePeriod.current(spec.kind, now, spec.timezone) do
+      {:ok, Anchor.new!(period.kind, period.start_at, period.end_at, timezone: period.timezone)}
+    end
+  end
+
+  defp asset_current_anchor_window(_asset, _now), do: :error
+
+  defp asset_freshness_target_node_key(plan, asset_ref) do
+    Enum.find(plan.target_node_keys, fn {ref, _window_key} -> ref == asset_ref end)
+    |> case do
+      nil -> {:error, :target_node_key_not_found}
+      node_key -> {:ok, node_key}
+    end
+  end
+
+  defp freshness_state_lookup(freshness_states) do
+    Enum.reduce(freshness_states, %{}, fn %AssetFreshnessState{} = state, acc ->
+      ref = {state.asset_ref_module, state.asset_ref_name}
+
+      acc
+      |> Map.put(state.latest_success_node_key, state)
+      |> Map.put({ref, state.freshness_key}, state)
+      |> Map.put(ref_to_string(ref) <> ":" <> state.freshness_key, state)
+    end)
   end
 
   defp freshness_detail(state, policy, latest_success, explanation, reasons) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -1117,6 +1117,22 @@ defmodule FavnOrchestrator do
     )
   end
 
+  defp freshness_detail_from_decision(_asset, policy, state, %{decision: :run})
+       when is_nil(state) or is_nil(state.latest_success_run_id) do
+    freshness_detail(
+      :unknown,
+      policy,
+      nil,
+      "No successful freshness evidence exists for this asset yet.",
+      [
+        %{
+          kind: :never_run,
+          message: "No successful freshness-producing run has been recorded."
+        }
+      ]
+    )
+  end
+
   defp freshness_detail_from_decision(asset, policy, state, %{
          decision: :run,
          reason: :upstream_version_changed,
@@ -1130,21 +1146,6 @@ defmodule FavnOrchestrator do
       latest_success_detail(state),
       stale_explanation(asset, reasons),
       reasons
-    )
-  end
-
-  defp freshness_detail_from_decision(_asset, policy, nil, %{decision: :run}) do
-    freshness_detail(
-      :unknown,
-      policy,
-      nil,
-      "No successful freshness evidence exists for this asset yet.",
-      [
-        %{
-          kind: :never_run,
-          message: "No successful freshness-producing run has been recorded."
-        }
-      ]
     )
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -94,6 +94,7 @@ defmodule FavnOrchestrator do
           required(:label) => String.t(),
           required(:name) => String.t(),
           required(:asset_ref) => String.t() | nil,
+          required(:canonical_asset_ref) => Favn.Ref.t(),
           required(:relation) => map() | nil,
           required(:type) => String.t() | nil,
           required(:status) => :healthy | :running | :failed | :unknown,
@@ -101,7 +102,25 @@ defmodule FavnOrchestrator do
           required(:latest_run_status) => atom() | nil,
           required(:latest_run_at) => DateTime.t() | nil,
           required(:window) => map() | nil,
+          required(:freshness) => asset_freshness_detail(),
           required(:timeline) => [asset_timeline_window()]
+        }
+
+  @type asset_freshness_reason :: %{
+          required(:kind) => atom(),
+          required(:message) => String.t(),
+          optional(:upstream_ref) => String.t() | nil,
+          optional(:previous_version) => String.t() | nil,
+          optional(:current_version) => String.t() | nil,
+          optional(:run_id) => String.t() | nil
+        }
+
+  @type asset_freshness_detail :: %{
+          required(:state) => :fresh | :stale | :unknown | :always_run,
+          required(:policy) => %{required(:kind) => atom(), required(:label) => String.t()},
+          required(:latest_success) => map() | nil,
+          required(:explanation) => String.t(),
+          required(:reasons) => [asset_freshness_reason()]
         }
 
   @doc """
@@ -1002,17 +1021,209 @@ defmodule FavnOrchestrator do
         target
         |> Map.take([:target_id, :label, :asset_ref, :relation, :type, :window])
         |> Map.put(:manifest_version_id, version.manifest_version_id)
+        |> Map.put(:canonical_asset_ref, asset.ref)
         |> Map.put(:name, asset_detail_name(target))
         |> Map.put(:status, catalogue_status(latest_freshness, latest_run))
         |> Map.put(:latest_run_id, latest_run_id(latest_freshness, latest_run))
         |> Map.put(:latest_run_status, latest_run_status(latest_freshness, latest_run))
         |> Map.put(:latest_run_at, latest_run_at(latest_freshness, latest_run))
+        |> Map.put(:freshness, asset_freshness_detail(asset, latest_freshness))
         |> Map.put(
           :timeline,
           asset_detail_timeline(asset, latest_freshness, latest_run, freshness_states, opts)
         )
     end
   end
+
+  defp asset_freshness_detail(asset, latest_freshness) do
+    policy = asset_freshness_policy(asset)
+
+    cond do
+      policy.kind == :always ->
+        freshness_detail(
+          :always_run,
+          policy,
+          nil,
+          "Freshness is intentionally bypassed; this asset runs whenever it is planned.",
+          [
+            %{kind: :always_run, message: "Manifest policy is always run."}
+          ]
+        )
+
+      policy.kind == :none ->
+        freshness_detail(
+          :unknown,
+          policy,
+          nil,
+          "No freshness policy is declared for this asset.",
+          [
+            %{kind: :no_freshness_policy, message: "No freshness policy is declared."}
+          ]
+        )
+
+      is_nil(latest_freshness) or is_nil(latest_freshness.latest_success_run_id) ->
+        freshness_detail(
+          :unknown,
+          policy,
+          latest_success_detail(latest_freshness),
+          "No successful freshness evidence exists for this asset yet.",
+          [
+            %{
+              kind: :never_run,
+              message: "No successful freshness-producing run has been recorded."
+            }
+          ]
+        )
+
+      true ->
+        explain_asset_freshness(asset, latest_freshness, policy)
+    end
+  end
+
+  defp explain_asset_freshness(asset, latest_freshness, policy) do
+    upstream_node_keys = Enum.map(asset.depends_on, &{&1, nil})
+
+    case explain_asset_staleness(asset.ref,
+           freshness_key: Favn.Freshness.Key.latest(),
+           upstream_node_keys: upstream_node_keys
+         ) do
+      {:ok, %{status: :fresh}} ->
+        freshness_detail(
+          :fresh,
+          policy,
+          latest_success_detail(latest_freshness),
+          "Backend freshness state currently satisfies this asset's policy.",
+          [
+            %{
+              kind: :policy_fresh,
+              message: "Backend freshness state satisfies the declared policy."
+            }
+          ]
+        )
+
+      {:ok, %{status: :stale, stale_reasons: reasons}} ->
+        reasons = Enum.map(reasons, &asset_freshness_reason/1)
+
+        freshness_detail(
+          :stale,
+          policy,
+          latest_success_detail(latest_freshness),
+          stale_explanation(asset, reasons),
+          reasons
+        )
+
+      {:error, _reason} ->
+        freshness_detail(
+          :unknown,
+          policy,
+          latest_success_detail(latest_freshness),
+          "Freshness state exists, but backend could not explain whether it is stale.",
+          [
+            %{
+              kind: :insufficient_state,
+              message: "Backend could not build a staleness explanation from available state."
+            }
+          ]
+        )
+    end
+  end
+
+  defp freshness_detail(state, policy, latest_success, explanation, reasons) do
+    %{
+      state: state,
+      policy: policy,
+      latest_success: latest_success,
+      explanation: explanation,
+      reasons: reasons
+    }
+  end
+
+  defp latest_success_detail(nil), do: nil
+
+  defp latest_success_detail(%AssetFreshnessState{latest_success_run_id: nil}), do: nil
+
+  defp latest_success_detail(%AssetFreshnessState{} = state) do
+    %{
+      run_id: state.latest_success_run_id,
+      at: state.latest_success_at,
+      freshness_key: state.freshness_key
+    }
+  end
+
+  defp asset_freshness_policy(%{freshness: nil}), do: %{kind: :none, label: "no freshness policy"}
+
+  defp asset_freshness_policy(%{
+         freshness: %Favn.Freshness.Policy{mode: :calendar_period, kind: :day, timezone: timezone}
+       }),
+       do: %{kind: :daily, label: "daily #{timezone || "Etc/UTC"}"}
+
+  defp asset_freshness_policy(%{
+         freshness: %Favn.Freshness.Policy{mode: :max_age, amount: amount, unit: unit}
+       }),
+       do: %{kind: :max_age, label: "max age #{amount} #{pluralize(unit, amount)}"}
+
+  defp asset_freshness_policy(%{freshness: %Favn.Freshness.Policy{mode: :window_success}}),
+    do: %{kind: :window_success, label: "window success"}
+
+  defp asset_freshness_policy(%{freshness: %Favn.Freshness.Policy{mode: :always}}),
+    do: %{kind: :always, label: "always run"}
+
+  defp asset_freshness_policy(_asset), do: %{kind: :none, label: "no freshness policy"}
+
+  defp asset_freshness_reason(%{type: :upstream_version_changed} = reason) do
+    upstream_ref = Map.get(reason, :upstream_ref)
+    label = ref_display_name(upstream_ref)
+
+    %{
+      kind: :upstream_version_changed,
+      message: "#{label} refreshed after this asset last consumed it.",
+      upstream_ref: ref_to_string(upstream_ref),
+      previous_version: Map.get(reason, :consumed_version),
+      current_version: Map.get(reason, :current_version),
+      run_id: Map.get(reason, :current_success_run_id)
+    }
+  end
+
+  defp asset_freshness_reason(%{type: :missing_upstream_version} = reason) do
+    upstream_ref = Map.get(reason, :upstream_ref)
+    label = ref_display_name(upstream_ref)
+
+    %{
+      kind: :upstream_missing,
+      message: "#{label} has no current upstream freshness version available.",
+      upstream_ref: ref_to_string(upstream_ref),
+      previous_version: Map.get(reason, :consumed_version),
+      current_version: nil,
+      run_id: nil
+    }
+  end
+
+  defp asset_freshness_reason(reason) do
+    %{
+      kind: :unknown,
+      message: "Backend returned an unrecognized stale reason: #{inspect(reason, limit: 5)}."
+    }
+  end
+
+  defp stale_explanation(asset, []),
+    do: "#{ref_display_name(asset.ref)} is stale according to backend freshness state."
+
+  defp stale_explanation(asset, [reason | _reasons]) do
+    "#{ref_display_name(asset.ref)} is stale because #{String.downcase(reason.message)}"
+  end
+
+  defp ref_display_name({module, name}) when is_atom(module) and is_atom(name) do
+    module
+    |> inspect()
+    |> String.split(".")
+    |> List.last()
+    |> Kernel.<>(".#{name}")
+  end
+
+  defp ref_display_name(ref), do: ref_to_string(ref)
+
+  defp pluralize(unit, 1), do: Atom.to_string(unit)
+  defp pluralize(unit, _amount), do: Atom.to_string(unit) <> "s"
 
   defp latest_run_for_ref(runs, ref_string) do
     runs

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -315,6 +315,11 @@ defmodule FavnOrchestrator.ManifestStoreTest do
           [{MyApp.WindowRaw, :asset}],
           WindowSpec.new!(:day)
         ),
+        freshness_asset(
+          {MyApp.NeverRunDownstream, :asset},
+          Favn.Freshness.Policy.from_value!(max_age: {:hours, 24}),
+          [{MyApp.RawOrders, :asset}]
+        ),
         freshness_asset({MyApp.AlwaysRun, :asset}, Favn.Freshness.Policy.from_value!(:always)),
         freshness_asset({MyApp.NoPolicy, :asset}, nil)
       ]
@@ -466,6 +471,14 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert window_reason.upstream_ref == "Elixir.MyApp.WindowRaw:asset"
     assert window_reason.previous_version == "window_raw:v1"
     assert window_reason.current_version == "window_raw:v2"
+
+    assert {:ok, never_run_downstream_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.NeverRunDownstream:asset",
+               now: now
+             )
+
+    assert never_run_downstream_detail.freshness.state == :unknown
+    assert [%{kind: :never_run}] = never_run_downstream_detail.freshness.reasons
 
     assert {:ok, never_run_detail} =
              FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.NeverRun:asset")

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -289,6 +289,32 @@ defmodule FavnOrchestrator.ManifestStoreTest do
           {MyApp.NeverRun, :asset},
           Favn.Freshness.Policy.from_value!(window_success: true)
         ),
+        freshness_asset(
+          {MyApp.WindowedOrders, :asset},
+          Favn.Freshness.Policy.from_value!(window_success: true),
+          [],
+          WindowSpec.new!(:day)
+        ),
+        freshness_asset(
+          {MyApp.FreshMaxAge, :asset},
+          Favn.Freshness.Policy.from_value!(max_age: {:hours, 24})
+        ),
+        freshness_asset(
+          {MyApp.ExpiredMaxAge, :asset},
+          Favn.Freshness.Policy.from_value!(max_age: {:hours, 24})
+        ),
+        freshness_asset(
+          {MyApp.WindowRaw, :asset},
+          Favn.Freshness.Policy.from_value!(window_success: true),
+          [],
+          WindowSpec.new!(:day)
+        ),
+        freshness_asset(
+          {MyApp.WindowGold, :asset},
+          Favn.Freshness.Policy.from_value!(window_success: true),
+          [{MyApp.WindowRaw, :asset}],
+          WindowSpec.new!(:day)
+        ),
         freshness_asset({MyApp.AlwaysRun, :asset}, Favn.Freshness.Policy.from_value!(:always)),
         freshness_asset({MyApp.NoPolicy, :asset}, nil)
       ]
@@ -298,9 +324,15 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert :ok = ManifestStore.register_manifest(version)
     assert :ok = ManifestStore.set_active_manifest("mv_freshness_detail")
 
+    daily_key = Favn.Freshness.Key.calendar!(:day, "Europe/Oslo", ~D[2026-05-10])
+    window_key = day_window_key(now)
+
     assert :ok =
              Storage.put_asset_freshness_state(
-               freshness_state({MyApp.RawOrders, :asset}, "raw:v2", now, run_id: "run_raw_v2")
+               freshness_state({MyApp.RawOrders, :asset}, "raw:v2", now,
+                 run_id: "run_raw_v2",
+                 freshness_key: daily_key
+               )
              )
 
     assert :ok =
@@ -318,16 +350,73 @@ defmodule FavnOrchestrator.ManifestStoreTest do
                )
              )
 
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state({MyApp.WindowedOrders, :asset}, "windowed:v1", now,
+                 run_id: "run_windowed_v1",
+                 freshness_key: Favn.Freshness.Key.window!(window_key),
+                 node_key: {{MyApp.WindowedOrders, :asset}, window_key}
+               )
+             )
+
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state({MyApp.FreshMaxAge, :asset}, "fresh_age:v1", now,
+                 run_id: "run_fresh_age"
+               )
+             )
+
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state(
+                 {MyApp.ExpiredMaxAge, :asset},
+                 "expired_age:v1",
+                 DateTime.add(now, -3, :day),
+                 run_id: "run_expired_age"
+               )
+             )
+
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state({MyApp.WindowRaw, :asset}, "window_raw:v2", now,
+                 run_id: "run_window_raw_v2",
+                 freshness_key: Favn.Freshness.Key.window!(window_key),
+                 node_key: {{MyApp.WindowRaw, :asset}, window_key}
+               )
+             )
+
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state({MyApp.WindowGold, :asset}, "window_gold:v1", now,
+                 run_id: "run_window_gold_v1",
+                 freshness_key: Favn.Freshness.Key.window!(window_key),
+                 node_key: {{MyApp.WindowGold, :asset}, window_key},
+                 input_versions: [
+                   %{
+                     upstream_ref: {MyApp.WindowRaw, :asset},
+                     upstream_node_key: {{MyApp.WindowRaw, :asset}, window_key},
+                     freshness_version: "window_raw:v1",
+                     success_run_id: "run_window_raw_v1"
+                   }
+                 ]
+               )
+             )
+
     assert {:ok, raw_detail} =
-             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.RawOrders:asset")
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.RawOrders:asset",
+               now: now
+             )
 
     assert raw_detail.freshness.state == :fresh
     assert raw_detail.freshness.policy == %{kind: :daily, label: "daily Europe/Oslo"}
     assert raw_detail.freshness.latest_success.run_id == "run_raw_v2"
+    assert raw_detail.freshness.latest_success.freshness_key == daily_key
     assert [%{kind: :policy_fresh}] = raw_detail.freshness.reasons
 
     assert {:ok, gold_detail} =
-             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.GoldOrders:asset")
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.GoldOrders:asset",
+               now: now
+             )
 
     assert gold_detail.freshness.state == :stale
     assert gold_detail.freshness.policy == %{kind: :max_age, label: "max age 24 hours"}
@@ -339,6 +428,44 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert reason.previous_version == "raw:v1"
     assert reason.current_version == "raw:v2"
     assert reason.run_id == "run_raw_v2"
+
+    assert {:ok, windowed_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.WindowedOrders:asset",
+               now: now
+             )
+
+    assert windowed_detail.freshness.state == :fresh
+    assert windowed_detail.freshness.policy == %{kind: :window_success, label: "window success"}
+
+    assert windowed_detail.freshness.latest_success.freshness_key ==
+             Favn.Freshness.Key.window!(window_key)
+
+    assert {:ok, fresh_age_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.FreshMaxAge:asset",
+               now: now
+             )
+
+    assert fresh_age_detail.freshness.state == :fresh
+
+    assert {:ok, expired_age_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.ExpiredMaxAge:asset",
+               now: now
+             )
+
+    assert expired_age_detail.freshness.state == :stale
+    assert [%{kind: :freshness_expired}] = expired_age_detail.freshness.reasons
+
+    assert {:ok, window_gold_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.WindowGold:asset",
+               now: now
+             )
+
+    assert window_gold_detail.freshness.state == :stale
+    assert [window_reason] = window_gold_detail.freshness.reasons
+    assert window_reason.kind == :upstream_version_changed
+    assert window_reason.upstream_ref == "Elixir.MyApp.WindowRaw:asset"
+    assert window_reason.previous_version == "window_raw:v1"
+    assert window_reason.current_version == "window_raw:v2"
 
     assert {:ok, never_run_detail} =
              FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.NeverRun:asset")
@@ -374,13 +501,14 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     version
   end
 
-  defp freshness_asset(ref, freshness, depends_on \\ []) do
+  defp freshness_asset(ref, freshness, depends_on \\ [], window \\ nil) do
     %Favn.Manifest.Asset{
       ref: ref,
       module: elem(ref, 0),
       name: elem(ref, 1),
       freshness: freshness,
-      depends_on: depends_on
+      depends_on: depends_on,
+      window: window
     }
   end
 
@@ -392,11 +520,11 @@ defmodule FavnOrchestrator.ManifestStoreTest do
       AssetFreshnessState.new(%{
         asset_ref_module: module,
         asset_ref_name: name,
-        freshness_key: Favn.Freshness.Key.latest(),
+        freshness_key: Keyword.get(opts, :freshness_key, Favn.Freshness.Key.latest()),
         status: Keyword.get(opts, :status, :ok),
         freshness_version: version,
         latest_success_run_id: run_id,
-        latest_success_node_key: {ref, nil},
+        latest_success_node_key: Keyword.get(opts, :node_key, {ref, nil}),
         latest_success_at: at,
         latest_attempt_run_id: run_id,
         latest_attempt_status: Keyword.get(opts, :status, :ok),
@@ -407,6 +535,11 @@ defmodule FavnOrchestrator.ManifestStoreTest do
       })
 
     state
+  end
+
+  defp day_window_key(now) do
+    {:ok, period} = Favn.TimePeriod.current(:day, now, "Etc/UTC")
+    Favn.Window.Key.new!(:day, period.start_at, "Etc/UTC")
   end
 
   defp run_state(id, ref, status, finished_at, manifest_version_id) do

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -182,6 +182,7 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert latest_window.run_enabled?
     assert is_nil(latest_window.run_disabled_reason)
     assert latest_window.run_label == "Run this window"
+    assert detail.canonical_asset_ref == {MyApp.AssetA, :asset}
 
     assert failed_window = Enum.find(detail.timeline, &(&1.date == ~D[2026-05-09]))
     assert failed_window.status == :failed
@@ -268,6 +269,99 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert {:error, :manifest_version_not_found} = ManifestStore.get_manifest("mv_duplicate")
   end
 
+  test "active asset detail includes view-facing freshness explanations" do
+    now = ~U[2026-05-10 12:00:00Z]
+
+    manifest = %Manifest{
+      assets: [
+        freshness_asset(
+          {MyApp.RawOrders, :asset},
+          Favn.Freshness.Policy.from_value!({:daily, timezone: "Europe/Oslo"})
+        ),
+        freshness_asset(
+          {MyApp.GoldOrders, :asset},
+          Favn.Freshness.Policy.from_value!(max_age: {:hours, 24}),
+          [
+            {MyApp.RawOrders, :asset}
+          ]
+        ),
+        freshness_asset(
+          {MyApp.NeverRun, :asset},
+          Favn.Freshness.Policy.from_value!(window_success: true)
+        ),
+        freshness_asset({MyApp.AlwaysRun, :asset}, Favn.Freshness.Policy.from_value!(:always)),
+        freshness_asset({MyApp.NoPolicy, :asset}, nil)
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: "mv_freshness_detail")
+    assert :ok = ManifestStore.register_manifest(version)
+    assert :ok = ManifestStore.set_active_manifest("mv_freshness_detail")
+
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state({MyApp.RawOrders, :asset}, "raw:v2", now, run_id: "run_raw_v2")
+             )
+
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state({MyApp.GoldOrders, :asset}, "gold:v1", now,
+                 run_id: "run_gold_v1",
+                 input_versions: [
+                   %{
+                     upstream_ref: {MyApp.RawOrders, :asset},
+                     upstream_node_key: {{MyApp.RawOrders, :asset}, nil},
+                     freshness_version: "raw:v1",
+                     success_run_id: "run_raw_v1"
+                   }
+                 ]
+               )
+             )
+
+    assert {:ok, raw_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.RawOrders:asset")
+
+    assert raw_detail.freshness.state == :fresh
+    assert raw_detail.freshness.policy == %{kind: :daily, label: "daily Europe/Oslo"}
+    assert raw_detail.freshness.latest_success.run_id == "run_raw_v2"
+    assert [%{kind: :policy_fresh}] = raw_detail.freshness.reasons
+
+    assert {:ok, gold_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.GoldOrders:asset")
+
+    assert gold_detail.freshness.state == :stale
+    assert gold_detail.freshness.policy == %{kind: :max_age, label: "max age 24 hours"}
+    assert gold_detail.freshness.explanation =~ "GoldOrders.asset is stale"
+
+    assert [reason] = gold_detail.freshness.reasons
+    assert reason.kind == :upstream_version_changed
+    assert reason.upstream_ref == "Elixir.MyApp.RawOrders:asset"
+    assert reason.previous_version == "raw:v1"
+    assert reason.current_version == "raw:v2"
+    assert reason.run_id == "run_raw_v2"
+
+    assert {:ok, never_run_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.NeverRun:asset")
+
+    assert never_run_detail.freshness.state == :unknown
+    assert never_run_detail.freshness.policy == %{kind: :window_success, label: "window success"}
+    assert [%{kind: :never_run}] = never_run_detail.freshness.reasons
+
+    assert {:ok, always_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.AlwaysRun:asset")
+
+    assert always_detail.freshness.state == :always_run
+    assert always_detail.freshness.policy == %{kind: :always, label: "always run"}
+    assert [%{kind: :always_run}] = always_detail.freshness.reasons
+
+    assert {:ok, no_policy_detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.NoPolicy:asset")
+
+    assert no_policy_detail.freshness.state == :unknown
+    assert no_policy_detail.freshness.policy == %{kind: :none, label: "no freshness policy"}
+    assert [%{kind: :no_freshness_policy}] = no_policy_detail.freshness.reasons
+  end
+
   defp manifest_version(manifest_version_id, ref, pipelines \\ [], window \\ nil) do
     manifest = %Manifest{
       assets: [
@@ -278,6 +372,41 @@ defmodule FavnOrchestrator.ManifestStoreTest do
 
     {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
     version
+  end
+
+  defp freshness_asset(ref, freshness, depends_on \\ []) do
+    %Favn.Manifest.Asset{
+      ref: ref,
+      module: elem(ref, 0),
+      name: elem(ref, 1),
+      freshness: freshness,
+      depends_on: depends_on
+    }
+  end
+
+  defp freshness_state(ref, version, at, opts) do
+    {module, name} = ref
+    run_id = Keyword.get(opts, :run_id, "run_#{name}")
+
+    {:ok, state} =
+      AssetFreshnessState.new(%{
+        asset_ref_module: module,
+        asset_ref_name: name,
+        freshness_key: Favn.Freshness.Key.latest(),
+        status: Keyword.get(opts, :status, :ok),
+        freshness_version: version,
+        latest_success_run_id: run_id,
+        latest_success_node_key: {ref, nil},
+        latest_success_at: at,
+        latest_attempt_run_id: run_id,
+        latest_attempt_status: Keyword.get(opts, :status, :ok),
+        latest_attempt_at: at,
+        manifest_version_id: Keyword.get(opts, :manifest_version_id, "mv_freshness_detail"),
+        input_versions: Keyword.get(opts, :input_versions, []),
+        updated_at: at
+      })
+
+    state
   end
 
   defp run_state(id, ref, status, finished_at, manifest_version_id) do

--- a/apps/favn_view/lib/favn_view/asset_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_detail_live.ex
@@ -21,6 +21,8 @@ defmodule FavnView.AssetDetailLive do
         asset: asset,
         active_mode: :timeline,
         selected_window: default_selected_window(asset),
+        run_config_open?: false,
+        run_config: default_run_config(),
         submitting_window_run?: false,
         submitted_run_id: nil,
         selected_window_error: nil,
@@ -48,6 +50,8 @@ defmodule FavnView.AssetDetailLive do
       {:noreply,
        assign(socket,
          selected_window: selected_window,
+         run_config_open?: false,
+         run_config: default_run_config(),
          selected_window_error: nil,
          submitted_run_id: nil
        )}
@@ -58,7 +62,7 @@ defmodule FavnView.AssetDetailLive do
 
   def handle_event("select_window", _params, socket), do: {:noreply, socket}
 
-  def handle_event("run_selected_window", _params, socket) do
+  def handle_event("open_run_config", _params, socket) do
     %{asset: asset, selected_window: selected_window} = socket.assigns
 
     cond do
@@ -74,31 +78,78 @@ defmodule FavnView.AssetDetailLive do
          )}
 
       true ->
-        socket =
-          assign(socket,
-            submitting_window_run?: true,
-            selected_window_error: nil,
-            submitted_run_id: nil
-          )
+        {:noreply,
+         assign(socket,
+           run_config_open?: true,
+           run_config: default_run_config(),
+           selected_window_error: nil,
+           submitted_run_id: nil
+         )}
+    end
+  end
 
-        case FavnOrchestrator.submit_asset_window_run(
-               asset.manifest_version_id,
-               asset.target_id,
-               selected_window.id
-             ) do
-          {:ok, run_id} ->
-            {:noreply,
-             socket
-             |> put_flash(:info, "Run submitted")
-             |> push_navigate(to: ~p"/runs/#{run_id}")}
+  def handle_event("close_run_config", _params, socket) do
+    {:noreply, assign(socket, :run_config_open?, false)}
+  end
+
+  def handle_event("run_selected_window", params, socket) do
+    %{asset: asset, selected_window: selected_window} = socket.assigns
+    run_config = run_config_from_params(params)
+
+    cond do
+      is_nil(asset) or is_nil(selected_window) ->
+        {:noreply, assign(socket, :selected_window_error, "Select a runnable window first.")}
+
+      !selected_window.run_enabled? ->
+        {:noreply,
+         assign(
+           socket,
+           :selected_window_error,
+           disabled_reason_label(selected_window.run_disabled_reason)
+         )}
+
+      true ->
+        case run_submit_opts(asset, run_config) do
+          {:ok, opts} ->
+            submit_selected_window(socket, asset, selected_window, run_config, opts)
 
           {:error, reason} ->
             {:noreply,
              assign(socket,
-               submitting_window_run?: false,
+               run_config: run_config,
                selected_window_error: submit_error_label(reason)
              )}
         end
+    end
+  end
+
+  defp submit_selected_window(socket, asset, selected_window, run_config, opts) do
+    socket =
+      assign(socket,
+        run_config: run_config,
+        submitting_window_run?: true,
+        selected_window_error: nil,
+        submitted_run_id: nil
+      )
+
+    case FavnOrchestrator.submit_asset_window_run(
+           asset.manifest_version_id,
+           asset.target_id,
+           selected_window.id,
+           opts
+         ) do
+      {:ok, run_id} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Run submitted")
+         |> push_navigate(to: ~p"/runs/#{run_id}")}
+
+      {:error, reason} ->
+        {:noreply,
+         assign(socket,
+           submitting_window_run?: false,
+           selected_window_error: submit_error_label(reason)
+         )}
     end
   end
 
@@ -114,7 +165,10 @@ defmodule FavnView.AssetDetailLive do
       nav_items={@nav_items}
       timeline={@asset.timeline}
       active_mode={@active_mode}
+      freshness={@asset.freshness}
       selected_window={@selected_window}
+      run_config_open?={@run_config_open?}
+      run_config={@run_config}
       submitting_window_run?={@submitting_window_run?}
       selected_window_error={@selected_window_error}
       submitted_run_id={@submitted_run_id}
@@ -162,9 +216,11 @@ defmodule FavnView.AssetDetailLive do
     %{
       manifest_version_id: detail.manifest_version_id,
       target_id: detail.target_id,
+      canonical_asset_ref: detail.canonical_asset_ref,
       title: detail.name || asset_name(detail),
       status: status_label(Map.get(detail, :status)),
       status_tone: status_tone(Map.get(detail, :status)),
+      freshness: Map.get(detail, :freshness, missing_freshness_detail()),
       window_range: window_range(timeline),
       timeline: timeline
     }
@@ -235,6 +291,63 @@ defmodule FavnView.AssetDetailLive do
   defp asset_timeline(nil), do: []
   defp asset_timeline(asset), do: Map.get(asset, :timeline, [])
 
+  defp missing_freshness_detail do
+    %{
+      state: :unknown,
+      policy: %{kind: :none, label: "no freshness policy"},
+      latest_success: nil,
+      explanation: "Freshness detail is not available from the backend.",
+      reasons: [
+        %{
+          kind: :insufficient_state,
+          message: "Freshness detail is not available from the backend."
+        }
+      ]
+    }
+  end
+
+  defp default_run_config, do: %{dependencies: "all", refresh: "auto"}
+
+  defp run_config_from_params(%{"run_config" => params}) when is_map(params) do
+    %{
+      dependencies: Map.get(params, "dependencies", "all"),
+      refresh: Map.get(params, "refresh", "auto")
+    }
+  end
+
+  defp run_config_from_params(_params), do: default_run_config()
+
+  defp run_submit_opts(asset, %{dependencies: dependencies, refresh: refresh}) do
+    with {:ok, dependencies} <- dependency_option(dependencies),
+         {:ok, refresh} <-
+           refresh_option(refresh, Map.get(asset, :canonical_asset_ref), dependencies) do
+      {:ok, [dependencies: dependencies, refresh: refresh]}
+    end
+  end
+
+  defp dependency_option("all"), do: {:ok, :all}
+  defp dependency_option("none"), do: {:ok, :none}
+  defp dependency_option(value), do: {:error, {:invalid_dependencies_mode, value}}
+
+  defp refresh_option("auto", _asset_ref, _dependencies), do: {:ok, :auto}
+  defp refresh_option("missing", _asset_ref, _dependencies), do: {:ok, :missing}
+  defp refresh_option("force_all", _asset_ref, _dependencies), do: {:ok, :force}
+
+  defp refresh_option("force_selected", asset_ref, _dependencies) when is_tuple(asset_ref) do
+    {:ok, {:force_assets, [asset_ref]}}
+  end
+
+  defp refresh_option("force_selected_upstream", _asset_ref, :none) do
+    {:error, {:refresh_include_upstream_requires_dependencies, :all}}
+  end
+
+  defp refresh_option("force_selected_upstream", asset_ref, :all) when is_tuple(asset_ref) do
+    {:ok, {:force_assets, [asset_ref], include_upstream: true}}
+  end
+
+  defp refresh_option(value, _asset_ref, _dependencies),
+    do: {:error, {:invalid_refresh_policy, value}}
+
   defp disabled_reason_label(:asset_has_no_window_policy), do: "This asset has no window policy."
   defp disabled_reason_label(:invalid_window), do: "This window cannot be run."
   defp disabled_reason_label(_reason), do: "This window is not runnable."
@@ -244,6 +357,13 @@ defmodule FavnView.AssetDetailLive do
 
   defp submit_error_label({:window_request_without_policy, _kind}),
     do: "This asset has no window policy."
+
+  defp submit_error_label({:refresh_include_upstream_requires_dependencies, :all}),
+    do: "Force selected + upstream requires including upstream dependencies."
+
+  defp submit_error_label({:invalid_dependencies_mode, _value}), do: "Dependency mode is invalid."
+
+  defp submit_error_label({:invalid_refresh_policy, _value}), do: "Refresh behavior is invalid."
 
   defp submit_error_label(_reason), do: "Could not submit run."
 end

--- a/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
@@ -17,7 +17,10 @@ defmodule FavnView.Components.AssetDetailPage do
   attr :nav_items, :list, required: true
   attr :timeline, :list, required: true
   attr :active_mode, :atom, default: :timeline
+  attr :freshness, :map, default: nil
   attr :selected_window, :map, default: nil
+  attr :run_config_open?, :boolean, default: false
+  attr :run_config, :map, default: %{dependencies: "all", refresh: "auto"}
   attr :submitting_window_run?, :boolean, default: false
   attr :selected_window_error, :string, default: nil
   attr :submitted_run_id, :string, default: nil
@@ -34,7 +37,10 @@ defmodule FavnView.Components.AssetDetailPage do
         active_mode={@active_mode}
         window_range={@window_range}
         timeline={@timeline}
+        freshness={@freshness}
         selected_window={@selected_window}
+        run_config_open?={@run_config_open?}
+        run_config={@run_config}
         submitting_window_run?={@submitting_window_run?}
         selected_window_error={@selected_window_error}
         submitted_run_id={@submitted_run_id}
@@ -50,7 +56,10 @@ defmodule FavnView.Components.AssetDetailPage do
   attr :active_mode, :atom, required: true
   attr :window_range, :string, required: true
   attr :timeline, :list, required: true
+  attr :freshness, :map, default: nil
   attr :selected_window, :map, default: nil
+  attr :run_config_open?, :boolean, default: false
+  attr :run_config, :map, default: %{dependencies: "all", refresh: "auto"}
   attr :submitting_window_run?, :boolean, default: false
   attr :selected_window_error, :string, default: nil
   attr :submitted_run_id, :string, default: nil
@@ -61,7 +70,10 @@ defmodule FavnView.Components.AssetDetailPage do
       :if={@active_mode == :timeline}
       window_range={@window_range}
       timeline={@timeline}
+      freshness={@freshness}
       selected_window={@selected_window}
+      run_config_open?={@run_config_open?}
+      run_config={@run_config}
       submitting_window_run?={@submitting_window_run?}
       selected_window_error={@selected_window_error}
       submitted_run_id={@submitted_run_id}
@@ -71,13 +83,16 @@ defmodule FavnView.Components.AssetDetailPage do
     <.placeholder_panel :if={@active_mode == :lineage} title="Lineage coming soon" />
     <.placeholder_panel :if={@active_mode == :docs} title="Docs coming soon" />
     <.placeholder_panel :if={@active_mode == :code} title="Code coming soon" />
-    <.placeholder_panel :if={@active_mode == :details} title="Details coming soon" />
+    <.freshness_detail_panel :if={@active_mode == :details} freshness={@freshness} />
     """
   end
 
   attr :window_range, :string, required: true
   attr :timeline, :list, required: true
+  attr :freshness, :map, default: nil
   attr :selected_window, :map, default: nil
+  attr :run_config_open?, :boolean, default: false
+  attr :run_config, :map, default: %{dependencies: "all", refresh: "auto"}
   attr :submitting_window_run?, :boolean, default: false
   attr :selected_window_error, :string, default: nil
   attr :submitted_run_id, :string, default: nil
@@ -124,6 +139,8 @@ defmodule FavnView.Components.AssetDetailPage do
           </div>
         </div>
 
+        <.freshness_summary freshness={@freshness} />
+
         <div class="overflow-x-auto pb-2">
           <div class="flex min-w-[58rem] items-end justify-between gap-3 pt-3">
             <.timeline_window
@@ -136,10 +153,121 @@ defmodule FavnView.Components.AssetDetailPage do
 
         <SelectedWindowActions.selected_window_actions
           selected_window={@selected_window}
+          run_config_open?={@run_config_open?}
+          run_config={@run_config}
           submitting_window_run?={@submitting_window_run?}
           selected_window_error={@selected_window_error}
           submitted_run_id={@submitted_run_id}
         />
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  attr :freshness, :map, default: nil
+
+  def freshness_summary(assigns) do
+    ~H"""
+    <div
+      :if={@freshness}
+      class={[
+        "rounded-box border p-4",
+        freshness_panel_class(@freshness[:state])
+      ]}
+      data-testid="asset-freshness-summary"
+    >
+      <div class="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div class="min-w-0">
+          <p class="text-xs uppercase tracking-[0.18em] text-base-content/45">Freshness</p>
+          <div class="mt-1 flex flex-wrap items-center gap-2">
+            <span class={freshness_badge_class(@freshness[:state])}>
+              {freshness_state_label(@freshness[:state])}
+            </span>
+            <span class="text-xs text-base-content/55">{freshness_policy_label(@freshness)}</span>
+          </div>
+          <p class="mt-2 text-sm text-base-content/70">{@freshness[:explanation]}</p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :freshness, :map, default: nil
+
+  def freshness_detail_panel(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel
+      class="mx-auto w-full max-w-4xl p-6 sm:p-8"
+      data-testid="asset-freshness-detail-panel"
+    >
+      <div :if={!@freshness} class="text-sm text-base-content/60">
+        Freshness detail is not available from the backend.
+      </div>
+
+      <div :if={@freshness} class="space-y-6">
+        <div>
+          <p class="text-xs uppercase tracking-[0.18em] text-base-content/45">Freshness detail</p>
+          <div class="mt-2 flex flex-wrap items-center gap-2">
+            <span class={freshness_badge_class(@freshness[:state])}>
+              {freshness_state_label(@freshness[:state])}
+            </span>
+            <span class="badge badge-ghost badge-sm">{freshness_policy_label(@freshness)}</span>
+          </div>
+          <p class="mt-3 text-sm text-base-content/70">{@freshness[:explanation]}</p>
+        </div>
+
+        <dl :if={freshness_latest_success(@freshness)} class="grid gap-3 sm:grid-cols-3">
+          <div class="rounded-box border border-base-content/10 bg-base-content/[0.03] p-3">
+            <dt class="text-xs uppercase tracking-[0.16em] text-base-content/45">Latest success</dt>
+            <dd class="mt-1 break-words font-mono text-xs text-base-content/75">
+              {freshness_latest_success(@freshness)[:run_id]}
+            </dd>
+          </div>
+          <div class="rounded-box border border-base-content/10 bg-base-content/[0.03] p-3">
+            <dt class="text-xs uppercase tracking-[0.16em] text-base-content/45">Freshness key</dt>
+            <dd class="mt-1 break-words font-mono text-xs text-base-content/75">
+              {freshness_latest_success(@freshness)[:freshness_key]}
+            </dd>
+          </div>
+          <div class="rounded-box border border-base-content/10 bg-base-content/[0.03] p-3">
+            <dt class="text-xs uppercase tracking-[0.16em] text-base-content/45">At</dt>
+            <dd class="mt-1 text-xs text-base-content/75">
+              {freshness_time(freshness_latest_success(@freshness)[:at])}
+            </dd>
+          </div>
+        </dl>
+
+        <div>
+          <h3 class="text-sm font-medium text-base-content">Backend reasons</h3>
+          <div class="mt-3 space-y-3" data-testid="asset-freshness-reasons">
+            <div
+              :for={reason <- freshness_reasons(@freshness)}
+              class="rounded-box border border-base-content/10 bg-base-content/[0.03] p-4"
+            >
+              <div class="flex flex-wrap items-center gap-2">
+                <span class="badge badge-ghost badge-sm">{reason[:kind]}</span>
+                <span :if={reason[:upstream_ref]} class="font-mono text-xs text-base-content/45">
+                  {reason[:upstream_ref]}
+                </span>
+              </div>
+              <p class="mt-2 text-sm text-base-content/75">{reason[:message]}</p>
+              <dl class="mt-3 grid gap-2 text-xs text-base-content/60 sm:grid-cols-3">
+                <div :if={reason[:previous_version]}>
+                  <dt class="uppercase tracking-[0.14em] text-base-content/40">Previous</dt>
+                  <dd class="mt-0.5 break-words font-mono">{reason[:previous_version]}</dd>
+                </div>
+                <div :if={reason[:current_version]}>
+                  <dt class="uppercase tracking-[0.14em] text-base-content/40">Current</dt>
+                  <dd class="mt-0.5 break-words font-mono">{reason[:current_version]}</dd>
+                </div>
+                <div :if={reason[:run_id]}>
+                  <dt class="uppercase tracking-[0.14em] text-base-content/40">Run</dt>
+                  <dd class="mt-0.5 break-words font-mono">{reason[:run_id]}</dd>
+                </div>
+              </dl>
+            </div>
+          </div>
+        </div>
       </div>
     </GlassPanel.glass_panel>
     """
@@ -265,6 +393,83 @@ defmodule FavnView.Components.AssetDetailPage do
     Enum.find(non_runnable_timeline(), & &1[:current])
   end
 
+  def sample_freshness(:fresh) do
+    %{
+      state: :fresh,
+      policy: %{kind: :daily, label: "daily Europe/Oslo"},
+      latest_success: %{
+        run_id: "run_fresh_customer_orders",
+        at: ~U[2026-06-12 08:00:00Z],
+        freshness_key: "latest"
+      },
+      explanation: "Backend freshness state currently satisfies this asset's policy.",
+      reasons: [
+        %{kind: :policy_fresh, message: "Backend freshness state satisfies the declared policy."}
+      ]
+    }
+  end
+
+  def sample_freshness(:stale) do
+    %{
+      state: :stale,
+      policy: %{kind: :daily, label: "daily Europe/Oslo"},
+      latest_success: %{
+        run_id: "run_old_gold_orders",
+        at: ~U[2026-06-11 08:00:00Z],
+        freshness_key: "latest"
+      },
+      explanation:
+        "GoldOrders.asset is stale because rawOrders.asset refreshed after this asset last consumed it.",
+      reasons: [
+        %{
+          kind: :upstream_version_changed,
+          message: "RawOrders.asset refreshed after this asset last consumed it.",
+          upstream_ref: "Elixir.FavnView.Assets.RawOrders:asset",
+          previous_version: "raw:v1",
+          current_version: "raw:v2",
+          run_id: "run_raw_v2"
+        }
+      ]
+    }
+  end
+
+  def sample_freshness(:unknown) do
+    %{
+      state: :unknown,
+      policy: %{kind: :window_success, label: "window success"},
+      latest_success: nil,
+      explanation: "No successful freshness evidence exists for this asset yet.",
+      reasons: [
+        %{kind: :never_run, message: "No successful freshness-producing run has been recorded."}
+      ]
+    }
+  end
+
+  def sample_freshness(:always_run) do
+    %{
+      state: :always_run,
+      policy: %{kind: :always, label: "always run"},
+      latest_success: nil,
+      explanation: "Freshness is intentionally bypassed; this asset runs whenever it is planned.",
+      reasons: [%{kind: :always_run, message: "Manifest policy is always run."}]
+    }
+  end
+
+  def sample_freshness(:failed_unknown) do
+    %{
+      state: :unknown,
+      policy: %{kind: :daily, label: "daily Europe/Oslo"},
+      latest_success: nil,
+      explanation: "Freshness state exists, but backend could not explain whether it is stale.",
+      reasons: [
+        %{
+          kind: :insufficient_state,
+          message: "Backend could not build a staleness explanation from available state."
+        }
+      ]
+    }
+  end
+
   def detail_modes do
     [
       %{id: :timeline, label: "Timeline", icon: "hero-calendar-days"},
@@ -313,8 +518,45 @@ defmodule FavnView.Components.AssetDetailPage do
   defp timeline_icon(:error), do: "hero-x-circle"
   defp timeline_icon(:muted), do: "hero-minus-circle"
 
-  defp timeline_label(:success), do: "healthy"
-  defp timeline_label(:warning), do: "late"
+  defp timeline_label(:success), do: "fresh"
+  defp timeline_label(:warning), do: "running"
   defp timeline_label(:error), do: "failed"
-  defp timeline_label(:muted), do: "pending"
+  defp timeline_label(:muted), do: "unknown"
+
+  defp freshness_state_label(:fresh), do: "Fresh"
+  defp freshness_state_label(:stale), do: "Stale"
+  defp freshness_state_label(:always_run), do: "Always run"
+  defp freshness_state_label(_state), do: "Unknown"
+
+  defp freshness_badge_class(:fresh), do: "badge badge-success badge-soft badge-sm"
+  defp freshness_badge_class(:stale), do: "badge badge-warning badge-soft badge-sm"
+  defp freshness_badge_class(:always_run), do: "badge badge-info badge-soft badge-sm"
+  defp freshness_badge_class(_state), do: "badge badge-neutral badge-soft badge-sm"
+
+  defp freshness_panel_class(:fresh), do: "border-success/20 bg-success/10"
+  defp freshness_panel_class(:stale), do: "border-warning/25 bg-warning/10"
+  defp freshness_panel_class(:always_run), do: "border-info/20 bg-info/10"
+  defp freshness_panel_class(_state), do: "border-base-content/10 bg-base-content/[0.035]"
+
+  defp freshness_policy_label(%{policy: %{label: label}}) when is_binary(label), do: label
+  defp freshness_policy_label(%{"policy" => %{"label" => label}}) when is_binary(label), do: label
+  defp freshness_policy_label(_freshness), do: "policy unavailable"
+
+  defp freshness_latest_success(%{latest_success: latest_success}) when is_map(latest_success),
+    do: latest_success
+
+  defp freshness_latest_success(%{"latest_success" => latest_success})
+       when is_map(latest_success),
+       do: latest_success
+
+  defp freshness_latest_success(_freshness), do: nil
+
+  defp freshness_reasons(%{reasons: reasons}) when is_list(reasons), do: reasons
+  defp freshness_reasons(%{"reasons" => reasons}) when is_list(reasons), do: reasons
+  defp freshness_reasons(_freshness), do: []
+
+  defp freshness_time(%DateTime{} = value),
+    do: Calendar.strftime(value, "%b %-d, %Y %H:%M:%S UTC")
+
+  defp freshness_time(_value), do: "-"
 end

--- a/apps/favn_view/lib/favn_view/components/run_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page.ex
@@ -293,6 +293,19 @@ defmodule FavnView.Components.RunDetailPage do
         duration: "1 ms",
         error: "Upstream failed",
         inspectable?: true
+      },
+      %{
+        id: "node-mart-orders-window-2026-06-12",
+        asset_ref: "FavnView.Assets.mart_orders",
+        display_name: "mart_orders",
+        secondary: "window:day:2026-06-12 · Stage 3",
+        status: "Failed",
+        status_tone: :error,
+        started_at: "Jun 12, 2026 14:00:03 UTC",
+        duration: "2.1 s",
+        error: "Warehouse timeout",
+        explanation: "Failed while executing this planned node.",
+        inspectable?: true
       }
     ])
   end

--- a/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
+++ b/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
@@ -130,6 +130,7 @@ defmodule FavnView.Components.RunOverviewHud do
         <p class="truncate text-sm font-medium text-base-content">{@asset.display_name}</p>
         <p class="truncate font-mono text-xs text-base-content/45">{@asset.asset_ref}</p>
         <p :if={@asset.secondary} class="text-xs text-base-content/50">{@asset.secondary}</p>
+        <p :if={@asset.explanation} class="mt-1 text-xs text-base-content/60">{@asset.explanation}</p>
         <p :if={@asset.error} class="mt-1 text-xs text-error">{@asset.error}</p>
       </div>
     </div>

--- a/apps/favn_view/lib/favn_view/components/selected_window_actions.ex
+++ b/apps/favn_view/lib/favn_view/components/selected_window_actions.ex
@@ -6,6 +6,8 @@ defmodule FavnView.Components.SelectedWindowActions do
   use FavnView, :html
 
   attr :selected_window, :map, default: nil
+  attr :run_config_open?, :boolean, default: false
+  attr :run_config, :map, default: %{dependencies: "all", refresh: "auto"}
   attr :submitting_window_run?, :boolean, default: false
   attr :selected_window_error, :string, default: nil
   attr :submitted_run_id, :string, default: nil
@@ -14,7 +16,7 @@ defmodule FavnView.Components.SelectedWindowActions do
     ~H"""
     <div
       :if={@selected_window}
-      class="flex flex-col gap-3 rounded-box border border-base-content/10 bg-base-content/[0.04] p-4 sm:flex-row sm:items-center sm:justify-between"
+      class="grid gap-3 rounded-box border border-base-content/10 bg-base-content/[0.04] p-4 sm:grid-cols-[1fr_auto] sm:items-center"
       data-testid="selected-window-actions"
     >
       <div class="min-w-0">
@@ -40,8 +42,7 @@ defmodule FavnView.Components.SelectedWindowActions do
         <button
           type="button"
           class="btn btn-primary btn-soft btn-sm"
-          phx-click="run_selected_window"
-          phx-disable-with="Submitting..."
+          phx-click="open_run_config"
           disabled={!@selected_window.run_enabled? || @submitting_window_run?}
           data-testid="run-selected-window"
         >
@@ -49,15 +50,167 @@ defmodule FavnView.Components.SelectedWindowActions do
           {@selected_window.run_label || "Run this window"}
         </button>
       </div>
+
+      <.run_config_panel
+        :if={@run_config_open?}
+        selected_window={@selected_window}
+        run_config={@run_config}
+        submitting_window_run?={@submitting_window_run?}
+      />
     </div>
     """
   end
 
-  defp status_label(:success), do: "healthy"
-  defp status_label(:warning), do: "late"
-  defp status_label(:error), do: "failed"
-  defp status_label(:muted), do: "pending"
-  defp status_label(_status), do: "unknown"
+  attr :selected_window, :map, required: true
+  attr :run_config, :map, required: true
+  attr :submitting_window_run?, :boolean, default: false
+
+  def run_config_panel(assigns) do
+    ~H"""
+    <div
+      class="mt-2 w-full rounded-box border border-primary/20 bg-base-100/70 p-4 shadow-lg shadow-primary/5 sm:col-span-2"
+      data-testid="run-config-panel"
+    >
+      <.form
+        for={%{}}
+        as={:run_config}
+        phx-submit="run_selected_window"
+        class="space-y-4"
+        data-testid="run-config-form"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div>
+            <h3 class="text-sm font-medium text-base-content">Run plan</h3>
+            <p class="mt-1 text-xs text-base-content/55">
+              Submit a planned graph rooted at {@selected_window.range_label}.
+            </p>
+          </div>
+          <button
+            type="button"
+            class="btn btn-ghost btn-xs"
+            phx-click="close_run_config"
+            disabled={@submitting_window_run?}
+            data-testid="close-run-config"
+          >
+            Close
+          </button>
+        </div>
+
+        <fieldset class="fieldset">
+          <legend class="fieldset-legend">Plan scope / dependencies</legend>
+          <.radio_card
+            name="run_config[dependencies]"
+            value="all"
+            checked?={@run_config.dependencies == "all"}
+            title="Include upstream dependencies"
+            description="Default. Plan the selected asset/window with its supported upstream graph."
+          />
+          <.radio_card
+            name="run_config[dependencies]"
+            value="none"
+            checked?={@run_config.dependencies == "none"}
+            title="Only this asset/window"
+            description="Plan only the selected target and window."
+          />
+        </fieldset>
+
+        <fieldset class="fieldset">
+          <legend class="fieldset-legend">Refresh behavior</legend>
+          <.radio_card
+            name="run_config[refresh]"
+            value="auto"
+            checked?={@run_config.refresh == "auto"}
+            title="Auto - obey freshness"
+            description="Default. Let backend freshness policies decide which nodes run or skip."
+          />
+          <.radio_card
+            name="run_config[refresh]"
+            value="missing"
+            checked?={@run_config.refresh == "missing"}
+            title="Run missing only"
+            description="Run nodes without prior successful freshness state."
+          />
+          <.radio_card
+            name="run_config[refresh]"
+            value="force_selected"
+            checked?={@run_config.refresh == "force_selected"}
+            title="Force selected asset"
+            description="Run the selected asset even when backend freshness says it is current. Upstream assets are not forced."
+          />
+          <.radio_card
+            name="run_config[refresh]"
+            value="force_selected_upstream"
+            checked?={@run_config.refresh == "force_selected_upstream"}
+            title="Force selected + upstream dependencies"
+            description="Force the selected asset and its planned upstream dependencies. Upstream changes can cause downstream nodes in the planned graph to rerun."
+          />
+          <.radio_card
+            name="run_config[refresh]"
+            value="force_all"
+            checked?={@run_config.refresh == "force_all"}
+            title="Force full planned graph"
+            description="Run every node in the planned graph regardless of stored freshness."
+          />
+        </fieldset>
+
+        <div class="rounded-box border border-warning/20 bg-warning/10 p-3 text-xs text-base-content/70">
+          Forcing upstream assets can change inputs and cause downstream assets to rerun. Forcing only the selected asset does not automatically rerun upstream assets unless upstream dependencies are included.
+        </div>
+
+        <div class="flex justify-end gap-2">
+          <button
+            type="button"
+            class="btn btn-ghost btn-sm"
+            phx-click="close_run_config"
+            disabled={@submitting_window_run?}
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            class="btn btn-primary btn-sm"
+            disabled={@submitting_window_run?}
+            phx-disable-with="Submitting..."
+            data-testid="submit-run-config"
+          >
+            <span :if={@submitting_window_run?} class="loading loading-spinner loading-xs"></span>
+            Submit run
+          </button>
+        </div>
+      </.form>
+    </div>
+    """
+  end
+
+  attr :name, :string, required: true
+  attr :value, :string, required: true
+  attr :checked?, :boolean, default: false
+  attr :title, :string, required: true
+  attr :description, :string, required: true
+
+  def radio_card(assigns) do
+    ~H"""
+    <label class="mt-2 flex cursor-pointer gap-3 rounded-box border border-base-content/10 bg-base-content/[0.025] p-3 text-sm hover:border-primary/30">
+      <input
+        type="radio"
+        name={@name}
+        value={@value}
+        checked={@checked?}
+        class="radio radio-primary radio-sm mt-0.5"
+      />
+      <span>
+        <span class="block font-medium text-base-content">{@title}</span>
+        <span class="mt-0.5 block text-xs leading-5 text-base-content/55">{@description}</span>
+      </span>
+    </label>
+    """
+  end
+
+  defp status_label(:success), do: "Fresh"
+  defp status_label(:warning), do: "Running"
+  defp status_label(:error), do: "Failed"
+  defp status_label(:muted), do: "Unknown / never run"
+  defp status_label(_status), do: "Unknown"
 
   defp run_disabled_reason_label(:asset_has_no_window_policy), do: "No window policy"
   defp run_disabled_reason_label(:invalid_window), do: "Invalid window"

--- a/apps/favn_view/lib/favn_view/run_step_view_model.ex
+++ b/apps/favn_view/lib/favn_view/run_step_view_model.ex
@@ -50,12 +50,14 @@ defmodule FavnView.RunStepViewModel do
       asset_ref: asset_ref,
       display_name: LogsViewModel.display_name(asset_ref),
       secondary: node_secondary(result),
-      status: LogsViewModel.status_label(Map.get(result, :status)),
+      status: step_status_label(Map.get(result, :status)),
+      raw_status: Map.get(result, :status),
       status_tone: LogsViewModel.status_tone(Map.get(result, :status)),
       duration: LogsViewModel.duration_ms_label(Map.get(result, :duration_ms)),
       started_at: LogsViewModel.timestamp_label(Map.get(result, :started_at)),
       attempt: Map.get(result, :attempt),
       error: error_summary(Map.get(result, :error) || Map.get(result, :reason)),
+      explanation: node_explanation(result),
       output: output_metadata(result),
       inspectable?: true
     }
@@ -69,12 +71,14 @@ defmodule FavnView.RunStepViewModel do
       asset_ref: asset_ref,
       display_name: LogsViewModel.display_name(asset_ref),
       secondary: asset_secondary(result),
-      status: LogsViewModel.status_label(Map.get(result, :status)),
+      status: step_status_label(Map.get(result, :status)),
+      raw_status: Map.get(result, :status),
       status_tone: LogsViewModel.status_tone(Map.get(result, :status)),
       duration: LogsViewModel.duration_ms_label(Map.get(result, :duration_ms)),
       started_at: LogsViewModel.timestamp_label(Map.get(result, :started_at)),
       attempt: Map.get(result, :attempt),
       error: error_summary(Map.get(result, :error)),
+      explanation: asset_explanation(result),
       output: output_metadata(result),
       inspectable?: true
     }
@@ -158,6 +162,69 @@ defmodule FavnView.RunStepViewModel do
   defp error_summary(reason) when is_binary(reason), do: reason
   defp error_summary(reason) when is_atom(reason), do: humanize(reason)
   defp error_summary(_error), do: "Execution error"
+
+  defp step_status_label(status) when status in [:ok, "ok"], do: "Ran"
+  defp step_status_label(status), do: LogsViewModel.status_label(status)
+
+  defp node_explanation(result) do
+    status = Map.get(result, :status)
+    reason = Map.get(result, :reason)
+
+    cond do
+      status in [:skipped_fresh, "skipped_fresh"] ->
+        freshness_suffix(result, "Skipped because backend marked this node fresh.")
+
+      status in [:blocked, "blocked"] ->
+        reason_suffix(reason, "Blocked by a backend execution decision.")
+
+      status in [:error, "error"] ->
+        "Failed while executing this planned node."
+
+      status in [:cancelled, "cancelled"] ->
+        "Cancelled before this planned node completed."
+
+      status in [:timed_out, "timed_out"] ->
+        "Timed out while executing this planned node."
+
+      status in [:ok, "ok"] and reason in [:forced, "forced", :force, "force"] ->
+        "Ran because refresh policy forced this node."
+
+      status in [:ok, "ok"] ->
+        "Ran as part of the backend plan."
+
+      status in [:pending, :running, :retrying, "pending", "running", "retrying"] ->
+        "Backend is still working on this planned node."
+
+      true ->
+        nil
+    end
+  end
+
+  defp asset_explanation(result) do
+    case Map.get(result, :status) do
+      status when status in [:ok, "ok"] ->
+        "Ran as part of the backend plan."
+
+      status when status in [:error, "error"] ->
+        "Failed while executing this asset."
+
+      status when status in [:pending, :running, :retrying, "pending", "running", "retrying"] ->
+        "Backend is still working on this asset."
+
+      _status ->
+        nil
+    end
+  end
+
+  defp freshness_suffix(result, fallback) do
+    case Map.get(result, :freshness_key) do
+      nil -> fallback
+      key -> "#{fallback} Freshness key: #{key}."
+    end
+  end
+
+  defp reason_suffix(nil, fallback), do: fallback
+  defp reason_suffix(reason, fallback), do: "#{fallback} Reason: #{humanize(reason)}."
 
   defp error_reason_summary(reason) when is_binary(reason), do: reason
   defp error_reason_summary(reason) when is_atom(reason), do: humanize(reason)

--- a/apps/favn_view/storybook/components/asset_detail_page.story.exs
+++ b/apps/favn_view/storybook/components/asset_detail_page.story.exs
@@ -20,6 +20,7 @@ defmodule FavnView.Storybook.Components.AssetDetailPage do
           window_range: "May 24 - Jun 22, 2026",
           nav_items: AssetDetailPage.sample_nav_items(),
           timeline: AssetDetailPage.sample_timeline(),
+          freshness: AssetDetailPage.sample_freshness(:fresh),
           active_mode: :timeline,
           selected_window: AssetDetailPage.selected_sample_window()
         }
@@ -33,9 +34,53 @@ defmodule FavnView.Storybook.Components.AssetDetailPage do
           window_range: "May 24 - Jun 22, 2026",
           nav_items: AssetDetailPage.sample_nav_items(),
           timeline: AssetDetailPage.sample_timeline(),
+          freshness: AssetDetailPage.sample_freshness(:fresh),
           active_mode: :timeline,
           selected_window: AssetDetailPage.selected_sample_window()
         }
+      },
+      %Variation{
+        id: :fresh_freshness_detail,
+        attributes: freshness_attributes(:fresh)
+      },
+      %Variation{
+        id: :stale_with_upstream_reason,
+        attributes: freshness_attributes(:stale)
+      },
+      %Variation{
+        id: :unknown_never_run_freshness,
+        attributes: freshness_attributes(:unknown)
+      },
+      %Variation{
+        id: :always_run_freshness,
+        attributes: freshness_attributes(:always_run)
+      },
+      %Variation{
+        id: :failed_latest_run_stale_unknown,
+        attributes:
+          freshness_attributes(:failed_unknown)
+          |> Map.merge(%{status: "Failed", status_tone: :error})
+      },
+      %Variation{
+        id: :default_auto_run_config,
+        attributes: run_config_attributes(%{dependencies: "all", refresh: "auto"})
+      },
+      %Variation{
+        id: :missing_only_run_config,
+        attributes: run_config_attributes(%{dependencies: "all", refresh: "missing"})
+      },
+      %Variation{
+        id: :force_selected_asset_run_config,
+        attributes: run_config_attributes(%{dependencies: "all", refresh: "force_selected"})
+      },
+      %Variation{
+        id: :force_selected_upstream_run_config,
+        attributes:
+          run_config_attributes(%{dependencies: "all", refresh: "force_selected_upstream"})
+      },
+      %Variation{
+        id: :force_full_graph_run_config,
+        attributes: run_config_attributes(%{dependencies: "all", refresh: "force_all"})
       },
       %Variation{
         id: :selected_non_runnable_window,
@@ -46,6 +91,7 @@ defmodule FavnView.Storybook.Components.AssetDetailPage do
           window_range: "May 24 - Jun 22, 2026",
           nav_items: AssetDetailPage.sample_nav_items(),
           timeline: AssetDetailPage.non_runnable_timeline(),
+          freshness: AssetDetailPage.sample_freshness(:unknown),
           active_mode: :timeline,
           selected_window: AssetDetailPage.selected_non_runnable_window()
         }
@@ -59,6 +105,7 @@ defmodule FavnView.Storybook.Components.AssetDetailPage do
           window_range: "May 24 - Jun 22, 2026",
           nav_items: AssetDetailPage.sample_nav_items(),
           timeline: AssetDetailPage.sample_timeline(),
+          freshness: AssetDetailPage.sample_freshness(:fresh),
           active_mode: :timeline,
           selected_window: AssetDetailPage.selected_sample_window(),
           submitted_run_id: "run_01HZ"
@@ -73,6 +120,7 @@ defmodule FavnView.Storybook.Components.AssetDetailPage do
           window_range: "May 24 - Jun 22, 2026",
           nav_items: AssetDetailPage.sample_nav_items(),
           timeline: AssetDetailPage.sample_timeline(),
+          freshness: AssetDetailPage.sample_freshness(:fresh),
           active_mode: :timeline,
           selected_window: AssetDetailPage.selected_sample_window(),
           selected_window_error: "Could not submit run."
@@ -87,6 +135,7 @@ defmodule FavnView.Storybook.Components.AssetDetailPage do
           window_range: "May 24 - Jun 22, 2026",
           nav_items: AssetDetailPage.sample_nav_items(),
           timeline: AssetDetailPage.muted_timeline(),
+          freshness: AssetDetailPage.sample_freshness(:unknown),
           active_mode: :timeline,
           selected_window: AssetDetailPage.selected_muted_window()
         }
@@ -100,10 +149,41 @@ defmodule FavnView.Storybook.Components.AssetDetailPage do
           window_range: "May 24 - Jun 22, 2026",
           nav_items: AssetDetailPage.sample_nav_items(),
           timeline: AssetDetailPage.sample_timeline(),
+          freshness: AssetDetailPage.sample_freshness(:fresh),
           active_mode: :runs,
           selected_window: AssetDetailPage.selected_sample_window()
         }
       }
     ]
+  end
+
+  defp run_config_attributes(run_config) do
+    %{
+      title: "customer_orders_daily",
+      status: "Healthy",
+      status_tone: :success,
+      window_range: "May 24 - Jun 22, 2026",
+      nav_items: AssetDetailPage.sample_nav_items(),
+      timeline: AssetDetailPage.sample_timeline(),
+      freshness: AssetDetailPage.sample_freshness(:fresh),
+      active_mode: :timeline,
+      selected_window: AssetDetailPage.selected_sample_window(),
+      run_config_open?: true,
+      run_config: run_config
+    }
+  end
+
+  defp freshness_attributes(state) do
+    %{
+      title: "customer_orders_daily",
+      status: "Healthy",
+      status_tone: :success,
+      window_range: "May 24 - Jun 22, 2026",
+      nav_items: AssetDetailPage.sample_nav_items(),
+      timeline: AssetDetailPage.sample_timeline(),
+      freshness: AssetDetailPage.sample_freshness(state),
+      active_mode: :details,
+      selected_window: AssetDetailPage.selected_sample_window()
+    }
   end
 end

--- a/apps/favn_view/storybook/components/selected_window_actions.story.exs
+++ b/apps/favn_view/storybook/components/selected_window_actions.story.exs
@@ -8,7 +8,7 @@ defmodule FavnView.Storybook.Components.SelectedWindowActions do
   def layout, do: :one_column
   def render_source, do: :function
 
-  def container, do: {:iframe, style: "width: 100%; height: 360px; border: 0;"}
+  def container, do: {:iframe, style: "width: 100%; height: 720px; border: 0;"}
 
   def template do
     """
@@ -27,6 +27,27 @@ defmodule FavnView.Storybook.Components.SelectedWindowActions do
         attributes: %{
           selected_window: AssetDetailPage.selected_sample_window()
         }
+      },
+      %Variation{
+        id: :run_window_config_default_auto,
+        attributes: run_config_attributes(%{dependencies: "all", refresh: "auto"})
+      },
+      %Variation{
+        id: :run_window_config_missing_only,
+        attributes: run_config_attributes(%{dependencies: "all", refresh: "missing"})
+      },
+      %Variation{
+        id: :run_window_config_force_selected_asset,
+        attributes: run_config_attributes(%{dependencies: "all", refresh: "force_selected"})
+      },
+      %Variation{
+        id: :run_window_config_force_selected_upstream,
+        attributes:
+          run_config_attributes(%{dependencies: "all", refresh: "force_selected_upstream"})
+      },
+      %Variation{
+        id: :run_window_config_force_full_graph,
+        attributes: run_config_attributes(%{dependencies: "all", refresh: "force_all"})
       },
       %Variation{
         id: :submitting,
@@ -56,5 +77,13 @@ defmodule FavnView.Storybook.Components.SelectedWindowActions do
         }
       }
     ]
+  end
+
+  defp run_config_attributes(run_config) do
+    %{
+      selected_window: AssetDetailPage.selected_sample_window(),
+      run_config_open?: true,
+      run_config: run_config
+    }
   end
 end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -937,6 +937,7 @@ defmodule FavnView.PageLiveTest do
              Storage.put_asset_freshness_state(
                freshness_state(:customer_orders_daily, "customer:v1", customer_at,
                  run_id: "run_customer_orders_daily",
+                 freshness_key: current_daily_freshness_key(now),
                  input_versions: [
                    %{
                      upstream_ref: {__MODULE__.Assets, :raw_payments},
@@ -956,7 +957,7 @@ defmodule FavnView.PageLiveTest do
       AssetFreshnessState.new(%{
         asset_ref_module: __MODULE__.Assets,
         asset_ref_name: name,
-        freshness_key: Favn.Freshness.Key.latest(),
+        freshness_key: Keyword.get(opts, :freshness_key, Favn.Freshness.Key.latest()),
         status: :ok,
         freshness_version: version,
         latest_success_run_id: run_id,
@@ -971,6 +972,11 @@ defmodule FavnView.PageLiveTest do
       })
 
     state
+  end
+
+  defp current_daily_freshness_key(now) do
+    {:ok, period} = Favn.TimePeriod.current(:day, now, "Europe/Oslo")
+    Favn.Freshness.Key.calendar!(:day, "Europe/Oslo", period.start_at)
   end
 
   defp terminal_asset_results(name) do

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -151,7 +151,6 @@ defmodule FavnView.PageLiveTest do
     {:ok, view, html} = live(conn, detail_path(:customer_orders_daily))
 
     assert html =~ "customer_orders_daily"
-    assert html =~ "Healthy"
     assert has_element?(view, ~s([data-testid="asset-freshness-summary"]), "Stale")
     assert has_element?(view, ~s([data-testid="asset-freshness-summary"]), "daily Europe/Oslo")
     assert html =~ "Window timeline"

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -9,6 +9,8 @@ defmodule FavnView.PageLiveTest do
   alias Favn.Run.AssetResult
   alias Favn.Run.NodeResult
   alias Favn.Window.Spec, as: WindowSpec
+  alias FavnView.Components.AssetDetailPage
+  alias FavnOrchestrator.AssetFreshnessState
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.Adapter.Memory
@@ -32,6 +34,7 @@ defmodule FavnView.PageLiveTest do
              Storage.put_run(empty_run_state(:stg_payments, :error, "run_failed_empty"))
 
     assert :ok = Storage.put_run(node_results_run_state())
+    seed_freshness_states!()
 
     seed_run_events!("run_customer_orders_daily")
     seed_run_events!("run_failed_empty", :error)
@@ -149,9 +152,80 @@ defmodule FavnView.PageLiveTest do
 
     assert html =~ "customer_orders_daily"
     assert html =~ "Healthy"
+    assert has_element?(view, ~s([data-testid="asset-freshness-summary"]), "Stale")
+    assert has_element?(view, ~s([data-testid="asset-freshness-summary"]), "daily Europe/Oslo")
     assert html =~ "Window timeline"
     assert has_element?(view, ~s([data-testid="window-timeline-panel"]))
     assert has_element?(view, ~s([aria-label="View modes"]))
+  end
+
+  test "asset detail renders stale freshness explanation in details mode", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Details"]))
+    |> render_click()
+
+    assert has_element?(view, ~s([data-testid="asset-freshness-detail-panel"]), "Stale")
+    assert has_element?(view, ~s([data-testid="asset-freshness-reasons"]), "raw_payments")
+    assert has_element?(view, ~s([data-testid="asset-freshness-reasons"]), "raw:v1")
+    assert has_element?(view, ~s([data-testid="asset-freshness-reasons"]), "raw:v2")
+  end
+
+  test "asset detail renders unknown freshness explanation", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:stg_payments))
+
+    assert has_element?(view, ~s([data-testid="asset-freshness-summary"]), "Unknown")
+    assert has_element?(view, ~s([data-testid="asset-freshness-summary"]), "No freshness policy")
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Details"]))
+    |> render_click()
+
+    assert has_element?(view, ~s([data-testid="asset-freshness-reasons"]), "No freshness policy")
+  end
+
+  test "asset detail renders always-run freshness explanation", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:always_refresh))
+
+    assert has_element?(view, ~s([data-testid="asset-freshness-summary"]), "Always run")
+    assert has_element?(view, ~s([data-testid="asset-freshness-summary"]), "always run")
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Details"]))
+    |> render_click()
+
+    assert has_element?(
+             view,
+             ~s([data-testid="asset-freshness-reasons"]),
+             "Manifest policy is always run"
+           )
+  end
+
+  test "asset detail component tolerates missing or partial freshness detail" do
+    attrs = %{
+      title: "partial_freshness_asset",
+      status: "Unknown",
+      status_tone: :neutral,
+      window_range: "No windows",
+      nav_items: AssetDetailPage.sample_nav_items(),
+      timeline: AssetDetailPage.sample_timeline(),
+      selected_window: AssetDetailPage.selected_sample_window(),
+      active_mode: :timeline,
+      freshness: nil
+    }
+
+    assert render_component(&AssetDetailPage.asset_detail_page/1, attrs) =~ "Window timeline"
+
+    html =
+      render_component(&AssetDetailPage.asset_detail_page/1, %{
+        attrs
+        | active_mode: :details,
+          freshness: %{state: :unknown, explanation: "Backend returned partial freshness detail."}
+      })
+
+    assert html =~ "Backend returned partial freshness detail."
+    assert html =~ "policy unavailable"
   end
 
   test "asset detail defaults to timeline mode", %{conn: conn} do
@@ -164,15 +238,32 @@ defmodule FavnView.PageLiveTest do
     refute has_element?(view, ~s([data-testid="asset-mode-placeholder"]))
   end
 
-  test "run selected window submits and navigates to run detail", %{conn: conn} do
+  test "run selected window opens run config panel with defaults", %{conn: conn} do
     {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
 
     view
     |> element(~s([data-testid="run-selected-window"]), "Run this window")
     |> render_click()
 
+    assert has_element?(view, ~s([data-testid="run-config-panel"]), "Plan scope / dependencies")
+    assert has_element?(view, ~s(input[name="run_config[dependencies]"][value="all"][checked]))
+    assert has_element?(view, ~s(input[name="run_config[refresh]"][value="auto"][checked]))
+  end
+
+  test "run selected window submits default auto config and navigates to run detail", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+
+    open_run_config(view)
+
+    view
+    |> element(~s([data-testid="run-config-form"]))
+    |> render_submit(%{"run_config" => %{"dependencies" => "all", "refresh" => "auto"}})
+
     assert {run_path, %{"info" => "Run submitted"}} = assert_redirect(view)
     assert String.starts_with?(run_path, "/runs/run_")
+    assert_submitted_refresh(run_path, :all, %{mode: :auto, refs: [], include_upstream?: false})
 
     {:ok, run_view, html} = live(conn, run_path)
 
@@ -181,12 +272,73 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(run_view, ~s([data-testid="run-overview-panel"]))
   end
 
+  test "run selected window submits missing refresh config", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+
+    open_run_config(view)
+
+    view
+    |> element(~s([data-testid="run-config-form"]))
+    |> render_submit(%{"run_config" => %{"dependencies" => "all", "refresh" => "missing"}})
+
+    assert {run_path, _flash} = assert_redirect(view)
+
+    assert_submitted_refresh(run_path, :all, %{mode: :missing, refs: [], include_upstream?: false})
+  end
+
+  test "run selected window submits force selected refresh config", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+
+    open_run_config(view)
+
+    view
+    |> element(~s([data-testid="run-config-form"]))
+    |> render_submit(%{"run_config" => %{"dependencies" => "all", "refresh" => "force_selected"}})
+
+    assert {run_path, _flash} = assert_redirect(view)
+
+    assert_submitted_refresh(run_path, :all, %{
+      mode: :force_assets,
+      refs: [{__MODULE__.Assets, :customer_orders_daily}],
+      include_upstream?: false
+    })
+  end
+
+  test "run selected window submits force selected plus upstream refresh config", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+
+    open_run_config(view)
+
+    view
+    |> element(~s([data-testid="run-config-form"]))
+    |> render_submit(%{
+      "run_config" => %{"dependencies" => "all", "refresh" => "force_selected_upstream"}
+    })
+
+    assert {run_path, _flash} = assert_redirect(view)
+
+    assert_submitted_refresh(run_path, :all, %{
+      mode: :force_assets,
+      refs: [{__MODULE__.Assets, :customer_orders_daily}],
+      include_upstream?: true
+    })
+  end
+
   test "non-runnable selected window keeps run disabled", %{conn: conn} do
     {:ok, view, _html} = live(conn, detail_path(:stg_payments))
 
     assert has_element?(view, ~s([data-testid="run-selected-window"][disabled]))
     refute has_element?(view, ~s([data-testid="create-backfill"]))
     assert has_element?(view, ~s([data-testid="selected-window-actions"]), "No window policy")
+
+    render_click(view, "open_run_config", %{})
+    refute has_element?(view, ~s([data-testid="run-config-panel"]))
+
+    assert has_element?(
+             view,
+             ~s([data-testid="selected-window-error"]),
+             "This asset has no window policy."
+           )
   end
 
   test "asset detail mode rail changes the central panel", %{conn: conn} do
@@ -219,7 +371,7 @@ defmodule FavnView.PageLiveTest do
 
     assert has_element?(
              view,
-             ~s([data-testid="timeline-window-#{window_id}"][aria-label*="pending"])
+             ~s([data-testid="timeline-window-#{window_id}"][aria-label*="unknown"])
            )
   end
 
@@ -580,9 +732,18 @@ defmodule FavnView.PageLiveTest do
   defp manifest_version do
     manifest = %Manifest{
       assets: [
-        asset(:customer_orders_daily, :snowflake, "sales", :sql, WindowSpec.new!(:day)),
-        asset(:raw_payments, :s3, "finance", :source),
-        asset(:stg_payments, :postgres, "finance", :sql)
+        asset(:raw_payments, :s3, "finance", :source,
+          freshness: Favn.Freshness.Policy.from_value!(max_age: {:hours, 24})
+        ),
+        asset(:customer_orders_daily, :snowflake, "sales", :sql,
+          window: WindowSpec.new!(:day),
+          freshness: Favn.Freshness.Policy.from_value!({:daily, timezone: "Europe/Oslo"}),
+          depends_on: [{__MODULE__.Assets, :raw_payments}]
+        ),
+        asset(:stg_payments, :postgres, "finance", :sql),
+        asset(:always_refresh, :snowflake, "sales", :sql,
+          freshness: Favn.Freshness.Policy.from_value!(:always)
+        )
       ]
     }
 
@@ -590,13 +751,15 @@ defmodule FavnView.PageLiveTest do
     version
   end
 
-  defp asset(name, connection, catalog, type, window \\ nil) do
+  defp asset(name, connection, catalog, type, opts \\ []) do
     %Favn.Manifest.Asset{
       ref: {__MODULE__.Assets, name},
       module: __MODULE__.Assets,
       name: name,
       type: type,
-      window: window,
+      window: Keyword.get(opts, :window),
+      freshness: Keyword.get(opts, :freshness),
+      depends_on: Keyword.get(opts, :depends_on, []),
       relation: %{connection: connection, catalog: catalog, name: Atom.to_string(name)}
     }
   end
@@ -761,6 +924,55 @@ defmodule FavnView.PageLiveTest do
     |> RunState.with_snapshot_hash()
   end
 
+  defp seed_freshness_states! do
+    now = DateTime.utc_now()
+    customer_at = DateTime.add(now, -600, :second)
+
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state(:raw_payments, "raw:v2", now, run_id: "run_raw_payments")
+             )
+
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state(:customer_orders_daily, "customer:v1", customer_at,
+                 run_id: "run_customer_orders_daily",
+                 input_versions: [
+                   %{
+                     upstream_ref: {__MODULE__.Assets, :raw_payments},
+                     upstream_node_key: {{__MODULE__.Assets, :raw_payments}, nil},
+                     freshness_version: "raw:v1",
+                     success_run_id: "run_raw_old"
+                   }
+                 ]
+               )
+             )
+  end
+
+  defp freshness_state(name, version, at, opts) do
+    run_id = Keyword.fetch!(opts, :run_id)
+
+    {:ok, state} =
+      AssetFreshnessState.new(%{
+        asset_ref_module: __MODULE__.Assets,
+        asset_ref_name: name,
+        freshness_key: Favn.Freshness.Key.latest(),
+        status: :ok,
+        freshness_version: version,
+        latest_success_run_id: run_id,
+        latest_success_node_key: {{__MODULE__.Assets, name}, nil},
+        latest_success_at: at,
+        latest_attempt_run_id: run_id,
+        latest_attempt_status: :ok,
+        latest_attempt_at: at,
+        manifest_version_id: "mv_view_assets",
+        input_versions: Keyword.get(opts, :input_versions, []),
+        updated_at: at
+      })
+
+    state
+  end
+
   defp terminal_asset_results(name) do
     ref = {__MODULE__.Assets, name}
     finished_at = DateTime.utc_now()
@@ -831,6 +1043,19 @@ defmodule FavnView.PageLiveTest do
     |> FavnView.RunStepViewModel.from_run()
     |> Enum.find(&(Map.get(&1, :display_name) == Atom.to_string(name)))
     |> Map.fetch!(:id)
+  end
+
+  defp open_run_config(view) do
+    view
+    |> element(~s([data-testid="run-selected-window"]), "Run this window")
+    |> render_click()
+  end
+
+  defp assert_submitted_refresh(run_path, dependencies, refresh_policy) do
+    run_id = String.replace_prefix(run_path, "/runs/", "")
+    assert {:ok, run} = Storage.get_run(run_id)
+    assert run.metadata.asset_dependencies == dependencies
+    assert run.metadata.refresh_policy == refresh_policy
   end
 
   defp target_id(name) do


### PR DESCRIPTION
## Summary
- Add asset-detail run configuration for selected windows with dependency and refresh policy choices.
- Expose backend-owned freshness detail on the orchestrator asset detail read model using the execution freshness decider's policy/key semantics.
- Update run step explanations, Storybook states, and LiveView/orchestrator coverage for the new asset run UX.

## Verification
- `cd apps/favn_orchestrator && mix compile --warnings-as-errors && mix test`
- `cd apps/favn_view && mix compile --warnings-as-errors && mix test`