### PR TITLE
Add pipelines catalogue view

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -11,6 +11,7 @@ defmodule FavnOrchestrator do
   alias Favn.Contracts.RelationInspectionRequest
   alias Favn.Contracts.RunnerClient
   alias Favn.Manifest.Index
+  alias Favn.Manifest.PipelineResolver
   alias Favn.Manifest.Version
   alias Favn.Window.Anchor
   alias Favn.Window.Policy
@@ -75,6 +76,20 @@ defmodule FavnOrchestrator do
           required(:latest_run_id) => String.t() | nil,
           required(:latest_run_status) => atom() | nil,
           required(:latest_run_at) => DateTime.t() | nil
+        }
+
+  @type pipeline_catalogue_entry :: %{
+          required(:target_id) => String.t(),
+          required(:label) => String.t(),
+          required(:name) => String.t(),
+          required(:selected_assets) => [String.t()],
+          required(:dependencies) => :all | :none | :unknown,
+          required(:window) => map() | nil,
+          required(:status) => :healthy | :running | :failed | :unknown,
+          required(:latest_run_id) => String.t() | nil,
+          required(:latest_run_status) => atom() | nil,
+          required(:latest_run_at) => DateTime.t() | nil,
+          required(:latest_run_duration_ms) => non_neg_integer() | nil
         }
 
   @type asset_timeline_window :: %{
@@ -263,6 +278,22 @@ defmodule FavnOrchestrator do
          {:ok, freshness_states} <- catalogue_freshness_states(manifest_version_id),
          {:ok, runs} <- catalogue_runs(manifest_version_id) do
       {:ok, asset_catalogue_entries(version, freshness_states, runs)}
+    end
+  end
+
+  @doc """
+  Returns operator-facing catalogue entries for pipelines in the active manifest.
+
+  Entries include manifest-level pipeline selection metadata enriched with the
+  latest persisted run that can be associated with each pipeline.
+  """
+  @spec active_pipeline_catalogue() :: {:ok, [pipeline_catalogue_entry()]} | {:error, term()}
+  def active_pipeline_catalogue do
+    with {:ok, manifest_version_id} <- active_manifest(),
+         {:ok, version} <- get_manifest(manifest_version_id),
+         {:ok, index} <- Index.build_from_version(version),
+         {:ok, runs} <- catalogue_runs(manifest_version_id) do
+      {:ok, pipeline_catalogue_entries(version, index, runs)}
     end
   end
 
@@ -1187,6 +1218,23 @@ defmodule FavnOrchestrator do
       |> Map.put(:latest_run_id, latest_run_id(freshness, run))
       |> Map.put(:latest_run_status, latest_run_status(freshness, run))
       |> Map.put(:latest_run_at, latest_run_at(freshness, run))
+    end)
+    |> Enum.sort_by(& &1.label)
+  end
+
+  defp pipeline_catalogue_entries(%Version{} = version, %Index{} = index, runs) do
+    version.manifest.pipelines
+    |> List.wrap()
+    |> Enum.map(fn pipeline ->
+      target = manifest_pipeline_target(index, pipeline)
+      latest_run = latest_pipeline_run(target, runs)
+
+      target
+      |> Map.put(:status, run_status(latest_run))
+      |> Map.put(:latest_run_id, latest_run_id(nil, latest_run))
+      |> Map.put(:latest_run_status, latest_run_status(nil, latest_run))
+      |> Map.put(:latest_run_at, latest_run_at(nil, latest_run))
+      |> Map.put(:latest_run_duration_ms, run_duration_ms(latest_run))
     end)
     |> Enum.sort_by(& &1.label)
   end
@@ -2155,17 +2203,69 @@ defmodule FavnOrchestrator do
   defp manifest_pipeline_targets(%Version{} = version) do
     version.manifest.pipelines
     |> List.wrap()
-    |> Enum.map(fn pipeline ->
-      target_module = pipeline.module
-
-      %{
-        target_id: target_id_for_pipeline(target_module),
-        label: inspect(target_module),
-        window: window_policy_dto(pipeline.window)
-      }
-    end)
+    |> Enum.map(&manifest_pipeline_target/1)
     |> Enum.sort_by(& &1.label)
   end
+
+  defp manifest_pipeline_target(pipeline) do
+    target_module = pipeline.module
+
+    %{
+      target_id: target_id_for_pipeline(target_module),
+      label: inspect(target_module),
+      window: window_policy_dto(pipeline.window)
+    }
+  end
+
+  defp manifest_pipeline_target(%Index{} = index, pipeline) do
+    base = manifest_pipeline_target(pipeline)
+    resolved_refs = resolve_pipeline_refs(index, pipeline)
+
+    base
+    |> Map.put(:name, pipeline_name(pipeline))
+    |> Map.put(:selected_assets, Enum.map(resolved_refs, &ref_to_string/1))
+    |> Map.put(:dependencies, pipeline_dependencies(pipeline))
+  end
+
+  defp resolve_pipeline_refs(%Index{} = index, pipeline) do
+    case PipelineResolver.resolve(index, pipeline, trigger: %{kind: :catalogue}) do
+      {:ok, resolution} -> resolution.target_refs
+      {:error, _reason} -> raw_pipeline_selector_refs(index, pipeline)
+    end
+  end
+
+  defp raw_pipeline_selector_refs(%Index{} = index, pipeline) do
+    pipeline.selectors
+    |> List.wrap()
+    |> Enum.map(&raw_pipeline_selector_ref/1)
+    |> Enum.filter(&(not is_nil(&1) and Map.has_key?(index.assets_by_ref, &1)))
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp raw_pipeline_selector_ref({:asset, ref}), do: ref
+
+  defp raw_pipeline_selector_ref({module, name} = ref) when is_atom(module) and is_atom(name),
+    do: ref
+
+  defp raw_pipeline_selector_ref(%{"module" => module, "name" => name})
+       when is_binary(module) and is_binary(name) do
+    {String.to_existing_atom(module), String.to_existing_atom(name)}
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp raw_pipeline_selector_ref(_selector), do: nil
+
+  defp pipeline_name(%{name: name}) when is_atom(name), do: Atom.to_string(name)
+
+  defp pipeline_name(%{module: module}) when is_atom(module),
+    do: module |> Atom.to_string() |> String.split(".") |> List.last()
+
+  defp pipeline_name(_pipeline), do: "pipeline"
+
+  defp pipeline_dependencies(%{deps: deps}) when deps in [:all, :none], do: deps
+  defp pipeline_dependencies(_pipeline), do: :unknown
 
   defp freshness_ref_string(%AssetFreshnessState{} = state) do
     ref_to_string({state.asset_ref_module, state.asset_ref_name})
@@ -2193,7 +2293,41 @@ defmodule FavnOrchestrator do
     )
   end
 
+  defp latest_pipeline_run(%{selected_assets: selected_assets, label: label}, runs) do
+    selected_assets = Enum.sort(selected_assets)
+
+    runs
+    |> Enum.filter(fn run ->
+      pipeline_submit_ref?(run, label) || pipeline_targets_match?(run, selected_assets)
+    end)
+    |> latest_run()
+  end
+
+  defp pipeline_submit_ref?(run, label) do
+    Map.get(run, :submit_kind) in [:pipeline, :backfill_pipeline] &&
+      inspect(Map.get(run, :submit_ref)) == label
+  end
+
+  defp pipeline_targets_match?(run, selected_assets) do
+    Map.get(run, :submit_kind) in [:pipeline, :backfill_pipeline] &&
+      selected_assets != [] &&
+      run
+      |> Map.get(:target_refs, [])
+      |> Enum.map(&ref_to_string/1)
+      |> Enum.sort()
+      |> Kernel.==(selected_assets)
+  end
+
   defp run_time_sort_key(run), do: run.finished_at || run.started_at || DateTime.from_unix!(0)
+
+  defp run_duration_ms(%{
+         started_at: %DateTime{} = started_at,
+         finished_at: %DateTime{} = finished_at
+       }) do
+    max(DateTime.diff(finished_at, started_at, :millisecond), 0)
+  end
+
+  defp run_duration_ms(_run), do: nil
 
   defp catalogue_status(%AssetFreshnessState{} = freshness, _run) do
     case freshness.latest_attempt_status || freshness.status do

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -1227,7 +1227,7 @@ defmodule FavnOrchestrator do
     |> List.wrap()
     |> Enum.map(fn pipeline ->
       target = manifest_pipeline_target(index, pipeline)
-      latest_run = latest_pipeline_run(target, runs)
+      latest_run = latest_pipeline_run(pipeline, target, runs)
 
       target
       |> Map.put(:status, run_status(latest_run))
@@ -2293,23 +2293,26 @@ defmodule FavnOrchestrator do
     )
   end
 
-  defp latest_pipeline_run(%{selected_assets: selected_assets, label: label}, runs) do
+  defp latest_pipeline_run(pipeline, %{selected_assets: selected_assets}, runs) do
     selected_assets = Enum.sort(selected_assets)
 
     runs
     |> Enum.filter(fn run ->
-      pipeline_submit_ref?(run, label) || pipeline_targets_match?(run, selected_assets)
+      pipeline_submit_ref_matches?(run, pipeline) ||
+        legacy_pipeline_targets_match?(run, selected_assets)
     end)
     |> latest_run()
   end
 
-  defp pipeline_submit_ref?(run, label) do
-    Map.get(run, :submit_kind) in [:pipeline, :backfill_pipeline] &&
-      inspect(Map.get(run, :submit_ref)) == label
+  defp pipeline_submit_ref_matches?(run, pipeline) do
+    case pipeline_submit_ref(run) do
+      nil -> false
+      submit_ref -> same_pipeline_ref?(submit_ref, pipeline.module)
+    end
   end
 
-  defp pipeline_targets_match?(run, selected_assets) do
-    Map.get(run, :submit_kind) in [:pipeline, :backfill_pipeline] &&
+  defp legacy_pipeline_targets_match?(run, selected_assets) do
+    is_nil(pipeline_submit_ref(run)) && pipeline_origin?(run) &&
       selected_assets != [] &&
       run
       |> Map.get(:target_refs, [])
@@ -2317,6 +2320,34 @@ defmodule FavnOrchestrator do
       |> Enum.sort()
       |> Kernel.==(selected_assets)
   end
+
+  defp pipeline_origin?(run) do
+    Map.get(run, :submit_kind) in [:pipeline, :backfill_pipeline] ||
+      not is_nil(pipeline_metadata_value(run, :pipeline_submit_ref)) ||
+      not is_nil(pipeline_metadata_value(run, :pipeline_target_refs))
+  end
+
+  defp pipeline_submit_ref(run) do
+    pipeline_metadata_value(run, :pipeline_submit_ref) || direct_pipeline_submit_ref(run)
+  end
+
+  defp direct_pipeline_submit_ref(run) do
+    if Map.get(run, :submit_kind) in [:pipeline, :backfill_pipeline] do
+      Map.get(run, :submit_ref)
+    end
+  end
+
+  defp pipeline_metadata_value(run, key) do
+    metadata = Map.get(run, :metadata, %{}) || %{}
+    Map.get(metadata, key) || Map.get(metadata, Atom.to_string(key))
+  end
+
+  defp same_pipeline_ref?(module, module) when is_atom(module), do: true
+
+  defp same_pipeline_ref?(value, module) when is_atom(module),
+    do: to_string(value) == Atom.to_string(module)
+
+  defp same_pipeline_ref?(_value, _module), do: false
 
   defp run_time_sort_key(run), do: run.finished_at || run.started_at || DateTime.from_unix!(0)
 

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -154,6 +154,28 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert entry.latest_run_status == :ok
     assert entry.latest_run_at == finished_at
 
+    assert :ok =
+             Storage.put_run(
+               pipeline_run_state(
+                 "run_pipeline_a",
+                 MyApp.PipelineA,
+                 [{MyApp.AssetA, :asset}],
+                 :ok,
+                 DateTime.add(finished_at, 5, :second),
+                 "mv_a"
+               )
+             )
+
+    assert {:ok, [pipeline_entry]} = FavnOrchestrator.active_pipeline_catalogue()
+    assert pipeline_entry.target_id == "pipeline:Elixir.MyApp.PipelineA"
+    assert pipeline_entry.name == "pipeline_a"
+    assert pipeline_entry.selected_assets == ["Elixir.MyApp.AssetA:asset"]
+    assert pipeline_entry.dependencies == :all
+    assert pipeline_entry.status == :healthy
+    assert pipeline_entry.latest_run_id == "run_pipeline_a"
+    assert pipeline_entry.latest_run_status == :ok
+    assert pipeline_entry.latest_run_duration_ms == 1_000
+
     assert {:error, :not_found} =
              FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.AssetA:not_real")
 
@@ -807,6 +829,28 @@ defmodule FavnOrchestrator.ManifestStoreTest do
         ]
       }
     )
+    |> Map.put(:updated_at, finished_at)
+    |> RunState.with_snapshot_hash()
+  end
+
+  defp pipeline_run_state(id, pipeline_module, refs, status, finished_at, manifest_version_id) do
+    started_at = DateTime.add(finished_at, -1, :second)
+
+    RunState.new(
+      id: id,
+      manifest_version_id: manifest_version_id,
+      manifest_content_hash: "hash_a",
+      asset_ref: List.first(refs),
+      target_refs: refs,
+      submit_kind: :pipeline,
+      metadata: %{
+        pipeline_submit_ref: pipeline_module,
+        pipeline_target_refs: refs,
+        pipeline_dependencies: :all
+      }
+    )
+    |> RunState.transition(status: status, result: %{asset_results: []})
+    |> Map.put(:inserted_at, started_at)
     |> Map.put(:updated_at, finished_at)
     |> RunState.with_snapshot_hash()
   end

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -753,6 +753,77 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert [%{kind: :no_freshness_policy}] = no_policy_detail.freshness.reasons
   end
 
+  test "pipeline catalogue matches runs by pipeline identity before target refs" do
+    ref = {MyApp.AssetA, :asset}
+
+    version =
+      manifest_version(
+        "mv_same_targets",
+        ref,
+        [
+          %Pipeline{module: MyApp.PipelineA, name: :pipeline_a, selectors: [ref], deps: :all},
+          %Pipeline{module: MyApp.PipelineB, name: :pipeline_b, selectors: [ref], deps: :none}
+        ]
+      )
+
+    assert :ok = ManifestStore.register_manifest(version)
+    assert :ok = ManifestStore.set_active_manifest("mv_same_targets")
+
+    assert :ok =
+             Storage.put_run(
+               pipeline_run_state(
+                 "run_pipeline_b",
+                 MyApp.PipelineB,
+                 [ref],
+                 :ok,
+                 ~U[2026-05-10 12:00:00Z],
+                 "mv_same_targets"
+               )
+             )
+
+    assert :ok =
+             Storage.put_run(
+               run_state(
+                 "run_manual_asset_a",
+                 ref,
+                 :error,
+                 ~U[2026-05-10 12:05:00Z],
+                 "mv_same_targets"
+               )
+             )
+
+    assert {:ok, entries} = FavnOrchestrator.active_pipeline_catalogue()
+    pipeline_a = Enum.find(entries, &(&1.name == "pipeline_a"))
+    pipeline_b = Enum.find(entries, &(&1.name == "pipeline_b"))
+
+    assert pipeline_a.status == :unknown
+    assert is_nil(pipeline_a.latest_run_id)
+    assert pipeline_b.status == :healthy
+    assert pipeline_b.latest_run_id == "run_pipeline_b"
+
+    assert :ok =
+             Storage.put_run(
+               pipeline_run_state(
+                 "run_pipeline_b_rerun",
+                 MyApp.PipelineB,
+                 [ref],
+                 :error,
+                 ~U[2026-05-10 12:10:00Z],
+                 "mv_same_targets",
+                 submit_kind: :rerun
+               )
+             )
+
+    assert {:ok, entries} = FavnOrchestrator.active_pipeline_catalogue()
+    pipeline_a = Enum.find(entries, &(&1.name == "pipeline_a"))
+    pipeline_b = Enum.find(entries, &(&1.name == "pipeline_b"))
+
+    assert pipeline_a.status == :unknown
+    assert is_nil(pipeline_a.latest_run_id)
+    assert pipeline_b.status == :failed
+    assert pipeline_b.latest_run_id == "run_pipeline_b_rerun"
+  end
+
   defp manifest_version(manifest_version_id, ref, pipelines \\ [], window \\ nil) do
     manifest = %Manifest{
       assets: [
@@ -833,7 +904,15 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     |> RunState.with_snapshot_hash()
   end
 
-  defp pipeline_run_state(id, pipeline_module, refs, status, finished_at, manifest_version_id) do
+  defp pipeline_run_state(
+         id,
+         pipeline_module,
+         refs,
+         status,
+         finished_at,
+         manifest_version_id,
+         opts \\ []
+       ) do
     started_at = DateTime.add(finished_at, -1, :second)
 
     RunState.new(
@@ -842,7 +921,7 @@ defmodule FavnOrchestrator.ManifestStoreTest do
       manifest_content_hash: "hash_a",
       asset_ref: List.first(refs),
       target_refs: refs,
-      submit_kind: :pipeline,
+      submit_kind: Keyword.get(opts, :submit_kind, :pipeline),
       metadata: %{
         pipeline_submit_ref: pipeline_module,
         pipeline_target_refs: refs,

--- a/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
@@ -312,6 +312,12 @@ defmodule FavnView.Components.AssetCataloguePage do
   def nav_items(active \\ :assets) do
     [
       %{label: "Assets", icon: "hero-sparkles", href: "/assets", active: active == :assets},
+      %{
+        label: "Pipelines",
+        icon: "hero-queue-list",
+        href: "/pipelines",
+        active: active == :pipelines
+      },
       %{label: "Lineage", icon: "hero-share", href: "#"},
       %{label: "Storage", icon: "hero-circle-stack", href: "#"},
       %{label: "Runs", icon: "hero-rocket-launch", href: "/runs", active: active == :runs},

--- a/apps/favn_view/lib/favn_view/components/pipelines_page.ex
+++ b/apps/favn_view/lib/favn_view/components/pipelines_page.ex
@@ -1,0 +1,365 @@
+defmodule FavnView.Components.PipelinesPage do
+  @moduledoc """
+  Pipelines list page components for scanning active manifest pipelines.
+  """
+
+  use FavnView, :html
+
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.GlassPanel
+  alias FavnView.Components.ModeRail
+
+  attr :pipelines, :list, required: true
+  attr :filters, :map, required: true
+  attr :active_mode, :atom, required: true
+  attr :loading, :boolean, default: false
+  attr :error, :string, default: nil
+  attr :nav_items, :list, required: true
+  attr :status_options, :list, required: true
+
+  def pipelines_page(assigns) do
+    ~H"""
+    <AppShell.app_shell
+      title="Pipelines"
+      subtitle="Monitor active manifest pipelines"
+      nav_items={@nav_items}
+    >
+      <div class="mx-auto w-full max-w-6xl pb-24 lg:pb-0" data-testid="pipelines-page">
+        <.loading_state :if={@loading} />
+        <.error_state :if={!@loading && @error} />
+
+        <div :if={!@loading && !@error} class="space-y-3.5 lg:space-y-5">
+          <div id="pipeline-filters" data-testid="pipeline-filters">
+            <.pipeline_filters filters={@filters} status_options={@status_options} />
+          </div>
+
+          <.empty_state :if={@pipelines == []} />
+
+          <GlassPanel.glass_panel :if={@pipelines != []} class="hidden overflow-visible lg:block">
+            <.pipeline_table pipelines={@pipelines} />
+          </GlassPanel.glass_panel>
+
+          <.pipeline_card_list :if={@pipelines != []} pipelines={@pipelines} />
+        </div>
+      </div>
+
+      <:mode_rail>
+        <ModeRail.mode_rail active={@active_mode} modes={pipeline_modes()} on_select="set_mode" />
+      </:mode_rail>
+    </AppShell.app_shell>
+    """
+  end
+
+  attr :filters, :map, required: true
+  attr :status_options, :list, required: true
+
+  def pipeline_filters(assigns) do
+    ~H"""
+    <form
+      phx-change="filter_pipelines"
+      phx-submit="filter_pipelines"
+      class="grid grid-cols-2 gap-2.5 lg:grid-cols-[1fr_12rem] lg:gap-3"
+    >
+      <label class="input input-sm favn-surface-control col-span-2 w-full gap-3 px-4 focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-primary lg:col-span-1">
+        <.icon name="hero-magnifying-glass" class="size-5 shrink-0 text-base-content/60" />
+        <span class="sr-only">Search pipelines</span>
+        <input
+          id="pipeline-search"
+          type="search"
+          name="filters[search]"
+          value={@filters.search}
+          placeholder="Search pipelines or selected assets"
+          autocomplete="off"
+          phx-debounce="200"
+        />
+      </label>
+
+      <label class="select select-sm favn-surface-control w-full gap-2 px-3 focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-primary">
+        <.icon name="hero-heart" class="size-5 shrink-0 text-base-content/65" />
+        <span class="sr-only">Health filter</span>
+        <select name="filters[status]" id="pipeline-status-filter" aria-label="Health filter">
+          <option
+            :for={{label, value} <- @status_options}
+            value={value}
+            selected={@filters.status == value}
+          >
+            {label}
+          </option>
+        </select>
+        <.icon name="hero-chevron-down" class="size-5 shrink-0 text-base-content/65" />
+      </label>
+    </form>
+    """
+  end
+
+  attr :pipelines, :list, required: true
+
+  def pipeline_table(assigns) do
+    ~H"""
+    <div class="overflow-x-auto overflow-y-visible p-5 sm:p-6">
+      <table class="table table-lg" data-testid="pipelines-table">
+        <thead>
+          <tr class="border-base-content/10 text-base-content/65">
+            <th class="font-medium">Pipeline</th>
+            <th class="font-medium">Deps</th>
+            <th class="font-medium">Window</th>
+            <th class="font-medium">Selected assets</th>
+            <th class="font-medium">Health</th>
+            <th class="font-medium">Last run</th>
+            <th class="font-medium">Runtime</th>
+          </tr>
+        </thead>
+        <tbody>
+          <.pipeline_table_row :for={pipeline <- @pipelines} pipeline={pipeline} />
+        </tbody>
+      </table>
+    </div>
+    """
+  end
+
+  attr :pipeline, :map, required: true
+
+  def pipeline_table_row(assigns) do
+    ~H"""
+    <tr class="group border-base-content/10 transition hover:bg-primary/10" data-testid="pipeline-row">
+      <td>
+        <div class="flex items-center gap-3 font-medium text-base-content">
+          <span class="flex size-8 items-center justify-center rounded-field border border-primary/25 bg-primary/10 text-primary">
+            <.icon name="hero-queue-list" class="size-4" />
+          </span>
+          <div class="min-w-0">
+            <p class="truncate">{@pipeline.name}</p>
+            <p class="truncate text-xs font-normal text-base-content/50" title={@pipeline.label}>
+              {@pipeline.label}
+            </p>
+          </div>
+        </div>
+      </td>
+      <td class="whitespace-nowrap text-base-content/70">{@pipeline.dependencies_label}</td>
+      <td class="whitespace-nowrap text-base-content/70">{@pipeline.window_label}</td>
+      <td class="min-w-56 max-w-80">
+        <.selected_assets pipeline={@pipeline} />
+      </td>
+      <td><.status_badge status={@pipeline.status} /></td>
+      <td class="whitespace-nowrap text-base-content/70">{@pipeline.last_run_label}</td>
+      <td class="whitespace-nowrap text-base-content/70">{@pipeline.runtime_label}</td>
+    </tr>
+    """
+  end
+
+  attr :pipelines, :list, required: true
+
+  def pipeline_card_list(assigns) do
+    ~H"""
+    <div class="space-y-2.5 lg:hidden" data-testid="pipeline-card-list">
+      <.pipeline_card :for={pipeline <- @pipelines} pipeline={pipeline} />
+    </div>
+    """
+  end
+
+  attr :pipeline, :map, required: true
+
+  def pipeline_card(assigns) do
+    ~H"""
+    <div
+      class="card glass favn-surface-list favn-density-list-card block rounded-box"
+      data-testid="pipeline-card"
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="min-w-0 flex-1 space-y-2">
+          <div class="flex items-start gap-3">
+            <span class="favn-density-list-card-icon flex shrink-0 items-center justify-center rounded-field border border-primary/30 bg-primary/10 text-primary">
+              <.icon name="hero-queue-list" class="size-4" />
+            </span>
+            <div class="min-w-0 flex-1">
+              <h2 class="truncate text-base font-medium leading-tight text-base-content">
+                {@pipeline.name}
+              </h2>
+              <p class="mt-0.5 truncate text-xs text-base-content/60">
+                {@pipeline.dependencies_label} · {@pipeline.window_label} · {asset_count_label(
+                  @pipeline
+                )}
+              </p>
+            </div>
+          </div>
+          <div class="flex flex-wrap items-center gap-3 text-xs text-base-content/65">
+            <.status_badge status={@pipeline.status} />
+            <span>{@pipeline.last_run_label}</span>
+            <span>{@pipeline.runtime_label}</span>
+          </div>
+          <p
+            class="truncate text-xs text-base-content/55"
+            title={Enum.join(@pipeline.selected_assets, ", ")}
+          >
+            {selected_assets_preview(@pipeline)}
+          </p>
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :pipeline, :map, required: true
+
+  def selected_assets(%{pipeline: %{selected_assets: []}} = assigns) do
+    ~H"""
+    <span class="text-sm text-base-content/55">No resolved assets</span>
+    """
+  end
+
+  def selected_assets(%{pipeline: %{selected_assets: [_single]}} = assigns) do
+    ~H"""
+    <p
+      class="truncate text-sm font-medium text-base-content"
+      title={List.first(@pipeline.selected_assets)}
+    >
+      {List.first(@pipeline.selected_assets)}
+    </p>
+    """
+  end
+
+  def selected_assets(assigns) do
+    ~H"""
+    <details class="dropdown dropdown-hover dropdown-bottom">
+      <summary class="list-none marker:content-none">
+        <span class="inline-flex max-w-full cursor-default items-center gap-2 align-middle">
+          <span
+            class="truncate text-sm font-medium text-base-content"
+            title={List.first(@pipeline.selected_assets)}
+          >
+            {List.first(@pipeline.selected_assets)}
+          </span>
+          <span class="badge badge-xs badge-soft badge-info shrink-0">
+            +{length(@pipeline.selected_assets) - 1}
+          </span>
+        </span>
+      </summary>
+      <div class="dropdown-content z-20 mt-2 w-80 rounded-box border border-base-content/10 bg-base-100 p-3 shadow-xl">
+        <p class="mb-2 text-xs font-medium uppercase tracking-[0.2em] text-base-content/45">
+          Selected assets
+        </p>
+        <ul class="space-y-1 text-xs text-base-content/75">
+          <li :for={asset <- @pipeline.selected_assets} class="truncate" title={asset}>{asset}</li>
+        </ul>
+      </div>
+    </details>
+    """
+  end
+
+  attr :status, :atom, required: true
+
+  def status_badge(assigns) do
+    ~H"""
+    <span class={["badge badge-sm badge-soft gap-2", status_badge_class(@status)]}>
+      <span class={["status", status_dot_class(@status)]}></span>
+      {status_label(@status)}
+    </span>
+    """
+  end
+
+  def loading_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="mx-auto flex min-h-64 max-w-2xl items-center justify-center p-10">
+      <div class="text-center">
+        <span class="loading loading-ring loading-lg text-primary"></span>
+        <p class="mt-4 text-base-content/60">Loading pipelines</p>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def empty_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel
+      class="mx-auto max-w-2xl p-10 text-center"
+      data-testid="pipelines-empty-state"
+    >
+      <h2 class="text-xl font-medium">No pipelines found</h2>
+      <p class="mt-2 text-base-content/60">Try changing the search or health filter.</p>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def error_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel
+      class="mx-auto max-w-2xl p-10 text-center"
+      data-testid="pipelines-error-state"
+    >
+      <h2 class="text-xl font-medium">Could not load pipelines</h2>
+      <p class="mt-2 text-base-content/60">Retry</p>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def pipeline_modes do
+    [
+      %{id: :list, label: "List", icon: "hero-list-bullet"},
+      %{id: :filters, label: "Filters", icon: "hero-funnel", disabled: true},
+      %{id: :more, label: "More", icon: "hero-ellipsis-vertical", disabled: true}
+    ]
+  end
+
+  def sample_pipelines do
+    [
+      %{
+        id: "pipeline:Elixir.FavnView.Pipelines.DailySales",
+        name: "daily_sales",
+        label: "FavnView.Pipelines.DailySales",
+        selected_assets: ["raw_orders", "stg_orders", "customer_orders_daily", "mart_daily_sales"],
+        asset_count: 4,
+        dependencies: :all,
+        dependencies_label: "Include deps",
+        window_label: "Day Europe/Oslo",
+        status: :healthy,
+        status_label: "Healthy",
+        last_run_label: "12m ago",
+        runtime_label: "34.5 s"
+      },
+      %{
+        id: "pipeline:Elixir.FavnView.Pipelines.Marketing",
+        name: "marketing_refresh",
+        label: "FavnView.Pipelines.Marketing",
+        selected_assets: ["campaign_spend", "mart_customer_360"],
+        asset_count: 2,
+        dependencies: :none,
+        dependencies_label: "Selected only",
+        window_label: "No window",
+        status: :running,
+        status_label: "Running",
+        last_run_label: "just now",
+        runtime_label: "8.1 s"
+      }
+    ]
+  end
+
+  def status_options do
+    [{"Health", "all"}, {"Healthy", "healthy"}, {"Running", "running"}, {"Failed", "failed"}]
+  end
+
+  def nav_items(active \\ :pipelines), do: AssetCataloguePage.nav_items(active)
+
+  defp selected_assets_preview(%{selected_assets: []}), do: "No resolved assets"
+  defp selected_assets_preview(%{selected_assets: assets}), do: Enum.join(assets, ", ")
+
+  defp asset_count_label(%{asset_count: 1}), do: "1 asset"
+  defp asset_count_label(%{asset_count: count}), do: "#{count} assets"
+
+  defp status_badge_class(:healthy), do: "badge-success"
+  defp status_badge_class(:running), do: "badge-info"
+  defp status_badge_class(:failed), do: "badge-error"
+  defp status_badge_class(:unknown), do: "badge-neutral"
+  defp status_badge_class(_status), do: "badge-neutral"
+
+  defp status_dot_class(:healthy), do: "status-success"
+  defp status_dot_class(:running), do: "status-info"
+  defp status_dot_class(:failed), do: "status-error"
+  defp status_dot_class(_status), do: "status-neutral"
+
+  defp status_label(:healthy), do: "Healthy"
+  defp status_label(:running), do: "Running"
+  defp status_label(:failed), do: "Failed"
+  defp status_label(:unknown), do: "Unknown"
+  defp status_label(_status), do: "Unknown"
+end

--- a/apps/favn_view/lib/favn_view/pipelines_live.ex
+++ b/apps/favn_view/lib/favn_view/pipelines_live.ex
@@ -75,7 +75,7 @@ defmodule FavnView.PipelinesLive do
       id: Map.fetch!(entry, :target_id),
       name: Map.get(entry, :name) || pipeline_name(Map.fetch!(entry, :label)),
       label: Map.fetch!(entry, :label),
-      selected_assets: Enum.map(selected_assets, &LogsViewModel.display_name/1),
+      selected_assets: Enum.map(selected_assets, &asset_ref_label/1),
       asset_count: length(selected_assets),
       dependencies: Map.get(entry, :dependencies, :unknown),
       dependencies_label: dependencies_label(Map.get(entry, :dependencies, :unknown)),
@@ -128,6 +128,14 @@ defmodule FavnView.PipelinesLive do
     |> String.split(".")
     |> List.last()
   end
+
+  defp asset_ref_label(ref) when is_binary(ref) do
+    ref
+    |> String.split(":")
+    |> List.last()
+  end
+
+  defp asset_ref_label(ref), do: to_string(ref)
 
   defp dependencies_label(:all), do: "Include deps"
   defp dependencies_label(:none), do: "Selected only"

--- a/apps/favn_view/lib/favn_view/pipelines_live.ex
+++ b/apps/favn_view/lib/favn_view/pipelines_live.ex
@@ -1,0 +1,169 @@
+defmodule FavnView.PipelinesLive do
+  @moduledoc false
+
+  use FavnView, :live_view
+
+  alias FavnView.Components.PipelinesPage
+  alias FavnView.LogsViewModel
+
+  @default_filters %{search: "", status: "all"}
+  @valid_modes ~w(list)
+
+  @impl true
+  def mount(_params, _session, socket) do
+    {pipelines, error} = load_pipelines()
+
+    socket =
+      assign(socket,
+        all_pipelines: pipelines,
+        pipelines: pipelines,
+        filters: @default_filters,
+        active_mode: :list,
+        loading: false,
+        error: error,
+        nav_items: PipelinesPage.nav_items(:pipelines),
+        status_options: status_options(pipelines)
+      )
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("filter_pipelines", %{"filters" => params}, socket) do
+    filters = normalize_filters(params)
+
+    {:noreply,
+     assign(socket,
+       filters: filters,
+       pipelines: filter_pipelines(socket.assigns.all_pipelines, filters)
+     )}
+  end
+
+  def handle_event("set_mode", %{"mode" => mode}, socket) when mode in @valid_modes do
+    {:noreply, assign(socket, :active_mode, String.to_existing_atom(mode))}
+  end
+
+  def handle_event("set_mode", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <PipelinesPage.pipelines_page
+      pipelines={@pipelines}
+      filters={@filters}
+      active_mode={@active_mode}
+      loading={@loading}
+      error={@error}
+      nav_items={@nav_items}
+      status_options={@status_options}
+    />
+    """
+  end
+
+  defp load_pipelines do
+    case FavnOrchestrator.active_pipeline_catalogue() do
+      {:ok, entries} -> {Enum.map(entries, &pipeline_from_entry/1), nil}
+      {:error, reason} -> {[], inspect(reason)}
+    end
+  end
+
+  defp pipeline_from_entry(entry) do
+    selected_assets = Map.get(entry, :selected_assets, [])
+    status = Map.get(entry, :status, :unknown)
+
+    %{
+      id: Map.fetch!(entry, :target_id),
+      name: Map.get(entry, :name) || pipeline_name(Map.fetch!(entry, :label)),
+      label: Map.fetch!(entry, :label),
+      selected_assets: Enum.map(selected_assets, &LogsViewModel.display_name/1),
+      asset_count: length(selected_assets),
+      dependencies: Map.get(entry, :dependencies, :unknown),
+      dependencies_label: dependencies_label(Map.get(entry, :dependencies, :unknown)),
+      window_label: window_label(Map.get(entry, :window)),
+      status: status,
+      status_label: status_label(status),
+      last_run_label: last_run_label(Map.get(entry, :latest_run_at)),
+      runtime_label: LogsViewModel.duration_ms_label(Map.get(entry, :latest_run_duration_ms))
+    }
+  end
+
+  defp normalize_filters(params) do
+    %{
+      search: Map.get(params, "search", ""),
+      status: Map.get(params, "status", "all")
+    }
+  end
+
+  defp filter_pipelines(pipelines, filters) do
+    search = filters.search |> String.downcase() |> String.trim()
+
+    Enum.filter(pipelines, fn pipeline ->
+      search_text =
+        [pipeline.name, pipeline.label | pipeline.selected_assets]
+        |> Enum.join(" ")
+        |> String.downcase()
+
+      matches_search? = search == "" || String.contains?(search_text, search)
+
+      matches_status? =
+        filters.status == "all" || Atom.to_string(pipeline.status) == filters.status
+
+      matches_search? && matches_status?
+    end)
+  end
+
+  defp status_options(pipelines) do
+    options =
+      pipelines
+      |> Enum.map(& &1.status)
+      |> Enum.uniq()
+      |> Enum.sort()
+      |> Enum.map(&{status_label(&1), Atom.to_string(&1)})
+
+    [{"Health", "all"} | options]
+  end
+
+  defp pipeline_name(label) do
+    label
+    |> String.split(".")
+    |> List.last()
+  end
+
+  defp dependencies_label(:all), do: "Include deps"
+  defp dependencies_label(:none), do: "Selected only"
+  defp dependencies_label(_dependencies), do: "Unknown deps"
+
+  defp window_label(nil), do: "No window"
+  defp window_label(%{kind: kind, timezone: timezone}), do: window_label(kind, timezone)
+  defp window_label(%{"kind" => kind, "timezone" => timezone}), do: window_label(kind, timezone)
+  defp window_label(_window), do: "Windowed"
+
+  defp window_label(kind, nil), do: humanize(kind)
+  defp window_label(kind, timezone), do: "#{humanize(kind)} #{timezone}"
+
+  defp status_label(:healthy), do: "Healthy"
+  defp status_label(:running), do: "Running"
+  defp status_label(:failed), do: "Failed"
+  defp status_label(:unknown), do: "Unknown"
+  defp status_label(_status), do: "Unknown"
+
+  defp last_run_label(%DateTime{} = datetime) do
+    seconds = DateTime.diff(DateTime.utc_now(), datetime, :second)
+
+    cond do
+      seconds < 60 -> "just now"
+      seconds < 3_600 -> "#{div(seconds, 60)}m ago"
+      seconds < 86_400 -> "#{div(seconds, 3_600)}h ago"
+      true -> Calendar.strftime(datetime, "%b %-d %H:%M")
+    end
+  end
+
+  defp last_run_label(_value), do: "No runs yet"
+
+  defp humanize(value) do
+    value
+    |> to_string()
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+end

--- a/apps/favn_view/lib/favn_view/pipelines_live.ex
+++ b/apps/favn_view/lib/favn_view/pipelines_live.ex
@@ -130,9 +130,11 @@ defmodule FavnView.PipelinesLive do
   end
 
   defp asset_ref_label(ref) when is_binary(ref) do
-    ref
-    |> String.split(":")
-    |> List.last()
+    case String.split(ref, ":", parts: 2) do
+      [module, "asset"] -> module |> String.split(".") |> List.last()
+      [_module, name] -> name
+      [value] -> value |> String.split(".") |> List.last()
+    end
   end
 
   defp asset_ref_label(ref), do: to_string(ref)

--- a/apps/favn_view/lib/favn_view/router.ex
+++ b/apps/favn_view/lib/favn_view/router.ex
@@ -20,6 +20,7 @@ defmodule FavnView.Router do
     live "/", PageLive, :home
     live "/assets", AssetCatalogueLive, :index
     live "/assets/:asset_id", AssetDetailLive, :show
+    live "/pipelines", PipelinesLive, :index
     live "/logs", LogsLive, :index
     live "/runs", RunsListLive, :index
     live "/runs/:run_id", RunDetailLive, :show

--- a/apps/favn_view/storybook/components/pipelines_page.story.exs
+++ b/apps/favn_view/storybook/components/pipelines_page.story.exs
@@ -1,0 +1,72 @@
+defmodule FavnView.Storybook.Components.PipelinesPage do
+  alias FavnView.Components.PipelinesPage
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &PipelinesPage.pipelines_page/1
+  def layout, do: :one_column
+  def render_source, do: :function
+
+  def container, do: {:iframe, style: "width: 100%; height: 980px; border: 0;"}
+
+  def template do
+    """
+    <div data-theme="favn-dark">
+      <.psb-variation/>
+    </div>
+    """
+  end
+
+  def variations do
+    [
+      %Variation{
+        id: :pipelines,
+        attributes: %{
+          pipelines: PipelinesPage.sample_pipelines(),
+          filters: %{search: "", status: "all"},
+          active_mode: :list,
+          loading: false,
+          error: nil,
+          nav_items: PipelinesPage.nav_items(),
+          status_options: PipelinesPage.status_options()
+        }
+      },
+      %Variation{
+        id: :empty,
+        attributes: %{
+          pipelines: [],
+          filters: %{search: "not_real", status: "failed"},
+          active_mode: :filters,
+          loading: false,
+          error: nil,
+          nav_items: PipelinesPage.nav_items(),
+          status_options: PipelinesPage.status_options()
+        }
+      },
+      %Variation{
+        id: :loading,
+        attributes: %{
+          pipelines: [],
+          filters: %{search: "", status: "all"},
+          active_mode: :list,
+          loading: true,
+          error: nil,
+          nav_items: PipelinesPage.nav_items(),
+          status_options: PipelinesPage.status_options()
+        }
+      },
+      %Variation{
+        id: :error,
+        attributes: %{
+          pipelines: [],
+          filters: %{search: "", status: "all"},
+          active_mode: :list,
+          loading: false,
+          error: "load_failed",
+          nav_items: PipelinesPage.nav_items(),
+          status_options: PipelinesPage.status_options()
+        }
+      }
+    ]
+  end
+end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -5,9 +5,11 @@ defmodule FavnView.PageLiveTest do
 
   alias Favn.Log.Entry
   alias Favn.Manifest
+  alias Favn.Manifest.Pipeline
   alias Favn.Manifest.Version
   alias Favn.Run.AssetResult
   alias Favn.Run.NodeResult
+  alias Favn.Window.Policy
   alias Favn.Window.Spec, as: WindowSpec
   alias FavnView.Components.AssetDetailPage
   alias FavnOrchestrator.AssetFreshnessState
@@ -23,6 +25,7 @@ defmodule FavnView.PageLiveTest do
     assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
     assert :ok = Storage.put_run(run_state(:customer_orders_daily, :ok, -600))
     assert :ok = Storage.put_run(run_state(:raw_payments, :running, -30))
+    assert :ok = Storage.put_run(pipeline_run_state())
 
     assert :ok =
              Storage.put_run(empty_run_state(:stg_payments, :running, "run_empty_running"))
@@ -83,6 +86,22 @@ defmodule FavnView.PageLiveTest do
     assert html =~ "1/1 asset"
     assert html =~ "2/3 steps"
     assert html =~ "+2"
+  end
+
+  test "renders the pipelines list", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/pipelines")
+
+    assert html =~ "Pipelines"
+    assert html =~ "Monitor active manifest pipelines"
+    assert has_element?(view, ~s([data-testid="pipelines-table"]))
+    assert has_element?(view, ~s([data-testid="pipeline-card-list"]))
+
+    assert html =~ "daily_orders"
+    assert html =~ "customer_orders_daily"
+    assert html =~ "Include deps"
+    assert html =~ "Day Europe/Oslo"
+    assert html =~ "Healthy"
+    assert html =~ "5.0 s"
   end
 
   test "runs list refreshes active runs", %{conn: conn} do
@@ -824,6 +843,15 @@ defmodule FavnView.PageLiveTest do
         asset(:always_refresh, :snowflake, "sales", :sql,
           freshness: Favn.Freshness.Policy.from_value!(:always)
         )
+      ],
+      pipelines: [
+        %Pipeline{
+          module: __MODULE__.Pipelines.DailyOrders,
+          name: :daily_orders,
+          selectors: [{:asset, {__MODULE__.Assets, :customer_orders_daily}}],
+          deps: :all,
+          window: Policy.new!(:daily, timezone: "Europe/Oslo")
+        }
       ]
     }
 
@@ -870,6 +898,33 @@ defmodule FavnView.PageLiveTest do
           }
         ]
       }
+    )
+    |> Map.put(:inserted_at, started_at)
+    |> Map.put(:updated_at, finished_at)
+    |> RunState.with_snapshot_hash()
+  end
+
+  defp pipeline_run_state do
+    ref = {__MODULE__.Assets, :customer_orders_daily}
+    finished_at = DateTime.add(DateTime.utc_now(), -900, :second)
+    started_at = DateTime.add(finished_at, -5, :second)
+
+    RunState.new(
+      id: "run_daily_orders",
+      manifest_version_id: "mv_view_assets",
+      manifest_content_hash: "hash_view_assets",
+      asset_ref: ref,
+      target_refs: [ref],
+      submit_kind: :pipeline,
+      metadata: %{
+        pipeline_submit_ref: __MODULE__.Pipelines.DailyOrders,
+        pipeline_target_refs: [ref],
+        pipeline_dependencies: :all
+      }
+    )
+    |> RunState.transition(
+      status: :ok,
+      result: %{asset_results: terminal_asset_results(:customer_orders_daily)}
     )
     |> Map.put(:inserted_at, started_at)
     |> Map.put(:updated_at, finished_at)


### PR DESCRIPTION
## Summary
- Add an orchestrator pipeline catalogue read model for active manifest pipelines, including selected assets, deps, window, health, last run, and runtime.
- Add the `/pipelines` LiveView, page component, navigation entry, and Storybook states matching the existing asset catalogue list design.
- Cover pipeline catalogue data and the new Pipelines page in orchestrator and LiveView tests.

## Verification
- `mix format`
- `mix compile --warnings-as-errors` in `apps/favn_orchestrator`
- `mix compile --warnings-as-errors` in `apps/favn_view`
- `mix test` in `apps/favn_orchestrator`
- `mix test` in `apps/favn_view`