### PR TITLE
Fix run snapshot selector atom decoding

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_snapshot_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_snapshot_codec.ex
@@ -936,7 +936,24 @@ defmodule FavnOrchestrator.Storage.RunSnapshotCodec do
 
   defp selector_atoms(_selectors), do: {:ok, []}
 
-  defp selector_atom([_kind, ref]), do: ref_atoms(ref)
+  defp selector_atom([kind, value]) when kind in [:asset, "asset"], do: ref_atoms(value)
+  defp selector_atom([kind, value]) when kind in [:module, "module"], do: module_atom(value)
+
+  defp selector_atom([kind, value]) when kind in [:tag, "tag", :category, "category"],
+    do: manifest_atom(value)
+
+  defp selector_atom(%{"module" => kind, "name" => value})
+       when kind in [:asset, "asset"],
+       do: ref_atoms(value)
+
+  defp selector_atom(%{"module" => kind, "name" => value})
+       when kind in [:module, "module"],
+       do: module_atom(value)
+
+  defp selector_atom(%{"module" => kind, "name" => value})
+       when kind in [:tag, "tag", :category, "category"],
+       do: manifest_atom(value)
+
   defp selector_atom(%{"value" => ref}), do: ref_atoms(ref)
   defp selector_atom(%{"ref" => ref}), do: ref_atoms(ref)
   defp selector_atom(%{"module" => _module, "name" => _name} = ref), do: ref_atoms(ref)

--- a/apps/favn_orchestrator/test/storage/run_snapshot_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/run_snapshot_codec_test.exs
@@ -3,6 +3,7 @@ defmodule FavnOrchestrator.Storage.RunSnapshotCodecTest do
 
   alias Favn.Manifest
   alias Favn.Manifest.Asset
+  alias Favn.Manifest.Pipeline
   alias Favn.Manifest.Version
   alias Favn.Plan
   alias Favn.Run.AssetResult
@@ -120,6 +121,41 @@ defmodule FavnOrchestrator.Storage.RunSnapshotCodecTest do
     assert projected.replay_mode == :exact_replay
     assert projected.pipeline.resolved_refs == [{__MODULE__.Asset, :asset}]
     assert projected.submit_ref == __MODULE__.Asset
+  end
+
+  test "allows asset refs named tag when manifest contains tag selectors" do
+    version = tag_asset_manifest_version("mv_run_snapshot_asset_named_tag")
+
+    run =
+      RunState.new(
+        id: "run_snapshot_asset_named_tag",
+        manifest_version_id: version.manifest_version_id,
+        manifest_content_hash: version.content_hash,
+        asset_ref: {__MODULE__.TaggedAsset, :tag},
+        target_refs: [{__MODULE__.TaggedAsset, :tag}],
+        metadata: %{
+          pipeline_context: %{
+            id: "pipeline_1",
+            name: "mercatus_raw_full_refresh",
+            run_kind: :pipeline,
+            resolved_refs: [{__MODULE__.TaggedAsset, :tag}],
+            deps: :none
+          }
+        }
+      )
+
+    assert {:ok, payload} = RunSnapshotCodec.encode_run(run)
+    assert {:ok, manifest_record} = ManifestCodec.to_record(version)
+
+    assert {:ok, restored} =
+             RunSnapshotCodec.decode_run(
+               %{run_blob: payload, manifest_version_id: version.manifest_version_id},
+               manifest_record
+             )
+
+    assert restored.asset_ref == {__MODULE__.TaggedAsset, :tag}
+    assert restored.target_refs == [{__MODULE__.TaggedAsset, :tag}]
+    assert restored.metadata.pipeline_context.resolved_refs == [{__MODULE__.TaggedAsset, :tag}]
   end
 
   test "operational in-flight execution ids remain atom-keyed after DTO roundtrip" do
@@ -428,6 +464,30 @@ defmodule FavnOrchestrator.Storage.RunSnapshotCodecTest do
       assets: [
         %Asset{ref: {__MODULE__.AssetA, :asset}, module: __MODULE__.AssetA, name: :asset},
         %Asset{ref: {__MODULE__.AssetB, :asset}, module: __MODULE__.AssetB, name: :asset}
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
+    version
+  end
+
+  defp tag_asset_manifest_version(manifest_version_id) do
+    manifest = %Manifest{
+      assets: [
+        %Asset{
+          ref: {__MODULE__.TaggedAsset, :tag},
+          module: __MODULE__.TaggedAsset,
+          name: :tag,
+          metadata: %{tags: [:mercatus_full_refresh]}
+        }
+      ],
+      pipelines: [
+        %Pipeline{
+          module: __MODULE__.TaggedPipeline,
+          name: :mercatus_raw_full_refresh,
+          selectors: [{:tag, :mercatus_full_refresh}],
+          deps: :none
+        }
       ]
     }
 


### PR DESCRIPTION
## Summary
- Decode manifest pipeline selectors by selector kind so tag/category selectors are not treated as asset refs.
- Add regression coverage for decoding a persisted run whose asset ref name is `:tag` and whose manifest contains a `tag(...)` selector.

## Verification
- `mix format`
- `mix compile --warnings-as-errors` from `apps/favn_orchestrator`
- `mix test` from `apps/favn_orchestrator`