### PR TITLE
Add pipeline details and live execution visibility

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -86,6 +86,8 @@ defmodule FavnOrchestrator do
           required(:selected_assets) => [String.t()],
           required(:dependencies) => :all | :none | :unknown,
           required(:window) => map() | nil,
+          required(:can_run_without_window?) => boolean(),
+          required(:can_backfill?) => boolean(),
           required(:status) => :healthy | :running | :failed | :unknown,
           required(:latest_run_id) => String.t() | nil,
           required(:latest_run_status) => atom() | nil,
@@ -112,6 +114,8 @@ defmodule FavnOrchestrator do
           required(:selected_assets) => [String.t()],
           required(:dependencies) => :all | :none | :unknown,
           required(:window) => map() | nil,
+          required(:can_run_without_window?) => boolean(),
+          required(:can_backfill?) => boolean(),
           required(:status) => :healthy | :running | :failed | :unknown,
           required(:latest_run_id) => String.t() | nil,
           required(:latest_run_status) => atom() | nil,
@@ -2296,9 +2300,18 @@ defmodule FavnOrchestrator do
     %{
       target_id: target_id_for_pipeline(target_module),
       label: inspect(target_module),
-      window: window_policy_dto(pipeline.window)
+      window: window_policy_dto(pipeline.window),
+      can_run_without_window?: pipeline_can_run_without_window?(pipeline.window),
+      can_backfill?: pipeline_can_backfill?(pipeline.window)
     }
   end
+
+  defp pipeline_can_run_without_window?(nil), do: true
+  defp pipeline_can_run_without_window?(%Policy{allow_full_load: true}), do: true
+  defp pipeline_can_run_without_window?(_window), do: false
+
+  defp pipeline_can_backfill?(nil), do: false
+  defp pipeline_can_backfill?(_window), do: true
 
   defp manifest_pipeline_target(%Index{} = index, pipeline) do
     base = manifest_pipeline_target(pipeline)

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -10,6 +10,7 @@ defmodule FavnOrchestrator do
   alias Favn.Assets.Planner
   alias Favn.Contracts.RelationInspectionRequest
   alias Favn.Contracts.RunnerClient
+  alias Favn.Backfill.RangeRequest
   alias Favn.Manifest.Index
   alias Favn.Manifest.PipelineResolver
   alias Favn.Manifest.Version
@@ -99,6 +100,7 @@ defmodule FavnOrchestrator do
           required(:started_at) => DateTime.t() | nil,
           required(:finished_at) => DateTime.t() | nil,
           required(:duration_ms) => non_neg_integer() | nil,
+          required(:scope) => map() | nil,
           required(:window) => map() | String.t() | nil
         }
 
@@ -653,13 +655,18 @@ defmodule FavnOrchestrator do
 
   @doc """
   Submits one pipeline run by manifest-scoped target id.
+
+  Thin callers may pass plain map input with an optional `:window` map. The
+  orchestrator validates and translates it into the runtime window request.
   """
-  @spec submit_pipeline_run_for_manifest(String.t(), String.t(), keyword()) ::
+  @spec submit_pipeline_run_for_manifest(String.t(), String.t(), keyword() | map()) ::
           {:ok, run_id()} | {:error, term()}
   def submit_pipeline_run_for_manifest(manifest_version_id, target_id, opts \\ [])
-      when is_binary(manifest_version_id) and is_binary(target_id) and is_list(opts) do
+      when is_binary(manifest_version_id) and is_binary(target_id) and
+             (is_list(opts) or is_map(opts)) do
     with {:ok, version} <- get_manifest(manifest_version_id),
-         {:ok, pipeline_module} <- resolve_pipeline_target_module(version, target_id) do
+         {:ok, pipeline_module} <- resolve_pipeline_target_module(version, target_id),
+         {:ok, opts} <- normalize_pipeline_run_submit_opts(opts) do
       submit_pipeline_run(
         pipeline_module,
         Keyword.put(opts, :manifest_version_id, manifest_version_id)
@@ -785,13 +792,19 @@ defmodule FavnOrchestrator do
 
   @doc """
   Submits one pipeline backfill by manifest-scoped target id.
+
+  Thin callers may pass plain map input with `:range` containing `:from`, `:to`,
+  `:kind`, and `:timezone`. The orchestrator validates and translates it into
+  the runtime backfill range request.
   """
-  @spec submit_pipeline_backfill_for_manifest(String.t(), String.t(), keyword()) ::
+  @spec submit_pipeline_backfill_for_manifest(String.t(), String.t(), keyword() | map()) ::
           {:ok, run_id()} | {:error, term()}
   def submit_pipeline_backfill_for_manifest(manifest_version_id, target_id, opts \\ [])
-      when is_binary(manifest_version_id) and is_binary(target_id) and is_list(opts) do
+      when is_binary(manifest_version_id) and is_binary(target_id) and
+             (is_list(opts) or is_map(opts)) do
     with {:ok, version} <- get_manifest(manifest_version_id),
-         {:ok, pipeline_module} <- resolve_pipeline_target_module(version, target_id) do
+         {:ok, pipeline_module} <- resolve_pipeline_target_module(version, target_id),
+         {:ok, opts} <- normalize_pipeline_backfill_submit_opts(opts) do
       submit_pipeline_backfill(
         pipeline_module,
         Keyword.put(opts, :manifest_version_id, manifest_version_id)
@@ -2381,6 +2394,8 @@ defmodule FavnOrchestrator do
   end
 
   defp pipeline_run_history_entry(run) do
+    scope = run_history_scope(run)
+
     %{
       id: run.id,
       status: run.status,
@@ -2388,17 +2403,99 @@ defmodule FavnOrchestrator do
       started_at: Map.get(run, :started_at),
       finished_at: Map.get(run, :finished_at),
       duration_ms: run_duration_ms(run),
-      window: run_history_window(run)
+      scope: scope,
+      window: legacy_run_history_window(scope)
     }
   end
 
-  defp run_history_window(run) do
+  defp run_history_scope(run) do
     params = Map.get(run, :params, %{}) || %{}
     metadata = Map.get(run, :metadata, %{}) || %{}
 
-    Map.get(params, :window) || Map.get(params, "window") || Map.get(metadata, :selected_window) ||
-      Map.get(metadata, "selected_window") || Map.get(metadata, :window) ||
-      Map.get(metadata, "window")
+    cond do
+      backfill = Map.get(metadata, :backfill) || Map.get(metadata, "backfill") ->
+        Map.put(normalize_scope_map(backfill), :type, :range)
+
+      window =
+          Map.get(params, :window) || Map.get(params, "window") ||
+            Map.get(metadata, :selected_window) || Map.get(metadata, "selected_window") ||
+            Map.get(metadata, :window) || Map.get(metadata, "window") ->
+        Map.put(normalize_scope_map(window), :type, :window)
+
+      true ->
+        nil
+    end
+  end
+
+  defp legacy_run_history_window(%{type: :window} = scope), do: Map.delete(scope, :type)
+  defp legacy_run_history_window(_scope), do: nil
+
+  defp normalize_scope_map(value) when is_map(value), do: Map.new(value, &normalize_scope_pair/1)
+  defp normalize_scope_map(value), do: %{label: to_string(value)}
+
+  defp normalize_scope_pair({"type", value}), do: {:type, value}
+  defp normalize_scope_pair({"kind", value}), do: {:kind, value}
+  defp normalize_scope_pair({"timezone", value}), do: {:timezone, value}
+  defp normalize_scope_pair({"range_start_at", value}), do: {:range_start_at, value}
+  defp normalize_scope_pair({"range_end_at", value}), do: {:range_end_at, value}
+  defp normalize_scope_pair({"requested_count", value}), do: {:requested_count, value}
+  defp normalize_scope_pair({"window_keys", value}), do: {:window_keys, value}
+  defp normalize_scope_pair({"id", value}), do: {:id, value}
+  defp normalize_scope_pair({"key", value}), do: {:key, value}
+  defp normalize_scope_pair({"label", value}), do: {:label, value}
+  defp normalize_scope_pair(pair), do: pair
+
+  defp normalize_pipeline_run_submit_opts(opts) when is_list(opts) do
+    with {:ok, window_request} <- normalize_window_request(Keyword.get(opts, :window_request)) do
+      {:ok, Keyword.put(opts, :window_request, window_request)}
+    end
+  end
+
+  defp normalize_pipeline_run_submit_opts(opts) when is_map(opts) do
+    with {:ok, window_request} <- normalize_window_request(field_value(opts, :window)) do
+      opts =
+        []
+        |> maybe_put_opt(:metadata, field_value(opts, :metadata))
+        |> maybe_put_opt(:window_request, window_request)
+
+      {:ok, opts}
+    end
+  end
+
+  defp normalize_pipeline_backfill_submit_opts(opts) when is_list(opts) do
+    with {:ok, range_request} <- RangeRequest.from_value(Keyword.get(opts, :range_request)) do
+      {:ok, Keyword.put(opts, :range_request, range_request)}
+    end
+  end
+
+  defp normalize_pipeline_backfill_submit_opts(opts) when is_map(opts) do
+    range = field_value(opts, :range) || field_value(opts, :range_request)
+
+    with {:ok, range_request} <- RangeRequest.from_value(range) do
+      submit_opts =
+        []
+        |> Keyword.put(:range_request, range_request)
+        |> maybe_put_opt(:metadata, field_value(opts, :metadata))
+        |> maybe_put_opt(:coverage_baseline_id, field_value(opts, :coverage_baseline_id))
+
+      {:ok, submit_opts}
+    end
+  end
+
+  defp normalize_window_request(nil), do: {:ok, nil}
+  defp normalize_window_request(%WindowRequest{} = request), do: WindowRequest.from_value(request)
+
+  defp normalize_window_request(value) when is_binary(value), do: WindowRequest.parse(value)
+  defp normalize_window_request(value) when is_map(value), do: WindowRequest.from_value(value)
+
+  defp normalize_window_request(value), do: {:error, {:invalid_window_request, value}}
+
+  defp maybe_put_opt(opts, _key, nil), do: opts
+  defp maybe_put_opt(opts, _key, ""), do: opts
+  defp maybe_put_opt(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp field_value(value, field) when is_map(value) do
+    Map.get(value, field) || Map.get(value, Atom.to_string(field))
   end
 
   defp pipeline_submit_ref_matches?(run, pipeline) do

--- a/apps/favn_view/lib/favn_view/components/log_viewer.ex
+++ b/apps/favn_view/lib/favn_view/components/log_viewer.ex
@@ -330,6 +330,16 @@ defmodule FavnView.Components.LogViewer do
           @wrap? && "whitespace-pre-wrap break-words",
           !@wrap? && "whitespace-pre"
         ]}><code>{@log.message}</code></pre>
+        <div :if={@log.details != []} class="mt-2 flex flex-wrap gap-1.5 text-[0.68rem] leading-4">
+          <span
+            :for={detail <- @log.details}
+            class="rounded-full border border-slate-700/80 bg-slate-900/80 px-2 py-0.5 text-slate-300"
+            title={detail.title}
+            data-testid="log-detail-chip"
+          >
+            <span class="text-slate-500">{detail.label}</span> {detail.display}
+          </span>
+        </div>
         <span
           :if={@log.truncated?}
           class="mt-1 inline-flex rounded-full border border-warning/30 px-2 py-0.5 text-[0.65rem] uppercase tracking-[0.16em] text-warning/80"

--- a/apps/favn_view/lib/favn_view/components/pipeline_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/pipeline_detail_page.ex
@@ -110,10 +110,22 @@ defmodule FavnView.Components.PipelineDetailPage do
             Submit the active manifest pipeline, equivalent to <code class="font-mono">mix favn.run</code>.
           </p>
           <form phx-submit="run_pipeline" class="mt-4" data-testid="run-pipeline-form">
-            <button type="submit" class="btn btn-primary" data-testid="run-pipeline-button">
+            <button
+              type="submit"
+              class="btn btn-primary"
+              disabled={!@pipeline.can_run_without_window?}
+              data-testid="run-pipeline-button"
+            >
               <.icon name="hero-play" class="size-4" /> Run pipeline
             </button>
           </form>
+          <p
+            :if={!@pipeline.can_run_without_window?}
+            class="mt-3 text-sm text-base-content/60"
+            data-testid="pipeline-run-disabled-help"
+          >
+            This pipeline requires an explicit window. Use backfill or choose a specific window.
+          </p>
           <p :if={@run_error} class="mt-3 text-sm text-error" data-testid="pipeline-run-error">
             {@run_error}
           </p>
@@ -137,6 +149,7 @@ defmodule FavnView.Components.PipelineDetailPage do
                 value={@backfill_config.from}
                 class="input input-sm favn-surface-control"
                 placeholder={backfill_placeholder(@backfill_config.kind)}
+                disabled={!@pipeline.can_backfill?}
               />
             </label>
             <label class="form-control">
@@ -146,11 +159,16 @@ defmodule FavnView.Components.PipelineDetailPage do
                 value={@backfill_config.to}
                 class="input input-sm favn-surface-control"
                 placeholder={backfill_placeholder(@backfill_config.kind)}
+                disabled={!@pipeline.can_backfill?}
               />
             </label>
             <label class="form-control">
               <span class="label-text text-xs">Kind</span>
-              <select name="backfill[kind]" class="select select-sm favn-surface-control">
+              <select
+                name="backfill[kind]"
+                class="select select-sm favn-surface-control"
+                disabled={!@pipeline.can_backfill?}
+              >
                 <option
                   :for={kind <- ~w(month day hour year)}
                   value={kind}
@@ -163,13 +181,25 @@ defmodule FavnView.Components.PipelineDetailPage do
             <button
               type="submit"
               class="btn btn-primary btn-soft self-end"
+              disabled={!@pipeline.can_backfill?}
               data-testid="submit-backfill-button"
             >
               Backfill
             </button>
           </form>
-          <p class="mt-2 text-xs text-base-content/55" data-testid="pipeline-backfill-defaults">
+          <p
+            :if={@pipeline.can_backfill?}
+            class="mt-2 text-xs text-base-content/55"
+            data-testid="pipeline-backfill-defaults"
+          >
             Defaults to {@backfill_config.kind} windows in {@backfill_config.timezone}.
+          </p>
+          <p
+            :if={!@pipeline.can_backfill?}
+            class="mt-2 text-xs text-base-content/55"
+            data-testid="pipeline-backfill-disabled-help"
+          >
+            Backfill requires a windowed pipeline.
           </p>
           <p
             :if={@backfill_error}
@@ -247,6 +277,8 @@ defmodule FavnView.Components.PipelineDetailPage do
       dependencies: :all,
       dependencies_label: "Include deps",
       window_label: "Month Etc/UTC",
+      can_run_without_window?: false,
+      can_backfill?: true,
       status: :healthy,
       status_label: "Healthy",
       last_run_label: "12m ago",

--- a/apps/favn_view/lib/favn_view/components/pipeline_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/pipeline_detail_page.ex
@@ -129,13 +129,14 @@ defmodule FavnView.Components.PipelineDetailPage do
             class="mt-4 grid gap-3 sm:grid-cols-[1fr_1fr_8rem_auto]"
             data-testid="pipeline-backfill-form"
           >
+            <input type="hidden" name="backfill[timezone]" value={@backfill_config.timezone} />
             <label class="form-control">
               <span class="label-text text-xs">From</span>
               <input
                 name="backfill[from]"
                 value={@backfill_config.from}
                 class="input input-sm favn-surface-control"
-                placeholder="2024-01"
+                placeholder={backfill_placeholder(@backfill_config.kind)}
               />
             </label>
             <label class="form-control">
@@ -144,7 +145,7 @@ defmodule FavnView.Components.PipelineDetailPage do
                 name="backfill[to]"
                 value={@backfill_config.to}
                 class="input input-sm favn-surface-control"
-                placeholder="2026-12"
+                placeholder={backfill_placeholder(@backfill_config.kind)}
               />
             </label>
             <label class="form-control">
@@ -167,6 +168,9 @@ defmodule FavnView.Components.PipelineDetailPage do
               Backfill
             </button>
           </form>
+          <p class="mt-2 text-xs text-base-content/55" data-testid="pipeline-backfill-defaults">
+            Defaults to {@backfill_config.kind} windows in {@backfill_config.timezone}.
+          </p>
           <p
             :if={@backfill_error}
             class="mt-3 text-sm text-error"
@@ -273,4 +277,10 @@ defmodule FavnView.Components.PipelineDetailPage do
   defp status_tone(:running), do: :info
   defp status_tone(:failed), do: :error
   defp status_tone(_status), do: :neutral
+
+  defp backfill_placeholder("hour"), do: "2026-01-31T13"
+  defp backfill_placeholder("day"), do: "2026-01-31"
+  defp backfill_placeholder("month"), do: "2026-01"
+  defp backfill_placeholder("year"), do: "2026"
+  defp backfill_placeholder(_kind), do: "2026-01"
 end

--- a/apps/favn_view/lib/favn_view/logs_view_model.ex
+++ b/apps/favn_view/lib/favn_view/logs_view_model.ex
@@ -21,9 +21,13 @@ defmodule FavnView.LogsViewModel do
       source_label: source_label(Map.get(entry, :source, :user_code)),
       run_id: Map.get(entry, :run_id),
       asset_step_id: Map.get(entry, :asset_step_id),
+      asset_ref: ref_label(Map.get(entry, :asset_ref)),
+      runner_execution_id: Map.get(entry, :runner_execution_id),
+      attempt: Map.get(entry, :attempt),
       message: Map.get(entry, :message, "") || "",
       metadata: Map.get(entry, :metadata, %{}) || %{},
       metadata_text: metadata_text(Map.get(entry, :metadata, %{}) || %{}),
+      details: details(entry),
       truncated?: Map.get(entry, :truncated, false) == true
     }
   end
@@ -44,7 +48,7 @@ defmodule FavnView.LogsViewModel do
   def plain_text(entries) when is_list(entries) do
     entries
     |> Enum.map(fn entry ->
-      [entry.timestamp, entry.level_label, entry.source_label, entry.message]
+      [entry.timestamp, entry.level_label, entry.source_label, entry.message, detail_text(entry)]
       |> Enum.reject(&(&1 in [nil, ""]))
       |> Enum.join("  ")
     end)
@@ -172,10 +176,51 @@ defmodule FavnView.LogsViewModel do
   defp search_match?(_entry, ""), do: true
 
   defp search_match?(entry, query) do
-    [entry.message, entry.source_label, entry.level_label, entry.metadata_text]
+    [
+      entry.message,
+      entry.source_label,
+      entry.level_label,
+      entry.metadata_text,
+      detail_text(entry)
+    ]
     |> Enum.join("\n")
     |> String.downcase()
     |> String.contains?(query)
+  end
+
+  defp details(entry) do
+    [
+      {"run", short_id(Map.get(entry, :run_id)), Map.get(entry, :run_id)},
+      {"asset", ref_label(Map.get(entry, :asset_ref)), ref_label(Map.get(entry, :asset_ref))},
+      {"step", Map.get(entry, :asset_step_id), Map.get(entry, :asset_step_id)},
+      {"attempt", attempt_label(Map.get(entry, :attempt)), Map.get(entry, :attempt)},
+      {"runner", short_id(Map.get(entry, :runner_execution_id)),
+       Map.get(entry, :runner_execution_id)},
+      {"producer", producer_label(entry), producer_label(entry)}
+    ]
+    |> Enum.reject(fn {_label, _display, value} -> value in [nil, ""] end)
+    |> Enum.map(fn {label, display, value} ->
+      %{label: label, display: display, title: to_string(value)}
+    end)
+  end
+
+  defp detail_text(%{details: details}) when is_list(details) do
+    details
+    |> Enum.map(fn detail -> "#{detail.label}=#{detail.title}" end)
+    |> Enum.join(" ")
+  end
+
+  defp detail_text(_entry), do: ""
+
+  defp attempt_label(nil), do: nil
+  defp attempt_label(attempt), do: "##{attempt}"
+
+  defp producer_label(entry) do
+    case {Map.get(entry, :producer_id), Map.get(entry, :producer_sequence)} do
+      {nil, _sequence} -> nil
+      {producer_id, nil} -> producer_id
+      {producer_id, sequence} -> "#{producer_id}:#{sequence}"
+    end
   end
 
   defp metadata_text(metadata) when map_size(metadata) == 0, do: ""

--- a/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
@@ -3,8 +3,6 @@ defmodule FavnView.PipelineDetailLive do
 
   use FavnView, :live_view
 
-  alias Favn.Backfill.RangeRequest
-  alias Favn.Window.Request, as: WindowRequest
   alias FavnView.AssetRoute
   alias FavnView.Components.AppShell
   alias FavnView.Components.GlassPanel
@@ -25,7 +23,7 @@ defmodule FavnView.PipelineDetailLive do
         active_mode: :runs,
         run_error: nil,
         backfill_error: nil,
-        backfill_config: %{from: "2024-01", to: "2026-12", kind: "month"},
+        backfill_config: default_backfill_config(pipeline),
         nav_items: PipelinesPage.nav_items(:pipelines)
       )
 
@@ -49,7 +47,7 @@ defmodule FavnView.PipelineDetailLive do
     case FavnOrchestrator.submit_pipeline_run_for_manifest(
            pipeline.manifest_version_id,
            pipeline.id,
-           pipeline_run_opts(pipeline)
+           %{}
          ) do
       {:ok, run_id} ->
         {:noreply,
@@ -78,19 +76,11 @@ defmodule FavnView.PipelineDetailLive do
     config = backfill_config(params)
     pipeline = socket.assigns.pipeline
 
-    with {:ok, kind} <- backfill_kind(config.kind),
-         {:ok, range_request} <-
-           RangeRequest.explicit(
-             from: config.from,
-             to: config.to,
-             kind: kind,
-             timezone: "Etc/UTC"
-           ),
-         {:ok, run_id} <-
+    with {:ok, run_id} <-
            FavnOrchestrator.submit_pipeline_backfill_for_manifest(
              pipeline.manifest_version_id,
              pipeline.id,
-             range_request: range_request
+             %{range: config}
            ) do
       {:noreply,
        socket
@@ -180,7 +170,7 @@ defmodule FavnView.PipelineDetailLive do
       short_id: short_id(run.id),
       status: run_status(Map.get(run, :status)),
       kind_label: kind_label(Map.get(run, :submit_kind)),
-      window_label: window_label_value(Map.get(run, :window)),
+      window_label: scope_label(Map.get(run, :scope) || Map.get(run, :window)),
       started_at_label: timestamp_label(Map.get(run, :started_at)),
       duration_label: LogsViewModel.duration_ms_label(Map.get(run, :duration_ms))
     }
@@ -190,31 +180,9 @@ defmodule FavnView.PipelineDetailLive do
     %{
       from: params |> Map.get("from", "") |> String.trim(),
       to: params |> Map.get("to", "") |> String.trim(),
-      kind: params |> Map.get("kind", "month") |> String.trim()
+      kind: params |> Map.get("kind", "month") |> String.trim(),
+      timezone: params |> Map.get("timezone", "Etc/UTC") |> String.trim()
     }
-  end
-
-  defp pipeline_run_opts(%{window: nil}), do: []
-
-  defp pipeline_run_opts(%{window: window}) do
-    kind = Map.get(window, :kind) || Map.get(window, "kind")
-    timezone = Map.get(window, :timezone) || Map.get(window, "timezone") || "Etc/UTC"
-
-    case current_window_request(kind, timezone) do
-      {:ok, request} -> [window_request: request]
-      {:error, _reason} -> []
-    end
-  end
-
-  defp current_window_request(kind, timezone) do
-    kind = normalize_window_kind(kind)
-
-    with kind when kind in [:hour, :day, :month, :year] <- kind,
-         {:ok, value} <- current_window_value(kind, timezone) do
-      WindowRequest.parse("#{kind}:#{value}", timezone: timezone)
-    else
-      _other -> {:error, :invalid_window_kind}
-    end
   end
 
   defp normalize_window_kind(kind) when kind in [:hour, :day, :month, :year], do: kind
@@ -233,24 +201,32 @@ defmodule FavnView.PipelineDetailLive do
 
   defp normalize_window_kind(_kind), do: nil
 
-  defp current_window_value(kind, timezone) do
-    with {:ok, datetime} <- DateTime.now(timezone) do
-      value =
-        case kind do
-          :hour -> Calendar.strftime(datetime, "%Y-%m-%dT%H")
-          :day -> Calendar.strftime(datetime, "%Y-%m-%d")
-          :month -> Calendar.strftime(datetime, "%Y-%m")
-          :year -> Calendar.strftime(datetime, "%Y")
-        end
+  defp default_backfill_config(nil), do: %{from: "", to: "", kind: "month", timezone: "Etc/UTC"}
+  defp default_backfill_config(%{window: nil}), do: default_backfill_config(nil)
 
-      {:ok, value}
+  defp default_backfill_config(%{window: window}) do
+    %{
+      from: "",
+      to: "",
+      kind: window |> window_kind() |> Atom.to_string(),
+      timezone: window_timezone(window)
+    }
+  end
+
+  defp window_kind(nil), do: :month
+
+  defp window_kind(window) do
+    window
+    |> then(&(Map.get(&1, :kind) || Map.get(&1, "kind")))
+    |> normalize_window_kind()
+    |> case do
+      nil -> :month
+      kind -> kind
     end
   end
 
-  defp backfill_kind(kind) when kind in ~w(hour day month year),
-    do: {:ok, String.to_existing_atom(kind)}
-
-  defp backfill_kind(kind), do: {:error, {:invalid_backfill_kind, kind}}
+  defp window_timezone(window),
+    do: Map.get(window, :timezone) || Map.get(window, "timezone") || "Etc/UTC"
 
   defp pipeline_name(label), do: label |> String.split(".") |> List.last()
 
@@ -276,15 +252,32 @@ defmodule FavnView.PipelineDetailLive do
   defp window_label(kind, nil), do: humanize(kind)
   defp window_label(kind, timezone), do: "#{humanize(kind)} #{timezone}"
 
-  defp window_label_value(nil), do: "-"
-  defp window_label_value(value) when is_binary(value), do: value
+  defp scope_label(nil), do: "-"
+  defp scope_label(value) when is_binary(value), do: value
 
-  defp window_label_value(value) when is_map(value) do
+  defp scope_label(%{type: :range} = value) do
+    [
+      Map.get(value, :kind),
+      range_boundary_label(Map.get(value, :range_start_at)),
+      range_boundary_label(Map.get(value, :range_end_at)),
+      Map.get(value, :timezone)
+    ]
+    |> Enum.reject(&(&1 in [nil, ""]))
+    |> case do
+      [] -> inspect(value)
+      [kind | rest] -> Enum.join([humanize(kind) | rest], " / ")
+    end
+  end
+
+  defp scope_label(value) when is_map(value) do
     Map.get(value, :label) || Map.get(value, "label") || Map.get(value, :id) ||
       Map.get(value, "id") || Map.get(value, :key) || Map.get(value, "key") || inspect(value)
   end
 
-  defp window_label_value(value), do: inspect(value)
+  defp scope_label(value), do: inspect(value)
+
+  defp range_boundary_label(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+  defp range_boundary_label(value), do: value
 
   defp status_label(:healthy), do: "Healthy"
   defp status_label(:running), do: "Running"
@@ -341,10 +334,11 @@ defmodule FavnView.PipelineDetailLive do
   defp short_id(id) when is_binary(id), do: id
   defp short_id(_id), do: "unknown"
 
-  defp submit_error_label({:invalid_backfill_kind, kind}), do: "Invalid backfill kind: #{kind}."
-
   defp submit_error_label({:invalid_backfill_range_request, _value}),
     do: "Invalid backfill range."
+
+  defp submit_error_label({:missing_window_request, kind}),
+    do: "This #{kind} pipeline requires an explicit window request."
 
   defp submit_error_label(:not_found), do: "Pipeline not found."
   defp submit_error_label(reason), do: "Submit failed: #{inspect(reason)}"

--- a/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
@@ -41,6 +41,11 @@ defmodule FavnView.PipelineDetailLive do
     {:noreply, assign(socket, :run_error, "Pipeline not found.")}
   end
 
+  def handle_event("run_pipeline", _params, %{assigns: %{pipeline: pipeline}} = socket)
+      when pipeline.can_run_without_window? == false do
+    {:noreply, socket}
+  end
+
   def handle_event("run_pipeline", _params, socket) do
     pipeline = socket.assigns.pipeline
 
@@ -76,7 +81,8 @@ defmodule FavnView.PipelineDetailLive do
     config = backfill_config(params)
     pipeline = socket.assigns.pipeline
 
-    with {:ok, run_id} <-
+    with true <- pipeline.can_backfill?,
+         {:ok, run_id} <-
            FavnOrchestrator.submit_pipeline_backfill_for_manifest(
              pipeline.manifest_version_id,
              pipeline.id,
@@ -87,6 +93,13 @@ defmodule FavnView.PipelineDetailLive do
        |> put_flash(:info, "Pipeline backfill submitted")
        |> push_navigate(to: ~p"/runs/#{run_id}")}
     else
+      false ->
+        {:noreply,
+         assign(socket,
+           backfill_config: config,
+           backfill_error: "Backfill requires a windowed pipeline."
+         )}
+
       {:error, reason} ->
         {:noreply,
          assign(socket,
@@ -156,6 +169,8 @@ defmodule FavnView.PipelineDetailLive do
       dependencies_label: dependencies_label(Map.get(detail, :dependencies, :unknown)),
       window: Map.get(detail, :window),
       window_label: window_label(Map.get(detail, :window)),
+      can_run_without_window?: Map.get(detail, :can_run_without_window?, true),
+      can_backfill?: Map.get(detail, :can_backfill?, false),
       status: status,
       status_label: status_label(status),
       last_run_label: last_run_label(Map.get(detail, :latest_run_at)),

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -170,7 +170,12 @@ defmodule FavnView.RunDetailLive do
 
   defp merge_event_rows(persisted_rows, event_rows) do
     event_rows_by_id = Map.new(event_rows, &{&1.id, &1})
-    event_rows_by_asset = Map.new(event_rows, &{&1.asset_ref, &1})
+    unique_asset_refs = unique_asset_refs(persisted_rows, event_rows)
+
+    event_rows_by_asset =
+      event_rows
+      |> Enum.filter(&MapSet.member?(unique_asset_refs, &1.asset_ref))
+      |> Map.new(&{&1.asset_ref, &1})
 
     merged_persisted_rows =
       Enum.map(persisted_rows, fn row ->
@@ -190,10 +195,27 @@ defmodule FavnView.RunDetailLive do
 
     new_event_rows =
       Enum.reject(event_rows, fn row ->
-        MapSet.member?(persisted_ids, row.id) || MapSet.member?(persisted_refs, row.asset_ref)
+        MapSet.member?(persisted_ids, row.id) ||
+          (MapSet.member?(unique_asset_refs, row.asset_ref) &&
+             MapSet.member?(persisted_refs, row.asset_ref))
       end)
 
     merged_persisted_rows ++ new_event_rows
+  end
+
+  defp unique_asset_refs(persisted_rows, event_rows) do
+    persisted_unique_refs = unique_refs(persisted_rows)
+    event_unique_refs = unique_refs(event_rows)
+
+    MapSet.intersection(persisted_unique_refs, event_unique_refs)
+  end
+
+  defp unique_refs(rows) do
+    rows
+    |> Enum.frequencies_by(& &1.asset_ref)
+    |> Enum.filter(fn {_asset_ref, count} -> count == 1 end)
+    |> Enum.map(fn {asset_ref, _count} -> asset_ref end)
+    |> MapSet.new()
   end
 
   defp append_waiting_rows(rows, waiting_rows) do

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -205,9 +205,7 @@ defmodule FavnView.RunDetailLive do
   defp event_execution_row(run_id, events) do
     latest = List.last(events)
 
-    first_started =
-      Enum.find(events, &(&1.raw_event_type in [:step_started, "step_started"])) ||
-        List.first(events)
+    first_started = started_event_for_attempt(events, latest.attempt) || List.first(events)
 
     asset_ref = latest.asset || "Unknown asset"
     status = event_step_status(latest)
@@ -335,8 +333,18 @@ defmodule FavnView.RunDetailLive do
 
   defp event_row_error(%{data: data}) do
     data
-    |> Map.get(:error)
+    |> event_data_value(:error)
     |> error_summary()
+  end
+
+  defp started_event_for_attempt(events, nil) do
+    Enum.find(Enum.reverse(events), &(&1.raw_event_type in [:step_started, "step_started"]))
+  end
+
+  defp started_event_for_attempt(events, attempt) do
+    Enum.find(Enum.reverse(events), fn event ->
+      event.raw_event_type in [:step_started, "step_started"] and event.attempt == attempt
+    end) || started_event_for_attempt(events, nil)
   end
 
   defp event_row_explanation(%{raw_event_type: type})
@@ -480,8 +488,10 @@ defmodule FavnView.RunDetailLive do
 
   defp event_data(event, key) do
     data = Map.get(event, :data, %{}) || %{}
-    Map.get(data, key) || Map.get(data, Atom.to_string(key))
+    event_data_value(data, key)
   end
+
+  defp event_data_value(data, key), do: Map.get(data, key) || Map.get(data, Atom.to_string(key))
 
   defp latest_event_summary([]), do: nil
   defp latest_event_summary(events), do: events |> List.last() |> Map.get(:summary)

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -170,10 +170,11 @@ defmodule FavnView.RunDetailLive do
 
   defp merge_event_rows(persisted_rows, event_rows) do
     event_rows_by_id = Map.new(event_rows, &{&1.id, &1})
+    event_rows_by_asset = Map.new(event_rows, &{&1.asset_ref, &1})
 
     merged_persisted_rows =
       Enum.map(persisted_rows, fn row ->
-        case Map.get(event_rows_by_id, row.id) do
+        case Map.get(event_rows_by_id, row.id) || Map.get(event_rows_by_asset, row.asset_ref) do
           nil ->
             row
 
@@ -185,7 +186,12 @@ defmodule FavnView.RunDetailLive do
       end)
 
     persisted_ids = MapSet.new(merged_persisted_rows, & &1.id)
-    new_event_rows = Enum.reject(event_rows, &MapSet.member?(persisted_ids, &1.id))
+    persisted_refs = MapSet.new(merged_persisted_rows, & &1.asset_ref)
+
+    new_event_rows =
+      Enum.reject(event_rows, fn row ->
+        MapSet.member?(persisted_ids, row.id) || MapSet.member?(persisted_refs, row.asset_ref)
+      end)
 
     merged_persisted_rows ++ new_event_rows
   end

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -6,6 +6,7 @@ defmodule FavnView.RunDetailLive do
   alias FavnView.Components.AssetCataloguePage
   alias FavnView.Components.RunDetailPage
   alias FavnView.AssetRoute
+  alias FavnView.LogsViewModel
   alias FavnView.RunStepViewModel
 
   @refresh_interval_ms 1_500
@@ -75,8 +76,8 @@ defmodule FavnView.RunDetailLive do
     target = target_label(Map.get(run, :asset_ref), Map.get(run, :target_refs, []))
     trigger = trigger_label(Map.get(run, :trigger, %{}), Map.get(run, :submit_kind))
     window = window_label(Map.get(run, :params, %{}), Map.get(run, :metadata, %{}))
-    asset_results = RunStepViewModel.from_run(run)
     event_items = event_items(events)
+    asset_results = execution_rows(run, event_items)
     back_asset_href = existing_back_asset_href || back_asset_href(Map.get(run, :asset_ref))
     failure_summary = failure_summary(status, asset_results, event_items)
     current_activity = current_activity(status, asset_results, event_items)
@@ -131,9 +132,16 @@ defmodule FavnView.RunDetailLive do
         raw_status: Map.get(event, :status),
         timestamp: timestamp_label(Map.get(event, :occurred_at)),
         event_type: event_type_label(Map.get(event, :event_type)),
+        raw_event_type: Map.get(event, :event_type),
         status: status_label(Map.get(event, :status)),
         status_tone: status_tone(Map.get(event, :status)),
         asset: event_asset(event),
+        asset_step_id: event_data(event, :asset_step_id),
+        runner_execution_id: event_data(event, :runner_execution_id),
+        attempt: event_data(event, :attempt),
+        stage: Map.get(event, :stage) || event_data(event, :stage),
+        occurred_at: Map.get(event, :occurred_at),
+        data: Map.get(event, :data, %{}) || %{},
         summary: event_summary(event)
       }
     end)
@@ -150,6 +158,200 @@ defmodule FavnView.RunDetailLive do
   defp target_label(nil, []), do: nil
   defp target_label(nil, refs), do: refs |> Enum.map(&ref_label/1) |> Enum.join(", ")
   defp target_label(ref, _refs), do: ref_label(ref)
+
+  defp execution_rows(run, event_items) do
+    persisted_rows = RunStepViewModel.from_run(run)
+
+    persisted_rows
+    |> merge_event_rows(event_execution_rows(run, event_items))
+    |> append_waiting_rows(waiting_execution_rows(run, persisted_rows, event_items))
+    |> Enum.sort_by(&execution_sort_key/1)
+  end
+
+  defp merge_event_rows(persisted_rows, event_rows) do
+    event_rows_by_id = Map.new(event_rows, &{&1.id, &1})
+
+    merged_persisted_rows =
+      Enum.map(persisted_rows, fn row ->
+        case Map.get(event_rows_by_id, row.id) do
+          nil ->
+            row
+
+          event_row ->
+            Map.merge(event_row, row, fn _key, event_value, persisted_value ->
+              persisted_value || event_value
+            end)
+        end
+      end)
+
+    persisted_ids = MapSet.new(merged_persisted_rows, & &1.id)
+    new_event_rows = Enum.reject(event_rows, &MapSet.member?(persisted_ids, &1.id))
+
+    merged_persisted_rows ++ new_event_rows
+  end
+
+  defp append_waiting_rows(rows, waiting_rows) do
+    row_refs = rows |> Enum.map(& &1.asset_ref) |> MapSet.new()
+    rows ++ Enum.reject(waiting_rows, &MapSet.member?(row_refs, &1.asset_ref))
+  end
+
+  defp event_execution_rows(run, event_items) do
+    event_items
+    |> Enum.filter(&step_event?/1)
+    |> Enum.group_by(&event_row_key(run.id, &1))
+    |> Enum.map(fn {_key, events} -> event_execution_row(run.id, events) end)
+  end
+
+  defp event_execution_row(run_id, events) do
+    latest = List.last(events)
+
+    first_started =
+      Enum.find(events, &(&1.raw_event_type in [:step_started, "step_started"])) ||
+        List.first(events)
+
+    asset_ref = latest.asset || "Unknown asset"
+    status = event_step_status(latest)
+
+    %{
+      id: latest.asset_step_id || LogsViewModel.deterministic_step_id(run_id, asset_ref),
+      asset_ref: asset_ref,
+      display_name: LogsViewModel.display_name(asset_ref) || asset_ref,
+      secondary: event_row_secondary(latest),
+      status: status_label(status),
+      raw_status: status,
+      status_tone: status_tone(status),
+      duration: event_row_duration(first_started, latest),
+      started_at: timestamp_label(first_started && first_started.occurred_at),
+      attempt: latest.attempt,
+      error: event_row_error(latest),
+      explanation: event_row_explanation(latest),
+      output: nil,
+      inspectable?: is_binary(latest.asset_step_id)
+    }
+  end
+
+  defp waiting_execution_rows(%{status: status} = run, persisted_rows, event_items)
+       when status in [:pending, :running, "pending", "running"] do
+    known_refs =
+      (Enum.map(persisted_rows, & &1.asset_ref) ++ Enum.map(event_items, & &1.asset))
+      |> Enum.reject(&is_nil/1)
+      |> MapSet.new()
+
+    run
+    |> Map.get(:target_refs, [])
+    |> Enum.map(&ref_label/1)
+    |> Enum.reject(&MapSet.member?(known_refs, &1))
+    |> Enum.map(fn asset_ref -> waiting_execution_row(run.id, asset_ref) end)
+  end
+
+  defp waiting_execution_rows(_run, _persisted_rows, _event_items), do: []
+
+  defp waiting_execution_row(run_id, asset_ref) do
+    %{
+      id: LogsViewModel.deterministic_step_id(run_id, asset_ref),
+      asset_ref: asset_ref,
+      display_name: LogsViewModel.display_name(asset_ref) || asset_ref,
+      secondary: "Waiting for scheduler",
+      status: "Waiting",
+      raw_status: :pending,
+      status_tone: :neutral,
+      duration: "-",
+      started_at: "-",
+      attempt: nil,
+      error: nil,
+      explanation: "Asset has not started yet for this run.",
+      output: nil,
+      inspectable?: false
+    }
+  end
+
+  defp execution_sort_key(row), do: {stage_sort(Map.get(row, :secondary)), row.asset_ref}
+
+  defp stage_sort(nil), do: 999_999
+
+  defp stage_sort(secondary) do
+    case Regex.run(~r/Stage (\d+)/, secondary) do
+      [_, stage] -> String.to_integer(stage)
+      _other -> 999_999
+    end
+  end
+
+  defp step_event?(%{raw_event_type: event_type}) when is_atom(event_type) do
+    String.starts_with?(Atom.to_string(event_type), "step_")
+  end
+
+  defp step_event?(%{raw_event_type: event_type}) when is_binary(event_type),
+    do: String.starts_with?(event_type, "step_")
+
+  defp step_event?(_event), do: false
+
+  defp event_row_key(run_id, event) do
+    event.asset_step_id || LogsViewModel.deterministic_step_id(run_id, event.asset || "unknown")
+  end
+
+  defp event_step_status(%{raw_event_type: event_type, raw_status: status}) do
+    case event_type do
+      type when type in [:step_started, "step_started"] -> :running
+      type when type in [:step_finished, "step_finished"] -> :ok
+      type when type in [:step_failed, "step_failed"] -> :error
+      type when type in [:step_timed_out, "step_timed_out"] -> :timed_out
+      type when type in [:step_cancelled, "step_cancelled"] -> :cancelled
+      type when type in [:step_retry_scheduled, "step_retry_scheduled"] -> :retrying
+      type when type in [:step_skipped_fresh, "step_skipped_fresh"] -> :skipped_fresh
+      type when type in [:step_blocked, "step_blocked"] -> :blocked
+      _other -> status || :running
+    end
+  end
+
+  defp event_row_secondary(event) do
+    [
+      event.stage && "Stage #{event.stage}",
+      event.attempt && "Attempt #{event.attempt}",
+      event.runner_execution_id && "Runner #{short_id(event.runner_execution_id)}"
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" · ")
+    |> case do
+      "" -> nil
+      secondary -> secondary
+    end
+  end
+
+  defp event_row_duration(%{occurred_at: %DateTime{} = started_at}, %{
+         occurred_at: %DateTime{} = occurred_at,
+         raw_event_type: event_type
+       })
+       when event_type not in [:step_started, "step_started"] do
+    DateTime.diff(occurred_at, started_at, :millisecond)
+    |> duration_ms_label()
+  end
+
+  defp event_row_duration(%{occurred_at: %DateTime{} = started_at}, _latest) do
+    DateTime.diff(DateTime.utc_now(), started_at, :millisecond)
+    |> duration_ms_label()
+  end
+
+  defp event_row_duration(_started, _latest), do: "-"
+
+  defp event_row_error(%{data: data}) do
+    data
+    |> Map.get(:error)
+    |> error_summary()
+  end
+
+  defp event_row_explanation(%{raw_event_type: type})
+       when type in [:step_started, "step_started"],
+       do: "Execution has started; waiting for runner result."
+
+  defp event_row_explanation(%{raw_event_type: type})
+       when type in [:step_retry_scheduled, "step_retry_scheduled"],
+       do: "Retry has been scheduled for this asset."
+
+  defp event_row_explanation(%{raw_event_type: type})
+       when type in [:step_finished, "step_finished"],
+       do: "Execution finished successfully."
+
+  defp event_row_explanation(_event), do: nil
 
   defp back_asset_href(nil), do: nil
 
@@ -276,6 +478,11 @@ defmodule FavnView.RunDetailLive do
     end
   end
 
+  defp event_data(event, key) do
+    data = Map.get(event, :data, %{}) || %{}
+    Map.get(data, key) || Map.get(data, Atom.to_string(key))
+  end
+
   defp latest_event_summary([]), do: nil
   defp latest_event_summary(events), do: events |> List.last() |> Map.get(:summary)
 
@@ -359,6 +566,15 @@ defmodule FavnView.RunDetailLive do
   defp submit_kind_label(value), do: humanize(value)
 
   defp debug_inspect(value), do: inspect(value, pretty: true, limit: 50, printable_limit: 2_000)
+
+  defp error_summary(nil), do: nil
+  defp error_summary(%{message: message}) when is_binary(message), do: message
+  defp error_summary(%{"message" => message}) when is_binary(message), do: message
+  defp error_summary(%{reason: reason}), do: error_summary(reason)
+  defp error_summary(%{"reason" => reason}), do: error_summary(reason)
+  defp error_summary(reason) when is_binary(reason), do: reason
+  defp error_summary(reason) when is_atom(reason), do: humanize(reason)
+  defp error_summary(reason), do: inspect(reason, limit: 5, printable_limit: 200)
 
   defp status_summary(nil), do: nil
   defp status_summary(status), do: "Status #{status_label(status)}"

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -112,7 +112,22 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="pipeline-summary-panel"]), "customer_orders_daily")
     assert has_element?(view, ~s([data-testid="pipeline-actions-panel"]), "Run pipeline")
     assert has_element?(view, ~s([data-testid="pipeline-backfill-form"]))
+    assert has_element?(view, ~s([data-testid="pipeline-backfill-defaults"]), "day")
+    assert has_element?(view, ~s([data-testid="pipeline-backfill-defaults"]), "Europe/Oslo")
     assert has_element?(view, ~s([data-testid="pipeline-runs-table"]), "run_daily_orders")
+  end
+
+  test "pipeline detail does not invent an implicit window for normal pipeline runs", %{
+    conn: conn
+  } do
+    {:ok, view, _html} = live(conn, pipeline_detail_path())
+
+    html =
+      view
+      |> element(~s([data-testid="run-pipeline-form"]))
+      |> render_submit()
+
+    assert html =~ "This day pipeline requires an explicit window request."
   end
 
   test "pipeline detail submits a pipeline run and navigates to run detail", %{conn: conn} do
@@ -129,6 +144,28 @@ defmodule FavnView.PageLiveTest do
     assert {:ok, run} = Storage.get_run(run_id)
     assert run.submit_kind == :pipeline
     assert run.metadata.pipeline_submit_ref == __MODULE__.Pipelines.FullRefresh
+  end
+
+  test "pipeline detail submits a backfill using pipeline window defaults", %{conn: conn} do
+    {:ok, view, _html} = live(conn, pipeline_detail_path())
+
+    view
+    |> element(~s([data-testid="pipeline-backfill-form"]))
+    |> render_submit(%{
+      "backfill" => %{
+        "from" => "2026-01-01",
+        "to" => "2026-01-02",
+        "kind" => "day",
+        "timezone" => "Europe/Oslo"
+      }
+    })
+
+    assert {run_path, %{"info" => "Pipeline backfill submitted"}} = assert_redirect(view)
+    run_id = String.replace_prefix(run_path, "/runs/", "")
+    assert {:ok, run} = Storage.get_run(run_id)
+    assert run.submit_kind == :backfill_pipeline
+    assert run.metadata.backfill.kind == :day
+    assert run.metadata.backfill.timezone == "Europe/Oslo"
   end
 
   test "runs list refreshes active runs", %{conn: conn} do

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -112,6 +112,8 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="pipeline-summary-panel"]), "customer_orders_daily")
     assert has_element?(view, ~s([data-testid="pipeline-actions-panel"]), "Run pipeline")
     assert has_element?(view, ~s([data-testid="pipeline-backfill-form"]))
+    assert has_element?(view, ~s([data-testid="run-pipeline-button"][disabled]))
+    assert has_element?(view, ~s([data-testid="pipeline-run-disabled-help"]), "explicit window")
     assert has_element?(view, ~s([data-testid="pipeline-backfill-defaults"]), "day")
     assert has_element?(view, ~s([data-testid="pipeline-backfill-defaults"]), "Europe/Oslo")
     assert has_element?(view, ~s([data-testid="pipeline-runs-table"]), "run_daily_orders")
@@ -127,7 +129,8 @@ defmodule FavnView.PageLiveTest do
       |> element(~s([data-testid="run-pipeline-form"]))
       |> render_submit()
 
-    assert html =~ "This day pipeline requires an explicit window request."
+    refute html =~ "Pipeline run submitted"
+    refute html =~ "pipeline-run-error"
   end
 
   test "pipeline detail submits a pipeline run and navigates to run detail", %{conn: conn} do
@@ -144,6 +147,20 @@ defmodule FavnView.PageLiveTest do
     assert {:ok, run} = Storage.get_run(run_id)
     assert run.submit_kind == :pipeline
     assert run.metadata.pipeline_submit_ref == __MODULE__.Pipelines.FullRefresh
+  end
+
+  test "pipeline detail disables backfill for non-windowed pipelines", %{conn: conn} do
+    {:ok, view, _html} = live(conn, pipeline_detail_path("full_refresh"))
+
+    assert has_element?(view, ~s([data-testid="submit-backfill-button"][disabled]))
+
+    assert has_element?(
+             view,
+             ~s([data-testid="pipeline-backfill-disabled-help"]),
+             "windowed pipeline"
+           )
+
+    refute has_element?(view, ~s([data-testid="pipeline-backfill-defaults"]))
   end
 
   test "pipeline detail submits a backfill using pipeline window defaults", %{conn: conn} do
@@ -687,7 +704,81 @@ defmodule FavnView.PageLiveTest do
 
     assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Running")
     assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Stage 0")
+    refute has_element?(view, ~s([data-testid="run-asset-result-row"]), "Waiting")
     refute has_element?(view, ~s([data-testid="run-asset-results-empty"]))
+  end
+
+  test "run detail does not duplicate event and persisted rows for same asset", %{conn: conn} do
+    ref = {__MODULE__.Assets, :customer_orders_daily}
+
+    assert :ok =
+             Storage.append_run_event("run_customer_orders_daily", %{
+               run_id: "run_customer_orders_daily",
+               sequence: 3,
+               event_type: :step_started,
+               occurred_at: DateTime.add(DateTime.utc_now(), -5, :second),
+               status: :running,
+               data: %{
+                 asset_ref: ref,
+                 asset_step_id: "different-live-step-id",
+                 stage: 0,
+                 attempt: 1
+               }
+             })
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily")
+    html = render(view)
+
+    assert asset_result_row_count(html) == 1
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "customer_orders_daily")
+    refute has_element?(view, ~s([data-testid="run-asset-result-row"]), "Running")
+  end
+
+  test "run detail renders retrying step event before results persist", %{conn: conn} do
+    step_id = "run_empty_running-stg-payments"
+    ref = {__MODULE__.Assets, :stg_payments}
+
+    assert :ok =
+             Storage.append_run_event("run_empty_running", %{
+               run_id: "run_empty_running",
+               sequence: 3,
+               event_type: :step_started,
+               occurred_at: DateTime.add(DateTime.utc_now(), -1, :second),
+               status: :running,
+               data: %{
+                 asset_ref: ref,
+                 asset_step_id: step_id,
+                 stage: 0,
+                 attempt: 1
+               }
+             })
+
+    assert :ok =
+             Storage.append_run_event("run_empty_running", %{
+               run_id: "run_empty_running",
+               sequence: 4,
+               event_type: :step_retry_scheduled,
+               occurred_at: DateTime.utc_now(),
+               status: :retrying,
+               data: %{
+                 asset_ref: ref,
+                 asset_step_id: step_id,
+                 stage: 0,
+                 attempt: 1
+               }
+             })
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
+
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Retrying")
+
+    assert has_element?(
+             view,
+             ~s([data-testid="run-asset-result-row"]),
+             "Retry has been scheduled"
+           )
+
+    refute has_element?(view, ~s([data-testid="run-asset-result-row"]), "Waiting")
   end
 
   test "run detail shows failed step event error before final results persist", %{conn: conn} do
@@ -1399,6 +1490,12 @@ defmodule FavnView.PageLiveTest do
 
   defp pipeline_detail_path(name \\ "daily_orders") do
     ~p"/pipelines/#{FavnView.AssetRoute.to_param(pipeline_target_id(name))}"
+  end
+
+  defp asset_result_row_count(html) do
+    ~r/data-testid="run-asset-result-row"/
+    |> Regex.scan(html)
+    |> length()
   end
 
   defp today_label do

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -579,7 +579,7 @@ defmodule FavnView.PageLiveTest do
     {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
 
     assert has_element?(view, ~s([data-testid="run-overview-panel"][data-run-active="true"]))
-    assert has_element?(view, ~s([data-testid="run-asset-results-empty"]), "Run accepted")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Waiting")
 
     {:ok, active_run} = Storage.get_run("run_empty_running")
 
@@ -614,15 +614,43 @@ defmodule FavnView.PageLiveTest do
   test "running run with no asset results shows waiting state and no fake rows", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
 
-    assert has_element?(view, ~s([data-testid="run-asset-results-empty"]), "Run accepted")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Waiting")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "stg_payments")
 
     assert has_element?(
              view,
              ~s([data-testid="run-current-activity"]),
              "Waiting for first execution event"
            )
+  end
 
-    refute has_element?(view, ~s([data-testid="run-asset-result-row"]))
+  test "run detail derives active asset rows from step events before results persist", %{
+    conn: conn
+  } do
+    step_id = "run_empty_running-stg-payments"
+    ref = {__MODULE__.Assets, :stg_payments}
+
+    assert :ok =
+             Storage.append_run_event("run_empty_running", %{
+               run_id: "run_empty_running",
+               sequence: 3,
+               event_type: :step_started,
+               occurred_at: DateTime.utc_now(),
+               status: :running,
+               data: %{
+                 asset_ref: ref,
+                 asset_step_id: step_id,
+                 stage: 0,
+                 attempt: 1,
+                 runner_execution_id: "exec_step_active"
+               }
+             })
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
+
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Running")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Stage 0")
+    refute has_element?(view, ~s([data-testid="run-asset-results-empty"]))
   end
 
   test "failed run surfaces failed asset and error in overview", %{conn: conn} do
@@ -762,6 +790,23 @@ defmodule FavnView.PageLiveTest do
     {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily/logs")
 
     assert render(view) =~ "Running SQL:\nSELECT customer_id\nFROM raw.orders"
+  end
+
+  test "logs expose execution context details", %{conn: conn} do
+    seed_log!("asset execution started",
+      run_id: "run_customer_orders_daily",
+      asset_step_id: "customer-step",
+      asset_ref: {__MODULE__.Assets, :customer_orders_daily},
+      runner_execution_id: "runner_exec_123456789",
+      attempt: 2
+    )
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily/logs")
+
+    assert has_element?(view, ~s([data-testid="log-row"]), "asset execution started")
+    assert has_element?(view, ~s([data-testid="log-detail-chip"]), "asset")
+    assert has_element?(view, ~s([data-testid="log-detail-chip"]), "customer_orders_daily")
+    assert has_element?(view, ~s([data-testid="log-detail-chip"]), "#2")
   end
 
   test "level source and search filters affect rendered logs", %{conn: conn} do
@@ -1219,6 +1264,9 @@ defmodule FavnView.PageLiveTest do
       global_sequence: Keyword.get(opts, :global_sequence),
       run_id: Keyword.get(opts, :run_id),
       asset_step_id: Keyword.get(opts, :asset_step_id),
+      asset_ref: Keyword.get(opts, :asset_ref),
+      runner_execution_id: Keyword.get(opts, :runner_execution_id),
+      attempt: Keyword.get(opts, :attempt),
       producer_id: Keyword.get(opts, :producer_id),
       producer_sequence: Keyword.get(opts, :producer_sequence),
       occurred_at: Keyword.get(opts, :occurred_at, DateTime.utc_now()),

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -734,6 +734,50 @@ defmodule FavnView.PageLiveTest do
     refute has_element?(view, ~s([data-testid="run-asset-result-row"]), "Running")
   end
 
+  test "run detail only merges by asset when asset refs are unique", %{conn: conn} do
+    ref = {__MODULE__.Assets, :stg_payments}
+
+    assert :ok = Storage.put_run(same_asset_node_results_run_state())
+
+    assert :ok =
+             Storage.append_run_event("run_same_asset_nodes", %{
+               run_id: "run_same_asset_nodes",
+               sequence: 3,
+               event_type: :step_started,
+               occurred_at: DateTime.add(DateTime.utc_now(), -2, :second),
+               status: :running,
+               data: %{
+                 asset_ref: ref,
+                 asset_step_id: "live-window-a",
+                 stage: 0,
+                 attempt: 1
+               }
+             })
+
+    assert :ok =
+             Storage.append_run_event("run_same_asset_nodes", %{
+               run_id: "run_same_asset_nodes",
+               sequence: 4,
+               event_type: :step_started,
+               occurred_at: DateTime.add(DateTime.utc_now(), -1, :second),
+               status: :running,
+               data: %{
+                 asset_ref: ref,
+                 asset_step_id: "live-window-b",
+                 stage: 1,
+                 attempt: 1
+               }
+             })
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_same_asset_nodes")
+    html = render(view)
+
+    assert asset_result_row_count(html) == 4
+    assert html =~ "window:day:2026-06-12"
+    assert html =~ "window:day:2026-06-13"
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Running")
+  end
+
   test "run detail renders retrying step event before results persist", %{conn: conn} do
     step_id = "run_empty_running-stg-payments"
     ref = {__MODULE__.Assets, :stg_payments}
@@ -1302,6 +1346,50 @@ defmodule FavnView.PageLiveTest do
             finished_at: finished_at,
             duration_ms: 1,
             error: %{reason: :upstream_failed}
+          })
+        ]
+      }
+    )
+    |> Map.put(:inserted_at, started_at)
+    |> Map.put(:updated_at, finished_at)
+    |> RunState.with_snapshot_hash()
+  end
+
+  defp same_asset_node_results_run_state do
+    finished_at = DateTime.add(DateTime.utc_now(), -1_200, :second)
+    started_at = DateTime.add(finished_at, -2, :second)
+    stg_ref = {__MODULE__.Assets, :stg_payments}
+
+    RunState.new(
+      id: "run_same_asset_nodes",
+      manifest_version_id: "mv_view_assets",
+      manifest_content_hash: "hash_view_assets",
+      asset_ref: stg_ref,
+      target_refs: [stg_ref]
+    )
+    |> RunState.transition(
+      status: :partial,
+      result: %{
+        node_results: [
+          NodeResult.new(%{
+            node_key: {stg_ref, "window:day:2026-06-12"},
+            ref: stg_ref,
+            window: %{id: "window:day:2026-06-12"},
+            stage: 0,
+            status: :ok,
+            started_at: started_at,
+            finished_at: DateTime.add(started_at, 1, :second),
+            duration_ms: 1_000
+          }),
+          NodeResult.new(%{
+            node_key: {stg_ref, "window:day:2026-06-13"},
+            ref: stg_ref,
+            window: %{id: "window:day:2026-06-13"},
+            stage: 1,
+            status: :ok,
+            started_at: DateTime.add(started_at, 1, :second),
+            finished_at: finished_at,
+            duration_ms: 1_000
           })
         ]
       }

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -653,6 +653,47 @@ defmodule FavnView.PageLiveTest do
     refute has_element?(view, ~s([data-testid="run-asset-results-empty"]))
   end
 
+  test "run detail shows failed step event error before final results persist", %{conn: conn} do
+    step_id = "run_empty_running-stg-payments"
+    ref = {__MODULE__.Assets, :stg_payments}
+
+    assert :ok =
+             Storage.append_run_event("run_empty_running", %{
+               run_id: "run_empty_running",
+               sequence: 3,
+               event_type: :step_started,
+               occurred_at: DateTime.add(DateTime.utc_now(), -1, :second),
+               status: :running,
+               data: %{
+                 asset_ref: ref,
+                 asset_step_id: step_id,
+                 stage: 0,
+                 attempt: 1
+               }
+             })
+
+    assert :ok =
+             Storage.append_run_event("run_empty_running", %{
+               run_id: "run_empty_running",
+               sequence: 4,
+               event_type: :step_failed,
+               occurred_at: DateTime.utc_now(),
+               status: :error,
+               data: %{
+                 "error" => %{"message" => "Warehouse timeout"},
+                 asset_ref: ref,
+                 asset_step_id: step_id,
+                 stage: 0,
+                 attempt: 1
+               }
+             })
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
+
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Failed")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Warehouse timeout")
+  end
+
   test "failed run surfaces failed asset and error in overview", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/runs/run_failed_customer_orders")
 


### PR DESCRIPTION
## Summary
- Add a pipeline detail LiveView with run history and manual pipeline actions.
- Keep pipeline run/backfill request parsing inside the orchestrator boundary so `favn_view` submits plain form data only.
- Derive backfill kind/timezone defaults from pipeline window metadata and expose normalized run scope for windows/backfill ranges.
- Surface live asset execution state on run detail pages from persisted step events before final results arrive.
- Show structured execution context in logs, including asset, step, attempt, runner, and producer details.

## Verification
- `mix format`
- `cd apps/favn_orchestrator && mix compile --warnings-as-errors`
- `cd apps/favn_orchestrator && mix test`
- `cd apps/favn_view && mix compile --warnings-as-errors`
- `cd apps/favn_view && mix test`