### PR TITLE
Add pipeline detail page

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -92,6 +92,32 @@ defmodule FavnOrchestrator do
           required(:latest_run_duration_ms) => non_neg_integer() | nil
         }
 
+  @type pipeline_run_history_entry :: %{
+          required(:id) => String.t(),
+          required(:status) => atom(),
+          required(:submit_kind) => atom() | nil,
+          required(:started_at) => DateTime.t() | nil,
+          required(:finished_at) => DateTime.t() | nil,
+          required(:duration_ms) => non_neg_integer() | nil,
+          required(:window) => map() | String.t() | nil
+        }
+
+  @type pipeline_detail :: %{
+          required(:target_id) => String.t(),
+          required(:manifest_version_id) => String.t(),
+          required(:label) => String.t(),
+          required(:name) => String.t(),
+          required(:selected_assets) => [String.t()],
+          required(:dependencies) => :all | :none | :unknown,
+          required(:window) => map() | nil,
+          required(:status) => :healthy | :running | :failed | :unknown,
+          required(:latest_run_id) => String.t() | nil,
+          required(:latest_run_status) => atom() | nil,
+          required(:latest_run_at) => DateTime.t() | nil,
+          required(:latest_run_duration_ms) => non_neg_integer() | nil,
+          required(:runs) => [pipeline_run_history_entry()]
+        }
+
   @type asset_timeline_window :: %{
           required(:id) => String.t(),
           required(:kind) => :hour | :day | :month | :year,
@@ -294,6 +320,26 @@ defmodule FavnOrchestrator do
          {:ok, index} <- Index.build_from_version(version),
          {:ok, runs} <- catalogue_runs(manifest_version_id) do
       {:ok, pipeline_catalogue_entries(version, index, runs)}
+    end
+  end
+
+  @doc """
+  Returns an operator-facing detail read model for one active pipeline target.
+
+  The detail is built at the orchestrator boundary and includes manifest target
+  metadata, selected assets, latest run state, and persisted run history matched
+  to the pipeline submit ref.
+  """
+  @spec active_pipeline_detail(String.t()) :: {:ok, pipeline_detail()} | {:error, term()}
+  def active_pipeline_detail(target_id) when is_binary(target_id) do
+    with {:ok, manifest_version_id} <- active_manifest(),
+         {:ok, version} <- get_manifest(manifest_version_id),
+         {:ok, index} <- Index.build_from_version(version),
+         {:ok, runs} <- catalogue_runs(manifest_version_id) do
+      case pipeline_detail_entry(version, index, target_id, runs) do
+        nil -> {:error, :not_found}
+        detail -> {:ok, detail}
+      end
     end
   end
 
@@ -1237,6 +1283,30 @@ defmodule FavnOrchestrator do
       |> Map.put(:latest_run_duration_ms, run_duration_ms(latest_run))
     end)
     |> Enum.sort_by(& &1.label)
+  end
+
+  defp pipeline_detail_entry(%Version{} = version, %Index{} = index, target_id, runs) do
+    version.manifest.pipelines
+    |> List.wrap()
+    |> Enum.find(&(manifest_pipeline_target(&1).target_id == target_id))
+    |> case do
+      nil ->
+        nil
+
+      pipeline ->
+        target = manifest_pipeline_target(index, pipeline)
+        pipeline_runs = pipeline_runs(pipeline, target, runs)
+        latest_run = latest_run(pipeline_runs)
+
+        target
+        |> Map.put(:manifest_version_id, version.manifest_version_id)
+        |> Map.put(:status, run_status(latest_run))
+        |> Map.put(:latest_run_id, latest_run_id(nil, latest_run))
+        |> Map.put(:latest_run_status, latest_run_status(nil, latest_run))
+        |> Map.put(:latest_run_at, latest_run_at(nil, latest_run))
+        |> Map.put(:latest_run_duration_ms, run_duration_ms(latest_run))
+        |> Map.put(:runs, Enum.map(pipeline_runs, &pipeline_run_history_entry/1))
+    end
   end
 
   defp asset_detail_entry(%Version{} = version, target_id, freshness_states, runs, opts) do
@@ -2294,6 +2364,12 @@ defmodule FavnOrchestrator do
   end
 
   defp latest_pipeline_run(pipeline, %{selected_assets: selected_assets}, runs) do
+    pipeline
+    |> pipeline_runs(%{selected_assets: selected_assets}, runs)
+    |> latest_run()
+  end
+
+  defp pipeline_runs(pipeline, %{selected_assets: selected_assets}, runs) do
     selected_assets = Enum.sort(selected_assets)
 
     runs
@@ -2301,7 +2377,28 @@ defmodule FavnOrchestrator do
       pipeline_submit_ref_matches?(run, pipeline) ||
         legacy_pipeline_targets_match?(run, selected_assets)
     end)
-    |> latest_run()
+    |> Enum.sort_by(&DateTime.to_unix(run_time_sort_key(&1), :microsecond), :desc)
+  end
+
+  defp pipeline_run_history_entry(run) do
+    %{
+      id: run.id,
+      status: run.status,
+      submit_kind: Map.get(run, :submit_kind),
+      started_at: Map.get(run, :started_at),
+      finished_at: Map.get(run, :finished_at),
+      duration_ms: run_duration_ms(run),
+      window: run_history_window(run)
+    }
+  end
+
+  defp run_history_window(run) do
+    params = Map.get(run, :params, %{}) || %{}
+    metadata = Map.get(run, :metadata, %{}) || %{}
+
+    Map.get(params, :window) || Map.get(params, "window") || Map.get(metadata, :selected_window) ||
+      Map.get(metadata, "selected_window") || Map.get(metadata, :window) ||
+      Map.get(metadata, "window")
   end
 
   defp pipeline_submit_ref_matches?(run, pipeline) do

--- a/apps/favn_view/lib/favn_view/components/pipeline_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/pipeline_detail_page.ex
@@ -1,0 +1,276 @@
+defmodule FavnView.Components.PipelineDetailPage do
+  @moduledoc """
+  Pipeline detail page components for run history and manual operations.
+  """
+
+  use FavnView, :html
+
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.GlassPanel
+  alias FavnView.Components.ModeRail
+  alias FavnView.Components.PipelinesPage
+
+  attr :pipeline, :map, required: true
+  attr :nav_items, :list, required: true
+  attr :active_mode, :atom, default: :runs
+  attr :run_error, :string, default: nil
+  attr :backfill_error, :string, default: nil
+  attr :backfill_config, :map, required: true
+
+  def pipeline_detail_page(assigns) do
+    ~H"""
+    <AppShell.app_shell
+      title={@pipeline.name}
+      subtitle={@pipeline.label}
+      status={@pipeline.status_label}
+      status_tone={status_tone(@pipeline.status)}
+      nav_items={@nav_items}
+    >
+      <div class="mx-auto w-full max-w-6xl space-y-4 pb-24 lg:pb-0" data-testid="pipeline-detail-page">
+        <.summary_panel pipeline={@pipeline} />
+        <.actions_panel
+          pipeline={@pipeline}
+          run_error={@run_error}
+          backfill_error={@backfill_error}
+          backfill_config={@backfill_config}
+        />
+        <.history_panel pipeline={@pipeline} />
+      </div>
+
+      <:mode_rail>
+        <ModeRail.mode_rail active={@active_mode} modes={detail_modes()} on_select="set_mode" />
+      </:mode_rail>
+    </AppShell.app_shell>
+    """
+  end
+
+  attr :pipeline, :map, required: true
+
+  def summary_panel(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="p-6 sm:p-8" data-testid="pipeline-summary-panel">
+      <div class="flex flex-col gap-5 lg:flex-row lg:items-start lg:justify-between">
+        <div class="min-w-0">
+          <p class="text-xs uppercase tracking-[0.2em] text-base-content/45">Pipeline</p>
+          <h2 class="mt-2 text-2xl font-medium tracking-tight">{@pipeline.name}</h2>
+          <p class="mt-2 break-words font-mono text-xs text-base-content/55">{@pipeline.label}</p>
+        </div>
+        <div class="flex flex-wrap gap-2">
+          <PipelinesPage.status_badge status={@pipeline.status} />
+          <span class="badge badge-ghost badge-sm">{@pipeline.dependencies_label}</span>
+          <span class="badge badge-ghost badge-sm">{@pipeline.window_label}</span>
+        </div>
+      </div>
+
+      <div class="mt-6 grid gap-3 sm:grid-cols-3">
+        <.summary_stat label="Selected assets" value={to_string(@pipeline.asset_count)} />
+        <.summary_stat label="Last run" value={@pipeline.last_run_label} />
+        <.summary_stat label="Runtime" value={@pipeline.runtime_label} />
+      </div>
+
+      <div class="mt-6">
+        <p class="text-xs uppercase tracking-[0.18em] text-base-content/45">Selected assets</p>
+        <div class="mt-3 flex flex-wrap gap-2">
+          <span :for={asset <- @pipeline.selected_assets} class="badge badge-soft badge-info">
+            {asset}
+          </span>
+          <span :if={@pipeline.selected_assets == []} class="text-sm text-base-content/55">
+            No resolved assets
+          </span>
+        </div>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+
+  def summary_stat(assigns) do
+    ~H"""
+    <div class="rounded-box border border-base-content/10 bg-base-content/[0.03] p-4">
+      <p class="text-xs uppercase tracking-[0.16em] text-base-content/45">{@label}</p>
+      <p class="mt-1 text-sm font-medium text-base-content">{@value}</p>
+    </div>
+    """
+  end
+
+  attr :pipeline, :map, required: true
+  attr :run_error, :string, default: nil
+  attr :backfill_error, :string, default: nil
+  attr :backfill_config, :map, required: true
+
+  def actions_panel(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="p-6 sm:p-8" data-testid="pipeline-actions-panel">
+      <div class="grid gap-6 lg:grid-cols-[1fr_1.4fr]">
+        <div>
+          <p class="text-xs uppercase tracking-[0.2em] text-base-content/45">Run pipeline</p>
+          <p class="mt-2 text-sm text-base-content/65">
+            Submit the active manifest pipeline, equivalent to <code class="font-mono">mix favn.run</code>.
+          </p>
+          <form phx-submit="run_pipeline" class="mt-4" data-testid="run-pipeline-form">
+            <button type="submit" class="btn btn-primary" data-testid="run-pipeline-button">
+              <.icon name="hero-play" class="size-4" /> Run pipeline
+            </button>
+          </form>
+          <p :if={@run_error} class="mt-3 text-sm text-error" data-testid="pipeline-run-error">
+            {@run_error}
+          </p>
+        </div>
+
+        <div>
+          <p class="text-xs uppercase tracking-[0.2em] text-base-content/45">Backfill</p>
+          <p class="mt-2 text-sm text-base-content/65">
+            Submit an explicit range, equivalent to <code class="font-mono">mix favn.backfill submit</code>.
+          </p>
+          <form
+            phx-submit="submit_backfill"
+            class="mt-4 grid gap-3 sm:grid-cols-[1fr_1fr_8rem_auto]"
+            data-testid="pipeline-backfill-form"
+          >
+            <label class="form-control">
+              <span class="label-text text-xs">From</span>
+              <input
+                name="backfill[from]"
+                value={@backfill_config.from}
+                class="input input-sm favn-surface-control"
+                placeholder="2024-01"
+              />
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs">To</span>
+              <input
+                name="backfill[to]"
+                value={@backfill_config.to}
+                class="input input-sm favn-surface-control"
+                placeholder="2026-12"
+              />
+            </label>
+            <label class="form-control">
+              <span class="label-text text-xs">Kind</span>
+              <select name="backfill[kind]" class="select select-sm favn-surface-control">
+                <option
+                  :for={kind <- ~w(month day hour year)}
+                  value={kind}
+                  selected={@backfill_config.kind == kind}
+                >
+                  {kind}
+                </option>
+              </select>
+            </label>
+            <button
+              type="submit"
+              class="btn btn-primary btn-soft self-end"
+              data-testid="submit-backfill-button"
+            >
+              Backfill
+            </button>
+          </form>
+          <p
+            :if={@backfill_error}
+            class="mt-3 text-sm text-error"
+            data-testid="pipeline-backfill-error"
+          >
+            {@backfill_error}
+          </p>
+        </div>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  attr :pipeline, :map, required: true
+
+  def history_panel(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel class="overflow-hidden" data-testid="pipeline-history-panel">
+      <div class="border-b border-base-content/10 p-5 sm:p-6">
+        <h2 class="text-lg font-medium">Run history</h2>
+        <p class="mt-1 text-sm text-base-content/60">
+          Pipeline and backfill runs matched to this pipeline.
+        </p>
+      </div>
+
+      <div :if={@pipeline.runs == []} class="p-8 text-center text-sm text-base-content/60">
+        No runs have been recorded for this pipeline yet.
+      </div>
+
+      <div :if={@pipeline.runs != []} class="overflow-x-auto">
+        <table class="table" data-testid="pipeline-runs-table">
+          <thead>
+            <tr class="border-base-content/10 text-base-content/65">
+              <th>Run</th>
+              <th>Status</th>
+              <th>Kind</th>
+              <th>Window</th>
+              <th>Started</th>
+              <th>Duration</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              :for={run <- @pipeline.runs}
+              class="border-base-content/10"
+              data-testid="pipeline-run-row"
+            >
+              <td>
+                <.link navigate={~p"/runs/#{run.id}"} class="link link-hover font-mono text-xs">
+                  {run.short_id}
+                </.link>
+              </td>
+              <td><PipelinesPage.status_badge status={run.status} /></td>
+              <td>{run.kind_label}</td>
+              <td>{run.window_label}</td>
+              <td>{run.started_at_label}</td>
+              <td>{run.duration_label}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def sample_pipeline do
+    %{
+      id: "pipeline:Elixir.SeiDp.Pipelines.MercatusRawFullRefresh",
+      manifest_version_id: "mv_sample",
+      name: "mercatus_raw_full_refresh",
+      label: "SeiDp.Pipelines.MercatusRawFullRefresh",
+      selected_assets: ["mercatus_raw", "mercatus_monthly"],
+      asset_count: 2,
+      dependencies: :all,
+      dependencies_label: "Include deps",
+      window_label: "Month Etc/UTC",
+      status: :healthy,
+      status_label: "Healthy",
+      last_run_label: "12m ago",
+      runtime_label: "34.5 s",
+      runs: [
+        %{
+          id: "run_mercatus_full_refresh",
+          short_id: "run_merc...fresh",
+          status: :healthy,
+          kind_label: "Pipeline",
+          window_label: "-",
+          started_at_label: "May 13 10:00",
+          duration_label: "34.5 s"
+        }
+      ]
+    }
+  end
+
+  def detail_modes do
+    [
+      %{id: :runs, label: "Runs", icon: "hero-clock"},
+      %{id: :assets, label: "Assets", icon: "hero-cube", disabled: true},
+      %{id: :more, label: "More", icon: "hero-ellipsis-vertical", disabled: true}
+    ]
+  end
+
+  defp status_tone(:healthy), do: :success
+  defp status_tone(:running), do: :info
+  defp status_tone(:failed), do: :error
+  defp status_tone(_status), do: :neutral
+end

--- a/apps/favn_view/lib/favn_view/components/pipelines_page.ex
+++ b/apps/favn_view/lib/favn_view/components/pipelines_page.ex
@@ -124,7 +124,10 @@ defmodule FavnView.Components.PipelinesPage do
     ~H"""
     <tr class="group border-base-content/10 transition hover:bg-primary/10" data-testid="pipeline-row">
       <td>
-        <div class="flex items-center gap-3 font-medium text-base-content">
+        <.link
+          navigate={~p"/pipelines/#{FavnView.AssetRoute.to_param(@pipeline.id)}"}
+          class="flex items-center gap-3 font-medium text-base-content"
+        >
           <span class="flex size-8 items-center justify-center rounded-field border border-primary/25 bg-primary/10 text-primary">
             <.icon name="hero-queue-list" class="size-4" />
           </span>
@@ -134,7 +137,7 @@ defmodule FavnView.Components.PipelinesPage do
               {@pipeline.label}
             </p>
           </div>
-        </div>
+        </.link>
       </td>
       <td class="whitespace-nowrap text-base-content/70">{@pipeline.dependencies_label}</td>
       <td class="whitespace-nowrap text-base-content/70">{@pipeline.window_label}</td>
@@ -162,7 +165,8 @@ defmodule FavnView.Components.PipelinesPage do
 
   def pipeline_card(assigns) do
     ~H"""
-    <div
+    <.link
+      navigate={~p"/pipelines/#{FavnView.AssetRoute.to_param(@pipeline.id)}"}
       class="card glass favn-surface-list favn-density-list-card block rounded-box"
       data-testid="pipeline-card"
     >
@@ -196,7 +200,7 @@ defmodule FavnView.Components.PipelinesPage do
           </p>
         </div>
       </div>
-    </div>
+    </.link>
     """
   end
 

--- a/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
@@ -1,0 +1,358 @@
+defmodule FavnView.PipelineDetailLive do
+  @moduledoc false
+
+  use FavnView, :live_view
+
+  alias Favn.Backfill.RangeRequest
+  alias Favn.Window.Request, as: WindowRequest
+  alias FavnView.AssetRoute
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.GlassPanel
+  alias FavnView.Components.PipelineDetailPage
+  alias FavnView.Components.PipelinesPage
+  alias FavnView.LogsViewModel
+
+  @valid_modes ~w(runs assets more)
+
+  @impl true
+  def mount(%{"pipeline_id" => pipeline_id}, _session, socket) do
+    pipeline = load_pipeline(pipeline_id)
+
+    socket =
+      assign(socket,
+        pipeline_id: pipeline_id,
+        pipeline: pipeline,
+        active_mode: :runs,
+        run_error: nil,
+        backfill_error: nil,
+        backfill_config: %{from: "2024-01", to: "2026-12", kind: "month"},
+        nav_items: PipelinesPage.nav_items(:pipelines)
+      )
+
+    {:ok, socket}
+  end
+
+  @impl true
+  def handle_event("set_mode", %{"mode" => mode}, socket) when mode in @valid_modes do
+    {:noreply, assign(socket, :active_mode, String.to_existing_atom(mode))}
+  end
+
+  def handle_event("set_mode", _params, socket), do: {:noreply, socket}
+
+  def handle_event("run_pipeline", _params, %{assigns: %{pipeline: nil}} = socket) do
+    {:noreply, assign(socket, :run_error, "Pipeline not found.")}
+  end
+
+  def handle_event("run_pipeline", _params, socket) do
+    pipeline = socket.assigns.pipeline
+
+    case FavnOrchestrator.submit_pipeline_run_for_manifest(
+           pipeline.manifest_version_id,
+           pipeline.id,
+           pipeline_run_opts(pipeline)
+         ) do
+      {:ok, run_id} ->
+        {:noreply,
+         socket
+         |> put_flash(:info, "Pipeline run submitted")
+         |> push_navigate(to: ~p"/runs/#{run_id}")}
+
+      {:error, reason} ->
+        {:noreply, assign(socket, :run_error, submit_error_label(reason))}
+    end
+  end
+
+  def handle_event(
+        "submit_backfill",
+        %{"backfill" => params},
+        %{assigns: %{pipeline: nil}} = socket
+      ) do
+    {:noreply,
+     assign(socket,
+       backfill_config: backfill_config(params),
+       backfill_error: "Pipeline not found."
+     )}
+  end
+
+  def handle_event("submit_backfill", %{"backfill" => params}, socket) do
+    config = backfill_config(params)
+    pipeline = socket.assigns.pipeline
+
+    with {:ok, kind} <- backfill_kind(config.kind),
+         {:ok, range_request} <-
+           RangeRequest.explicit(
+             from: config.from,
+             to: config.to,
+             kind: kind,
+             timezone: "Etc/UTC"
+           ),
+         {:ok, run_id} <-
+           FavnOrchestrator.submit_pipeline_backfill_for_manifest(
+             pipeline.manifest_version_id,
+             pipeline.id,
+             range_request: range_request
+           ) do
+      {:noreply,
+       socket
+       |> put_flash(:info, "Pipeline backfill submitted")
+       |> push_navigate(to: ~p"/runs/#{run_id}")}
+    else
+      {:error, reason} ->
+        {:noreply,
+         assign(socket,
+           backfill_config: config,
+           backfill_error: submit_error_label(reason)
+         )}
+    end
+  end
+
+  def handle_event("submit_backfill", _params, socket), do: {:noreply, socket}
+
+  @impl true
+  def render(assigns) do
+    ~H"""
+    <PipelineDetailPage.pipeline_detail_page
+      :if={@pipeline}
+      pipeline={@pipeline}
+      nav_items={@nav_items}
+      active_mode={@active_mode}
+      run_error={@run_error}
+      backfill_error={@backfill_error}
+      backfill_config={@backfill_config}
+    />
+
+    <AppShell.app_shell
+      :if={!@pipeline}
+      title="Pipeline not found"
+      subtitle={@pipeline_id}
+      nav_items={@nav_items}
+    >
+      <div class="mx-auto w-full max-w-4xl">
+        <GlassPanel.glass_panel class="p-8 text-center" data-testid="pipeline-not-found-state">
+          <h2 class="text-xl font-medium">Pipeline not found</h2>
+          <p class="mt-2 text-base-content/60">
+            No active manifest pipeline matches this pipeline id.
+          </p>
+          <.link navigate={~p"/pipelines"} class="btn btn-primary btn-soft mt-6">
+            Back to pipelines
+          </.link>
+        </GlassPanel.glass_panel>
+      </div>
+    </AppShell.app_shell>
+    """
+  end
+
+  defp load_pipeline(pipeline_id) do
+    target_id = AssetRoute.from_param(pipeline_id)
+
+    case FavnOrchestrator.active_pipeline_detail(target_id) do
+      {:ok, detail} -> pipeline_from_detail(detail)
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp pipeline_from_detail(detail) do
+    selected_assets = Map.get(detail, :selected_assets, [])
+    status = Map.get(detail, :status, :unknown)
+
+    %{
+      id: Map.fetch!(detail, :target_id),
+      manifest_version_id: Map.fetch!(detail, :manifest_version_id),
+      name: Map.get(detail, :name) || pipeline_name(Map.fetch!(detail, :label)),
+      label: Map.fetch!(detail, :label),
+      selected_assets: Enum.map(selected_assets, &asset_ref_label/1),
+      asset_count: length(selected_assets),
+      dependencies: Map.get(detail, :dependencies, :unknown),
+      dependencies_label: dependencies_label(Map.get(detail, :dependencies, :unknown)),
+      window: Map.get(detail, :window),
+      window_label: window_label(Map.get(detail, :window)),
+      status: status,
+      status_label: status_label(status),
+      last_run_label: last_run_label(Map.get(detail, :latest_run_at)),
+      runtime_label: LogsViewModel.duration_ms_label(Map.get(detail, :latest_run_duration_ms)),
+      runs: Enum.map(Map.get(detail, :runs, []), &run_from_detail/1)
+    }
+  end
+
+  defp run_from_detail(run) do
+    %{
+      id: run.id,
+      short_id: short_id(run.id),
+      status: run_status(Map.get(run, :status)),
+      kind_label: kind_label(Map.get(run, :submit_kind)),
+      window_label: window_label_value(Map.get(run, :window)),
+      started_at_label: timestamp_label(Map.get(run, :started_at)),
+      duration_label: LogsViewModel.duration_ms_label(Map.get(run, :duration_ms))
+    }
+  end
+
+  defp backfill_config(params) do
+    %{
+      from: params |> Map.get("from", "") |> String.trim(),
+      to: params |> Map.get("to", "") |> String.trim(),
+      kind: params |> Map.get("kind", "month") |> String.trim()
+    }
+  end
+
+  defp pipeline_run_opts(%{window: nil}), do: []
+
+  defp pipeline_run_opts(%{window: window}) do
+    kind = Map.get(window, :kind) || Map.get(window, "kind")
+    timezone = Map.get(window, :timezone) || Map.get(window, "timezone") || "Etc/UTC"
+
+    case current_window_request(kind, timezone) do
+      {:ok, request} -> [window_request: request]
+      {:error, _reason} -> []
+    end
+  end
+
+  defp current_window_request(kind, timezone) do
+    kind = normalize_window_kind(kind)
+
+    with kind when kind in [:hour, :day, :month, :year] <- kind,
+         {:ok, value} <- current_window_value(kind, timezone) do
+      WindowRequest.parse("#{kind}:#{value}", timezone: timezone)
+    else
+      _other -> {:error, :invalid_window_kind}
+    end
+  end
+
+  defp normalize_window_kind(kind) when kind in [:hour, :day, :month, :year], do: kind
+  defp normalize_window_kind(:hourly), do: :hour
+  defp normalize_window_kind(:daily), do: :day
+  defp normalize_window_kind(:monthly), do: :month
+  defp normalize_window_kind(:yearly), do: :year
+
+  defp normalize_window_kind(kind) when kind in ["hour", "day", "month", "year"],
+    do: String.to_existing_atom(kind)
+
+  defp normalize_window_kind("hourly"), do: :hour
+  defp normalize_window_kind("daily"), do: :day
+  defp normalize_window_kind("monthly"), do: :month
+  defp normalize_window_kind("yearly"), do: :year
+
+  defp normalize_window_kind(_kind), do: nil
+
+  defp current_window_value(kind, timezone) do
+    with {:ok, datetime} <- DateTime.now(timezone) do
+      value =
+        case kind do
+          :hour -> Calendar.strftime(datetime, "%Y-%m-%dT%H")
+          :day -> Calendar.strftime(datetime, "%Y-%m-%d")
+          :month -> Calendar.strftime(datetime, "%Y-%m")
+          :year -> Calendar.strftime(datetime, "%Y")
+        end
+
+      {:ok, value}
+    end
+  end
+
+  defp backfill_kind(kind) when kind in ~w(hour day month year),
+    do: {:ok, String.to_existing_atom(kind)}
+
+  defp backfill_kind(kind), do: {:error, {:invalid_backfill_kind, kind}}
+
+  defp pipeline_name(label), do: label |> String.split(".") |> List.last()
+
+  defp asset_ref_label(ref) when is_binary(ref) do
+    case String.split(ref, ":", parts: 2) do
+      [module, "asset"] -> module |> String.split(".") |> List.last()
+      [_module, name] -> name
+      [value] -> value |> String.split(".") |> List.last()
+    end
+  end
+
+  defp asset_ref_label(ref), do: to_string(ref)
+
+  defp dependencies_label(:all), do: "Include deps"
+  defp dependencies_label(:none), do: "Selected only"
+  defp dependencies_label(_dependencies), do: "Unknown deps"
+
+  defp window_label(nil), do: "No window"
+  defp window_label(%{kind: kind, timezone: timezone}), do: window_label(kind, timezone)
+  defp window_label(%{"kind" => kind, "timezone" => timezone}), do: window_label(kind, timezone)
+  defp window_label(_window), do: "Windowed"
+
+  defp window_label(kind, nil), do: humanize(kind)
+  defp window_label(kind, timezone), do: "#{humanize(kind)} #{timezone}"
+
+  defp window_label_value(nil), do: "-"
+  defp window_label_value(value) when is_binary(value), do: value
+
+  defp window_label_value(value) when is_map(value) do
+    Map.get(value, :label) || Map.get(value, "label") || Map.get(value, :id) ||
+      Map.get(value, "id") || Map.get(value, :key) || Map.get(value, "key") || inspect(value)
+  end
+
+  defp window_label_value(value), do: inspect(value)
+
+  defp status_label(:healthy), do: "Healthy"
+  defp status_label(:running), do: "Running"
+  defp status_label(:failed), do: "Failed"
+  defp status_label(_status), do: "Unknown"
+
+  defp run_status(status) when status in [:ok, :skipped_fresh, "ok", "skipped_fresh"],
+    do: :healthy
+
+  defp run_status(status)
+       when status in [:running, :pending, :retrying, "running", "pending", "retrying"],
+       do: :running
+
+  defp run_status(status)
+       when status in [
+              :error,
+              :blocked,
+              :cancelled,
+              :timed_out,
+              "error",
+              "blocked",
+              "cancelled",
+              "timed_out"
+            ],
+       do: :failed
+
+  defp run_status(_status), do: :unknown
+
+  defp kind_label(:backfill_pipeline), do: "Backfill"
+  defp kind_label("backfill_pipeline"), do: "Backfill"
+  defp kind_label(nil), do: "Pipeline"
+  defp kind_label(kind), do: humanize(kind)
+
+  defp last_run_label(%DateTime{} = datetime) do
+    seconds = DateTime.diff(DateTime.utc_now(), datetime, :second)
+
+    cond do
+      seconds < 60 -> "just now"
+      seconds < 3_600 -> "#{div(seconds, 60)}m ago"
+      seconds < 86_400 -> "#{div(seconds, 3_600)}h ago"
+      true -> Calendar.strftime(datetime, "%b %-d %H:%M")
+    end
+  end
+
+  defp last_run_label(_value), do: "No runs yet"
+
+  defp timestamp_label(%DateTime{} = datetime), do: Calendar.strftime(datetime, "%b %-d %H:%M")
+  defp timestamp_label(_value), do: "-"
+
+  defp short_id(id) when is_binary(id) and byte_size(id) > 18 do
+    binary_part(id, 0, 9) <> "..." <> binary_part(id, byte_size(id) - 6, 6)
+  end
+
+  defp short_id(id) when is_binary(id), do: id
+  defp short_id(_id), do: "unknown"
+
+  defp submit_error_label({:invalid_backfill_kind, kind}), do: "Invalid backfill kind: #{kind}."
+
+  defp submit_error_label({:invalid_backfill_range_request, _value}),
+    do: "Invalid backfill range."
+
+  defp submit_error_label(:not_found), do: "Pipeline not found."
+  defp submit_error_label(reason), do: "Submit failed: #{inspect(reason)}"
+
+  defp humanize(value) do
+    value
+    |> to_string()
+    |> String.replace("_", " ")
+    |> String.capitalize()
+  end
+end

--- a/apps/favn_view/lib/favn_view/router.ex
+++ b/apps/favn_view/lib/favn_view/router.ex
@@ -21,6 +21,7 @@ defmodule FavnView.Router do
     live "/assets", AssetCatalogueLive, :index
     live "/assets/:asset_id", AssetDetailLive, :show
     live "/pipelines", PipelinesLive, :index
+    live "/pipelines/:pipeline_id", PipelineDetailLive, :show
     live "/logs", LogsLive, :index
     live "/runs", RunsListLive, :index
     live "/runs/:run_id", RunDetailLive, :show

--- a/apps/favn_view/storybook/components/pipeline_detail_page.story.exs
+++ b/apps/favn_view/storybook/components/pipeline_detail_page.story.exs
@@ -1,0 +1,38 @@
+defmodule FavnView.Storybook.Components.PipelineDetailPage do
+  use PhoenixStorybook.Story, :component
+
+  alias FavnView.Components.PipelineDetailPage
+  alias FavnView.Components.PipelinesPage
+
+  def function, do: &PipelineDetailPage.pipeline_detail_page/1
+
+  def imports, do: [{PipelineDetailPage, []}]
+
+  def variations do
+    [
+      %Variation{
+        id: :default,
+        attributes: %{
+          pipeline: PipelineDetailPage.sample_pipeline(),
+          nav_items: PipelinesPage.nav_items(:pipelines),
+          active_mode: :runs,
+          backfill_config: %{from: "2024-01", to: "2026-12", kind: "month"}
+        }
+      },
+      %Variation{
+        id: :empty_history,
+        attributes: %{
+          pipeline: %{
+            PipelineDetailPage.sample_pipeline()
+            | runs: [],
+              status: :unknown,
+              status_label: "Unknown"
+          },
+          nav_items: PipelinesPage.nav_items(:pipelines),
+          active_mode: :runs,
+          backfill_config: %{from: "2024-01", to: "2026-12", kind: "month"}
+        }
+      }
+    ]
+  end
+end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -97,11 +97,38 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="pipeline-card-list"]))
 
     assert html =~ "daily_orders"
+    assert has_element?(view, ~s(a[href="#{pipeline_detail_path()}"]), "daily_orders")
     assert html =~ "customer_orders_daily"
     assert html =~ "Include deps"
     assert html =~ "Day Europe/Oslo"
     assert html =~ "Healthy"
     assert html =~ "5.0 s"
+  end
+
+  test "renders the pipeline detail page with run history and actions", %{conn: conn} do
+    {:ok, view, html} = live(conn, pipeline_detail_path())
+
+    assert html =~ "daily_orders"
+    assert has_element?(view, ~s([data-testid="pipeline-summary-panel"]), "customer_orders_daily")
+    assert has_element?(view, ~s([data-testid="pipeline-actions-panel"]), "Run pipeline")
+    assert has_element?(view, ~s([data-testid="pipeline-backfill-form"]))
+    assert has_element?(view, ~s([data-testid="pipeline-runs-table"]), "run_daily_orders")
+  end
+
+  test "pipeline detail submits a pipeline run and navigates to run detail", %{conn: conn} do
+    {:ok, view, _html} = live(conn, pipeline_detail_path("full_refresh"))
+
+    view
+    |> element(~s([data-testid="run-pipeline-form"]))
+    |> render_submit()
+
+    assert {run_path, %{"info" => "Pipeline run submitted"}} = assert_redirect(view)
+    assert String.starts_with?(run_path, "/runs/run_")
+
+    run_id = String.replace_prefix(run_path, "/runs/", "")
+    assert {:ok, run} = Storage.get_run(run_id)
+    assert run.submit_kind == :pipeline
+    assert run.metadata.pipeline_submit_ref == __MODULE__.Pipelines.FullRefresh
   end
 
   test "runs list refreshes active runs", %{conn: conn} do
@@ -851,6 +878,13 @@ defmodule FavnView.PageLiveTest do
           selectors: [{:asset, {__MODULE__.Assets, :customer_orders_daily}}],
           deps: :all,
           window: Policy.new!(:daily, timezone: "Europe/Oslo")
+        },
+        %Pipeline{
+          module: __MODULE__.Pipelines.FullRefresh,
+          name: :full_refresh,
+          selectors: [{:asset, {__MODULE__.Assets, :customer_orders_daily}}],
+          deps: :all,
+          window: nil
         }
       ]
     }
@@ -1227,6 +1261,18 @@ defmodule FavnView.PageLiveTest do
 
   defp detail_path(name) do
     ~p"/assets/#{FavnView.AssetRoute.to_param(target_id(name))}"
+  end
+
+  defp pipeline_target_id(name) do
+    {:ok, entries} = FavnOrchestrator.active_pipeline_catalogue()
+
+    entries
+    |> Enum.find(&(&1.name == name))
+    |> Map.fetch!(:target_id)
+  end
+
+  defp pipeline_detail_path(name \\ "daily_orders") do
+    ~p"/pipelines/#{FavnView.AssetRoute.to_param(pipeline_target_id(name))}"
   end
 
   defp today_label do


### PR DESCRIPTION
## Summary
- Add an orchestrator pipeline detail read model with matched run history.
- Add a pipeline detail LiveView with run and backfill submission actions.
- Link pipeline list entries to details and cover the flow with Storybook and LiveView tests.

## Verification
- mix format
- mix compile --warnings-as-errors in apps/favn_orchestrator
- mix compile --warnings-as-errors in apps/favn_view
- mix test in apps/favn_orchestrator
- mix test in apps/favn_view