### PR TITLE
Tier consumer dependency install tests

### DIFF
--- a/apps/favn/test/consumer_dependency_install_test.exs
+++ b/apps/favn/test/consumer_dependency_install_test.exs
@@ -1,8 +1,6 @@
 defmodule Favn.ConsumerDependencyInstallTest do
   use ExUnit.Case, async: false
 
-  @moduletag :slow
-
   setup do
     base_dir =
       Path.join(
@@ -20,6 +18,23 @@ defmodule Favn.ConsumerDependencyInstallTest do
     %{snapshot_dir: snapshot_dir, consumer_dir: consumer_dir}
   end
 
+  test "public package dependency boundary stays standalone-consumer safe" do
+    deps = Favn.MixProject.project()[:deps]
+    dep_apps = Enum.map(deps, &elem(&1, 0))
+
+    refute :favn in dep_apps
+    refute Enum.any?(deps, fn {_app, opts} -> Keyword.has_key?(opts, :in_umbrella) end)
+
+    assert runtime_deps(deps) == [:favn_authoring, :favn_local, :favn_sql_runtime]
+    assert test_only_deps(deps) == [:favn_orchestrator, :favn_runner, :favn_test_support]
+
+    assert Enum.all?(deps, fn {_app, opts} ->
+             path = Keyword.fetch!(opts, :path)
+             String.starts_with?(path, "../")
+           end)
+  end
+
+  @tag :slow
   test "fresh consumer can deps.get and compile favn from git umbrella subdir", %{
     snapshot_dir: snapshot_dir,
     consumer_dir: consumer_dir
@@ -71,6 +86,7 @@ defmodule Favn.ConsumerDependencyInstallTest do
     assert {_, 0} = System.cmd("mix", ["compile"], cd: consumer_dir, stderr_to_stdout: true)
   end
 
+  @tag :slow
   test "fresh local consumer can resolve favn with plugin path dependencies", %{
     consumer_dir: consumer_dir
   } do
@@ -91,24 +107,16 @@ defmodule Favn.ConsumerDependencyInstallTest do
     assert {_, 0} = System.cmd("mix", ["compile"], cd: consumer_dir, stderr_to_stdout: true)
   end
 
-  test "fresh local consumer can resolve favn with sqlite storage path dependency", %{
-    consumer_dir: consumer_dir
-  } do
-    repo_root = Path.expand("../../..", __DIR__)
+  defp runtime_deps(deps) do
+    deps
+    |> Enum.reject(fn {_app, opts} -> Keyword.get(opts, :only) == :test end)
+    |> Enum.map(&elem(&1, 0))
+  end
 
-    assert {_, 0} = System.cmd("mix", ["new", consumer_dir, "--sup"])
-
-    File.write!(
-      Path.join(consumer_dir, "mix.exs"),
-      consumer_mix_exs_with_sqlite_storage_path(repo_root)
-    )
-
-    {output, status} = System.cmd("mix", ["deps.get"], cd: consumer_dir, stderr_to_stdout: true)
-
-    assert status == 0, String.slice(output, -4_000, 4_000)
-    refute output =~ "Dependencies have diverged"
-
-    assert {_, 0} = System.cmd("mix", ["compile"], cd: consumer_dir, stderr_to_stdout: true)
+  defp test_only_deps(deps) do
+    deps
+    |> Enum.filter(fn {_app, opts} -> Keyword.get(opts, :only) == :test end)
+    |> Enum.map(&elem(&1, 0))
   end
 
   defp consumer_mix_exs(repo_url, ref) do
@@ -162,35 +170,6 @@ defmodule Favn.ConsumerDependencyInstallTest do
         [
           {:favn, path: "#{Path.join(repo_root, "apps/favn")}"},
           {:favn_duckdb, path: "#{Path.join(repo_root, "apps/favn_duckdb")}"}
-        ]
-      end
-    end
-    """
-  end
-
-  defp consumer_mix_exs_with_sqlite_storage_path(repo_root) do
-    """
-    defmodule FavnConsumerInstall.MixProject do
-      use Mix.Project
-
-      def project do
-        [
-          app: :favn_consumer_install,
-          version: "0.1.0",
-          elixir: "~> 1.19",
-          start_permanent: Mix.env() == :prod,
-          deps: deps()
-        ]
-      end
-
-      def application do
-        [extra_applications: [:logger]]
-      end
-
-      defp deps do
-        [
-          {:favn, path: "#{Path.join(repo_root, "apps/favn")}"},
-          {:favn_storage_sqlite, path: "#{Path.join(repo_root, "apps/favn_storage_sqlite")}"}
         ]
       end
     end

--- a/docs/structure/favn.md
+++ b/docs/structure/favn.md
@@ -12,6 +12,9 @@ Code:
 Tests:
 - `apps/favn/test/`
 - `apps/favn/test/favn_test.exs` doctests the public facade and depends on docs being emitted for `Favn`
+- `apps/favn/test/consumer_dependency_install_test.exs` keeps one fast public
+  package-boundary check while full fresh-project dependency resolution runs in
+  the `:slow` tier
 - public Mix task tests under `apps/favn/test/mix_tasks/`
 - bootstrap and diagnostics task argument/default coverage in `apps/favn/test/mix_tasks/public_tasks_test.exs`
 


### PR DESCRIPTION
## Summary
- Split `apps/favn/test/consumer_dependency_install_test.exs` so fast CI keeps a cheap public `:favn` package-boundary check.
- Keep fresh consumer `deps.get`/compile coverage in the `:slow` tier.
- Remove the SQLite storage consumer dependency case because storage adapters are internal runtime/package tooling, not ordinary consumer dependencies.

## Measurements
- Before split, focused consumer dependency file: 3 tests, 62.0s ExUnit, 93.54s wall.
- Before split slowest tests: SQLite storage path 32.5s, DuckDB plugin path 15.5s, git umbrella subdir 13.8s.
- After split fast boundary check: 0.06s ExUnit, 1.78s wall.
- After split slow consumer install checks: 29.8s ExUnit, 31.58s wall.
- `mix test.slow`: 33.22s wall.

## Verification
- `mix format`
- `git diff --check`
- `MIX_ENV=test mix do --app favn cmd mix test --no-compile test/consumer_dependency_install_test.exs --exclude slow --slowest 20`
- `MIX_ENV=test mix do --app favn cmd mix test --no-compile test/consumer_dependency_install_test.exs --only slow --slowest 20`
- `MIX_ENV=test mix do --app favn cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser --slowest 20`
- `mix test.slow`
- `elixir scripts/check_test_tag_tiers.exs`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `mix test`