### PR TITLE
Fix run detail status and backfill failure context

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -81,6 +81,7 @@ defmodule FavnOrchestrator.RunReadModel do
           required(:runner_execution_id) => String.t() | nil,
           required(:event_seq) => pos_integer(),
           required(:steps) => [step_summary()],
+          required(:backfill_failures) => [map()],
           required(:events) => [RunEvent.t()]
         }
 
@@ -114,10 +115,11 @@ defmodule FavnOrchestrator.RunReadModel do
     with {:ok, %RunState{} = run} <- Storage.get_run(run_id),
          {:ok, events} <- Storage.list_run_events(run_id) do
       events = Enum.map(events, &RunEvent.from_map/1)
+      public_run = with_public_status(run)
 
       {:ok,
        %{
-         summary: summary(run),
+         summary: summary(public_run),
          params: run.params,
          trigger: run.trigger,
          metadata: run.metadata,
@@ -125,7 +127,8 @@ defmodule FavnOrchestrator.RunReadModel do
          error: run.error,
          runner_execution_id: run.runner_execution_id,
          event_seq: run.event_seq,
-         steps: step_summaries(run, events),
+         steps: step_summaries(public_run, events),
+         backfill_failures: backfill_failures(run),
          events: events
        }}
     end
@@ -150,6 +153,7 @@ defmodule FavnOrchestrator.RunReadModel do
 
   @spec summary(RunState.t()) :: run_summary()
   def summary(%RunState{} = run) do
+    run = with_public_status(run)
     role = classify(run)
     progress = progress(run, role)
     window = window(run, role)
@@ -175,6 +179,32 @@ defmodule FavnOrchestrator.RunReadModel do
       duration_ms: duration_ms(run)
     }
   end
+
+  defp with_public_status(%RunState{} = run) do
+    %{run | status: public_status(run)}
+  end
+
+  defp public_status(%RunState{submit_kind: :pipeline, status: :ok} = run) do
+    if incomplete_pipeline_success?(run), do: :running, else: :ok
+  end
+
+  defp public_status(%RunState{status: status}), do: status
+
+  defp incomplete_pipeline_success?(%RunState{} = run) do
+    expected = expected_step_count(run)
+
+    expected > 0 and terminal_step_count(persisted_steps(run)) < expected
+  end
+
+  defp expected_step_count(%RunState{plan: %Favn.Plan{nodes: nodes}})
+       when is_map(nodes) and map_size(nodes) > 0,
+       do: map_size(nodes)
+
+  defp expected_step_count(%RunState{target_refs: refs}) when is_list(refs), do: length(refs)
+  defp expected_step_count(_run), do: 0
+
+  defp terminal_step_count(steps) when is_list(steps),
+    do: Enum.count(steps, &terminal_status?(&1.status))
 
   defp classify(%RunState{submit_kind: :rerun}), do: :rerun
 
@@ -241,6 +271,85 @@ defmodule FavnOrchestrator.RunReadModel do
         error
     end
   end
+
+  defp backfill_failures(%RunState{} = run) do
+    case classify(run) do
+      :backfill_parent ->
+        case list_all_backfill_windows(run.id) do
+          {:ok, windows} ->
+            windows
+            |> Enum.filter(&failed_backfill_window?/1)
+            |> Enum.map(&backfill_failure/1)
+
+          {:error, _reason} ->
+            []
+        end
+
+      _role ->
+        []
+    end
+  end
+
+  defp failed_backfill_window?(%BackfillWindow{status: status}),
+    do: status in [:error, :timed_out, :cancelled]
+
+  defp backfill_failure(%BackfillWindow{} = window) do
+    child_context = child_failure_context(window)
+    error = child_context.error || window_error(window)
+
+    %{
+      child_run_id: window.latest_attempt_run_id || window.child_run_id,
+      status: window.status,
+      window: backfill_window(window),
+      asset_ref: child_context.asset_ref,
+      error: error,
+      attempt_count: window.attempt_count,
+      started_at: window.started_at,
+      finished_at: window.finished_at,
+      duration_ms: duration_ms(window.started_at, window.finished_at)
+    }
+  end
+
+  defp child_failure_context(%BackfillWindow{} = window) do
+    case window.latest_attempt_run_id || window.child_run_id do
+      run_id when is_binary(run_id) ->
+        with {:ok, %RunState{} = child} <- Storage.get_run(run_id),
+             {:ok, events} <- Storage.list_run_events(run_id) do
+          child_failure_context(child, Enum.map(events, &RunEvent.from_map/1))
+        else
+          _other -> %{asset_ref: nil, error: nil}
+        end
+
+      _other ->
+        %{asset_ref: nil, error: nil}
+    end
+  end
+
+  defp child_failure_context(%RunState{} = child, events) do
+    failed_step =
+      child
+      |> step_summaries(events)
+      |> Enum.find(&(failure_step_status?(&1.status) and not is_nil(&1.error)))
+
+    %{
+      asset_ref: failed_step && failed_step.asset_ref,
+      error: (failed_step && failed_step.error) || child.error
+    }
+  end
+
+  defp failure_step_status?(status),
+    do: status in [:error, :timed_out, :blocked, "error", "timed_out", "blocked"]
+
+  defp window_error(%BackfillWindow{last_error: last_error}) when not is_nil(last_error),
+    do: last_error
+
+  defp window_error(%BackfillWindow{errors: errors}) when is_list(errors), do: List.last(errors)
+  defp window_error(_window), do: nil
+
+  defp duration_ms(%DateTime{} = started_at, %DateTime{} = finished_at),
+    do: DateTime.diff(finished_at, started_at, :millisecond)
+
+  defp duration_ms(_started_at, _finished_at), do: nil
 
   defp step_summaries(%RunState{} = run, events) do
     persisted_steps = persisted_steps(run)
@@ -674,7 +783,23 @@ defmodule FavnOrchestrator.RunReadModel do
   defp has_node_results?(_run), do: false
 
   defp terminal_status?(status),
-    do: status in [:ok, :partial, :error, :blocked, :cancelled, :timed_out, :skipped_fresh]
+    do:
+      status in [
+        :ok,
+        :partial,
+        :error,
+        :blocked,
+        :cancelled,
+        :timed_out,
+        :skipped_fresh,
+        "ok",
+        "partial",
+        "error",
+        "blocked",
+        "cancelled",
+        "timed_out",
+        "skipped_fresh"
+      ]
 
   defp unit_label(:assets, 1), do: "asset"
   defp unit_label(:assets, _total), do: "assets"

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -490,10 +490,9 @@ defmodule FavnOrchestrator.RunReadModel do
       |> MapSet.new()
 
     waiting_steps =
-      run.target_refs
-      |> List.wrap()
-      |> Enum.map(&public_ref/1)
-      |> Enum.reject(&MapSet.member?(known_refs, &1))
+      run
+      |> planned_waiting_candidates()
+      |> Enum.reject(&MapSet.member?(known_refs, &1.asset_ref))
       |> Enum.map(&waiting_step(run.id, &1))
 
     steps ++ waiting_steps
@@ -501,14 +500,54 @@ defmodule FavnOrchestrator.RunReadModel do
 
   defp append_waiting_steps(steps, _run, _event_steps, _settling?), do: steps
 
-  defp waiting_step(run_id, asset_ref) do
+  defp planned_waiting_candidates(%RunState{plan: %Favn.Plan{nodes: nodes, node_stages: stages}})
+       when is_map(nodes) and map_size(nodes) > 0 do
+    ordered_node_keys = List.flatten(stages || [])
+    remaining_node_keys = Map.keys(nodes) -- ordered_node_keys
+
+    (ordered_node_keys ++ remaining_node_keys)
+    |> Enum.uniq()
+    |> Enum.flat_map(fn node_key ->
+      case Map.fetch(nodes, node_key) do
+        {:ok, node} ->
+          [
+            %{
+              node_key: node_key,
+              asset_ref: public_ref(Map.get(node, :ref)),
+              canonical_asset_ref: Map.get(node, :ref),
+              stage: Map.get(node, :stage),
+              window: public_window(Map.get(node, :window) || %{})
+            }
+          ]
+
+        :error ->
+          []
+      end
+    end)
+  end
+
+  defp planned_waiting_candidates(%RunState{} = run) do
+    run.target_refs
+    |> List.wrap()
+    |> Enum.map(fn ref ->
+      %{
+        node_key: nil,
+        asset_ref: public_ref(ref),
+        canonical_asset_ref: nil,
+        stage: nil,
+        window: nil
+      }
+    end)
+  end
+
+  defp waiting_step(run_id, candidate) do
     %{
-      id: AssetStepIdentity.asset_step_id(run_id, nil, asset_ref),
-      asset_ref: asset_ref,
-      canonical_asset_ref: nil,
+      id: AssetStepIdentity.asset_step_id(run_id, candidate.node_key, candidate.asset_ref),
+      asset_ref: candidate.asset_ref,
+      canonical_asset_ref: candidate.canonical_asset_ref,
       status: :pending,
-      stage: nil,
-      window: nil,
+      stage: candidate.stage,
+      window: candidate.window,
       duration_ms: nil,
       started_at: nil,
       attempt: nil,

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -16,6 +16,8 @@ defmodule FavnOrchestrator.RunReadModel do
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
 
+  @backfill_failure_detail_limit 10
+
   @type run_role :: :asset | :pipeline | :backfill_parent | :backfill_child | :rerun
 
   @type window_summary :: %{
@@ -71,6 +73,18 @@ defmodule FavnOrchestrator.RunReadModel do
           required(:duration_ms) => non_neg_integer() | nil
         }
 
+  @type backfill_failure :: %{
+          required(:child_run_id) => String.t() | nil,
+          required(:status) => BackfillWindow.status(),
+          required(:window) => window_summary(),
+          required(:asset_ref) => String.t() | nil,
+          required(:error) => term(),
+          required(:attempt_count) => non_neg_integer(),
+          required(:started_at) => DateTime.t() | nil,
+          required(:finished_at) => DateTime.t() | nil,
+          required(:duration_ms) => non_neg_integer() | nil
+        }
+
   @type run_detail :: %{
           required(:summary) => run_summary(),
           required(:params) => map(),
@@ -81,7 +95,8 @@ defmodule FavnOrchestrator.RunReadModel do
           required(:runner_execution_id) => String.t() | nil,
           required(:event_seq) => pos_integer(),
           required(:steps) => [step_summary()],
-          required(:backfill_failures) => [map()],
+          required(:backfill_failures) => [backfill_failure()],
+          required(:backfill_failure_count) => non_neg_integer(),
           required(:events) => [RunEvent.t()]
         }
 
@@ -116,10 +131,12 @@ defmodule FavnOrchestrator.RunReadModel do
          {:ok, events} <- Storage.list_run_events(run_id) do
       events = Enum.map(events, &RunEvent.from_map/1)
       public_run = with_public_status(run)
+      backfill_windows = detail_backfill_windows(run)
+      {backfill_failures, backfill_failure_count} = backfill_failures(run, backfill_windows)
 
       {:ok,
        %{
-         summary: summary(public_run),
+         summary: summary(public_run, backfill_windows),
          params: run.params,
          trigger: run.trigger,
          metadata: run.metadata,
@@ -127,8 +144,9 @@ defmodule FavnOrchestrator.RunReadModel do
          error: run.error,
          runner_execution_id: run.runner_execution_id,
          event_seq: run.event_seq,
-         steps: step_summaries(public_run, events),
-         backfill_failures: backfill_failures(run),
+         steps: step_summaries(run, events),
+         backfill_failures: backfill_failures,
+         backfill_failure_count: backfill_failure_count,
          events: events
        }}
     end
@@ -153,9 +171,13 @@ defmodule FavnOrchestrator.RunReadModel do
 
   @spec summary(RunState.t()) :: run_summary()
   def summary(%RunState{} = run) do
+    summary(run, nil)
+  end
+
+  defp summary(%RunState{} = run, backfill_windows) do
     run = with_public_status(run)
     role = classify(run)
-    progress = progress(run, role)
+    progress = progress(run, role, backfill_windows)
     window = window(run, role)
 
     %{
@@ -191,10 +213,22 @@ defmodule FavnOrchestrator.RunReadModel do
   defp public_status(%RunState{status: status}), do: status
 
   defp incomplete_pipeline_success?(%RunState{} = run) do
+    incomplete_step_results?(run, persisted_steps(run))
+  end
+
+  defp incomplete_step_results?(%RunState{} = run, persisted_steps) do
     expected = expected_step_count(run)
 
-    expected > 0 and terminal_step_count(persisted_steps(run)) < expected
+    pipeline_like_run?(run) and expected > 0 and terminal_step_count(persisted_steps) < expected
   end
+
+  defp pipeline_like_run?(%RunState{submit_kind: :pipeline}), do: true
+
+  defp pipeline_like_run?(%RunState{submit_kind: :rerun, metadata: metadata})
+       when is_map(metadata),
+       do: Map.get(metadata, :replay_submit_kind) == :pipeline
+
+  defp pipeline_like_run?(_run), do: false
 
   defp expected_step_count(%RunState{plan: %Favn.Plan{nodes: nodes}})
        when is_map(nodes) and map_size(nodes) > 0,
@@ -218,7 +252,7 @@ defmodule FavnOrchestrator.RunReadModel do
   defp classify(%RunState{submit_kind: :pipeline}), do: :pipeline
   defp classify(%RunState{}), do: :asset
 
-  defp progress(%RunState{} = run, :backfill_parent) do
+  defp progress(%RunState{} = run, :backfill_parent, nil) do
     case list_all_backfill_windows(run.id) do
       {:ok, []} -> nil
       {:ok, windows} -> window_progress(windows)
@@ -226,7 +260,13 @@ defmodule FavnOrchestrator.RunReadModel do
     end
   end
 
-  defp progress(%RunState{} = run, role) do
+  defp progress(%RunState{}, :backfill_parent, []), do: nil
+
+  defp progress(%RunState{}, :backfill_parent, windows) when is_list(windows) do
+    window_progress(windows)
+  end
+
+  defp progress(%RunState{} = run, role, _backfill_windows) do
     steps = persisted_steps(run)
     total = max(length(steps), length(run.target_refs || []))
 
@@ -272,22 +312,41 @@ defmodule FavnOrchestrator.RunReadModel do
     end
   end
 
-  defp backfill_failures(%RunState{} = run) do
+  defp detail_backfill_windows(%RunState{} = run) do
     case classify(run) do
       :backfill_parent ->
         case list_all_backfill_windows(run.id) do
-          {:ok, windows} ->
-            windows
-            |> Enum.filter(&failed_backfill_window?/1)
-            |> Enum.map(&backfill_failure/1)
-
-          {:error, _reason} ->
-            []
+          {:ok, windows} -> windows
+          {:error, _reason} -> nil
         end
 
       _role ->
-        []
+        nil
     end
+  end
+
+  defp backfill_failures(%RunState{} = run, nil) do
+    case classify(run) do
+      :backfill_parent ->
+        case list_all_backfill_windows(run.id) do
+          {:ok, windows} -> backfill_failures(run, windows)
+          {:error, _reason} -> {[], 0}
+        end
+
+      _role ->
+        {[], 0}
+    end
+  end
+
+  defp backfill_failures(%RunState{}, windows) when is_list(windows) do
+    failed = Enum.filter(windows, &failed_backfill_window?/1)
+
+    failures =
+      failed
+      |> Enum.take(@backfill_failure_detail_limit)
+      |> Enum.map(&backfill_failure/1)
+
+    {failures, length(failed)}
   end
 
   defp failed_backfill_window?(%BackfillWindow{status: status}),
@@ -354,10 +413,11 @@ defmodule FavnOrchestrator.RunReadModel do
   defp step_summaries(%RunState{} = run, events) do
     persisted_steps = persisted_steps(run)
     event_steps = event_steps(run, events)
+    settling? = incomplete_step_results?(run, persisted_steps)
 
     persisted_steps
-    |> merge_event_steps(event_steps, run)
-    |> append_waiting_steps(run, event_steps)
+    |> merge_event_steps(event_steps, run, settling?)
+    |> append_waiting_steps(run, event_steps, settling?)
     |> mark_cascade_failures(events)
     |> Enum.sort_by(&{&1.stage || 999_999, &1.asset_ref})
   end
@@ -381,13 +441,13 @@ defmodule FavnOrchestrator.RunReadModel do
     |> Enum.map(fn {_id, grouped} -> event_step_summary(run.id, grouped) end)
   end
 
-  defp merge_event_steps(persisted_steps, _event_steps, %RunState{status: status})
+  defp merge_event_steps(persisted_steps, _event_steps, %RunState{status: status}, false)
        when persisted_steps != [] and status in [:ok, :partial, :error, :cancelled, :timed_out],
        do: persisted_steps
 
-  defp merge_event_steps([], event_steps, _run), do: event_steps
+  defp merge_event_steps([], event_steps, _run, _settling?), do: event_steps
 
-  defp merge_event_steps(persisted_steps, event_steps, _run) do
+  defp merge_event_steps(persisted_steps, event_steps, _run, _settling?) do
     event_steps_by_id = Map.new(event_steps, &{&1.id, &1})
     unique_asset_refs = unique_asset_refs(persisted_steps, event_steps)
 
@@ -422,8 +482,8 @@ defmodule FavnOrchestrator.RunReadModel do
     merged_persisted_steps ++ new_event_steps
   end
 
-  defp append_waiting_steps(steps, %RunState{status: status} = run, event_steps)
-       when status in [:pending, :running] do
+  defp append_waiting_steps(steps, %RunState{status: status} = run, event_steps, settling?)
+       when status in [:pending, :running] or settling? do
     known_refs =
       (Enum.map(steps, & &1.asset_ref) ++ Enum.map(event_steps, & &1.asset_ref))
       |> Enum.reject(&is_nil/1)
@@ -439,7 +499,7 @@ defmodule FavnOrchestrator.RunReadModel do
     steps ++ waiting_steps
   end
 
-  defp append_waiting_steps(steps, _run, _event_steps), do: steps
+  defp append_waiting_steps(steps, _run, _event_steps, _settling?), do: steps
 
   defp waiting_step(run_id, asset_ref) do
     %{

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -37,6 +37,7 @@ defmodule FavnOrchestrator.RunReadModel do
 
   @type step_summary :: %{
           required(:id) => String.t(),
+          required(:node_key) => Favn.Plan.node_key() | nil,
           required(:asset_ref) => String.t(),
           required(:canonical_asset_ref) => Favn.Ref.t() | nil,
           required(:status) => atom() | nil,
@@ -268,7 +269,7 @@ defmodule FavnOrchestrator.RunReadModel do
 
   defp progress(%RunState{} = run, role, _backfill_windows) do
     steps = persisted_steps(run)
-    total = max(length(steps), length(run.target_refs || []))
+    total = progress_total(run, steps)
 
     unit =
       if(role in [:pipeline, :backfill_child] or has_node_results?(run),
@@ -291,6 +292,15 @@ defmodule FavnOrchestrator.RunReadModel do
           label: "#{completed}/#{total} #{unit_label(unit, total)}",
           counts: %{total: total, completed: completed}
         }
+    end
+  end
+
+  defp progress_total(%RunState{} = run, steps) do
+    expected = expected_step_count(run)
+
+    cond do
+      pipeline_like_run?(run) and expected > 0 -> max(length(steps), expected)
+      true -> max(length(steps), length(run.target_refs || []))
     end
   end
 
@@ -484,21 +494,43 @@ defmodule FavnOrchestrator.RunReadModel do
 
   defp append_waiting_steps(steps, %RunState{status: status} = run, event_steps, settling?)
        when status in [:pending, :running] or settling? do
-    known_refs =
-      (Enum.map(steps, & &1.asset_ref) ++ Enum.map(event_steps, & &1.asset_ref))
-      |> Enum.reject(&is_nil/1)
-      |> MapSet.new()
+    known = known_waiting_identities(steps, event_steps)
+
+    candidates = planned_waiting_candidates(run)
+    candidate_ref_counts = Enum.frequencies_by(candidates, & &1.asset_ref)
 
     waiting_steps =
-      run
-      |> planned_waiting_candidates()
-      |> Enum.reject(&MapSet.member?(known_refs, &1.asset_ref))
+      candidates
+      |> Enum.reject(&known_waiting_candidate?(run.id, known, &1, candidate_ref_counts))
       |> Enum.map(&waiting_step(run.id, &1))
 
     steps ++ waiting_steps
   end
 
   defp append_waiting_steps(steps, _run, _event_steps, _settling?), do: steps
+
+  defp known_waiting_identities(steps, event_steps) do
+    all_steps = steps ++ event_steps
+
+    %{
+      ids: all_steps |> Enum.map(& &1.id) |> Enum.reject(&is_nil/1) |> MapSet.new(),
+      node_keys:
+        all_steps |> Enum.map(&Map.get(&1, :node_key)) |> Enum.reject(&is_nil/1) |> MapSet.new(),
+      asset_refs: all_steps |> Enum.map(& &1.asset_ref) |> Enum.reject(&is_nil/1) |> MapSet.new()
+    }
+  end
+
+  defp known_waiting_candidate?(run_id, known, %{node_key: node_key} = candidate, ref_counts)
+       when not is_nil(node_key) do
+    MapSet.member?(known.node_keys, node_key) ||
+      MapSet.member?(known.ids, candidate_step_id(run_id, candidate)) ||
+      (Map.get(ref_counts, candidate.asset_ref) == 1 and
+         MapSet.member?(known.asset_refs, candidate.asset_ref))
+  end
+
+  defp known_waiting_candidate?(_run_id, known, candidate, _ref_counts) do
+    MapSet.member?(known.asset_refs, candidate.asset_ref)
+  end
 
   defp planned_waiting_candidates(%RunState{plan: %Favn.Plan{nodes: nodes, node_stages: stages}})
        when is_map(nodes) and map_size(nodes) > 0 do
@@ -540,9 +572,14 @@ defmodule FavnOrchestrator.RunReadModel do
     end)
   end
 
+  defp candidate_step_id(run_id, candidate) do
+    AssetStepIdentity.asset_step_id(run_id, candidate.node_key, candidate.canonical_asset_ref)
+  end
+
   defp waiting_step(run_id, candidate) do
     %{
-      id: AssetStepIdentity.asset_step_id(run_id, candidate.node_key, candidate.asset_ref),
+      id: candidate_step_id(run_id, candidate),
+      node_key: candidate.node_key,
       asset_ref: candidate.asset_ref,
       canonical_asset_ref: candidate.canonical_asset_ref,
       status: :pending,
@@ -588,6 +625,7 @@ defmodule FavnOrchestrator.RunReadModel do
 
     %{
       id: step_id,
+      node_key: node_key,
       asset_ref: asset_ref,
       canonical_asset_ref: canonical_asset_ref,
       status: Map.get(result, :status) || Map.get(result, "status"),
@@ -618,6 +656,7 @@ defmodule FavnOrchestrator.RunReadModel do
 
     %{
       id: event_step_id(run_id, latest),
+      node_key: Map.get(data, :node_key) || Map.get(data, "node_key"),
       asset_ref: asset_ref,
       canonical_asset_ref: latest.asset_ref,
       status: event_step_status(latest.event_type, latest.status),

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -565,7 +565,7 @@ defmodule FavnOrchestrator.RunReadModel do
       %{
         node_key: nil,
         asset_ref: public_ref(ref),
-        canonical_asset_ref: nil,
+        canonical_asset_ref: ref,
         stage: nil,
         window: nil
       }

--- a/apps/favn_orchestrator/test/run_read_model_test.exs
+++ b/apps/favn_orchestrator/test/run_read_model_test.exs
@@ -330,6 +330,128 @@ defmodule FavnOrchestrator.RunReadModelTest do
     assert step.explanation == "Failed while executing this asset."
   end
 
+  test "pipeline success remains active while persisted step results are incomplete" do
+    gold_ref = {MyApp.Assets.Gold, :asset}
+    silver_ref = {MyApp.Assets.Silver, :asset}
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    run =
+      run("pipeline_success_gap", submit_kind: :pipeline)
+      |> Map.put(:target_refs, [gold_ref, silver_ref])
+      |> RunState.transition(
+        status: :ok,
+        result: %{
+          node_results: [
+            NodeResult.new(%{
+              node_key: {gold_ref, nil},
+              ref: gold_ref,
+              stage: 0,
+              status: :ok,
+              started_at: started_at,
+              finished_at: DateTime.add(started_at, 1, :second),
+              duration_ms: 1_000,
+              asset_step_id: "gold-step"
+            })
+          ]
+        }
+      )
+
+    assert :ok = Storage.put_run(run)
+
+    assert :ok =
+             Storage.append_run_event(run.id, %{
+               run_id: run.id,
+               sequence: run.event_seq + 1,
+               event_type: :step_started,
+               occurred_at: DateTime.add(started_at, 2, :second),
+               status: :running,
+               asset_ref: silver_ref,
+               stage: 0,
+               data: %{asset_step_id: "silver-step"}
+             })
+
+    assert {:ok, detail} = FavnOrchestrator.get_run_detail(run.id)
+
+    assert detail.summary.status == :running
+    assert detail.summary.finished_at == nil
+
+    steps_by_ref = Map.new(detail.steps, &{&1.asset_ref, &1})
+    assert steps_by_ref["MyApp.Assets.Gold.asset"].status == :ok
+    assert steps_by_ref["MyApp.Assets.Silver.asset"].status == :running
+  end
+
+  test "backfill parent detail includes failed child window context" do
+    parent =
+      run("backfill_parent_failure", submit_kind: :backfill_pipeline)
+      |> RunState.transition(status: :error, error: :failed, result: %{status: :error})
+
+    failed_ref = {MyApp.Assets.Inventory, :inventory_by_day}
+    started_at = ~U[2026-05-01 00:00:00Z]
+    finished_at = DateTime.add(started_at, 2, :second)
+    anchor = anchor(started_at)
+
+    child =
+      run("backfill_child_failure",
+        submit_kind: :pipeline,
+        parent_run_id: parent.id,
+        root_run_id: parent.id,
+        lineage_depth: 1,
+        trigger: %{
+          kind: :backfill,
+          backfill_run_id: parent.id,
+          pipeline_module: MyApp.Pipelines.Daily,
+          window_key: window_key(anchor)
+        },
+        metadata: %{pipeline_submit_ref: MyApp.Pipelines.Daily}
+      )
+      |> Map.put(:target_refs, [failed_ref])
+      |> RunState.transition(
+        status: :error,
+        error: :failed,
+        result: %{
+          node_results: [
+            NodeResult.new(%{
+              node_key: {failed_ref, window_key(anchor)},
+              ref: failed_ref,
+              stage: 0,
+              status: :error,
+              started_at: started_at,
+              finished_at: finished_at,
+              duration_ms: 2_000,
+              error: %{message: "DuckDB ADBC connection bootstrap failed at attach_mart"},
+              asset_step_id: "failed-inventory-step"
+            })
+          ]
+        }
+      )
+
+    window =
+      parent.id
+      |> backfill_window(anchor, :error)
+      |> Map.merge(%{
+        child_run_id: child.id,
+        latest_attempt_run_id: child.id,
+        attempt_count: 1,
+        last_error: :failed,
+        started_at: started_at,
+        finished_at: finished_at,
+        updated_at: finished_at
+      })
+
+    assert :ok = Storage.put_run(parent)
+    assert :ok = Storage.put_run(child)
+    assert :ok = Storage.put_backfill_window(window)
+
+    assert {:ok, detail} = FavnOrchestrator.get_run_detail(parent.id)
+
+    assert [failure] = detail.backfill_failures
+    assert failure.child_run_id == child.id
+    assert failure.asset_ref == "MyApp.Assets.Inventory.inventory_by_day"
+    assert failure.window.key == window_key(anchor)
+    assert failure.duration_ms == 2_000
+    assert failure.error == %{message: "DuckDB ADBC connection bootstrap failed at attach_mart"}
+  end
+
   defp run(run_id, opts) do
     RunState.new(
       id: run_id,

--- a/apps/favn_orchestrator/test/run_read_model_test.exs
+++ b/apps/favn_orchestrator/test/run_read_model_test.exs
@@ -380,6 +380,59 @@ defmodule FavnOrchestrator.RunReadModelTest do
     assert steps_by_ref["MyApp.Assets.Silver.asset"].status == :running
   end
 
+  test "failed pipeline keeps failure status while filling incomplete step rows" do
+    gold_ref = {MyApp.Assets.Gold, :asset}
+    silver_ref = {MyApp.Assets.Silver, :asset}
+    bronze_ref = {MyApp.Assets.Bronze, :asset}
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    run =
+      run("pipeline_failed_gap", submit_kind: :pipeline)
+      |> Map.put(:target_refs, [gold_ref, silver_ref, bronze_ref])
+      |> RunState.transition(
+        status: :error,
+        error: :failed,
+        result: %{
+          node_results: [
+            NodeResult.new(%{
+              node_key: {gold_ref, nil},
+              ref: gold_ref,
+              stage: 0,
+              status: :error,
+              started_at: started_at,
+              finished_at: DateTime.add(started_at, 1, :second),
+              duration_ms: 1_000,
+              error: %{message: "warehouse unavailable"},
+              asset_step_id: "gold-step"
+            })
+          ]
+        }
+      )
+
+    assert :ok = Storage.put_run(run)
+
+    assert :ok =
+             Storage.append_run_event(run.id, %{
+               run_id: run.id,
+               sequence: run.event_seq + 1,
+               event_type: :step_started,
+               occurred_at: DateTime.add(started_at, 2, :second),
+               status: :running,
+               asset_ref: silver_ref,
+               stage: 0,
+               data: %{asset_step_id: "silver-step"}
+             })
+
+    assert {:ok, detail} = FavnOrchestrator.get_run_detail(run.id)
+
+    assert detail.summary.status == :error
+
+    steps_by_ref = Map.new(detail.steps, &{&1.asset_ref, &1})
+    assert steps_by_ref["MyApp.Assets.Gold.asset"].status == :error
+    assert steps_by_ref["MyApp.Assets.Silver.asset"].status == :running
+    assert steps_by_ref["MyApp.Assets.Bronze.asset"].status == :pending
+  end
+
   test "backfill parent detail includes failed child window context" do
     parent =
       run("backfill_parent_failure", submit_kind: :backfill_pipeline)
@@ -450,6 +503,31 @@ defmodule FavnOrchestrator.RunReadModelTest do
     assert failure.window.key == window_key(anchor)
     assert failure.duration_ms == 2_000
     assert failure.error == %{message: "DuckDB ADBC connection bootstrap failed at attach_mart"}
+  end
+
+  test "backfill parent detail caps enriched failed window context" do
+    parent =
+      run("backfill_parent_many_failures", submit_kind: :backfill_pipeline)
+      |> RunState.transition(status: :error, error: :failed, result: %{status: :error})
+
+    assert :ok = Storage.put_run(parent)
+
+    for day <- 1..12 do
+      anchor = anchor(DateTime.add(~U[2026-05-01 00:00:00Z], (day - 1) * 86_400, :second))
+
+      window =
+        parent.id
+        |> backfill_window(anchor, :error)
+        |> Map.put(:last_error, {:failed_window, day})
+
+      assert :ok = Storage.put_backfill_window(window)
+    end
+
+    assert {:ok, detail} = FavnOrchestrator.get_run_detail(parent.id)
+
+    assert detail.backfill_failure_count == 12
+    assert length(detail.backfill_failures) == 10
+    assert detail.summary.progress.counts.failed == 12
   end
 
   defp run(run_id, opts) do

--- a/apps/favn_orchestrator/test/run_read_model_test.exs
+++ b/apps/favn_orchestrator/test/run_read_model_test.exs
@@ -491,6 +491,27 @@ defmodule FavnOrchestrator.RunReadModelTest do
     assert Enum.map(detail.steps, & &1.status) == [:running, :pending]
   end
 
+  test "no-plan active run creates distinct pending ids for multiple targets" do
+    gold_ref = {MyApp.Assets.Gold, :asset}
+    silver_ref = {MyApp.Assets.Silver, :asset}
+
+    run =
+      run("active_no_plan_multiple_targets", submit_kind: :pipeline)
+      |> Map.put(:target_refs, [gold_ref, silver_ref])
+      |> RunState.transition(status: :running, result: %{node_results: []})
+
+    assert :ok = Storage.put_run(run)
+
+    assert {:ok, detail} = FavnOrchestrator.get_run_detail(run.id)
+
+    assert Enum.map(detail.steps, & &1.asset_ref) == [
+             "MyApp.Assets.Gold.asset",
+             "MyApp.Assets.Silver.asset"
+           ]
+
+    assert detail.steps |> Enum.map(& &1.id) |> Enum.uniq() |> length() == 2
+  end
+
   test "backfill parent detail includes failed child window context" do
     parent =
       run("backfill_parent_failure", submit_kind: :backfill_pipeline)

--- a/apps/favn_orchestrator/test/run_read_model_test.exs
+++ b/apps/favn_orchestrator/test/run_read_model_test.exs
@@ -388,7 +388,8 @@ defmodule FavnOrchestrator.RunReadModelTest do
 
     run =
       run("pipeline_failed_gap", submit_kind: :pipeline)
-      |> Map.put(:target_refs, [gold_ref, silver_ref, bronze_ref])
+      |> Map.put(:target_refs, [bronze_ref])
+      |> Map.put(:plan, dependency_plan([gold_ref, silver_ref, bronze_ref]))
       |> RunState.transition(
         status: :error,
         error: :failed,
@@ -553,6 +554,36 @@ defmodule FavnOrchestrator.RunReadModelTest do
   end
 
   defp window_key(%Anchor{} = anchor), do: WindowKey.encode(anchor.key)
+
+  defp dependency_plan(refs) do
+    node_keys = Enum.map(refs, &{&1, nil})
+
+    nodes =
+      refs
+      |> Enum.zip(node_keys)
+      |> Enum.with_index()
+      |> Map.new(fn {{ref, node_key}, stage} ->
+        {node_key,
+         %{
+           ref: ref,
+           node_key: node_key,
+           window: nil,
+           upstream: Enum.take(node_keys, stage),
+           downstream: Enum.drop(node_keys, stage + 1),
+           stage: stage,
+           action: :run
+         }}
+      end)
+
+    %Favn.Plan{
+      target_refs: [List.last(refs)],
+      target_node_keys: [List.last(node_keys)],
+      nodes: nodes,
+      topo_order: refs,
+      stages: Enum.map(refs, &[&1]),
+      node_stages: Enum.map(node_keys, &[&1])
+    }
+  end
 
   defp backfill_window(parent_run_id, %Anchor{} = anchor, status) do
     {:ok, window} =

--- a/apps/favn_orchestrator/test/run_read_model_test.exs
+++ b/apps/favn_orchestrator/test/run_read_model_test.exs
@@ -427,11 +427,68 @@ defmodule FavnOrchestrator.RunReadModelTest do
     assert {:ok, detail} = FavnOrchestrator.get_run_detail(run.id)
 
     assert detail.summary.status == :error
+    assert detail.summary.progress.label == "1/3 steps"
 
     steps_by_ref = Map.new(detail.steps, &{&1.asset_ref, &1})
     assert steps_by_ref["MyApp.Assets.Gold.asset"].status == :error
     assert steps_by_ref["MyApp.Assets.Silver.asset"].status == :running
     assert steps_by_ref["MyApp.Assets.Bronze.asset"].status == :pending
+  end
+
+  test "pending rows keep repeated asset refs for distinct planned nodes" do
+    ref = {MyApp.Assets.Gold, :asset}
+    window_a = %{key: "window:a", label: "Window A"}
+    window_b = %{key: "window:b", label: "Window B"}
+    node_a = {ref, "window:a"}
+    node_b = {ref, "window:b"}
+
+    run =
+      run("pipeline_repeated_asset_gap", submit_kind: :pipeline)
+      |> Map.put(:target_refs, [ref])
+      |> Map.put(
+        :plan,
+        %Favn.Plan{
+          target_refs: [ref],
+          target_node_keys: [node_a, node_b],
+          nodes: %{
+            node_a => plan_node(ref, node_a, window_a, 0),
+            node_b => plan_node(ref, node_b, window_b, 0)
+          },
+          topo_order: [ref],
+          stages: [[ref]],
+          node_stages: [[node_a, node_b]]
+        }
+      )
+      |> RunState.transition(
+        status: :running,
+        result: %{
+          node_results: [
+            NodeResult.new(%{
+              node_key: node_a,
+              ref: ref,
+              window: window_a,
+              stage: 0,
+              status: :running,
+              started_at: ~U[2026-05-01 00:00:00Z],
+              asset_step_id: "window-a-step"
+            })
+          ]
+        }
+      )
+
+    assert :ok = Storage.put_run(run)
+
+    assert {:ok, detail} = FavnOrchestrator.get_run_detail(run.id)
+
+    assert length(detail.steps) == 2
+
+    assert Enum.map(detail.steps, & &1.asset_ref) == [
+             "MyApp.Assets.Gold.asset",
+             "MyApp.Assets.Gold.asset"
+           ]
+
+    assert Enum.map(detail.steps, & &1.window.key) == ["window:a", "window:b"]
+    assert Enum.map(detail.steps, & &1.status) == [:running, :pending]
   end
 
   test "backfill parent detail includes failed child window context" do
@@ -582,6 +639,18 @@ defmodule FavnOrchestrator.RunReadModelTest do
       topo_order: refs,
       stages: Enum.map(refs, &[&1]),
       node_stages: Enum.map(node_keys, &[&1])
+    }
+  end
+
+  defp plan_node(ref, node_key, window, stage) do
+    %{
+      ref: ref,
+      node_key: node_key,
+      window: window,
+      upstream: [],
+      downstream: [],
+      stage: stage,
+      action: :run
     }
   end
 

--- a/apps/favn_view/lib/favn_view/components/app_shell.ex
+++ b/apps/favn_view/lib/favn_view/components/app_shell.ex
@@ -28,7 +28,7 @@ defmodule FavnView.Components.AppShell do
       <IconNav.icon_nav items={@nav_items} />
 
       <div class="relative z-10 flex h-screen min-h-0 flex-col px-5 py-3 md:py-4 md:pl-32 md:pr-8 lg:pr-32">
-        <header class="mx-auto flex w-full max-w-7xl shrink-0 items-center justify-between gap-3">
+        <header class="mx-auto flex w-full max-w-[96rem] shrink-0 items-center justify-between gap-3">
           <div class="flex min-w-0 items-center gap-2">
             <IconNav.mobile_icon_nav items={@nav_items} />
             <a href={~p"/"} class="btn btn-ghost gap-2 px-2 md:hidden" aria-label="Favn home">
@@ -69,20 +69,20 @@ defmodule FavnView.Components.AppShell do
           </div>
         </header>
 
-        <main class="mx-auto flex min-h-0 w-full max-w-7xl flex-1 flex-col justify-start overflow-y-auto py-4 md:py-6">
+        <main class="mx-auto flex min-h-0 w-full max-w-[96rem] flex-1 flex-col justify-start overflow-y-auto py-4 md:py-6">
           <section
             :if={@show_header?}
             class="mb-4 flex flex-col gap-4 md:mb-5 lg:flex-row lg:items-end lg:justify-between"
           >
             <div class="min-w-0">
               <div class="flex flex-col gap-2 sm:flex-row sm:items-center md:gap-3">
-                <h1 class="truncate text-2xl font-light tracking-tight text-base-content sm:text-3xl lg:text-4xl">
+                <h1 class="truncate text-xl font-light tracking-tight text-base-content sm:text-2xl lg:text-3xl">
                   {@title}
                 </h1>
                 <span
                   :if={@status}
                   class={[
-                    "badge badge-soft favn-status-glow gap-2 px-3 py-3",
+                    "badge badge-soft favn-status-glow gap-2 px-2.5 py-2 text-xs",
                     status_badge_class(@status_tone)
                   ]}
                 >
@@ -91,12 +91,16 @@ defmodule FavnView.Components.AppShell do
                 </span>
               </div>
 
-              <p :if={@subtitle} class="mt-1.5 text-sm text-base-content/60 md:text-base">
+              <p
+                :if={@subtitle}
+                class="mt-1.5 max-w-3xl truncate text-xs text-base-content/60 md:text-sm"
+                title={@subtitle}
+              >
                 {@subtitle}
               </p>
             </div>
 
-            <dl :if={@facts != []} class="grid gap-4 text-sm sm:grid-cols-3 lg:min-w-[28rem]">
+            <dl :if={@facts != []} class="grid gap-4 text-xs sm:grid-cols-3 lg:min-w-[28rem]">
               <div
                 :for={fact <- @facts}
                 class="border-base-content/20 sm:border-l sm:pl-5 first:border-l-0 first:pl-0"

--- a/apps/favn_view/lib/favn_view/components/run_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page.ex
@@ -210,6 +210,7 @@ defmodule FavnView.Components.RunDetailPage do
       latest_event_summary: "All selected assets completed successfully.",
       current_activity: sample_current_activity(status),
       failure_summary: sample_failure_summary(status),
+      backfill_failures: [],
       asset_empty_message: sample_asset_empty_message(status),
       outputs: [],
       context: sample_context(),

--- a/apps/favn_view/lib/favn_view/components/run_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page.ex
@@ -211,6 +211,7 @@ defmodule FavnView.Components.RunDetailPage do
       current_activity: sample_current_activity(status),
       failure_summary: sample_failure_summary(status),
       backfill_failures: [],
+      backfill_failure_count: 0,
       asset_empty_message: sample_asset_empty_message(status),
       outputs: [],
       context: sample_context(),

--- a/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
+++ b/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
@@ -48,7 +48,19 @@ defmodule FavnView.Components.RunOverviewHud do
             </button>
           </div>
           <p
-            :if={@run.failure_summary.count > 0 && @run.failure_summary.total > 0}
+            :if={@run.failure_summary.kind == :backfill && @run.failure_summary.count > 0}
+            class="mt-2 font-medium text-error"
+          >
+            {@run.failure_summary.count} backfill {if(@run.failure_summary.count == 1,
+              do: "window",
+              else: "windows"
+            )} failed.
+          </p>
+          <p
+            :if={
+              @run.failure_summary.kind != :backfill && @run.failure_summary.count > 0 &&
+                @run.failure_summary.total > 0
+            }
             class="mt-2 font-medium text-error"
           >
             {@run.failure_summary.count} of {@run.failure_summary.total} assets failed.
@@ -70,7 +82,11 @@ defmodule FavnView.Components.RunOverviewHud do
             <div>
               <p class="font-medium text-error">Failed backfill window</p>
               <p class="mt-1 text-base-content/60">
-                Open the failed child run for the actionable execution context.
+                Showing {length(@run.backfill_failures)} of {@run.backfill_failure_count} failed {if(
+                  @run.backfill_failure_count == 1,
+                  do: "window",
+                  else: "windows"
+                )}. Open a child run for the actionable execution context.
               </p>
             </div>
           </div>

--- a/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
+++ b/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
@@ -14,25 +14,25 @@ defmodule FavnView.Components.RunOverviewHud do
     <GlassPanel.glass_panel
       id="run-overview-panel"
       phx-hook="FavnClipboard"
-      class="mx-auto w-full max-w-6xl p-5 sm:p-6 lg:p-7"
+      class="mx-auto w-full max-w-[96rem] p-4 sm:p-5 lg:p-6"
       data-testid="run-overview-panel"
       data-run-active={to_string(@run.active?)}
     >
-      <div class="flex flex-col gap-7">
+      <div class="flex flex-col gap-5">
         <div class="flex flex-col gap-4 lg:flex-row lg:items-center">
           <div class="min-w-[10rem]">
-            <p class="text-sm font-semibold text-base-content">Run status</p>
-            <div class={["mt-3 flex items-center gap-3", status_text_class(@run.status_tone)]}>
-              <.icon name={status_icon(@run.status_tone)} class="size-7" />
-              <p class="text-2xl font-medium tracking-tight">{@run.status}</p>
+            <p class="text-xs font-semibold text-base-content">Run status</p>
+            <div class={["mt-2 flex items-center gap-2.5", status_text_class(@run.status_tone)]}>
+              <.icon name={status_icon(@run.status_tone)} class="size-6" />
+              <p class="text-xl font-medium tracking-tight">{@run.status}</p>
             </div>
           </div>
-          <p class="text-sm text-base-content/65">{status_sentence(@run.status)}</p>
+          <p class="text-xs text-base-content/65 sm:text-sm">{status_sentence(@run.status)}</p>
         </div>
 
         <div
           :if={@run.failure_summary}
-          class="rounded-box border border-error/25 bg-error/10 p-4 text-sm text-base-content/80"
+          class="rounded-box border border-error/25 bg-error/10 p-4 text-xs text-base-content/80"
           data-testid="run-failure-summary"
         >
           <div class="flex items-start justify-between gap-3">
@@ -62,15 +62,66 @@ defmodule FavnView.Components.RunOverviewHud do
         </div>
 
         <div
+          :if={@run.backfill_failures != []}
+          class="rounded-box border border-error/30 bg-error/10 p-4 text-xs text-base-content/85 shadow-lg shadow-error/10"
+          data-testid="backfill-failure-list"
+        >
+          <div class="flex flex-col gap-2 sm:flex-row sm:items-start sm:justify-between">
+            <div>
+              <p class="font-medium text-error">Failed backfill window</p>
+              <p class="mt-1 text-base-content/60">
+                Open the failed child run for the actionable execution context.
+              </p>
+            </div>
+          </div>
+
+          <div class="mt-3 max-h-64 space-y-2 overflow-y-auto pr-1">
+            <div
+              :for={failure <- @run.backfill_failures}
+              class="rounded-box border border-error/20 bg-base-300/25 p-3"
+              data-testid="backfill-failure-row"
+            >
+              <div class="flex flex-col gap-2 lg:flex-row lg:items-start lg:justify-between">
+                <div class="min-w-0 space-y-1">
+                  <p class="font-mono text-xs font-medium text-base-content">
+                    {failure.asset_ref || "Failed child run"}
+                  </p>
+                  <p class="text-base-content/60">
+                    <span class="text-base-content/45">Window:</span> {failure.window}
+                  </p>
+                  <p :if={failure.error} class="text-error">
+                    {failure.error}
+                  </p>
+                </div>
+
+                <div class="flex shrink-0 flex-wrap items-center gap-2 text-base-content/60">
+                  <span class="badge badge-error badge-soft badge-sm">{failure.status}</span>
+                  <span :if={failure.attempt_count}>Attempt {failure.attempt_count}</span>
+                  <span :if={failure.duration != "-"}>{failure.duration}</span>
+                  <.link
+                    :if={failure.child_run_href}
+                    navigate={failure.child_run_href}
+                    class="btn btn-error btn-soft btn-xs rounded-box"
+                    data-testid="backfill-child-run-link"
+                  >
+                    Open child run
+                  </.link>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div
           :if={@run.current_activity}
-          class="rounded-box border border-info/20 bg-info/10 p-4 text-sm text-info-content/80"
+          class="rounded-box border border-info/35 bg-info/15 p-3 text-xs text-base-content/85 shadow-sm shadow-info/10"
           data-testid="run-current-activity"
         >
           {@run.current_activity}
         </div>
 
-        <div class="border-t border-base-content/10 pt-5" data-testid="run-asset-results">
-          <div class="grid grid-cols-[1fr_10rem_8rem_10rem_2rem] gap-4 px-4 pb-3 text-sm text-base-content/60 max-lg:hidden">
+        <div class="border-t border-base-content/10 pt-4" data-testid="run-asset-results">
+          <div class="grid grid-cols-[minmax(0,1fr)_8rem_6rem_9rem_1.5rem] gap-3 px-3 pb-2 text-xs text-base-content/60 max-lg:hidden">
             <span>Asset</span>
             <span>Status</span>
             <span>Duration</span>
@@ -80,13 +131,13 @@ defmodule FavnView.Components.RunOverviewHud do
 
           <div
             :if={@run.asset_results == []}
-            class="rounded-box border border-dashed border-base-content/15 p-5 text-sm text-base-content/55"
+            class="rounded-box border border-dashed border-base-content/15 p-4 text-xs text-base-content/55"
             data-testid="run-asset-results-empty"
           >
             {@run.asset_empty_message}
           </div>
 
-          <div :if={@run.asset_results != []} class="space-y-2">
+          <div :if={@run.asset_results != []} class="space-y-1.5">
             <.asset_result_row :for={asset <- @run.asset_results} asset={asset} run_id={@run.id} />
           </div>
         </div>
@@ -154,15 +205,15 @@ defmodule FavnView.Components.RunOverviewHud do
 
   def asset_result_row_content(assigns) do
     ~H"""
-    <div class="flex min-w-0 items-center gap-3">
+    <div class="flex min-w-0 items-center gap-2.5">
       <span class={[
-        "flex size-9 shrink-0 items-center justify-center rounded-box",
+        "flex size-8 shrink-0 items-center justify-center rounded-box",
         icon_shell_class(@asset.status_tone)
       ]}>
-        <.icon name="hero-table-cells" class="size-5" />
+        <.icon name="hero-table-cells" class="size-4" />
       </span>
       <div class="min-w-0">
-        <p class="truncate text-sm font-medium text-base-content">{@asset.display_name}</p>
+        <p class="truncate text-xs font-medium text-base-content">{@asset.display_name}</p>
         <p class="truncate font-mono text-xs text-base-content/45">{@asset.asset_ref}</p>
         <p :if={@asset.secondary} class="text-xs text-base-content/50">{@asset.secondary}</p>
         <p :if={@asset.explanation} class="mt-1 text-xs text-base-content/60">{@asset.explanation}</p>
@@ -170,7 +221,7 @@ defmodule FavnView.Components.RunOverviewHud do
       </div>
     </div>
 
-    <div class="flex items-center gap-2 text-sm font-medium">
+    <div class="flex items-center gap-2 text-xs font-medium">
       <.icon
         name={status_icon(@asset.status_tone)}
         class={["size-4", status_text_class(@asset.status_tone)]}
@@ -178,12 +229,12 @@ defmodule FavnView.Components.RunOverviewHud do
       <span class={status_text_class(@asset.status_tone)}>{@asset.status}</span>
     </div>
 
-    <p class="text-sm text-base-content/85">{@asset.duration}</p>
-    <p class="text-sm text-base-content/70">{@asset.started_at}</p>
+    <p class="text-xs text-base-content/85">{@asset.duration}</p>
+    <p class="text-xs text-base-content/70">{@asset.started_at}</p>
     <.icon
       :if={@asset.inspectable?}
       name="hero-chevron-right"
-      class="size-5 text-base-content/60 transition group-hover:text-primary"
+      class="size-4 text-base-content/60 transition group-hover:text-primary"
     />
     """
   end
@@ -220,14 +271,14 @@ defmodule FavnView.Components.RunOverviewHud do
 
   defp row_class(asset, :link) do
     [
-      "group grid gap-3 rounded-box border bg-base-content/[0.025] p-4 transition hover:border-primary/35 hover:bg-primary/[0.045] hover:shadow-lg hover:shadow-primary/10 lg:grid-cols-[1fr_10rem_8rem_10rem_2rem] lg:items-center no-underline",
+      "group grid gap-2.5 rounded-box border bg-base-content/[0.025] p-3 transition hover:border-primary/35 hover:bg-primary/[0.045] hover:shadow-lg hover:shadow-primary/10 lg:grid-cols-[minmax(0,1fr)_8rem_6rem_9rem_1.5rem] lg:items-center no-underline",
       row_border_class(asset.status_tone)
     ]
   end
 
   defp row_class(asset, :static) do
     [
-      "group grid gap-3 rounded-box border bg-base-content/[0.025] p-4 transition lg:grid-cols-[1fr_10rem_8rem_10rem_2rem] lg:items-center",
+      "group grid gap-2.5 rounded-box border bg-base-content/[0.025] p-3 transition lg:grid-cols-[minmax(0,1fr)_8rem_6rem_9rem_1.5rem] lg:items-center",
       row_border_class(asset.status_tone)
     ]
   end

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -99,7 +99,11 @@ defmodule FavnView.RunDetailLive do
     status = summary.status
     steps = Enum.map(Map.get(detail, :steps, []), &step_from_public/1)
     events = Enum.map(Map.get(detail, :events, []), &event_from_public/1)
-    failure_summary = failure_summary(status, steps, events)
+
+    backfill_failures =
+      Enum.map(Map.get(detail, :backfill_failures, []), &backfill_failure_from_public/1)
+
+    failure_summary = failure_summary(status, steps, events, backfill_failures)
 
     %{
       found?: true,
@@ -123,6 +127,7 @@ defmodule FavnView.RunDetailLive do
       latest_event_summary: latest_event_summary(events),
       current_activity: current_activity(status, steps, events),
       failure_summary: failure_summary,
+      backfill_failures: backfill_failures,
       asset_empty_message: asset_empty_message(status, failure_summary),
       outputs: outputs(steps),
       context: context_items(summary, target, window),
@@ -226,6 +231,23 @@ defmodule FavnView.RunDetailLive do
     }
   end
 
+  defp backfill_failure_from_public(failure) do
+    window = Map.get(failure, :window) || %{}
+    child_run_id = Map.get(failure, :child_run_id)
+
+    %{
+      child_run_id: child_run_id,
+      child_run_href: child_run_id && "/runs/#{child_run_id}",
+      status: LogsViewModel.status_label(Map.get(failure, :status)),
+      status_tone: LogsViewModel.status_tone(Map.get(failure, :status)),
+      asset_ref: Map.get(failure, :asset_ref),
+      error: error_summary(Map.get(failure, :error)),
+      window: window_label(window) || "Unknown window",
+      attempt_count: Map.get(failure, :attempt_count),
+      duration: LogsViewModel.duration_ms_label(Map.get(failure, :duration_ms))
+    }
+  end
+
   defp step_secondary(step) do
     [window_label(step.window), step.stage && "Stage #{step.stage}"]
     |> Enum.reject(&is_nil/1)
@@ -237,7 +259,13 @@ defmodule FavnView.RunDetailLive do
   end
 
   defp target_label(%{target_refs: refs}) when is_list(refs) and refs != [] do
-    refs |> Enum.map(&LogsViewModel.ref_label/1) |> Enum.join(", ")
+    case refs do
+      [single_ref] ->
+        LogsViewModel.ref_label(single_ref)
+
+      refs ->
+        "#{length(refs)} selected assets"
+    end
   end
 
   defp target_label(%{asset_ref: ref}), do: LogsViewModel.ref_label(ref)
@@ -276,7 +304,18 @@ defmodule FavnView.RunDetailLive do
     end
   end
 
-  defp failure_summary(status, steps, events) when status in [:partial, :error, :timed_out] do
+  defp failure_summary(status, _steps, _events, [failure | _rest])
+       when status in [:partial, :error, :timed_out] do
+    %{
+      count: 1,
+      total: 1,
+      asset: failure.asset_ref,
+      error: failure.error
+    }
+  end
+
+  defp failure_summary(status, steps, events, _backfill_failures)
+       when status in [:partial, :error, :timed_out] do
     failed = Enum.filter(steps, &(&1.status_tone == :error))
     first = List.first(failed)
     latest_error = Enum.find(Enum.reverse(events), &(&1.status_tone == :error))
@@ -289,16 +328,19 @@ defmodule FavnView.RunDetailLive do
     }
   end
 
-  defp failure_summary(_status, _steps, _events), do: nil
+  defp failure_summary(_status, _steps, _events, _backfill_failures), do: nil
 
   defp current_activity(status, steps, events) when status in [:pending, :running] do
     running = Enum.find(steps, &(&1.status == "Running"))
     latest = List.last(events)
+    latest_asset = latest && meaningful_activity(latest.asset)
+    latest_summary = latest && meaningful_activity(latest.summary)
 
     cond do
       running -> "Currently executing #{running.asset_ref}"
-      latest && latest.asset -> "Latest event: #{latest.asset}"
-      latest -> "Latest event: #{latest.summary}"
+      latest_asset -> "Latest event: #{latest_asset}"
+      latest_summary -> "Latest event: #{latest_summary}"
+      latest -> nil
       true -> "Waiting for first execution event..."
     end
   end
@@ -338,6 +380,18 @@ defmodule FavnView.RunDetailLive do
   end
 
   defp latest_event_sequence(_run, fallback), do: fallback
+
+  defp meaningful_activity(value) when is_binary(value) do
+    value = String.trim(value)
+
+    if value in ["", "nil", "Asset nil", "Unknown"] do
+      nil
+    else
+      value
+    end
+  end
+
+  defp meaningful_activity(_value), do: nil
 
   defp active_status?(status), do: status in @active_statuses
   defp subtitle(parts), do: parts |> Enum.reject(&is_nil/1) |> Enum.join(" · ")

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -103,7 +103,10 @@ defmodule FavnView.RunDetailLive do
     backfill_failures =
       Enum.map(Map.get(detail, :backfill_failures, []), &backfill_failure_from_public/1)
 
-    failure_summary = failure_summary(status, steps, events, backfill_failures)
+    backfill_failure_count = Map.get(detail, :backfill_failure_count, length(backfill_failures))
+
+    failure_summary =
+      failure_summary(status, steps, events, backfill_failures, backfill_failure_count)
 
     %{
       found?: true,
@@ -128,6 +131,7 @@ defmodule FavnView.RunDetailLive do
       current_activity: current_activity(status, steps, events),
       failure_summary: failure_summary,
       backfill_failures: backfill_failures,
+      backfill_failure_count: backfill_failure_count,
       asset_empty_message: asset_empty_message(status, failure_summary),
       outputs: outputs(steps),
       context: context_items(summary, target, window),
@@ -304,23 +308,25 @@ defmodule FavnView.RunDetailLive do
     end
   end
 
-  defp failure_summary(status, _steps, _events, [failure | _rest])
+  defp failure_summary(status, _steps, _events, [failure | _rest], backfill_failure_count)
        when status in [:partial, :error, :timed_out] do
     %{
-      count: 1,
-      total: 1,
+      kind: :backfill,
+      count: backfill_failure_count,
+      total: backfill_failure_count,
       asset: failure.asset_ref,
       error: failure.error
     }
   end
 
-  defp failure_summary(status, steps, events, _backfill_failures)
+  defp failure_summary(status, steps, events, _backfill_failures, _backfill_failure_count)
        when status in [:partial, :error, :timed_out] do
     failed = Enum.filter(steps, &(&1.status_tone == :error))
     first = List.first(failed)
     latest_error = Enum.find(Enum.reverse(events), &(&1.status_tone == :error))
 
     %{
+      kind: :assets,
       count: length(failed),
       total: length(steps),
       asset: first && first.asset_ref,
@@ -328,7 +334,8 @@ defmodule FavnView.RunDetailLive do
     }
   end
 
-  defp failure_summary(_status, _steps, _events, _backfill_failures), do: nil
+  defp failure_summary(_status, _steps, _events, _backfill_failures, _backfill_failure_count),
+    do: nil
 
   defp current_activity(status, steps, events) when status in [:pending, :running] do
     running = Enum.find(steps, &(&1.status == "Running"))

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -16,6 +16,7 @@ defmodule FavnView.PageLiveTest do
   alias FavnOrchestrator.Auth
   alias FavnOrchestrator.Auth.Store, as: AuthStore
   alias FavnOrchestrator.AssetFreshnessState
+  alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.RunEvent
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
@@ -754,6 +755,25 @@ defmodule FavnView.PageLiveTest do
            )
   end
 
+  test "run detail hides nil latest event activity", %{conn: conn} do
+    assert :ok =
+             Storage.append_run_event("run_empty_running", %{
+               run_id: "run_empty_running",
+               sequence: 3,
+               event_type: :run_started,
+               occurred_at: DateTime.utc_now(),
+               status: nil,
+               asset_ref: "nil",
+               data: %{}
+             })
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
+
+    refute has_element?(view, ~s([data-testid="run-current-activity"]))
+    refute render(view) =~ "Latest event: nil"
+    refute render(view) =~ "Asset nil"
+  end
+
   test "run detail derives active asset rows from step events before results persist", %{
     conn: conn
   } do
@@ -1051,6 +1071,104 @@ defmodule FavnView.PageLiveTest do
 
     assert has_element?(view, ~s([data-testid="run-failure-summary"]), "Warehouse timeout")
     refute has_element?(view, ~s([data-testid="run-asset-result-row"]))
+  end
+
+  test "backfill parent surfaces failed child window context", %{conn: conn} do
+    parent_id = "run_backfill_parent_failed_child"
+    child_id = "run_backfill_child_failed_asset"
+    failed_ref = {__MODULE__.Assets, :inventory_by_day}
+    started_at = ~U[2026-05-01 00:00:00Z]
+    finished_at = DateTime.add(started_at, 2, :second)
+    window_key = "day:2026-05-01"
+
+    parent =
+      RunState.new(
+        id: parent_id,
+        manifest_version_id: "mv_view_assets",
+        manifest_content_hash: "hash_view_assets",
+        asset_ref: failed_ref,
+        target_refs: [failed_ref],
+        submit_kind: :backfill_pipeline,
+        trigger: %{kind: :backfill, pipeline_module: __MODULE__.Pipelines.DailyOrders},
+        metadata: %{pipeline_submit_ref: __MODULE__.Pipelines.DailyOrders}
+      )
+      |> RunState.transition(status: :error, error: :failed, result: %{status: :error})
+
+    child =
+      RunState.new(
+        id: child_id,
+        manifest_version_id: "mv_view_assets",
+        manifest_content_hash: "hash_view_assets",
+        asset_ref: failed_ref,
+        target_refs: [failed_ref],
+        submit_kind: :pipeline,
+        parent_run_id: parent_id,
+        root_run_id: parent_id,
+        lineage_depth: 1,
+        trigger: %{
+          kind: :backfill,
+          backfill_run_id: parent_id,
+          pipeline_module: __MODULE__.Pipelines.DailyOrders,
+          window_key: window_key
+        },
+        metadata: %{pipeline_submit_ref: __MODULE__.Pipelines.DailyOrders}
+      )
+      |> RunState.transition(
+        status: :error,
+        error: :failed,
+        result: %{
+          node_results: [
+            NodeResult.new(%{
+              node_key: {failed_ref, window_key},
+              ref: failed_ref,
+              stage: 0,
+              status: :error,
+              started_at: started_at,
+              finished_at: finished_at,
+              duration_ms: 2_000,
+              error: %{message: "DuckDB ADBC connection bootstrap failed at attach_mart"},
+              asset_step_id: "failed-inventory-step"
+            })
+          ]
+        }
+      )
+
+    {:ok, window} =
+      BackfillWindow.new(%{
+        backfill_run_id: parent_id,
+        child_run_id: child_id,
+        latest_attempt_run_id: child_id,
+        pipeline_module: __MODULE__.Pipelines.DailyOrders,
+        manifest_version_id: "mv_view_assets",
+        window_kind: :day,
+        window_start_at: started_at,
+        window_end_at: DateTime.add(started_at, 1, :day),
+        timezone: "Etc/UTC",
+        window_key: window_key,
+        status: :error,
+        attempt_count: 1,
+        last_error: :failed,
+        started_at: started_at,
+        finished_at: finished_at,
+        updated_at: finished_at
+      })
+
+    assert :ok = Storage.put_run(parent)
+    assert :ok = Storage.put_run(child)
+    assert :ok = Storage.put_backfill_window(window)
+
+    {:ok, view, _html} = live(conn, ~p"/runs/#{parent_id}")
+
+    assert has_element?(view, ~s([data-testid="backfill-failure-list"]), "Failed backfill window")
+    assert has_element?(view, ~s([data-testid="backfill-failure-row"]), "inventory_by_day")
+
+    assert has_element?(
+             view,
+             ~s([data-testid="backfill-failure-row"]),
+             "DuckDB ADBC connection bootstrap failed at attach_mart"
+           )
+
+    assert has_element?(view, ~s(a[href="/runs/#{child_id}"]), "Open child run")
   end
 
   test "run detail mode rail changes to events mode", %{conn: conn} do

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -1159,7 +1159,9 @@ defmodule FavnView.PageLiveTest do
 
     {:ok, view, _html} = live(conn, ~p"/runs/#{parent_id}")
 
+    assert has_element?(view, ~s([data-testid="run-failure-summary"]), "1 backfill window failed")
     assert has_element?(view, ~s([data-testid="backfill-failure-list"]), "Failed backfill window")
+    assert has_element?(view, ~s([data-testid="backfill-failure-list"]), "Showing 1 of 1")
     assert has_element?(view, ~s([data-testid="backfill-failure-row"]), "inventory_by_day")
 
     assert has_element?(


### PR DESCRIPTION
## Summary
- Keep pipeline run details active until all expected step results are visible, preventing asset rows from disappearing during terminal-result gaps.
- Surface failed backfill child/window context on parent run pages, including failed asset, window, actionable error, and child-run link.
- Tighten run detail layout density and avoid rendering nil/latest-event noise.

## Verification
- mix format
- mix compile --warnings-as-errors
- MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/run_read_model_test.exs
- MIX_ENV=test mix do --app favn_view cmd mix test test/favn_view/page_live_test.exs