### PR TITLE
Add Azure PostgreSQL Entra DuckLake bootstrap

### DIFF
--- a/apps/favn/lib/favn/ai.ex
+++ b/apps/favn/lib/favn/ai.ex
@@ -74,9 +74,15 @@ defmodule Favn.AI do
     values come from environment variables or secrets, also read
     `Favn.RuntimeConfig.Ref`.
   - To configure DuckDB/DuckLake connection bootstrap for extension loading,
-    Azure credential-chain secrets, DuckLake attach, or ADLS paths, read
-    `Favn.Connection`, `Favn.RuntimeConfig.Ref`, and
-    `Favn.SQL.Adapter.DuckDB`.
+    Azure credential-chain secrets, ADLS `SCOPE`/`CHAIN`, PostgreSQL metadata
+    secrets, DuckLake `META_SECRET` attach, or ADLS paths, read
+    `Favn.Connection`, `Favn.RuntimeConfig.Ref`, `Favn.SQL.Adapter.DuckDB`, and
+    `Favn.Azure.PostgresEntraToken`. If the deployment uses the ADBC DuckDB
+    adapter, also read `Favn.SQL.Adapter.DuckDB.ADBC`. Azure PostgreSQL Entra
+    auth can fetch managed identity or Azure CLI tokens during session bootstrap
+    for DuckLake PostgreSQL metadata catalogs. The PostgreSQL `user` must be the
+    role created for the Entra principal, and token expiry requires reconnect and
+    rebootstrap.
   - To run SQL queries from plain Elixir code using named Favn connections, read
     `Favn.SQLClient`.
   - To compile a manifest, read `Favn generate_manifest`, then
@@ -132,7 +138,12 @@ defmodule Favn.AI do
   - `Favn.RuntimeConfig.Ref`: when you need the manifest-safe representation of
     required environment values and secret environment values
   - `Favn.SQL.Adapter.DuckDB`: when a DuckDB connection needs the
-    `bootstrap_schema_field/0` helper for DuckLake session setup
+    `bootstrap_schema_field/0` helper for DuckLake session setup, Azure ADLS
+    DuckDB secrets, or PostgreSQL metadata secret wiring
+  - `Favn.SQL.Adapter.DuckDB.ADBC`: when the ADBC DuckDB adapter needs the same
+    DuckLake bootstrap shape with explicit DuckDB driver control
+  - `Favn.Azure.PostgresEntraToken`: when DuckDB bootstrap needs runtime Azure
+    PostgreSQL Entra token acquisition through managed identity or Azure CLI
 
   ## Working Style
 

--- a/apps/favn_azure/lib/favn/azure/postgres_entra_token.ex
+++ b/apps/favn_azure/lib/favn/azure/postgres_entra_token.ex
@@ -1,0 +1,66 @@
+defmodule Favn.Azure.PostgresEntraToken do
+  @moduledoc """
+  Fetches Microsoft Entra access tokens for Azure Database for PostgreSQL.
+
+  The raw HTTP and Azure CLI providers request the PostgreSQL resource exactly as
+  `https://ossrdbms-aad.database.windows.net`. Returned tokens are runtime-only
+  values for immediate connection bootstrap use and are not cached.
+  """
+
+  alias Favn.Azure.PostgresEntraToken.{AzureCLI, ManagedIdentity}
+  alias Favn.Azure.{Token, TokenError}
+
+  @type auth :: keyword() | map()
+  @type opts :: keyword()
+
+  @spec fetch_token(auth(), opts()) :: {:ok, Token.t()} | {:error, TokenError.t()}
+  def fetch_token(auth, opts \\ []) do
+    with {:ok, auth} <- normalize_auth(auth) do
+      provider = Keyword.get(opts, :provider_module) || provider_module(auth)
+      provider.fetch_token(auth, opts)
+    end
+  end
+
+  defp normalize_auth(auth) when is_map(auth), do: normalize_auth(Map.to_list(auth))
+
+  defp normalize_auth(auth) when is_list(auth) do
+    if Keyword.keyword?(auth), do: {:ok, auth}, else: invalid_auth_config()
+  end
+
+  defp normalize_auth(_auth), do: invalid_auth_config()
+
+  defp invalid_auth_config do
+    {:error,
+     %TokenError{
+       type: :invalid_config,
+       message: "invalid Azure PostgreSQL Entra auth config",
+       details: %{reason: :invalid_auth_config}
+     }}
+  end
+
+  defp provider_module(auth) do
+    case Keyword.get(auth, :provider) do
+      :managed_identity -> ManagedIdentity
+      :azure_cli -> AzureCLI
+      _other -> UnsupportedProvider
+    end
+  end
+
+  defmodule UnsupportedProvider do
+    @moduledoc false
+
+    alias Favn.Azure.TokenError
+
+    @behaviour Favn.Azure.PostgresEntraTokenProvider
+
+    @impl true
+    def fetch_token(auth, _opts) do
+      {:error,
+       %TokenError{
+         type: :invalid_config,
+         message: "unsupported Azure PostgreSQL Entra token provider",
+         details: %{provider: inspect(Keyword.get(auth, :provider))}
+       }}
+    end
+  end
+end

--- a/apps/favn_azure/lib/favn/azure/postgres_entra_token/azure_cli.ex
+++ b/apps/favn_azure/lib/favn/azure/postgres_entra_token/azure_cli.ex
@@ -1,0 +1,56 @@
+defmodule Favn.Azure.PostgresEntraToken.AzureCLI do
+  @moduledoc """
+  Azure CLI token provider for Azure Database for PostgreSQL Entra auth.
+  """
+
+  alias Favn.Azure.{Token, TokenError}
+
+  @behaviour Favn.Azure.PostgresEntraTokenProvider
+
+  @resource "https://ossrdbms-aad.database.windows.net"
+
+  @impl true
+  def fetch_token(_auth, opts) do
+    cmd = Keyword.get(opts, :system_cmd, &System.cmd/3)
+
+    case cmd.("az", ["account", "get-access-token", "--resource", @resource, "--output", "json"],
+           stderr_to_stdout: false
+         ) do
+      {json, 0} -> parse_token(json)
+      {_output, status} -> {:error, cli_error(status)}
+    end
+  rescue
+    error in ErlangError ->
+      {:error,
+       %TokenError{
+         type: :connection_error,
+         message: "Azure CLI token acquisition failed",
+         retryable?: false,
+         details: %{reason: inspect(error.original)}
+       }}
+  end
+
+  defp parse_token(json) do
+    with {:ok, decoded} <- Jason.decode(json),
+         token when is_binary(token) and token != "" <- decoded["accessToken"] do
+      {:ok, %Token{access_token: token, expires_on: decoded["expiresOn"]}}
+    else
+      _other ->
+        {:error,
+         %TokenError{
+           type: :execution_error,
+           message: "Azure CLI returned an invalid token response",
+           details: %{reason: :invalid_token_response}
+         }}
+    end
+  end
+
+  defp cli_error(status) do
+    %TokenError{
+      type: :authentication_error,
+      message: "Azure CLI token acquisition failed",
+      retryable?: false,
+      details: %{status: status}
+    }
+  end
+end

--- a/apps/favn_azure/lib/favn/azure/postgres_entra_token/managed_identity.ex
+++ b/apps/favn_azure/lib/favn/azure/postgres_entra_token/managed_identity.ex
@@ -1,0 +1,170 @@
+defmodule Favn.Azure.PostgresEntraToken.ManagedIdentity do
+  @moduledoc """
+  Managed identity token provider for Azure Database for PostgreSQL Entra auth.
+
+  `endpoint: :auto` selects Azure App Service managed identity when both
+  `IDENTITY_ENDPOINT` and `IDENTITY_HEADER` are present; otherwise it falls back
+  to the Azure Instance Metadata Service endpoint.
+  """
+
+  alias Favn.Azure.{Token, TokenError}
+
+  @behaviour Favn.Azure.PostgresEntraTokenProvider
+
+  @resource "https://ossrdbms-aad.database.windows.net"
+  @imds_endpoint "http://169.254.169.254/metadata/identity/oauth2/token"
+  @imds_api_version "2018-02-01"
+  @azure_app_service_api_version "2019-08-01"
+  @retry_statuses [404, 429, 500, 502, 503, 504]
+  @retry_delays [100, 200, 400]
+
+  @impl true
+  def fetch_token(auth, opts) do
+    with {:ok, request} <- build_request(auth, opts) do
+      request_with_retry(request, opts, @retry_delays)
+    end
+  end
+
+  defp build_request(auth, opts) do
+    env = Keyword.get(opts, :env, &System.get_env/1)
+    endpoint = Keyword.get(auth, :endpoint, :auto)
+
+    case resolve_endpoint(endpoint, env) do
+      {:ok, :imds, url, headers} ->
+        {:ok, request(url, headers, auth, @imds_api_version)}
+
+      {:ok, :azure_app_service, url, headers} ->
+        {:ok, request(url, headers, auth, @azure_app_service_api_version)}
+
+      {:error, %TokenError{} = error} ->
+        {:error, error}
+    end
+  end
+
+  defp resolve_endpoint(:auto, env) do
+    case {env.("IDENTITY_ENDPOINT"), env.("IDENTITY_HEADER")} do
+      {endpoint, header}
+      when is_binary(endpoint) and endpoint != "" and is_binary(header) and header != "" ->
+        {:ok, :azure_app_service, endpoint, [{~c"X-IDENTITY-HEADER", to_charlist(header)}]}
+
+      _missing ->
+        {:ok, :imds, @imds_endpoint, [{~c"Metadata", ~c"true"}]}
+    end
+  end
+
+  defp resolve_endpoint(:imds, _env), do: {:ok, :imds, @imds_endpoint, [{~c"Metadata", ~c"true"}]}
+
+  defp resolve_endpoint(:azure_app_service, env) do
+    case {env.("IDENTITY_ENDPOINT"), env.("IDENTITY_HEADER")} do
+      {endpoint, header}
+      when is_binary(endpoint) and endpoint != "" and is_binary(header) and header != "" ->
+        {:ok, :azure_app_service, endpoint, [{~c"X-IDENTITY-HEADER", to_charlist(header)}]}
+
+      _missing ->
+        {:error,
+         %TokenError{
+           type: :invalid_config,
+           message: "Azure App Service managed identity endpoint is not configured",
+           details: %{reason: :missing_identity_endpoint}
+         }}
+    end
+  end
+
+  defp resolve_endpoint(endpoint, _env) do
+    {:error,
+     %TokenError{
+       type: :invalid_config,
+       message: "invalid managed identity endpoint",
+       details: %{endpoint: inspect(endpoint)}
+     }}
+  end
+
+  defp request(url, headers, auth, api_version) do
+    query =
+      [api_version: api_version, resource: @resource]
+      |> maybe_put(:client_id, Keyword.get(auth, :client_id))
+      |> URI.encode_query()
+
+    separator = if String.contains?(url, "?"), do: "&", else: "?"
+    {String.to_charlist(url <> separator <> query), headers}
+  end
+
+  defp maybe_put(query, _key, nil), do: query
+  defp maybe_put(query, key, value), do: Keyword.put(query, key, value)
+
+  defp request_with_retry(request, opts, delays) do
+    case http_request(request, opts) do
+      {:ok, token} ->
+        {:ok, token}
+
+      {:error, %TokenError{retryable?: true} = error} when delays != [] ->
+        retry(request, opts, delays, error)
+
+      {:error, %TokenError{} = error} ->
+        {:error, error}
+    end
+  end
+
+  defp retry(request, opts, [delay | rest], _error) do
+    sleeper = Keyword.get(opts, :sleeper, &Process.sleep/1)
+    sleeper.(delay)
+    request_with_retry(request, opts, rest)
+  end
+
+  defp http_request({url, headers}, opts) do
+    http_client = Keyword.get(opts, :http_client, &:httpc.request/4)
+
+    case http_client.(:get, {url, headers}, [{:timeout, 5_000}], body_format: :binary) do
+      {:ok, {{_version, status, _reason}, _headers, body}} when status in 200..299 ->
+        parse_token(body)
+
+      {:ok, {{_version, status, _reason}, _headers, _body}} ->
+        {:error, http_error(status)}
+
+      {:error, :timeout} ->
+        {:error, timeout_error()}
+
+      {:error, reason} ->
+        {:error,
+         %TokenError{
+           type: :connection_error,
+           message: "managed identity token request failed",
+           retryable?: false,
+           details: %{reason: inspect(reason)}
+         }}
+    end
+  end
+
+  defp parse_token(json) do
+    with {:ok, decoded} <- Jason.decode(json),
+         token when is_binary(token) and token != "" <- decoded["access_token"] do
+      {:ok, %Token{access_token: token, expires_on: decoded["expires_on"]}}
+    else
+      _other ->
+        {:error,
+         %TokenError{
+           type: :execution_error,
+           message: "managed identity returned an invalid token response",
+           details: %{reason: :invalid_token_response}
+         }}
+    end
+  end
+
+  defp http_error(status) do
+    %TokenError{
+      type: if(status in @retry_statuses, do: :connection_error, else: :authentication_error),
+      message: "managed identity token request failed",
+      retryable?: status in @retry_statuses,
+      details: %{status: status}
+    }
+  end
+
+  defp timeout_error do
+    %TokenError{
+      type: :connection_error,
+      message: "managed identity token request timed out",
+      retryable?: true,
+      details: %{reason: :timeout}
+    }
+  end
+end

--- a/apps/favn_azure/lib/favn/azure/postgres_entra_token/managed_identity.ex
+++ b/apps/favn_azure/lib/favn/azure/postgres_entra_token/managed_identity.ex
@@ -81,7 +81,7 @@ defmodule Favn.Azure.PostgresEntraToken.ManagedIdentity do
 
   defp request(url, headers, auth, api_version) do
     query =
-      [api_version: api_version, resource: @resource]
+      [{:"api-version", api_version}, {:resource, @resource}]
       |> maybe_put(:client_id, Keyword.get(auth, :client_id))
       |> URI.encode_query()
 

--- a/apps/favn_azure/lib/favn/azure/postgres_entra_token_provider.ex
+++ b/apps/favn_azure/lib/favn/azure/postgres_entra_token_provider.ex
@@ -1,0 +1,12 @@
+defmodule Favn.Azure.PostgresEntraTokenProvider do
+  @moduledoc """
+  Behaviour for Azure PostgreSQL Microsoft Entra token providers.
+  """
+
+  alias Favn.Azure.{Token, TokenError}
+
+  @type auth :: keyword() | map()
+  @type opts :: keyword()
+
+  @callback fetch_token(auth(), opts()) :: {:ok, Token.t()} | {:error, TokenError.t()}
+end

--- a/apps/favn_azure/lib/favn/azure/token.ex
+++ b/apps/favn_azure/lib/favn/azure/token.ex
@@ -1,0 +1,13 @@
+defmodule Favn.Azure.Token do
+  @moduledoc """
+  Runtime Azure access token returned by Favn Azure token providers.
+
+  Tokens are intended for immediate adapter bootstrap use. Callers must not
+  persist, log, or expose `access_token` values.
+  """
+
+  @enforce_keys [:access_token]
+  defstruct [:access_token, :expires_on]
+
+  @type t :: %__MODULE__{access_token: String.t(), expires_on: term()}
+end

--- a/apps/favn_azure/lib/favn/azure/token_error.ex
+++ b/apps/favn_azure/lib/favn/azure/token_error.ex
@@ -1,0 +1,17 @@
+defmodule Favn.Azure.TokenError do
+  @moduledoc """
+  Redacted Azure token acquisition error.
+  """
+
+  @enforce_keys [:type, :message]
+  defstruct [:type, :message, retryable?: false, details: %{}]
+
+  @type type :: :invalid_config | :authentication_error | :connection_error | :execution_error
+
+  @type t :: %__MODULE__{
+          type: type(),
+          message: String.t(),
+          retryable?: boolean(),
+          details: map()
+        }
+end

--- a/apps/favn_azure/mix.exs
+++ b/apps/favn_azure/mix.exs
@@ -1,0 +1,28 @@
+defmodule FavnAzure.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :favn_azure,
+      version: "0.5.0-dev",
+      description: "Azure integration helpers for Favn adapters",
+      build_path: "../../_build",
+      config_path: "../../config/config.exs",
+      deps_path: "../../deps",
+      lockfile: "../../mix.lock",
+      elixir: "~> 1.19",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [extra_applications: [:logger, :inets, :ssl]]
+  end
+
+  defp deps do
+    [
+      {:jason, "~> 1.4"}
+    ]
+  end
+end

--- a/apps/favn_azure/test/favn/azure/postgres_entra_token_test.exs
+++ b/apps/favn_azure/test/favn/azure/postgres_entra_token_test.exs
@@ -30,7 +30,7 @@ defmodule Favn.Azure.PostgresEntraTokenTest do
     http_client = fn :get, {url, headers}, _http_opts, _opts ->
       url = to_string(url)
       assert url =~ "http://localhost/msi/token?"
-      assert url =~ "api_version=2019-08-01"
+      assert url =~ "api-version=2019-08-01"
       assert url =~ "resource=https%3A%2F%2Fossrdbms-aad.database.windows.net"
       assert url =~ "client_id=client-1"
       assert {~c"X-IDENTITY-HEADER", ~c"identity-header"} in headers
@@ -56,7 +56,7 @@ defmodule Favn.Azure.PostgresEntraTokenTest do
 
     http_client = fn :get, {url, headers}, _http_opts, _opts ->
       assert to_string(url) =~ "http://169.254.169.254/metadata/identity/oauth2/token?"
-      assert to_string(url) =~ "api_version=2018-02-01"
+      assert to_string(url) =~ "api-version=2018-02-01"
       assert {~c"Metadata", ~c"true"} in headers
 
       {:ok,

--- a/apps/favn_azure/test/favn/azure/postgres_entra_token_test.exs
+++ b/apps/favn_azure/test/favn/azure/postgres_entra_token_test.exs
@@ -1,0 +1,127 @@
+defmodule Favn.Azure.PostgresEntraTokenTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Azure.PostgresEntraToken
+  alias Favn.Azure.PostgresEntraToken.ManagedIdentity
+  alias Favn.Azure.TokenError
+
+  @resource "https://ossrdbms-aad.database.windows.net"
+
+  test "Azure CLI provider parses accessToken and expiresOn" do
+    system_cmd = fn "az", args, opts ->
+      assert args == ["account", "get-access-token", "--resource", @resource, "--output", "json"]
+      assert opts == [stderr_to_stdout: false]
+      {Jason.encode!(%{accessToken: "cli-token", expiresOn: "2026-05-12 12:00:00.000000"}), 0}
+    end
+
+    assert {:ok, token} =
+             PostgresEntraToken.fetch_token([provider: :azure_cli], system_cmd: system_cmd)
+
+    assert token.access_token == "cli-token"
+    assert token.expires_on == "2026-05-12 12:00:00.000000"
+  end
+
+  test "managed identity auto uses Azure App Service endpoint when environment is present" do
+    env = fn
+      "IDENTITY_ENDPOINT" -> "http://localhost/msi/token"
+      "IDENTITY_HEADER" -> "identity-header"
+    end
+
+    http_client = fn :get, {url, headers}, _http_opts, _opts ->
+      url = to_string(url)
+      assert url =~ "http://localhost/msi/token?"
+      assert url =~ "api_version=2019-08-01"
+      assert url =~ "resource=https%3A%2F%2Fossrdbms-aad.database.windows.net"
+      assert url =~ "client_id=client-1"
+      assert {~c"X-IDENTITY-HEADER", ~c"identity-header"} in headers
+
+      {:ok,
+       {{~c"HTTP/1.1", 200, ~c"OK"}, [],
+        Jason.encode!(%{access_token: "msi-token", expires_on: "1770000000"})}}
+    end
+
+    assert {:ok, token} =
+             ManagedIdentity.fetch_token(
+               [provider: :managed_identity, client_id: "client-1", endpoint: :auto],
+               env: env,
+               http_client: http_client
+             )
+
+    assert token.access_token == "msi-token"
+    assert token.expires_on == "1770000000"
+  end
+
+  test "managed identity auto falls back to IMDS" do
+    env = fn _name -> nil end
+
+    http_client = fn :get, {url, headers}, _http_opts, _opts ->
+      assert to_string(url) =~ "http://169.254.169.254/metadata/identity/oauth2/token?"
+      assert to_string(url) =~ "api_version=2018-02-01"
+      assert {~c"Metadata", ~c"true"} in headers
+
+      {:ok,
+       {{~c"HTTP/1.1", 200, ~c"OK"}, [],
+        ~s({"access_token":"imds-token","expires_on":"1770000000"})}}
+    end
+
+    assert {:ok, token} =
+             ManagedIdentity.fetch_token([provider: :managed_identity],
+               env: env,
+               http_client: http_client
+             )
+
+    assert token.access_token == "imds-token"
+  end
+
+  test "managed identity retries only transient failures" do
+    parent = self()
+
+    http_client = fn :get, _request, _http_opts, _opts ->
+      send(parent, :request)
+
+      case Process.get(:requests, 0) do
+        0 ->
+          Process.put(:requests, 1)
+          {:ok, {{~c"HTTP/1.1", 429, ~c"Too Many Requests"}, [], ""}}
+
+        _count ->
+          {:ok,
+           {{~c"HTTP/1.1", 200, ~c"OK"}, [],
+            ~s({"access_token":"retry-token","expires_on":"1770000000"})}}
+      end
+    end
+
+    sleeper = fn delay -> send(parent, {:sleep, delay}) end
+
+    assert {:ok, token} =
+             ManagedIdentity.fetch_token([provider: :managed_identity, endpoint: :imds],
+               env: fn _ -> nil end,
+               http_client: http_client,
+               sleeper: sleeper
+             )
+
+    assert token.access_token == "retry-token"
+    assert_received :request
+    assert_received :request
+    assert_received {:sleep, 100}
+  end
+
+  test "managed identity does not retry normal auth errors" do
+    parent = self()
+
+    http_client = fn :get, _request, _http_opts, _opts ->
+      send(parent, :request)
+      {:ok, {{~c"HTTP/1.1", 401, ~c"Unauthorized"}, [], ""}}
+    end
+
+    assert {:error, %TokenError{type: :authentication_error, retryable?: false}} =
+             ManagedIdentity.fetch_token([provider: :managed_identity, endpoint: :imds],
+               env: fn _ -> nil end,
+               http_client: http_client,
+               sleeper: fn _ -> flunk("should not sleep") end
+             )
+
+    assert_received :request
+    refute_received :request
+  end
+end

--- a/apps/favn_azure/test/test_helper.exs
+++ b/apps/favn_azure/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/apps/favn_duckdb/lib/favn/sql/adapter/duckdb.ex
+++ b/apps/favn_duckdb/lib/favn/sql/adapter/duckdb.ex
@@ -53,13 +53,29 @@ defmodule Favn.SQL.Adapter.DuckDB do
                 azure_adls: [
                   type: :azure,
                   provider: :credential_chain,
-                  account_name: Favn.RuntimeConfig.Ref.env!("AZURE_STORAGE_ACCOUNT")
+                  account_name: Favn.RuntimeConfig.Ref.env!("AZURE_STORAGE_ACCOUNT"),
+                  chain: [:cli, :env],
+                  scope: Favn.RuntimeConfig.Ref.env!("DUCKLAKE_DATA_SCOPE")
+                ],
+                oceanos_meta: [
+                  type: :postgres,
+                  host: Favn.RuntimeConfig.Ref.env!("DUCKLAKE_POSTGRES_HOST"),
+                  port: 5432,
+                  database: Favn.RuntimeConfig.Ref.env!("DUCKLAKE_POSTGRES_DATABASE"),
+                  user: Favn.RuntimeConfig.Ref.env!("DUCKLAKE_POSTGRES_USER"),
+                  auth: [
+                    type: :azure_postgres_entra,
+                    provider: :managed_identity,
+                    client_id: Favn.RuntimeConfig.Ref.env!("AZURE_CLIENT_ID", required?: false),
+                    endpoint: :auto
+                  ],
+                  sslmode: :require
                 ]
               ],
               attach: [
                 name: :lake,
                 type: :ducklake,
-                metadata: Favn.RuntimeConfig.Ref.secret_env!("DUCKLAKE_POSTGRES_DSN"),
+                metadata: [type: :postgres, secret: :oceanos_meta],
                 data_path: Favn.RuntimeConfig.Ref.env!("DUCKLAKE_DATA_PATH")
               ],
               use: :lake
@@ -69,6 +85,52 @@ defmodule Favn.SQL.Adapter.DuckDB do
 
   Bootstrap failures return `Favn.SQL.Error` values with `operation: :bootstrap`,
   the failing step id, and redacted diagnostics.
+
+  ## Supported DuckLake bootstrap secrets
+
+  DuckDB bootstrap is intentionally DuckDB-specific. It can install/load
+  extensions, create temporary DuckDB secrets, attach a DuckLake catalog, and set
+  the active catalog with `USE`.
+
+  Azure ADLS secrets support DuckDB's `credential_chain` provider with optional
+  `:chain` and `:scope` fields. Chain values must be one or more of `:cli`,
+  `:managed_identity`, `:workload_identity`, `:env`, or `:default`; they render
+  as DuckDB's semicolon-separated `CHAIN` value. Scoped Azure secrets must use a
+  trailing slash, for example `abfss://container@account.dfs.core.windows.net/path/`.
+
+  PostgreSQL metadata catalog credentials can be supplied as DuckDB Postgres
+  secrets and then referenced from DuckLake attach metadata with
+  `metadata: [type: :postgres, secret: :secret_name]`. The optional `:sslmode`
+  value is passed through the DuckLake/Postgres metadata path because DuckDB's
+  Postgres secret type does not accept `SSLMODE` as a secret parameter.
+
+  PostgreSQL secrets accept either `:password` or Azure PostgreSQL Entra `:auth`,
+  not both. Azure auth supports managed identity and Azure CLI dogfooding:
+
+      auth: [
+        type: :azure_postgres_entra,
+        provider: :managed_identity,
+        client_id: Favn.RuntimeConfig.Ref.env!("AZURE_CLIENT_ID", required?: false),
+        endpoint: :auto
+      ]
+
+      auth: [type: :azure_postgres_entra, provider: :azure_cli]
+
+  Managed identity `endpoint: :auto` uses Azure App Service managed identity when
+  `IDENTITY_ENDPOINT` and `IDENTITY_HEADER` are present, otherwise IMDS. The
+  PostgreSQL `:user` must be the PostgreSQL role created for the Entra principal
+  or managed identity, for example with
+  `select * from pgaadauth_create_principal('<identity_name>', false, false);`.
+  Tokens are fetched during DuckDB bootstrap immediately before the temporary
+  `CREATE SECRET` statement, injected as `PASSWORD`, never cached or persisted,
+  and require reconnect/rebootstrap after expiry.
+
+  Existing `metadata: Favn.RuntimeConfig.Ref.secret_env!("DUCKLAKE_POSTGRES_DSN")`
+  attach configuration remains supported as a fallback, but storing PostgreSQL
+  credentials in DuckDB secrets is preferred because connection-string failures
+  can expose raw credentials in lower-level errors.
+
+  Generated bootstrap SQL uses temporary DuckDB secrets (`CREATE SECRET`) only.
   """
 
   @behaviour Favn.SQL.Adapter

--- a/apps/favn_duckdb/lib/favn/sql/adapter/duckdb/bootstrap.ex
+++ b/apps/favn_duckdb/lib/favn/sql/adapter/duckdb/bootstrap.ex
@@ -32,8 +32,8 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
 
   @spec run(DuckDB.Conn.t(), Resolved.t(), keyword()) :: :ok | {:error, Error.t()}
   def run(%DuckDB.Conn{} = conn, %Resolved{} = resolved, opts) do
-    with {:ok, steps} <- build_steps(resolved, opts) do
-      execute_steps(conn, resolved, steps)
+    with {:ok, steps} <- build_steps(resolved) do
+      execute_steps(conn, resolved, steps, opts)
     end
   end
 
@@ -41,7 +41,7 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
   def build_steps(%Resolved{} = resolved), do: build_steps(resolved, [])
 
   @spec build_steps(Resolved.t(), keyword()) :: {:ok, [step()]} | {:error, Error.t()}
-  def build_steps(%Resolved{} = resolved, opts) do
+  def build_steps(%Resolved{} = resolved, _opts) do
     case Map.get(resolved.config || %{}, @config_key) do
       nil ->
         {:ok, []}
@@ -53,26 +53,24 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
         config
         |> normalize_config()
         |> case do
-          {:ok, normalized} -> build_normalized_steps(resolved, normalized, opts)
+          {:ok, normalized} -> build_normalized_steps(normalized)
           {:error, reason} -> {:error, config_error(resolved, reason)}
         end
     end
   end
 
-  defp build_normalized_steps(%Resolved{} = resolved, normalized, opts) do
-    case materialize_auth_secrets(normalized.secrets, opts) do
-      {:ok, secrets} -> {:ok, steps(%{normalized | secrets: secrets})}
-      {:error, secret, %TokenError{} = error} -> {:error, token_error(resolved, secret, error)}
-    end
-  end
+  defp build_normalized_steps(normalized), do: {:ok, steps(normalized)}
 
-  defp execute_steps(_conn, _resolved, []), do: :ok
+  defp execute_steps(_conn, _resolved, [], _opts), do: :ok
 
-  defp execute_steps(%DuckDB.Conn{} = conn, %Resolved{} = resolved, steps) do
+  defp execute_steps(%DuckDB.Conn{} = conn, %Resolved{} = resolved, steps, opts) do
     Enum.reduce_while(steps, :ok, fn step, :ok ->
-      case DuckDB.execute(conn, step.statement, []) do
-        {:ok, _result} ->
-          {:cont, :ok}
+      with {:ok, step} <- materialize_step(step, opts),
+           {:ok, _result} <- DuckDB.execute(conn, step.statement, []) do
+        {:cont, :ok}
+      else
+        {:error, %TokenError{} = error} ->
+          {:halt, {:error, token_error(resolved, step, error)}}
 
         {:error, %Error{} = error} ->
           {:halt, {:error, bootstrap_error(resolved, step, error)}}
@@ -228,21 +226,7 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
   defp normalize_managed_identity_endpoint(endpoint),
     do: {:error, {:invalid_managed_identity_endpoint, endpoint}}
 
-  defp materialize_auth_secrets(secrets, opts) do
-    secrets
-    |> Enum.reduce_while({:ok, []}, fn secret, {:ok, acc} ->
-      case materialize_auth_secret(secret, opts) do
-        {:ok, secret} -> {:cont, {:ok, [secret | acc]}}
-        {:error, %TokenError{} = error} -> {:halt, {:error, secret, error}}
-      end
-    end)
-    |> case do
-      {:ok, secrets} -> {:ok, Enum.reverse(secrets)}
-      {:error, _secret, %TokenError{} = _error} = error -> error
-    end
-  end
-
-  defp materialize_auth_secret(%{type: :postgres, auth: auth} = secret, opts)
+  defp materialize_step(%{postgres_secret: secret, postgres_auth: auth}, opts)
        when is_list(auth) do
     token_opts =
       case Keyword.get(opts, :azure_token_provider_module) do
@@ -251,12 +235,12 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
       end
 
     case PostgresEntraToken.fetch_token(auth, token_opts) do
-      {:ok, token} -> {:ok, %{secret | password: token.access_token}}
+      {:ok, token} -> {:ok, postgres_secret_step(secret, token.access_token, nil)}
       {:error, %TokenError{} = error} -> {:error, error}
     end
   end
 
-  defp materialize_auth_secret(secret, _opts), do: {:ok, secret}
+  defp materialize_step(step, _opts), do: {:ok, step}
 
   defp normalize_attach(nil), do: {:ok, nil}
 
@@ -521,17 +505,41 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
     }
   end
 
-  defp secret_step(%{
-         name: name,
-         type: :postgres,
-         host: host,
-         port: port,
-         database: database,
-         user: user,
-         password: password,
-         auth: _auth,
-         sslmode: _sslmode
-       }) do
+  defp secret_step(
+         %{
+           name: name,
+           type: :postgres,
+           host: host,
+           port: port,
+           database: database,
+           user: user,
+           password: password,
+           auth: auth,
+           sslmode: _sslmode
+         } = secret
+       ) do
+    step = postgres_secret_step(secret, password, auth)
+
+    if is_list(auth) do
+      step
+      |> Map.put(:postgres_secret, %{
+        name: name,
+        host: host,
+        port: port,
+        database: database,
+        user: user
+      })
+      |> Map.put(:postgres_auth, auth)
+    else
+      step
+    end
+  end
+
+  defp postgres_secret_step(
+         %{name: name, host: host, port: port, database: database, user: user},
+         password,
+         auth
+       ) do
     options = [
       "TYPE postgres",
       ["HOST ", quote_literal(host)],
@@ -551,7 +559,8 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
     ]
 
     safe_options =
-      safe_options ++ if(password, do: [["PASSWORD ", quote_literal(:redacted)]], else: [])
+      safe_options ++
+        if(password || auth, do: [["PASSWORD ", quote_literal(:redacted)]], else: [])
 
     %{
       id: step_id(:create_secret, name),
@@ -716,9 +725,7 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
     }
   end
 
-  defp token_error(%Resolved{} = resolved, secret, %TokenError{} = error) do
-    step = %{id: step_id(:create_secret, secret.name), kind: :create_secret}
-
+  defp token_error(%Resolved{} = resolved, step, %TokenError{} = error) do
     %Error{
       type: error.type,
       message: "DuckDB connection bootstrap failed at #{step.id}",
@@ -729,8 +736,7 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
       details: %{
         step: step.id,
         bootstrap_kind: step.kind,
-        statement:
-          "CREATE SECRET #{IO.iodata_to_binary(quote_ident(secret.name))} (TYPE postgres, PASSWORD 'redacted')",
+        statement: IO.iodata_to_binary(step.safe_statement),
         reason: error.message,
         adapter_error_type: error.type,
         adapter_details: Error.redact(error.details)

--- a/apps/favn_duckdb/lib/favn/sql/adapter/duckdb/bootstrap.ex
+++ b/apps/favn_duckdb/lib/favn/sql/adapter/duckdb/bootstrap.ex
@@ -2,10 +2,13 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
   @moduledoc false
 
   alias Favn.Connection.Resolved
+  alias Favn.Azure.{PostgresEntraToken, TokenError}
   alias Favn.SQL.Adapter.DuckDB
   alias Favn.SQL.Error
 
   @config_key :duckdb_bootstrap
+  @azure_credential_chain_values ~w(cli managed_identity workload_identity env default)
+  @postgres_sslmodes ~w(disable allow prefer require verify-ca verify-full)
 
   @type step :: %{id: String.t(), kind: atom(), statement: iodata(), safe_statement: iodata()}
 
@@ -28,14 +31,17 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
   def validate_config(_value), do: {:error, :expected_duckdb_bootstrap_keyword_or_map}
 
   @spec run(DuckDB.Conn.t(), Resolved.t(), keyword()) :: :ok | {:error, Error.t()}
-  def run(%DuckDB.Conn{} = conn, %Resolved{} = resolved, _opts) do
-    with {:ok, steps} <- build_steps(resolved) do
+  def run(%DuckDB.Conn{} = conn, %Resolved{} = resolved, opts) do
+    with {:ok, steps} <- build_steps(resolved, opts) do
       execute_steps(conn, resolved, steps)
     end
   end
 
   @spec build_steps(Resolved.t()) :: {:ok, [step()]} | {:error, Error.t()}
-  def build_steps(%Resolved{} = resolved) do
+  def build_steps(%Resolved{} = resolved), do: build_steps(resolved, [])
+
+  @spec build_steps(Resolved.t(), keyword()) :: {:ok, [step()]} | {:error, Error.t()}
+  def build_steps(%Resolved{} = resolved, opts) do
     case Map.get(resolved.config || %{}, @config_key) do
       nil ->
         {:ok, []}
@@ -47,9 +53,16 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
         config
         |> normalize_config()
         |> case do
-          {:ok, normalized} -> {:ok, steps(normalized)}
+          {:ok, normalized} -> build_normalized_steps(resolved, normalized, opts)
           {:error, reason} -> {:error, config_error(resolved, reason)}
         end
+    end
+  end
+
+  defp build_normalized_steps(%Resolved{} = resolved, normalized, opts) do
+    case materialize_auth_secrets(normalized.secrets, opts) do
+      {:ok, secrets} -> {:ok, steps(%{normalized | secrets: secrets})}
+      {:error, secret, %TokenError{} = error} -> {:error, token_error(resolved, secret, error)}
     end
   end
 
@@ -72,6 +85,7 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
          {:ok, extensions} <- normalize_extensions(Keyword.get(normalized, :extensions, [])),
          {:ok, secrets} <- normalize_secrets(Keyword.get(normalized, :secrets, [])),
          {:ok, attach} <- normalize_attach(Keyword.get(normalized, :attach)),
+         {:ok, attach} <- inherit_attach_metadata_options(attach, secrets),
          {:ok, use_catalog} <- normalize_optional_identifier(Keyword.get(normalized, :use)) do
       {:ok, %{extensions: extensions, secrets: secrets, attach: attach, use: use_catalog}}
     end
@@ -130,13 +144,44 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
   defp normalize_secret_config(name, secret) do
     case {Keyword.get(secret, :type), Keyword.get(secret, :provider)} do
       {:azure, :credential_chain} ->
-        account_name = Keyword.get(secret, :account_name)
-
-        if present_string?(account_name) do
+        with {:ok, account_name} <- fetch_secret_value(secret, name, :account_name),
+             {:ok, chain} <- normalize_azure_chain(Keyword.get(secret, :chain)),
+             {:ok, scope} <- normalize_azure_scope(Keyword.get(secret, :scope)) do
           {:ok,
-           %{name: name, type: :azure, provider: :credential_chain, account_name: account_name}}
-        else
-          {:error, {:missing_secret_field, name, :account_name}}
+           %{
+             name: name,
+             type: :azure,
+             provider: :credential_chain,
+             account_name: account_name,
+             chain: chain,
+             scope: scope
+           }}
+        end
+
+      {:postgres, nil} ->
+        with {:ok, host} <- fetch_secret_value(secret, name, :host),
+             {:ok, port} <- normalize_postgres_port(Keyword.get(secret, :port), name),
+             {:ok, database} <- fetch_secret_value(secret, name, :database),
+             {:ok, user} <- fetch_secret_value(secret, name, :user),
+             {:ok, password} <- normalize_postgres_password(secret, name),
+             {:ok, auth} <- normalize_postgres_auth(Keyword.get(secret, :auth), name),
+             {:ok, sslmode} <- normalize_postgres_sslmode(Keyword.get(secret, :sslmode)) do
+          if password && auth do
+            {:error, {:conflicting_secret_fields, name, [:password, :auth]}}
+          else
+            {:ok,
+             %{
+               name: name,
+               type: :postgres,
+               host: host,
+               port: port,
+               database: database,
+               user: user,
+               password: password,
+               auth: auth,
+               sslmode: sslmode
+             }}
+          end
         end
 
       other ->
@@ -144,12 +189,81 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
     end
   end
 
+  defp normalize_postgres_password(secret, name) do
+    normalize_optional_secret_string(Keyword.get(secret, :password), name, :password)
+  end
+
+  defp normalize_postgres_auth(nil, _name), do: {:ok, nil}
+
+  defp normalize_postgres_auth(auth, name) when is_map(auth) or is_list(auth) do
+    with {:ok, auth} <- normalize_keyword_config(auth, {:postgres_auth, name}) do
+      case {Keyword.get(auth, :type), Keyword.get(auth, :provider)} do
+        {:azure_postgres_entra, :managed_identity} ->
+          with {:ok, endpoint} <-
+                 normalize_managed_identity_endpoint(Keyword.get(auth, :endpoint, :auto)) do
+            {:ok,
+             [
+               type: :azure_postgres_entra,
+               provider: :managed_identity,
+               client_id: Keyword.get(auth, :client_id),
+               endpoint: endpoint
+             ]}
+          end
+
+        {:azure_postgres_entra, :azure_cli} ->
+          {:ok, [type: :azure_postgres_entra, provider: :azure_cli]}
+
+        other ->
+          {:error, {:unsupported_postgres_auth, name, other}}
+      end
+    end
+  end
+
+  defp normalize_postgres_auth(_auth, name), do: {:error, {:invalid_secret_field, name, :auth}}
+
+  defp normalize_managed_identity_endpoint(endpoint)
+       when endpoint in [:auto, :imds, :azure_app_service],
+       do: {:ok, endpoint}
+
+  defp normalize_managed_identity_endpoint(endpoint),
+    do: {:error, {:invalid_managed_identity_endpoint, endpoint}}
+
+  defp materialize_auth_secrets(secrets, opts) do
+    secrets
+    |> Enum.reduce_while({:ok, []}, fn secret, {:ok, acc} ->
+      case materialize_auth_secret(secret, opts) do
+        {:ok, secret} -> {:cont, {:ok, [secret | acc]}}
+        {:error, %TokenError{} = error} -> {:halt, {:error, secret, error}}
+      end
+    end)
+    |> case do
+      {:ok, secrets} -> {:ok, Enum.reverse(secrets)}
+      {:error, _secret, %TokenError{} = _error} = error -> error
+    end
+  end
+
+  defp materialize_auth_secret(%{type: :postgres, auth: auth} = secret, opts)
+       when is_list(auth) do
+    token_opts =
+      case Keyword.get(opts, :azure_token_provider_module) do
+        nil -> []
+        provider_module -> [provider_module: provider_module]
+      end
+
+    case PostgresEntraToken.fetch_token(auth, token_opts) do
+      {:ok, token} -> {:ok, %{secret | password: token.access_token}}
+      {:error, %TokenError{} = error} -> {:error, error}
+    end
+  end
+
+  defp materialize_auth_secret(secret, _opts), do: {:ok, secret}
+
   defp normalize_attach(nil), do: {:ok, nil}
 
   defp normalize_attach(config) do
     with {:ok, attach} <- normalize_keyword_config(config, :attach),
          {:ok, name} <- normalize_identifier(Keyword.get(attach, :name)),
-         {:ok, metadata} <- fetch_present_value(attach, :metadata),
+         {:ok, metadata} <- normalize_attach_metadata(Keyword.get(attach, :metadata)),
          {:ok, data_path} <- fetch_present_value(attach, :data_path) do
       case Keyword.get(attach, :type) do
         :ducklake ->
@@ -166,6 +280,135 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
       end
     end
   end
+
+  defp fetch_secret_value(keyword, name, key) do
+    case Keyword.fetch(keyword, key) do
+      {:ok, value} ->
+        if present_string?(value) do
+          {:ok, value}
+        else
+          {:error, {:missing_secret_field, name, key}}
+        end
+
+      :error ->
+        {:error, {:missing_secret_field, name, key}}
+    end
+  end
+
+  defp normalize_azure_chain(nil), do: {:ok, nil}
+  defp normalize_azure_chain([]), do: {:error, {:invalid_azure_credential_chain, []}}
+
+  defp normalize_azure_chain(chain) when is_list(chain) do
+    chain
+    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
+      case normalize_azure_chain_value(value) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, values} -> {:ok, Enum.reverse(values)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp normalize_azure_chain(chain), do: normalize_azure_chain([chain])
+
+  defp normalize_azure_chain_value(value) when is_atom(value),
+    do: normalize_azure_chain_value(Atom.to_string(value))
+
+  defp normalize_azure_chain_value(value) when is_binary(value) do
+    if value in @azure_credential_chain_values do
+      {:ok, value}
+    else
+      {:error, {:invalid_azure_credential_chain, value}}
+    end
+  end
+
+  defp normalize_azure_chain_value(value), do: {:error, {:invalid_azure_credential_chain, value}}
+
+  defp normalize_azure_scope(nil), do: {:ok, nil}
+
+  defp normalize_azure_scope(scope) when is_binary(scope) and scope != "" do
+    if String.ends_with?(scope, "/") do
+      {:ok, scope}
+    else
+      {:error, {:invalid_azure_scope, :missing_trailing_slash}}
+    end
+  end
+
+  defp normalize_azure_scope(scope), do: {:error, {:invalid_azure_scope, scope}}
+
+  defp normalize_postgres_port(port, _name) when is_integer(port) and port in 1..65_535,
+    do: {:ok, port}
+
+  defp normalize_postgres_port(_port, name), do: {:error, {:missing_secret_field, name, :port}}
+
+  defp normalize_optional_secret_string(nil, _name, _key), do: {:ok, nil}
+
+  defp normalize_optional_secret_string(value, _name, _key) when is_binary(value),
+    do: {:ok, value}
+
+  defp normalize_optional_secret_string(_value, name, key),
+    do: {:error, {:invalid_secret_field, name, key}}
+
+  defp normalize_postgres_sslmode(nil), do: {:ok, nil}
+
+  defp normalize_postgres_sslmode(value) when is_atom(value) do
+    value
+    |> Atom.to_string()
+    |> String.replace("_", "-")
+    |> normalize_postgres_sslmode()
+  end
+
+  defp normalize_postgres_sslmode(value) when is_binary(value) do
+    if value in @postgres_sslmodes do
+      {:ok, value}
+    else
+      {:error, {:invalid_postgres_sslmode, value}}
+    end
+  end
+
+  defp normalize_postgres_sslmode(value), do: {:error, {:invalid_postgres_sslmode, value}}
+
+  defp inherit_attach_metadata_options(nil, _secrets), do: {:ok, nil}
+
+  defp inherit_attach_metadata_options(
+         %{metadata: {:postgres_secret, secret, metadata_options}} = attach,
+         secrets
+       ) do
+    secret_options =
+      secrets
+      |> Enum.find(%{}, &(&1.name == secret and &1.type == :postgres))
+      |> Map.take([:sslmode])
+
+    {:ok,
+     %{attach | metadata: {:postgres_secret, secret, Map.merge(secret_options, metadata_options)}}}
+  end
+
+  defp inherit_attach_metadata_options(attach, _secrets), do: {:ok, attach}
+
+  defp normalize_attach_metadata(metadata) when is_binary(metadata) and metadata != "",
+    do: {:ok, {:dsn, metadata}}
+
+  defp normalize_attach_metadata(metadata) when is_map(metadata) or is_list(metadata) do
+    with {:ok, metadata} <- normalize_keyword_config(metadata, :attach_metadata) do
+      case {Keyword.get(metadata, :type), Keyword.get(metadata, :secret)} do
+        {:postgres, secret} ->
+          with {:ok, secret} <- normalize_identifier(secret),
+               {:ok, sslmode} <- normalize_postgres_sslmode(Keyword.get(metadata, :sslmode)) do
+            metadata_options = if sslmode, do: %{sslmode: sslmode}, else: %{}
+
+            {:ok, {:postgres_secret, secret, metadata_options}}
+          end
+
+        other ->
+          {:error, {:unsupported_attach_metadata, other}}
+      end
+    end
+  end
+
+  defp normalize_attach_metadata(_metadata), do: {:error, {:missing_attach_field, :metadata}}
 
   defp normalize_optional_identifier(nil), do: {:ok, nil}
   defp normalize_optional_identifier(value), do: normalize_identifier(value)
@@ -227,21 +470,45 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
          name: name,
          type: :azure,
          provider: :credential_chain,
-         account_name: account_name
+         account_name: account_name,
+         chain: chain,
+         scope: scope
        }) do
+    options = [
+      "TYPE azure",
+      "PROVIDER credential_chain",
+      ["ACCOUNT_NAME ", quote_literal(account_name)]
+    ]
+
+    options =
+      options ++ if(chain, do: [["CHAIN ", quote_literal(Enum.join(chain, ";"))]], else: [])
+
+    options = options ++ if(scope, do: [["SCOPE ", quote_literal(scope)]], else: [])
+
+    safe_options = [
+      "TYPE azure",
+      "PROVIDER credential_chain",
+      ["ACCOUNT_NAME ", quote_literal(:redacted)]
+    ]
+
+    safe_options =
+      safe_options ++ if(chain, do: [["CHAIN ", quote_literal(Enum.join(chain, ";"))]], else: [])
+
+    safe_options = safe_options ++ if(scope, do: [["SCOPE ", quote_literal(:redacted)]], else: [])
+
     statement = [
       "CREATE SECRET ",
       quote_ident(name),
-      " (TYPE azure, PROVIDER credential_chain, ACCOUNT_NAME ",
-      quote_literal(account_name),
+      " (",
+      Enum.intersperse(options, ", "),
       ")"
     ]
 
     safe_statement = [
       "CREATE SECRET ",
       quote_ident(name),
-      " (TYPE azure, PROVIDER credential_chain, ACCOUNT_NAME ",
-      quote_literal(:redacted),
+      " (",
+      Enum.intersperse(safe_options, ", "),
       ")"
     ]
 
@@ -250,13 +517,65 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
       kind: :create_secret,
       statement: statement,
       safe_statement: safe_statement,
-      sensitive_values: [account_name]
+      sensitive_values: [account_name, scope]
+    }
+  end
+
+  defp secret_step(%{
+         name: name,
+         type: :postgres,
+         host: host,
+         port: port,
+         database: database,
+         user: user,
+         password: password,
+         auth: _auth,
+         sslmode: _sslmode
+       }) do
+    options = [
+      "TYPE postgres",
+      ["HOST ", quote_literal(host)],
+      ["PORT ", Integer.to_string(port)],
+      ["DATABASE ", quote_literal(database)],
+      ["USER ", quote_literal(user)]
+    ]
+
+    options = options ++ if(password, do: [["PASSWORD ", quote_literal(password)]], else: [])
+
+    safe_options = [
+      "TYPE postgres",
+      ["HOST ", quote_literal(host)],
+      ["PORT ", Integer.to_string(port)],
+      ["DATABASE ", quote_literal(database)],
+      ["USER ", quote_literal(user)]
+    ]
+
+    safe_options =
+      safe_options ++ if(password, do: [["PASSWORD ", quote_literal(:redacted)]], else: [])
+
+    %{
+      id: step_id(:create_secret, name),
+      kind: :create_secret,
+      statement: ["CREATE SECRET ", quote_ident(name), " (", Enum.intersperse(options, ", "), ")"],
+      safe_statement: [
+        "CREATE SECRET ",
+        quote_ident(name),
+        " (",
+        Enum.intersperse(safe_options, ", "),
+        ")"
+      ],
+      sensitive_values: [password]
     }
   end
 
   defp attach_steps(nil), do: []
 
-  defp attach_steps(%{name: name, type: :ducklake, metadata: metadata, data_path: data_path}) do
+  defp attach_steps(%{
+         name: name,
+         type: :ducklake,
+         metadata: {:dsn, metadata},
+         data_path: data_path
+       }) do
     statement = [
       "ATTACH ",
       quote_literal(metadata),
@@ -286,6 +605,58 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
         sensitive_values: [metadata, data_path]
       }
     ]
+  end
+
+  defp attach_steps(%{
+         name: name,
+         type: :ducklake,
+         metadata: {:postgres_secret, secret, metadata_options},
+         data_path: data_path
+       }) do
+    metadata_path = postgres_ducklake_metadata_path(metadata_options)
+
+    statement = [
+      "ATTACH ",
+      quote_literal(metadata_path),
+      " AS ",
+      quote_ident(name),
+      " (DATA_PATH ",
+      quote_literal(data_path),
+      ", META_SECRET ",
+      quote_ident(secret),
+      ")"
+    ]
+
+    safe_statement = [
+      "ATTACH ",
+      quote_literal(metadata_path),
+      " AS ",
+      quote_ident(name),
+      " (DATA_PATH ",
+      quote_literal(:redacted),
+      ", META_SECRET ",
+      quote_ident(secret),
+      ")"
+    ]
+
+    [
+      %{
+        id: step_id(:attach, name),
+        kind: :ducklake_attach,
+        statement: statement,
+        safe_statement: safe_statement,
+        sensitive_values: [data_path]
+      }
+    ]
+  end
+
+  defp postgres_ducklake_metadata_path(%{sslmode: nil}), do: "ducklake:postgres:"
+
+  defp postgres_ducklake_metadata_path(metadata_options) when map_size(metadata_options) == 0,
+    do: "ducklake:postgres:"
+
+  defp postgres_ducklake_metadata_path(%{sslmode: sslmode}) do
+    "ducklake:postgres:sslmode=#{sslmode}"
   end
 
   defp use_steps(nil), do: []
@@ -342,6 +713,28 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
       operation: :bootstrap,
       connection: resolved.name,
       details: %{reason: inspect(reason)}
+    }
+  end
+
+  defp token_error(%Resolved{} = resolved, secret, %TokenError{} = error) do
+    step = %{id: step_id(:create_secret, secret.name), kind: :create_secret}
+
+    %Error{
+      type: error.type,
+      message: "DuckDB connection bootstrap failed at #{step.id}",
+      retryable?: error.retryable?,
+      adapter: DuckDB,
+      operation: :bootstrap,
+      connection: resolved.name,
+      details: %{
+        step: step.id,
+        bootstrap_kind: step.kind,
+        statement:
+          "CREATE SECRET #{IO.iodata_to_binary(quote_ident(secret.name))} (TYPE postgres, PASSWORD 'redacted')",
+        reason: error.message,
+        adapter_error_type: error.type,
+        adapter_details: Error.redact(error.details)
+      }
     }
   end
 

--- a/apps/favn_duckdb/lib/favn/sql/adapter/duckdb/bootstrap.ex
+++ b/apps/favn_duckdb/lib/favn/sql/adapter/duckdb/bootstrap.ex
@@ -65,15 +65,18 @@ defmodule Favn.SQL.Adapter.DuckDB.Bootstrap do
 
   defp execute_steps(%DuckDB.Conn{} = conn, %Resolved{} = resolved, steps, opts) do
     Enum.reduce_while(steps, :ok, fn step, :ok ->
-      with {:ok, step} <- materialize_step(step, opts),
-           {:ok, _result} <- DuckDB.execute(conn, step.statement, []) do
-        {:cont, :ok}
-      else
+      case materialize_step(step, opts) do
+        {:ok, executable_step} ->
+          case DuckDB.execute(conn, executable_step.statement, []) do
+            {:ok, _result} ->
+              {:cont, :ok}
+
+            {:error, %Error{} = error} ->
+              {:halt, {:error, bootstrap_error(resolved, executable_step, error)}}
+          end
+
         {:error, %TokenError{} = error} ->
           {:halt, {:error, token_error(resolved, step, error)}}
-
-        {:error, %Error{} = error} ->
-          {:halt, {:error, bootstrap_error(resolved, step, error)}}
       end
     end)
   end

--- a/apps/favn_duckdb/mix.exs
+++ b/apps/favn_duckdb/mix.exs
@@ -25,6 +25,7 @@ defmodule FavnDuckdb.MixProject do
 
   defp deps do
     [
+      internal_dep(:favn_azure, "../favn_azure"),
       internal_dep(:favn_runner, "../favn_runner"),
       internal_dep(:favn_sql_runtime, "../favn_sql_runtime"),
       {:duckdbex, "~> 0.4.0"}

--- a/apps/favn_duckdb/test/sql/adapter/duckdb_bootstrap_test.exs
+++ b/apps/favn_duckdb/test/sql/adapter/duckdb_bootstrap_test.exs
@@ -29,6 +29,36 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
     end
   end
 
+  defmodule FakeTokenProvider do
+    @behaviour Favn.Azure.PostgresEntraTokenProvider
+
+    alias Favn.Azure.Token
+    alias FavnDuckdb.TestSupport
+
+    @impl true
+    def fetch_token(auth, _opts) do
+      TestSupport.record({:token_auth, auth})
+      {:ok, %Token{access_token: "entra-token", expires_on: "1770000000"}}
+    end
+  end
+
+  defmodule FailingTokenProvider do
+    @behaviour Favn.Azure.PostgresEntraTokenProvider
+
+    alias Favn.Azure.TokenError
+
+    @impl true
+    def fetch_token(_auth, _opts) do
+      {:error,
+       %TokenError{
+         type: :connection_error,
+         message: "managed identity token request failed",
+         retryable?: true,
+         details: %{status: 429, access_token: "entra-token"}
+       }}
+    end
+  end
+
   setup do
     TestSupport.start_events()
 
@@ -56,6 +86,103 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
              validator.(extensions: [load: ["invalid extension"]])
   end
 
+  test "schema field validates Azure credential chain and scope" do
+    assert %{type: {:custom, validator}} = DuckDB.bootstrap_schema_field()
+
+    assert :ok =
+             validator.(
+               secrets: [
+                 azure_adls: [
+                   type: :azure,
+                   provider: :credential_chain,
+                   account_name: "storageaccount",
+                   chain: [:cli, "env"],
+                   scope: "abfss://lake@storageaccount.dfs.core.windows.net/"
+                 ]
+               ]
+             )
+
+    assert {:error, {:invalid_azure_credential_chain, "bad"}} =
+             validator.(
+               secrets: [
+                 azure_adls: [
+                   type: :azure,
+                   provider: :credential_chain,
+                   account_name: "storageaccount",
+                   chain: [:cli, "bad"]
+                 ]
+               ]
+             )
+
+    assert {:error, {:invalid_azure_scope, :missing_trailing_slash}} =
+             validator.(
+               secrets: [
+                 azure_adls: [
+                   type: :azure,
+                   provider: :credential_chain,
+                   account_name: "storageaccount",
+                   scope: "abfss://lake@storageaccount.dfs.core.windows.net"
+                 ]
+               ]
+             )
+  end
+
+  test "schema field redacts invalid PostgreSQL password values" do
+    assert %{type: {:custom, validator}} = DuckDB.bootstrap_schema_field()
+
+    assert {:error, {:invalid_secret_field, "oceanos_meta", :password}} =
+             validator.(
+               secrets: [
+                 oceanos_meta: [
+                   type: :postgres,
+                   host: "pg.example.com",
+                   port: 5432,
+                   database: "ducklake",
+                   user: "ducklake_user",
+                   password: {:raw_secret, "super-secret"}
+                 ]
+               ]
+             )
+  end
+
+  test "schema field accepts Azure PostgreSQL Entra auth and rejects password conflicts" do
+    assert %{type: {:custom, validator}} = DuckDB.bootstrap_schema_field()
+
+    assert :ok =
+             validator.(
+               secrets: [
+                 oceanos_meta: [
+                   type: :postgres,
+                   host: "pg.example.com",
+                   port: 5432,
+                   database: "ducklake",
+                   user: "ducklake_user",
+                   auth: [
+                     type: :azure_postgres_entra,
+                     provider: :managed_identity,
+                     client_id: "client-1",
+                     endpoint: :auto
+                   ]
+                 ]
+               ]
+             )
+
+    assert {:error, {:conflicting_secret_fields, "oceanos_meta", [:password, :auth]}} =
+             validator.(
+               secrets: [
+                 oceanos_meta: [
+                   type: :postgres,
+                   host: "pg.example.com",
+                   port: 5432,
+                   database: "ducklake",
+                   user: "ducklake_user",
+                   password: "super-secret",
+                   auth: [type: :azure_postgres_entra, provider: :azure_cli]
+                 ]
+               ]
+             )
+  end
+
   test "runs DuckLake bootstrap statements in configured order" do
     {:ok, conn} = DuckDB.connect(resolved(), duckdb_client: FakeClient)
 
@@ -72,6 +199,66 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
              "ATTACH 'postgres://user:password@localhost:5432/ducklake' AS \"lake\" (TYPE ducklake, DATA_PATH 'abfss://lake@storageaccount.dfs.core.windows.net/raw')",
              ~s(USE "lake")
            ]
+  end
+
+  test "runs DuckLake bootstrap with ADLS and PostgreSQL secrets" do
+    resolved = ducklake_postgres_resolved()
+    {:ok, conn} = DuckDB.connect(resolved, duckdb_client: FakeClient)
+
+    assert :ok = DuckDB.bootstrap(conn, resolved, [])
+
+    assert statements() == [
+             "LOAD ducklake",
+             "LOAD postgres",
+             "LOAD azure",
+             "CREATE SECRET \"azure_adls\" (TYPE azure, PROVIDER credential_chain, ACCOUNT_NAME 'storageaccount', CHAIN 'cli;env', SCOPE 'abfss://lake@storageaccount.dfs.core.windows.net/')",
+             "CREATE SECRET \"oceanos_meta\" (TYPE postgres, HOST 'pg.example.com', PORT 5432, DATABASE 'ducklake', USER 'ducklake_user', PASSWORD 'super-secret')",
+             "ATTACH 'ducklake:postgres:sslmode=require' AS \"oceanos_lake\" (DATA_PATH 'abfss://lake@storageaccount.dfs.core.windows.net/data/', META_SECRET \"oceanos_meta\")",
+             ~s(USE "oceanos_lake")
+           ]
+  end
+
+  test "injects Azure PostgreSQL Entra token into temporary PostgreSQL secret" do
+    resolved = ducklake_postgres_entra_resolved()
+    {:ok, conn} = DuckDB.connect(resolved, duckdb_client: FakeClient)
+
+    assert :ok = DuckDB.bootstrap(conn, resolved, azure_token_provider_module: FakeTokenProvider)
+
+    assert {:token_auth,
+            [
+              type: :azure_postgres_entra,
+              provider: :managed_identity,
+              client_id: "client-1",
+              endpoint: :auto
+            ]} in TestSupport.events()
+
+    assert statements() == [
+             "LOAD ducklake",
+             "LOAD postgres",
+             "CREATE SECRET \"oceanos_meta\" (TYPE postgres, HOST 'pg.example.com', PORT 5432, DATABASE 'ducklake', USER 'ducklake_user', PASSWORD 'entra-token')",
+             "ATTACH 'ducklake:postgres:sslmode=require' AS \"oceanos_lake\" (DATA_PATH 'abfss://lake@storageaccount.dfs.core.windows.net/data/', META_SECRET \"oceanos_meta\")",
+             ~s(USE "oceanos_lake")
+           ]
+  end
+
+  test "token acquisition failure returns redacted bootstrap error" do
+    resolved = ducklake_postgres_entra_resolved()
+    {:ok, conn} = DuckDB.connect(resolved, duckdb_client: FakeClient)
+
+    assert {:error,
+            %Error{
+              type: :connection_error,
+              operation: :bootstrap,
+              message: "DuckDB connection bootstrap failed at create_secret_oceanos_meta",
+              details: %{statement: safe_statement, adapter_details: adapter_details}
+            }} =
+             DuckDB.bootstrap(conn, resolved, azure_token_provider_module: FailingTokenProvider)
+
+    assert safe_statement =~ "PASSWORD 'redacted'"
+    refute safe_statement =~ "entra-token"
+    refute inspect(adapter_details) =~ "entra-token"
+    assert adapter_details.access_token == :redacted
+    assert statements() == []
   end
 
   test "bootstrap failure reports failing step without exposing secret values" do
@@ -104,6 +291,33 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
     refute inspect(adapter_details) =~ secret_metadata
     assert safe_statement =~ "redacted"
     assert reason =~ "redacted"
+  end
+
+  test "PostgreSQL secret bootstrap failure redacts password only" do
+    resolved = ducklake_postgres_resolved()
+    {:ok, conn} = DuckDB.connect(resolved, duckdb_client: FakeClient)
+
+    failing_sql =
+      "CREATE SECRET \"oceanos_meta\" (TYPE postgres, HOST 'pg.example.com', PORT 5432, DATABASE 'ducklake', USER 'ducklake_user', PASSWORD 'super-secret')"
+
+    TestSupport.put_mode(:bootstrap_fail_sql, failing_sql)
+
+    assert {:error,
+            %Error{
+              operation: :bootstrap,
+              details: %{
+                statement: safe_statement,
+                reason: reason,
+                adapter_details: adapter_details
+              }
+            }} = DuckDB.bootstrap(conn, resolved, [])
+
+    refute safe_statement =~ "super-secret"
+    refute reason =~ "super-secret"
+    refute inspect(adapter_details) =~ "super-secret"
+    assert safe_statement =~ "HOST 'pg.example.com'"
+    assert safe_statement =~ "USER 'ducklake_user'"
+    assert safe_statement =~ "PASSWORD 'redacted'"
   end
 
   test "invalid bootstrap config returns structured invalid config error" do
@@ -183,6 +397,84 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
             data_path: "abfss://lake@storageaccount.dfs.core.windows.net/raw"
           ],
           use: :lake
+        ]
+      },
+      secret_fields: [:duckdb_bootstrap]
+    }
+  end
+
+  defp ducklake_postgres_resolved do
+    %Resolved{
+      name: :warehouse,
+      adapter: DuckDB,
+      module: __MODULE__,
+      config: %{
+        database: ":memory:",
+        duckdb_bootstrap: [
+          extensions: [load: [:ducklake, :postgres, :azure]],
+          secrets: [
+            azure_adls: [
+              type: :azure,
+              provider: :credential_chain,
+              account_name: "storageaccount",
+              chain: [:cli, :env],
+              scope: "abfss://lake@storageaccount.dfs.core.windows.net/"
+            ],
+            oceanos_meta: [
+              type: :postgres,
+              host: "pg.example.com",
+              port: 5432,
+              database: "ducklake",
+              user: "ducklake_user",
+              password: "super-secret",
+              sslmode: :require
+            ]
+          ],
+          attach: [
+            name: :oceanos_lake,
+            type: :ducklake,
+            metadata: [type: :postgres, secret: :oceanos_meta],
+            data_path: "abfss://lake@storageaccount.dfs.core.windows.net/data/"
+          ],
+          use: :oceanos_lake
+        ]
+      },
+      secret_fields: [:duckdb_bootstrap]
+    }
+  end
+
+  defp ducklake_postgres_entra_resolved do
+    %Resolved{
+      name: :warehouse,
+      adapter: DuckDB,
+      module: __MODULE__,
+      config: %{
+        database: ":memory:",
+        duckdb_bootstrap: [
+          extensions: [load: [:ducklake, :postgres]],
+          secrets: [
+            oceanos_meta: [
+              type: :postgres,
+              host: "pg.example.com",
+              port: 5432,
+              database: "ducklake",
+              user: "ducklake_user",
+              auth: [
+                type: :azure_postgres_entra,
+                provider: :managed_identity,
+                client_id: "client-1",
+                endpoint: :auto
+              ],
+              sslmode: :require
+            ]
+          ],
+          attach: [
+            name: :oceanos_lake,
+            type: :ducklake,
+            metadata: [type: :postgres, secret: :oceanos_meta],
+            data_path: "abfss://lake@storageaccount.dfs.core.windows.net/data/"
+          ],
+          use: :oceanos_lake
         ]
       },
       secret_fields: [:duckdb_bootstrap]

--- a/apps/favn_duckdb/test/sql/adapter/duckdb_bootstrap_test.exs
+++ b/apps/favn_duckdb/test/sql/adapter/duckdb_bootstrap_test.exs
@@ -3,6 +3,7 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
 
   alias Favn.Connection.Resolved
   alias Favn.SQL.Adapter.DuckDB
+  alias Favn.SQL.Adapter.DuckDB.Bootstrap
   alias Favn.SQL.Error
   alias FavnDuckdb.TestSupport
 
@@ -241,6 +242,26 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
            ]
   end
 
+  test "builds Azure PostgreSQL Entra bootstrap steps without fetching token" do
+    resolved = ducklake_postgres_entra_resolved()
+
+    assert {:ok, steps} =
+             Bootstrap.build_steps(resolved, azure_token_provider_module: FakeTokenProvider)
+
+    refute {:token_auth,
+            [
+              type: :azure_postgres_entra,
+              provider: :managed_identity,
+              client_id: "client-1",
+              endpoint: :auto
+            ]} in TestSupport.events()
+
+    create_secret = Enum.find(steps, &(&1.id == "create_secret_oceanos_meta"))
+
+    refute IO.iodata_to_binary(create_secret.statement) =~ "entra-token"
+    assert IO.iodata_to_binary(create_secret.safe_statement) =~ "PASSWORD 'redacted'"
+  end
+
   test "token acquisition failure returns redacted bootstrap error" do
     resolved = ducklake_postgres_entra_resolved()
     {:ok, conn} = DuckDB.connect(resolved, duckdb_client: FakeClient)
@@ -258,7 +279,7 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
     refute safe_statement =~ "entra-token"
     refute inspect(adapter_details) =~ "entra-token"
     assert adapter_details.access_token == :redacted
-    assert statements() == []
+    assert statements() == ["LOAD ducklake", "LOAD postgres"]
   end
 
   test "bootstrap failure reports failing step without exposing secret values" do

--- a/apps/favn_duckdb/test/sql/adapter/duckdb_bootstrap_test.exs
+++ b/apps/favn_duckdb/test/sql/adapter/duckdb_bootstrap_test.exs
@@ -282,6 +282,32 @@ defmodule FavnDuckdb.SQLAdapterDuckDBBootstrapTest do
     assert statements() == ["LOAD ducklake", "LOAD postgres"]
   end
 
+  test "PostgreSQL Entra secret execution failure redacts fetched token" do
+    resolved = ducklake_postgres_entra_resolved()
+    {:ok, conn} = DuckDB.connect(resolved, duckdb_client: FakeClient)
+
+    failing_sql =
+      "CREATE SECRET \"oceanos_meta\" (TYPE postgres, HOST 'pg.example.com', PORT 5432, DATABASE 'ducklake', USER 'ducklake_user', PASSWORD 'entra-token')"
+
+    TestSupport.put_mode(:bootstrap_fail_sql, failing_sql)
+
+    assert {:error,
+            %Error{
+              operation: :bootstrap,
+              details: %{
+                statement: safe_statement,
+                reason: reason,
+                adapter_details: adapter_details
+              }
+            }} = DuckDB.bootstrap(conn, resolved, azure_token_provider_module: FakeTokenProvider)
+
+    refute safe_statement =~ "entra-token"
+    refute reason =~ "entra-token"
+    refute inspect(adapter_details) =~ "entra-token"
+    assert safe_statement =~ "PASSWORD 'redacted'"
+    assert reason =~ "PASSWORD 'redacted'"
+  end
+
   test "bootstrap failure reports failing step without exposing secret values" do
     {:ok, conn} = DuckDB.connect(resolved(), duckdb_client: FakeClient)
 

--- a/apps/favn_duckdb_adbc/lib/favn/sql/adapter/duckdb/adbc.ex
+++ b/apps/favn_duckdb_adbc/lib/favn/sql/adapter/duckdb/adbc.ex
@@ -40,6 +40,33 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC do
   Large data movement should stay in DuckDB via `execute/3` and explicit SQL such
   as `COPY TO`, `COPY FROM`, `read_json`, or `read_ndjson` against caller-owned
   paths.
+
+  ## DuckLake bootstrap
+
+  This adapter supports the same `:duckdb_bootstrap` shape as
+  `Favn.SQL.Adapter.DuckDB`, including extension loading, Azure ADLS
+  `credential_chain` secrets with validated `:chain` and trailing-slash `:scope`,
+  PostgreSQL DuckDB secrets, DuckLake attach through `META_SECRET`, and the
+  existing metadata DSN fallback.
+
+  PostgreSQL secrets accept either `:password` or Azure PostgreSQL Entra `:auth`,
+  not both. Azure auth supports managed identity and Azure CLI dogfooding:
+
+      auth: [
+        type: :azure_postgres_entra,
+        provider: :managed_identity,
+        client_id: Favn.RuntimeConfig.Ref.env!("AZURE_CLIENT_ID", required?: false),
+        endpoint: :auto
+      ]
+
+      auth: [type: :azure_postgres_entra, provider: :azure_cli]
+
+  The PostgreSQL `:user` must be the PostgreSQL role created for the Entra
+  principal or managed identity, for example with
+  `select * from pgaadauth_create_principal('<identity_name>', false, false);`.
+  Tokens are fetched during bootstrap immediately before temporary `CREATE
+  SECRET`, injected as `PASSWORD`, never cached or persisted, and require
+  reconnect/rebootstrap after expiry.
   """
 
   @behaviour Favn.SQL.Adapter

--- a/apps/favn_duckdb_adbc/lib/favn/sql/adapter/duckdb/adbc/bootstrap.ex
+++ b/apps/favn_duckdb_adbc/lib/favn/sql/adapter/duckdb/adbc/bootstrap.ex
@@ -62,14 +62,18 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
 
   defp execute_steps(%ADBC.Conn{} = conn, %Resolved{} = resolved, steps, opts) do
     Enum.reduce_while(steps, :ok, fn step, :ok ->
-      with {:ok, step} <- materialize_step(step, opts),
-           {:ok, _result} <- ADBC.execute(conn, step.statement, []) do
-        {:cont, :ok}
-      else
+      case materialize_step(step, opts) do
+        {:ok, executable_step} ->
+          case ADBC.execute(conn, executable_step.statement, []) do
+            {:ok, _result} ->
+              {:cont, :ok}
+
+            {:error, %Error{} = error} ->
+              {:halt, {:error, bootstrap_error(resolved, executable_step, error)}}
+          end
+
         {:error, %TokenError{} = error} ->
           {:halt, {:error, token_error(resolved, step, error)}}
-
-        {:error, %Error{} = error} -> {:halt, {:error, bootstrap_error(resolved, step, error)}}
       end
     end)
   end

--- a/apps/favn_duckdb_adbc/lib/favn/sql/adapter/duckdb/adbc/bootstrap.ex
+++ b/apps/favn_duckdb_adbc/lib/favn/sql/adapter/duckdb/adbc/bootstrap.ex
@@ -32,8 +32,8 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
 
   @spec run(ADBC.Conn.t(), Resolved.t(), keyword()) :: :ok | {:error, Error.t()}
   def run(%ADBC.Conn{} = conn, %Resolved{} = resolved, opts) do
-    with {:ok, steps} <- build_steps(resolved, opts) do
-      execute_steps(conn, resolved, steps)
+    with {:ok, steps} <- build_steps(resolved) do
+      execute_steps(conn, resolved, steps, opts)
     end
   end
 
@@ -49,26 +49,26 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
     end
   end
 
-  defp build_configured_steps(%Resolved{} = resolved, config, opts) do
+  defp build_configured_steps(%Resolved{} = resolved, config, _opts) do
     case normalize_config(config) do
-      {:ok, normalized} -> build_normalized_steps(resolved, normalized, opts)
+      {:ok, normalized} -> build_normalized_steps(normalized)
       {:error, reason} -> {:error, config_error(resolved, reason)}
     end
   end
 
-  defp build_normalized_steps(%Resolved{} = resolved, normalized, opts) do
-    case materialize_auth_secrets(normalized.secrets, opts) do
-      {:ok, secrets} -> {:ok, steps(%{normalized | secrets: secrets})}
-      {:error, secret, %TokenError{} = error} -> {:error, token_error(resolved, secret, error)}
-    end
-  end
+  defp build_normalized_steps(normalized), do: {:ok, steps(normalized)}
 
-  defp execute_steps(_conn, _resolved, []), do: :ok
+  defp execute_steps(_conn, _resolved, [], _opts), do: :ok
 
-  defp execute_steps(%ADBC.Conn{} = conn, %Resolved{} = resolved, steps) do
+  defp execute_steps(%ADBC.Conn{} = conn, %Resolved{} = resolved, steps, opts) do
     Enum.reduce_while(steps, :ok, fn step, :ok ->
-      case ADBC.execute(conn, step.statement, []) do
-        {:ok, _result} -> {:cont, :ok}
+      with {:ok, step} <- materialize_step(step, opts),
+           {:ok, _result} <- ADBC.execute(conn, step.statement, []) do
+        {:cont, :ok}
+      else
+        {:error, %TokenError{} = error} ->
+          {:halt, {:error, token_error(resolved, step, error)}}
+
         {:error, %Error{} = error} -> {:halt, {:error, bootstrap_error(resolved, step, error)}}
       end
     end)
@@ -218,21 +218,7 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
   defp normalize_managed_identity_endpoint(endpoint),
     do: {:error, {:invalid_managed_identity_endpoint, endpoint}}
 
-  defp materialize_auth_secrets(secrets, opts) do
-    secrets
-    |> Enum.reduce_while({:ok, []}, fn secret, {:ok, acc} ->
-      case materialize_auth_secret(secret, opts) do
-        {:ok, secret} -> {:cont, {:ok, [secret | acc]}}
-        {:error, %TokenError{} = error} -> {:halt, {:error, secret, error}}
-      end
-    end)
-    |> case do
-      {:ok, secrets} -> {:ok, Enum.reverse(secrets)}
-      {:error, _secret, %TokenError{} = _error} = error -> error
-    end
-  end
-
-  defp materialize_auth_secret(%{type: :postgres, auth: auth} = secret, opts) when is_list(auth) do
+  defp materialize_step(%{postgres_secret: secret, postgres_auth: auth}, opts) when is_list(auth) do
     token_opts =
       case Keyword.get(opts, :azure_token_provider_module) do
         nil -> []
@@ -240,12 +226,12 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
       end
 
     case PostgresEntraToken.fetch_token(auth, token_opts) do
-      {:ok, token} -> {:ok, %{secret | password: token.access_token}}
+      {:ok, token} -> {:ok, postgres_secret_step(secret, token.access_token, nil)}
       {:error, %TokenError{} = error} -> {:error, error}
     end
   end
 
-  defp materialize_auth_secret(secret, _opts), do: {:ok, secret}
+  defp materialize_step(step, _opts), do: {:ok, step}
 
   defp normalize_attach(nil), do: {:ok, nil}
 
@@ -484,9 +470,21 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
          database: database,
          user: user,
          password: password,
-         auth: _auth,
+         auth: auth,
          sslmode: _sslmode
-       }) do
+       } = secret) do
+    step = postgres_secret_step(secret, password, auth)
+
+    if is_list(auth) do
+      step
+      |> Map.put(:postgres_secret, %{name: name, host: host, port: port, database: database, user: user})
+      |> Map.put(:postgres_auth, auth)
+    else
+      step
+    end
+  end
+
+  defp postgres_secret_step(%{name: name, host: host, port: port, database: database, user: user}, password, auth) do
     options = [
       "TYPE postgres",
       ["HOST ", quote_literal(host)],
@@ -506,7 +504,7 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
     ]
 
     safe_options =
-      safe_options ++ if(password, do: [["PASSWORD ", quote_literal(:redacted)]], else: [])
+      safe_options ++ if(password || auth, do: [["PASSWORD ", quote_literal(:redacted)]], else: [])
 
     %{
       id: step_id(:create_secret, name),
@@ -657,9 +655,7 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
     }
   end
 
-  defp token_error(%Resolved{} = resolved, secret, %TokenError{} = error) do
-    step = %{id: step_id(:create_secret, secret.name), kind: :create_secret}
-
+  defp token_error(%Resolved{} = resolved, step, %TokenError{} = error) do
     %Error{
       type: error.type,
       message: "DuckDB ADBC connection bootstrap failed at #{step.id}",
@@ -670,7 +666,7 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
       details: %{
         step: step.id,
         bootstrap_kind: step.kind,
-        statement: "CREATE SECRET #{IO.iodata_to_binary(quote_ident(secret.name))} (TYPE postgres, PASSWORD 'redacted')",
+        statement: IO.iodata_to_binary(step.safe_statement),
         reason: error.message,
         adapter_error_type: error.type,
         adapter_details: Error.redact(error.details)

--- a/apps/favn_duckdb_adbc/lib/favn/sql/adapter/duckdb/adbc/bootstrap.ex
+++ b/apps/favn_duckdb_adbc/lib/favn/sql/adapter/duckdb/adbc/bootstrap.ex
@@ -2,10 +2,13 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
   @moduledoc false
 
   alias Favn.Connection.Resolved
+  alias Favn.Azure.{PostgresEntraToken, TokenError}
   alias Favn.SQL.Adapter.DuckDB.ADBC
   alias Favn.SQL.Error
 
   @config_key :duckdb_bootstrap
+  @azure_credential_chain_values ~w(cli managed_identity workload_identity env default)
+  @postgres_sslmodes ~w(disable allow prefer require verify-ca verify-full)
 
   @type step :: %{id: String.t(), kind: atom(), statement: iodata(), safe_statement: iodata()}
 
@@ -28,25 +31,35 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
   def validate_config(_value), do: {:error, :expected_duckdb_bootstrap_keyword_or_map}
 
   @spec run(ADBC.Conn.t(), Resolved.t(), keyword()) :: :ok | {:error, Error.t()}
-  def run(%ADBC.Conn{} = conn, %Resolved{} = resolved, _opts) do
-    with {:ok, steps} <- build_steps(resolved) do
+  def run(%ADBC.Conn{} = conn, %Resolved{} = resolved, opts) do
+    with {:ok, steps} <- build_steps(resolved, opts) do
       execute_steps(conn, resolved, steps)
     end
   end
 
   @spec build_steps(Resolved.t()) :: {:ok, [step()]} | {:error, Error.t()}
-  def build_steps(%Resolved{} = resolved) do
+  def build_steps(%Resolved{} = resolved), do: build_steps(resolved, [])
+
+  @spec build_steps(Resolved.t(), keyword()) :: {:ok, [step()]} | {:error, Error.t()}
+  def build_steps(%Resolved{} = resolved, opts) do
     case Map.get(resolved.config || %{}, @config_key) do
       nil -> {:ok, []}
       [] -> {:ok, []}
-      config -> build_configured_steps(resolved, config)
+      config -> build_configured_steps(resolved, config, opts)
     end
   end
 
-  defp build_configured_steps(%Resolved{} = resolved, config) do
+  defp build_configured_steps(%Resolved{} = resolved, config, opts) do
     case normalize_config(config) do
-      {:ok, normalized} -> {:ok, steps(normalized)}
+      {:ok, normalized} -> build_normalized_steps(resolved, normalized, opts)
       {:error, reason} -> {:error, config_error(resolved, reason)}
+    end
+  end
+
+  defp build_normalized_steps(%Resolved{} = resolved, normalized, opts) do
+    case materialize_auth_secrets(normalized.secrets, opts) do
+      {:ok, secrets} -> {:ok, steps(%{normalized | secrets: secrets})}
+      {:error, secret, %TokenError{} = error} -> {:error, token_error(resolved, secret, error)}
     end
   end
 
@@ -66,6 +79,7 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
          {:ok, extensions} <- normalize_extensions(Keyword.get(normalized, :extensions, [])),
          {:ok, secrets} <- normalize_secrets(Keyword.get(normalized, :secrets, [])),
          {:ok, attach} <- normalize_attach(Keyword.get(normalized, :attach)),
+         {:ok, attach} <- inherit_attach_metadata_options(attach, secrets),
          {:ok, use_catalog} <- normalize_optional_identifier(Keyword.get(normalized, :use)) do
       {:ok, %{extensions: extensions, secrets: secrets, attach: attach, use: use_catalog}}
     end
@@ -122,13 +136,44 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
   defp normalize_secret_config(name, secret) do
     case {Keyword.get(secret, :type), Keyword.get(secret, :provider)} do
       {:azure, :credential_chain} ->
-        account_name = Keyword.get(secret, :account_name)
-
-        if present_string?(account_name) do
+        with {:ok, account_name} <- fetch_secret_value(secret, name, :account_name),
+             {:ok, chain} <- normalize_azure_chain(Keyword.get(secret, :chain)),
+             {:ok, scope} <- normalize_azure_scope(Keyword.get(secret, :scope)) do
           {:ok,
-           %{name: name, type: :azure, provider: :credential_chain, account_name: account_name}}
-        else
-          {:error, {:missing_secret_field, name, :account_name}}
+           %{
+             name: name,
+             type: :azure,
+             provider: :credential_chain,
+             account_name: account_name,
+             chain: chain,
+             scope: scope
+           }}
+        end
+
+      {:postgres, nil} ->
+        with {:ok, host} <- fetch_secret_value(secret, name, :host),
+             {:ok, port} <- normalize_postgres_port(Keyword.get(secret, :port), name),
+             {:ok, database} <- fetch_secret_value(secret, name, :database),
+             {:ok, user} <- fetch_secret_value(secret, name, :user),
+              {:ok, password} <- normalize_postgres_password(secret, name),
+              {:ok, auth} <- normalize_postgres_auth(Keyword.get(secret, :auth), name),
+              {:ok, sslmode} <- normalize_postgres_sslmode(Keyword.get(secret, :sslmode)) do
+          if password && auth do
+            {:error, {:conflicting_secret_fields, name, [:password, :auth]}}
+          else
+            {:ok,
+             %{
+               name: name,
+               type: :postgres,
+               host: host,
+               port: port,
+               database: database,
+               user: user,
+               password: password,
+               auth: auth,
+               sslmode: sslmode
+             }}
+          end
         end
 
       other ->
@@ -136,12 +181,78 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
     end
   end
 
+  defp normalize_postgres_password(secret, name) do
+    normalize_optional_secret_string(Keyword.get(secret, :password), name, :password)
+  end
+
+  defp normalize_postgres_auth(nil, _name), do: {:ok, nil}
+
+  defp normalize_postgres_auth(auth, name) when is_map(auth) or is_list(auth) do
+    with {:ok, auth} <- normalize_keyword_config(auth, {:postgres_auth, name}) do
+      case {Keyword.get(auth, :type), Keyword.get(auth, :provider)} do
+        {:azure_postgres_entra, :managed_identity} ->
+          with {:ok, endpoint} <- normalize_managed_identity_endpoint(Keyword.get(auth, :endpoint, :auto)) do
+            {:ok,
+             [
+               type: :azure_postgres_entra,
+               provider: :managed_identity,
+               client_id: Keyword.get(auth, :client_id),
+               endpoint: endpoint
+             ]}
+          end
+
+        {:azure_postgres_entra, :azure_cli} ->
+          {:ok, [type: :azure_postgres_entra, provider: :azure_cli]}
+
+        other ->
+          {:error, {:unsupported_postgres_auth, name, other}}
+      end
+    end
+  end
+
+  defp normalize_postgres_auth(_auth, name), do: {:error, {:invalid_secret_field, name, :auth}}
+
+  defp normalize_managed_identity_endpoint(endpoint) when endpoint in [:auto, :imds, :azure_app_service],
+    do: {:ok, endpoint}
+
+  defp normalize_managed_identity_endpoint(endpoint),
+    do: {:error, {:invalid_managed_identity_endpoint, endpoint}}
+
+  defp materialize_auth_secrets(secrets, opts) do
+    secrets
+    |> Enum.reduce_while({:ok, []}, fn secret, {:ok, acc} ->
+      case materialize_auth_secret(secret, opts) do
+        {:ok, secret} -> {:cont, {:ok, [secret | acc]}}
+        {:error, %TokenError{} = error} -> {:halt, {:error, secret, error}}
+      end
+    end)
+    |> case do
+      {:ok, secrets} -> {:ok, Enum.reverse(secrets)}
+      {:error, _secret, %TokenError{} = _error} = error -> error
+    end
+  end
+
+  defp materialize_auth_secret(%{type: :postgres, auth: auth} = secret, opts) when is_list(auth) do
+    token_opts =
+      case Keyword.get(opts, :azure_token_provider_module) do
+        nil -> []
+        provider_module -> [provider_module: provider_module]
+      end
+
+    case PostgresEntraToken.fetch_token(auth, token_opts) do
+      {:ok, token} -> {:ok, %{secret | password: token.access_token}}
+      {:error, %TokenError{} = error} -> {:error, error}
+    end
+  end
+
+  defp materialize_auth_secret(secret, _opts), do: {:ok, secret}
+
   defp normalize_attach(nil), do: {:ok, nil}
 
   defp normalize_attach(config) do
     with {:ok, attach} <- normalize_keyword_config(config, :attach),
          {:ok, name} <- normalize_identifier(Keyword.get(attach, :name)),
-         {:ok, metadata} <- fetch_present_value(attach, :metadata),
+         {:ok, metadata} <- normalize_attach_metadata(Keyword.get(attach, :metadata)),
          {:ok, data_path} <- fetch_present_value(attach, :data_path) do
       case Keyword.get(attach, :type) do
         :ducklake ->
@@ -152,6 +263,122 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
       end
     end
   end
+
+  defp fetch_secret_value(keyword, name, key) do
+    case Keyword.fetch(keyword, key) do
+      {:ok, value} when is_binary(value) and value != "" -> {:ok, value}
+      _missing_or_blank -> {:error, {:missing_secret_field, name, key}}
+    end
+  end
+
+  defp normalize_azure_chain(nil), do: {:ok, nil}
+  defp normalize_azure_chain([]), do: {:error, {:invalid_azure_credential_chain, []}}
+
+  defp normalize_azure_chain(chain) when is_list(chain) do
+    chain
+    |> Enum.reduce_while({:ok, []}, fn value, {:ok, acc} ->
+      case normalize_azure_chain_value(value) do
+        {:ok, normalized} -> {:cont, {:ok, [normalized | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, values} -> {:ok, Enum.reverse(values)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp normalize_azure_chain(chain), do: normalize_azure_chain([chain])
+
+  defp normalize_azure_chain_value(value) when is_atom(value),
+    do: normalize_azure_chain_value(Atom.to_string(value))
+
+  defp normalize_azure_chain_value(value) when is_binary(value) do
+    if value in @azure_credential_chain_values,
+      do: {:ok, value},
+      else: {:error, {:invalid_azure_credential_chain, value}}
+  end
+
+  defp normalize_azure_chain_value(value), do: {:error, {:invalid_azure_credential_chain, value}}
+
+  defp normalize_azure_scope(nil), do: {:ok, nil}
+
+  defp normalize_azure_scope(scope) when is_binary(scope) and scope != "" do
+    if String.ends_with?(scope, "/"),
+      do: {:ok, scope},
+      else: {:error, {:invalid_azure_scope, :missing_trailing_slash}}
+  end
+
+  defp normalize_azure_scope(scope), do: {:error, {:invalid_azure_scope, scope}}
+
+  defp normalize_postgres_port(port, _name) when is_integer(port) and port in 1..65_535,
+    do: {:ok, port}
+
+  defp normalize_postgres_port(_port, name), do: {:error, {:missing_secret_field, name, :port}}
+
+  defp normalize_optional_secret_string(nil, _name, _key), do: {:ok, nil}
+
+  defp normalize_optional_secret_string(value, _name, _key) when is_binary(value),
+    do: {:ok, value}
+
+  defp normalize_optional_secret_string(_value, name, key),
+    do: {:error, {:invalid_secret_field, name, key}}
+
+  defp normalize_postgres_sslmode(nil), do: {:ok, nil}
+
+  defp normalize_postgres_sslmode(value) when is_atom(value) do
+    value
+    |> Atom.to_string()
+    |> String.replace("_", "-")
+    |> normalize_postgres_sslmode()
+  end
+
+  defp normalize_postgres_sslmode(value) when is_binary(value) do
+    if value in @postgres_sslmodes,
+      do: {:ok, value},
+      else: {:error, {:invalid_postgres_sslmode, value}}
+  end
+
+  defp normalize_postgres_sslmode(value), do: {:error, {:invalid_postgres_sslmode, value}}
+
+  defp inherit_attach_metadata_options(nil, _secrets), do: {:ok, nil}
+
+  defp inherit_attach_metadata_options(
+         %{metadata: {:postgres_secret, secret, metadata_options}} = attach,
+         secrets
+       ) do
+    secret_options =
+      secrets
+      |> Enum.find(%{}, &(&1.name == secret and &1.type == :postgres))
+      |> Map.take([:sslmode])
+
+    {:ok,
+     %{attach | metadata: {:postgres_secret, secret, Map.merge(secret_options, metadata_options)}}}
+  end
+
+  defp inherit_attach_metadata_options(attach, _secrets), do: {:ok, attach}
+
+  defp normalize_attach_metadata(metadata) when is_binary(metadata) and metadata != "",
+    do: {:ok, {:dsn, metadata}}
+
+  defp normalize_attach_metadata(metadata) when is_map(metadata) or is_list(metadata) do
+    with {:ok, metadata} <- normalize_keyword_config(metadata, :attach_metadata) do
+      case {Keyword.get(metadata, :type), Keyword.get(metadata, :secret)} do
+        {:postgres, secret} ->
+          with {:ok, secret} <- normalize_identifier(secret),
+               {:ok, sslmode} <- normalize_postgres_sslmode(Keyword.get(metadata, :sslmode)) do
+            metadata_options = if sslmode, do: %{sslmode: sslmode}, else: %{}
+
+            {:ok, {:postgres_secret, secret, metadata_options}}
+          end
+
+        other ->
+          {:error, {:unsupported_attach_metadata, other}}
+      end
+    end
+  end
+
+  defp normalize_attach_metadata(_metadata), do: {:error, {:missing_attach_field, :metadata}}
 
   defp normalize_optional_identifier(nil), do: {:ok, nil}
   defp normalize_optional_identifier(value), do: normalize_identifier(value)
@@ -204,21 +431,39 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
          name: name,
          type: :azure,
          provider: :credential_chain,
-         account_name: account_name
+         account_name: account_name,
+         chain: chain,
+         scope: scope
        }) do
-    statement = [
-      "CREATE SECRET ",
-      quote_ident(name),
-      " (TYPE azure, PROVIDER credential_chain, ACCOUNT_NAME ",
-      quote_literal(account_name),
-      ")"
+    options = [
+      "TYPE azure",
+      "PROVIDER credential_chain",
+      ["ACCOUNT_NAME ", quote_literal(account_name)]
     ]
+
+    options =
+      options ++ if(chain, do: [["CHAIN ", quote_literal(Enum.join(chain, ";"))]], else: [])
+
+    options = options ++ if(scope, do: [["SCOPE ", quote_literal(scope)]], else: [])
+
+    safe_options = [
+      "TYPE azure",
+      "PROVIDER credential_chain",
+      ["ACCOUNT_NAME ", quote_literal(:redacted)]
+    ]
+
+    safe_options =
+      safe_options ++ if(chain, do: [["CHAIN ", quote_literal(Enum.join(chain, ";"))]], else: [])
+
+    safe_options = safe_options ++ if(scope, do: [["SCOPE ", quote_literal(:redacted)]], else: [])
+
+    statement = ["CREATE SECRET ", quote_ident(name), " (", Enum.intersperse(options, ", "), ")"]
 
     safe_statement = [
       "CREATE SECRET ",
       quote_ident(name),
-      " (TYPE azure, PROVIDER credential_chain, ACCOUNT_NAME ",
-      quote_literal(:redacted),
+      " (",
+      Enum.intersperse(safe_options, ", "),
       ")"
     ]
 
@@ -227,13 +472,65 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
       kind: :create_secret,
       statement: statement,
       safe_statement: safe_statement,
-      sensitive_values: [account_name]
+      sensitive_values: [account_name, scope]
+    }
+  end
+
+  defp secret_step(%{
+         name: name,
+         type: :postgres,
+         host: host,
+         port: port,
+         database: database,
+         user: user,
+         password: password,
+         auth: _auth,
+         sslmode: _sslmode
+       }) do
+    options = [
+      "TYPE postgres",
+      ["HOST ", quote_literal(host)],
+      ["PORT ", Integer.to_string(port)],
+      ["DATABASE ", quote_literal(database)],
+      ["USER ", quote_literal(user)]
+    ]
+
+    options = options ++ if(password, do: [["PASSWORD ", quote_literal(password)]], else: [])
+
+    safe_options = [
+      "TYPE postgres",
+      ["HOST ", quote_literal(host)],
+      ["PORT ", Integer.to_string(port)],
+      ["DATABASE ", quote_literal(database)],
+      ["USER ", quote_literal(user)]
+    ]
+
+    safe_options =
+      safe_options ++ if(password, do: [["PASSWORD ", quote_literal(:redacted)]], else: [])
+
+    %{
+      id: step_id(:create_secret, name),
+      kind: :create_secret,
+      statement: ["CREATE SECRET ", quote_ident(name), " (", Enum.intersperse(options, ", "), ")"],
+      safe_statement: [
+        "CREATE SECRET ",
+        quote_ident(name),
+        " (",
+        Enum.intersperse(safe_options, ", "),
+        ")"
+      ],
+      sensitive_values: [password]
     }
   end
 
   defp attach_steps(nil), do: []
 
-  defp attach_steps(%{name: name, type: :ducklake, metadata: metadata, data_path: data_path}) do
+  defp attach_steps(%{
+         name: name,
+         type: :ducklake,
+         metadata: {:dsn, metadata},
+         data_path: data_path
+       }) do
     statement = [
       "ATTACH ",
       quote_literal(metadata),
@@ -265,6 +562,58 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
     ]
   end
 
+  defp attach_steps(%{
+         name: name,
+         type: :ducklake,
+         metadata: {:postgres_secret, secret, metadata_options},
+         data_path: data_path
+       }) do
+    metadata_path = postgres_ducklake_metadata_path(metadata_options)
+
+    statement = [
+      "ATTACH ",
+      quote_literal(metadata_path),
+      " AS ",
+      quote_ident(name),
+      " (DATA_PATH ",
+      quote_literal(data_path),
+      ", META_SECRET ",
+      quote_ident(secret),
+      ")"
+    ]
+
+    safe_statement = [
+      "ATTACH ",
+      quote_literal(metadata_path),
+      " AS ",
+      quote_ident(name),
+      " (DATA_PATH ",
+      quote_literal(:redacted),
+      ", META_SECRET ",
+      quote_ident(secret),
+      ")"
+    ]
+
+    [
+      %{
+        id: step_id(:attach, name),
+        kind: :ducklake_attach,
+        statement: statement,
+        safe_statement: safe_statement,
+        sensitive_values: [data_path]
+      }
+    ]
+  end
+
+  defp postgres_ducklake_metadata_path(%{sslmode: nil}), do: "ducklake:postgres:"
+
+  defp postgres_ducklake_metadata_path(metadata_options) when map_size(metadata_options) == 0,
+    do: "ducklake:postgres:"
+
+  defp postgres_ducklake_metadata_path(%{sslmode: sslmode}) do
+    "ducklake:postgres:sslmode=#{sslmode}"
+  end
+
   defp use_steps(nil), do: []
 
   defp use_steps(name),
@@ -290,7 +639,6 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
   end
 
   defp normalize_identifier(value), do: {:error, {:invalid_identifier, value}}
-  defp present_string?(value), do: is_binary(value) and value != ""
 
   defp quote_ident(identifier),
     do: [~s("), String.replace(to_string(identifier), ~s("), ~s("")), ~s(")]
@@ -306,6 +654,27 @@ defmodule Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap do
       operation: :bootstrap,
       connection: resolved.name,
       details: %{reason: inspect(reason)}
+    }
+  end
+
+  defp token_error(%Resolved{} = resolved, secret, %TokenError{} = error) do
+    step = %{id: step_id(:create_secret, secret.name), kind: :create_secret}
+
+    %Error{
+      type: error.type,
+      message: "DuckDB ADBC connection bootstrap failed at #{step.id}",
+      retryable?: error.retryable?,
+      adapter: ADBC,
+      operation: :bootstrap,
+      connection: resolved.name,
+      details: %{
+        step: step.id,
+        bootstrap_kind: step.kind,
+        statement: "CREATE SECRET #{IO.iodata_to_binary(quote_ident(secret.name))} (TYPE postgres, PASSWORD 'redacted')",
+        reason: error.message,
+        adapter_error_type: error.type,
+        adapter_details: Error.redact(error.details)
+      }
     }
   end
 

--- a/apps/favn_duckdb_adbc/mix.exs
+++ b/apps/favn_duckdb_adbc/mix.exs
@@ -23,6 +23,7 @@ defmodule FavnDuckdbADBC.MixProject do
 
   defp deps do
     [
+      internal_dep(:favn_azure, "../favn_azure"),
       internal_dep(:favn_runner, "../favn_runner"),
       internal_dep(:favn_sql_runtime, "../favn_sql_runtime"),
       internal_dep(:favn_authoring, "../favn_authoring", only: :test),

--- a/apps/favn_duckdb_adbc/test/sql/adapter/duckdb_adbc_bootstrap_test.exs
+++ b/apps/favn_duckdb_adbc/test/sql/adapter/duckdb_adbc_bootstrap_test.exs
@@ -3,6 +3,7 @@ defmodule FavnDuckdbADBC.SQLAdapterDuckDBADBCBootstrapTest do
 
   alias Favn.Connection.Resolved
   alias Favn.SQL.Adapter.DuckDB.ADBC
+  alias Favn.SQL.Adapter.DuckDB.ADBC.Bootstrap
   alias Favn.SQL.Error
   alias FavnDuckdbADBC.TestSupport
 
@@ -115,7 +116,19 @@ defmodule FavnDuckdbADBC.SQLAdapterDuckDBADBCBootstrapTest do
              "CREATE SECRET \"oceanos_meta\" (TYPE postgres, HOST 'pg.example.com', PORT 5432, DATABASE 'ducklake', USER 'ducklake_user', PASSWORD 'entra-token')",
              "ATTACH 'ducklake:postgres:sslmode=require' AS \"oceanos_lake\" (DATA_PATH 'abfss://lake@storageaccount.dfs.core.windows.net/data/', META_SECRET \"oceanos_meta\")",
              ~s(USE "oceanos_lake")
-           ]
+            ]
+  end
+
+  test "builds Azure PostgreSQL Entra bootstrap steps without fetching token" do
+    resolved = ducklake_postgres_entra_resolved()
+
+    assert {:ok, steps} = Bootstrap.build_steps(resolved, azure_token_provider_module: FakeTokenProvider)
+
+    create_secret = Enum.find(steps, &(&1.id == "create_secret_oceanos_meta"))
+
+    refute IO.iodata_to_binary(create_secret.statement) =~ "entra-token"
+    assert IO.iodata_to_binary(create_secret.safe_statement) =~ "PASSWORD 'redacted'"
+    assert statements() == []
   end
 
   test "token acquisition failure returns redacted bootstrap error" do
@@ -134,7 +147,7 @@ defmodule FavnDuckdbADBC.SQLAdapterDuckDBADBCBootstrapTest do
     refute safe_statement =~ "entra-token"
     refute inspect(adapter_details) =~ "entra-token"
     assert adapter_details.access_token == :redacted
-    assert statements() == []
+    assert statements() == ["LOAD ducklake", "LOAD postgres"]
   end
 
   test "bootstrap failure reports failing step without exposing secret values" do

--- a/apps/favn_duckdb_adbc/test/sql/adapter/duckdb_adbc_bootstrap_test.exs
+++ b/apps/favn_duckdb_adbc/test/sql/adapter/duckdb_adbc_bootstrap_test.exs
@@ -23,6 +23,34 @@ defmodule FavnDuckdbADBC.SQLAdapterDuckDBADBCBootstrapTest do
     end
   end
 
+  defmodule FakeTokenProvider do
+    @behaviour Favn.Azure.PostgresEntraTokenProvider
+
+    alias Favn.Azure.Token
+
+    @impl true
+    def fetch_token(_auth, _opts) do
+      {:ok, %Token{access_token: "entra-token", expires_on: "1770000000"}}
+    end
+  end
+
+  defmodule FailingTokenProvider do
+    @behaviour Favn.Azure.PostgresEntraTokenProvider
+
+    alias Favn.Azure.TokenError
+
+    @impl true
+    def fetch_token(_auth, _opts) do
+      {:error,
+       %TokenError{
+         type: :connection_error,
+         message: "managed identity token request failed",
+         retryable?: true,
+         details: %{status: 429, access_token: "entra-token"}
+       }}
+    end
+  end
+
   setup do
     TestSupport.start_events()
 
@@ -56,6 +84,57 @@ defmodule FavnDuckdbADBC.SQLAdapterDuckDBADBCBootstrapTest do
              "ATTACH 'postgres://user:password@localhost:5432/ducklake' AS \"lake\" (TYPE ducklake, DATA_PATH 'abfss://lake@storageaccount.dfs.core.windows.net/raw')",
              ~s(USE "lake")
            ]
+  end
+
+  test "runs DuckLake bootstrap with ADLS and PostgreSQL secrets" do
+    resolved = ducklake_postgres_resolved()
+    {:ok, conn} = ADBC.connect(resolved, duckdb_adbc_client: FakeClient)
+
+    assert :ok = ADBC.bootstrap(conn, resolved, [])
+
+    assert statements() == [
+             "LOAD ducklake",
+             "LOAD postgres",
+             "LOAD azure",
+             "CREATE SECRET \"azure_adls\" (TYPE azure, PROVIDER credential_chain, ACCOUNT_NAME 'storageaccount', CHAIN 'cli;env', SCOPE 'abfss://lake@storageaccount.dfs.core.windows.net/')",
+             "CREATE SECRET \"oceanos_meta\" (TYPE postgres, HOST 'pg.example.com', PORT 5432, DATABASE 'ducklake', USER 'ducklake_user', PASSWORD 'super-secret')",
+             "ATTACH 'ducklake:postgres:sslmode=require' AS \"oceanos_lake\" (DATA_PATH 'abfss://lake@storageaccount.dfs.core.windows.net/data/', META_SECRET \"oceanos_meta\")",
+             ~s(USE "oceanos_lake")
+           ]
+  end
+
+  test "injects Azure PostgreSQL Entra token into temporary PostgreSQL secret" do
+    resolved = ducklake_postgres_entra_resolved()
+    {:ok, conn} = ADBC.connect(resolved, duckdb_adbc_client: FakeClient)
+
+    assert :ok = ADBC.bootstrap(conn, resolved, azure_token_provider_module: FakeTokenProvider)
+
+    assert statements() == [
+             "LOAD ducklake",
+             "LOAD postgres",
+             "CREATE SECRET \"oceanos_meta\" (TYPE postgres, HOST 'pg.example.com', PORT 5432, DATABASE 'ducklake', USER 'ducklake_user', PASSWORD 'entra-token')",
+             "ATTACH 'ducklake:postgres:sslmode=require' AS \"oceanos_lake\" (DATA_PATH 'abfss://lake@storageaccount.dfs.core.windows.net/data/', META_SECRET \"oceanos_meta\")",
+             ~s(USE "oceanos_lake")
+           ]
+  end
+
+  test "token acquisition failure returns redacted bootstrap error" do
+    resolved = ducklake_postgres_entra_resolved()
+    {:ok, conn} = ADBC.connect(resolved, duckdb_adbc_client: FakeClient)
+
+    assert {:error,
+            %Error{
+              type: :connection_error,
+              operation: :bootstrap,
+              message: "DuckDB ADBC connection bootstrap failed at create_secret_oceanos_meta",
+              details: %{statement: safe_statement, adapter_details: adapter_details}
+            }} = ADBC.bootstrap(conn, resolved, azure_token_provider_module: FailingTokenProvider)
+
+    assert safe_statement =~ "PASSWORD 'redacted'"
+    refute safe_statement =~ "entra-token"
+    refute inspect(adapter_details) =~ "entra-token"
+    assert adapter_details.access_token == :redacted
+    assert statements() == []
   end
 
   test "bootstrap failure reports failing step without exposing secret values" do
@@ -114,6 +193,79 @@ defmodule FavnDuckdbADBC.SQLAdapterDuckDBADBCBootstrapTest do
             data_path: "abfss://lake@storageaccount.dfs.core.windows.net/raw"
           ],
           use: :lake
+        ]
+      },
+      secret_fields: [:duckdb_bootstrap]
+    }
+  end
+
+  defp ducklake_postgres_resolved do
+    %Resolved{
+      name: :warehouse,
+      adapter: ADBC,
+      module: __MODULE__,
+      config: %{
+        database: ":memory:",
+        duckdb_bootstrap: [
+          extensions: [load: [:ducklake, :postgres, :azure]],
+          secrets: [
+            azure_adls: [
+              type: :azure,
+              provider: :credential_chain,
+              account_name: "storageaccount",
+              chain: [:cli, :env],
+              scope: "abfss://lake@storageaccount.dfs.core.windows.net/"
+            ],
+            oceanos_meta: [
+              type: :postgres,
+              host: "pg.example.com",
+              port: 5432,
+              database: "ducklake",
+              user: "ducklake_user",
+              password: "super-secret",
+              sslmode: :require
+            ]
+          ],
+          attach: [
+            name: :oceanos_lake,
+            type: :ducklake,
+            metadata: [type: :postgres, secret: :oceanos_meta],
+            data_path: "abfss://lake@storageaccount.dfs.core.windows.net/data/"
+          ],
+          use: :oceanos_lake
+        ]
+      },
+      secret_fields: [:duckdb_bootstrap]
+    }
+  end
+
+  defp ducklake_postgres_entra_resolved do
+    %Resolved{
+      name: :warehouse,
+      adapter: ADBC,
+      module: __MODULE__,
+      config: %{
+        database: ":memory:",
+        duckdb_bootstrap: [
+          extensions: [load: [:ducklake, :postgres]],
+          secrets: [
+            oceanos_meta: [
+              type: :postgres,
+              host: "pg.example.com",
+              port: 5432,
+              database: "ducklake",
+              user: "ducklake_user",
+              auth: [type: :azure_postgres_entra, provider: :azure_cli],
+              sslmode: :require
+            ]
+          ],
+          attach: [
+            name: :oceanos_lake,
+            type: :ducklake,
+            metadata: [type: :postgres, secret: :oceanos_meta],
+            data_path: "abfss://lake@storageaccount.dfs.core.windows.net/data/"
+          ],
+          use: :oceanos_lake
         ]
       },
       secret_fields: [:duckdb_bootstrap]

--- a/apps/favn_duckdb_adbc/test/sql/adapter/duckdb_adbc_bootstrap_test.exs
+++ b/apps/favn_duckdb_adbc/test/sql/adapter/duckdb_adbc_bootstrap_test.exs
@@ -150,6 +150,32 @@ defmodule FavnDuckdbADBC.SQLAdapterDuckDBADBCBootstrapTest do
     assert statements() == ["LOAD ducklake", "LOAD postgres"]
   end
 
+  test "PostgreSQL Entra secret execution failure redacts fetched token" do
+    resolved = ducklake_postgres_entra_resolved()
+    {:ok, conn} = ADBC.connect(resolved, duckdb_adbc_client: FakeClient)
+
+    failing_sql =
+      "CREATE SECRET \"oceanos_meta\" (TYPE postgres, HOST 'pg.example.com', PORT 5432, DATABASE 'ducklake', USER 'ducklake_user', PASSWORD 'entra-token')"
+
+    TestSupport.put_mode(:bootstrap_fail_sql, failing_sql)
+
+    assert {:error,
+            %Error{
+              operation: :bootstrap,
+              details: %{
+                statement: safe_statement,
+                reason: reason,
+                adapter_details: adapter_details
+              }
+            }} = ADBC.bootstrap(conn, resolved, azure_token_provider_module: FakeTokenProvider)
+
+    refute safe_statement =~ "entra-token"
+    refute reason =~ "entra-token"
+    refute inspect(adapter_details) =~ "entra-token"
+    assert safe_statement =~ "PASSWORD 'redacted'"
+    assert reason =~ "PASSWORD 'redacted'"
+  end
+
   test "bootstrap failure reports failing step without exposing secret values" do
     {:ok, conn} = ADBC.connect(resolved(), duckdb_adbc_client: FakeClient)
 

--- a/mix.exs
+++ b/mix.exs
@@ -7,6 +7,7 @@ defmodule FavnUmbrella.MixProject do
       apps: [
         :favn,
         :favn_authoring,
+        :favn_azure,
         :favn_core,
         :favn_duckdb,
         :favn_duckdb_adbc,
@@ -42,6 +43,7 @@ defmodule FavnUmbrella.MixProject do
         "do --app favn_test_support test",
         "do --app favn_core test",
         "do --app favn_authoring test",
+        "do --app favn_azure test",
         "do --app favn test",
         "do --app favn_sql_runtime test",
         "do --app favn_runner test",


### PR DESCRIPTION
## Summary
- Add a new `favn_azure` app for Azure PostgreSQL Entra token acquisition via managed identity or Azure CLI.
- Extend DuckDB and ADBC bootstrap to create scoped Azure secrets, PostgreSQL metadata secrets, and DuckLake `META_SECRET` attaches.
- Inject runtime Entra tokens into temporary DuckDB Postgres secrets with redacted diagnostics and session-scoped token semantics.

## Verification
- `mix format --check-formatted`
- `git diff --check`
- `mix compile --warnings-as-errors` in `apps/favn_azure`, `apps/favn_duckdb`, `apps/favn_duckdb_adbc`, and `apps/favn`
- `mix test` in `apps/favn_azure`: 5 tests, 0 failures
- `mix test` in `apps/favn_duckdb`: 61 tests, 0 failures
- `mix test` in `apps/favn_duckdb_adbc`: 16 tests, 0 failures (1 excluded)
- `mix test` in `apps/favn`: 101 tests, 0 failures

Closes #175