### PR TITLE
Fix asset timeline and log visibility

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -2150,6 +2150,12 @@ defmodule FavnOrchestrator do
   defp refresh_status_from_latest(_freshness, %{status: status})
        when status in [:running, :pending], do: :running
 
+  defp refresh_status_from_latest(_freshness, %{status: :ok}), do: :fresh
+
+  defp refresh_status_from_latest(_freshness, %{status: status})
+       when status in [:partial, :error, :cancelled, :timed_out],
+       do: :failed
+
   defp refresh_status_from_latest(_freshness, _run), do: :unknown
 
   defp default_timeline_run_config(source, kind, value, timezone) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/transition_writer.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/transition_writer.ex
@@ -10,6 +10,7 @@ defmodule FavnOrchestrator.TransitionWriter do
   alias FavnOrchestrator.Projector
   alias FavnOrchestrator.RunEvent
   alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage.JsonSafe
   alias FavnOrchestrator.Storage
 
   require Logger
@@ -112,8 +113,15 @@ defmodule FavnOrchestrator.TransitionWriter do
       event_type: event.event_type,
       status: event.status,
       stage: event.stage,
-      data: event.data || %{}
+      attempt: data_field(event, :attempt),
+      max_attempts: data_field(event, :max_attempts),
+      freshness_key: data_field(event, :freshness_key),
+      result_status: data_field(event, :result_status),
+      error: JsonSafe.error(data_field(event, :error)),
+      reason: JsonSafe.error(data_field(event, :reason))
     }
+    |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+    |> Map.new()
   end
 
   defp data_field(%RunEvent{data: data}, key) when is_map(data) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/transition_writer.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/transition_writer.ex
@@ -5,6 +5,7 @@ defmodule FavnOrchestrator.TransitionWriter do
 
   alias FavnOrchestrator.Backfill
   alias FavnOrchestrator.Events
+  alias FavnOrchestrator.LogWriter
   alias FavnOrchestrator.OperationalEvents
   alias FavnOrchestrator.Projector
   alias FavnOrchestrator.RunEvent
@@ -29,6 +30,7 @@ defmodule FavnOrchestrator.TransitionWriter do
 
         Events.broadcast_run_event(event)
         project_derived_state(run_state, event_type, data)
+        safe_emit_transition_log(event)
         :ok
 
       :idempotent ->
@@ -54,6 +56,71 @@ defmodule FavnOrchestrator.TransitionWriter do
     safe_project(Backfill.Projector, run_state, event_type, data)
     safe_project(Backfill.CoverageProjector, run_state, event_type, data)
   end
+
+  defp safe_emit_transition_log(%RunEvent{entity: :step} = event) do
+    entry = %{
+      run_id: event.run_id,
+      asset_step_id: data_field(event, :asset_step_id),
+      node_key: data_field(event, :node_key),
+      asset_ref: event.asset_ref,
+      runner_execution_id: data_field(event, :runner_execution_id),
+      attempt: data_field(event, :attempt),
+      occurred_at: event.occurred_at,
+      level: transition_log_level(event.event_type),
+      source: :orchestrator,
+      message: transition_log_message(event.event_type),
+      metadata: transition_log_metadata(event),
+      producer_id: "orchestrator:#{event.run_id}",
+      producer_sequence: event.sequence
+    }
+
+    case LogWriter.write(entry) do
+      {:ok, _entries} -> :ok
+      {:error, reason} -> Logger.warning("transition log write failed: #{inspect(reason)}")
+    end
+  rescue
+    error -> Logger.warning("transition log write raised: #{Exception.message(error)}")
+  catch
+    kind, reason -> Logger.warning("transition log write exited: #{inspect({kind, reason})}")
+  end
+
+  defp safe_emit_transition_log(%RunEvent{}), do: :ok
+
+  defp transition_log_level(event_type)
+       when event_type in [:step_failed, :step_timed_out, :step_cancelled, :step_blocked],
+       do: :error
+
+  defp transition_log_level(:step_retry_scheduled), do: :warning
+  defp transition_log_level(_event_type), do: :info
+
+  defp transition_log_message(:step_started), do: "asset execution started"
+  defp transition_log_message(:step_finished), do: "asset execution finished"
+  defp transition_log_message(:step_failed), do: "asset execution failed"
+  defp transition_log_message(:step_timed_out), do: "asset execution timed out"
+  defp transition_log_message(:step_cancelled), do: "asset execution cancelled"
+  defp transition_log_message(:step_retry_scheduled), do: "asset execution retry scheduled"
+  defp transition_log_message(:step_skipped_fresh), do: "asset skipped because it is fresh"
+  defp transition_log_message(:step_blocked), do: "asset execution blocked"
+
+  defp transition_log_message(event_type) when is_atom(event_type),
+    do: event_type |> Atom.to_string() |> String.replace("_", " ")
+
+  defp transition_log_message(event_type), do: to_string(event_type)
+
+  defp transition_log_metadata(%RunEvent{} = event) do
+    %{
+      event_type: event.event_type,
+      status: event.status,
+      stage: event.stage,
+      data: event.data || %{}
+    }
+  end
+
+  defp data_field(%RunEvent{data: data}, key) when is_map(data) do
+    Map.get(data, key) || Map.get(data, Atom.to_string(key))
+  end
+
+  defp data_field(%RunEvent{}, _key), do: nil
 
   defp safe_project(projector, %RunState{} = run_state, event_type, data) do
     case projector.project_transition(run_state, event_type, data) do

--- a/apps/favn_orchestrator/test/logs_test.exs
+++ b/apps/favn_orchestrator/test/logs_test.exs
@@ -7,6 +7,7 @@ defmodule FavnOrchestrator.LogsTest do
   alias FavnOrchestrator.RunnerLogBridge
   alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.Adapter.Memory
+  alias FavnOrchestrator.TransitionWriter
 
   defmodule RunnerClientLogStub do
     def subscribe_execution_logs(execution_id, subscriber, opts) do
@@ -275,6 +276,63 @@ defmodule FavnOrchestrator.LogsTest do
     RunnerLogBridge.stop(bridge, RunnerClientLogStub, "exec_bad_log", runner_opts)
   end
 
+  test "step transition logs are durable and idempotent" do
+    run = transition_run("run_transition_log_once", :running)
+    data = transition_data("step_once", :step_started)
+
+    assert :ok = TransitionWriter.persist_transition(run, :step_started, data)
+    assert :ok = TransitionWriter.persist_transition(run, :step_started, data)
+
+    assert {:ok, page} = FavnOrchestrator.list_logs(%Filter{run_id: run.id})
+    assert [%Entry{} = entry] = page.items
+    assert entry.message == "asset execution started"
+    assert entry.producer_id == "orchestrator:#{run.id}"
+    assert entry.producer_sequence == run.event_seq
+  end
+
+  test "step transition logs use lifecycle levels and sanitized metadata" do
+    failed = transition_run("run_transition_log_failed", :error)
+    retrying = transition_run("run_transition_log_retrying", :running)
+
+    assert :ok =
+             TransitionWriter.persist_transition(
+               failed,
+               :step_failed,
+               transition_data("step_failed", :step_failed,
+                 error: %{kind: :error, reason: {:db_password, "secret"}},
+                 reason: {:db_password, "secret"},
+                 result_status: :error
+               )
+             )
+
+    assert :ok =
+             TransitionWriter.persist_transition(
+               retrying,
+               :step_retry_scheduled,
+               transition_data("step_retrying", :step_retry_scheduled,
+                 reason: :retryable,
+                 attempt: 2,
+                 max_attempts: 3
+               )
+             )
+
+    assert {:ok, failed_page} = FavnOrchestrator.list_logs(%Filter{run_id: failed.id})
+    assert [%Entry{} = failed_entry] = failed_page.items
+    assert failed_entry.level == :error
+    assert failed_entry.message == "asset execution failed"
+    assert failed_entry.metadata["event_type"] == "step_failed"
+    assert failed_entry.metadata["result_status"] == "error"
+    assert failed_entry.metadata["error"]["redacted"] == true
+    refute Map.has_key?(failed_entry.metadata, "data")
+
+    assert {:ok, retry_page} = FavnOrchestrator.list_logs(%Filter{run_id: retrying.id})
+    assert [%Entry{} = retry_entry] = retry_page.items
+    assert retry_entry.level == :warning
+    assert retry_entry.message == "asset execution retry scheduled"
+    assert retry_entry.metadata["attempt"] == 2
+    assert retry_entry.metadata["max_attempts"] == 3
+  end
+
   test "live run subscriptions deliver only matching run entries" do
     assert {:ok, subscription} = FavnOrchestrator.subscribe_logs(%Filter{run_id: "run_live_a"})
 
@@ -391,6 +449,36 @@ defmodule FavnOrchestrator.LogsTest do
     |> :erlang.term_to_binary()
     |> Base.url_encode64(padding: false)
     |> String.replace(~r/[^a-zA-Z0-9_-]+/, "-")
+  end
+
+  defp transition_run(run_id, status) do
+    RunState.new(
+      id: run_id,
+      manifest_version_id: "manifest_logs_test",
+      manifest_content_hash: "hash_logs_test",
+      asset_ref: {__MODULE__.TransitionAsset, :asset},
+      target_refs: [{__MODULE__.TransitionAsset, :asset}]
+    )
+    |> RunState.transition(status: status)
+  end
+
+  defp transition_data(asset_step_id, event_type, opts \\ []) do
+    asset_ref = {__MODULE__.TransitionAsset, :asset}
+
+    %{
+      asset_ref: asset_ref,
+      asset_step_id: asset_step_id,
+      node_key: {asset_ref, nil},
+      stage: 0,
+      attempt: Keyword.get(opts, :attempt, 1),
+      max_attempts: Keyword.get(opts, :max_attempts, 1),
+      event_type: event_type,
+      freshness_key: Keyword.get(opts, :freshness_key, Favn.Freshness.Key.latest()),
+      result_status: Keyword.get(opts, :result_status),
+      error: Keyword.get(opts, :error),
+      reason: Keyword.get(opts, :reason),
+      unsafe_extra: %{credentials: "secret"}
+    }
   end
 
   defp restore_env(app, key, nil), do: Application.delete_env(app, key)

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -395,6 +395,58 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert length(refresh_run.plan.target_node_keys) == 2
   end
 
+  test "refresh timeline marks latest successful run without latest freshness state" do
+    ref = {MyApp.ReportingBaseline, :asset}
+    now = ~U[2026-05-19 12:00:00Z]
+    {:ok, period} = Favn.TimePeriod.current(:month, now, "Etc/UTC")
+    window_key = Favn.Window.Key.new!(:month, period.start_at, "Etc/UTC")
+
+    manifest = %Manifest{
+      assets: [
+        freshness_asset(
+          ref,
+          Favn.Freshness.Policy.from_value!(window_success: true),
+          [],
+          WindowSpec.new!(:month)
+        )
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: "mv_refresh_marker")
+    assert :ok = ManifestStore.register_manifest(version)
+    assert :ok = ManifestStore.set_active_manifest("mv_refresh_marker")
+
+    assert :ok =
+             Storage.put_run(
+               run_state("run_reporting_baseline", ref, :ok, now, "mv_refresh_marker")
+             )
+
+    assert :ok =
+             Storage.put_asset_freshness_state(
+               freshness_state(ref, "reporting:v1", now,
+                 run_id: "run_reporting_baseline",
+                 freshness_key: Favn.Freshness.Key.window!(window_key),
+                 node_key: {ref, window_key},
+                 manifest_version_id: "mv_refresh_marker"
+               )
+             )
+
+    assert {:ok, detail} =
+             FavnOrchestrator.active_asset_detail("asset:Elixir.MyApp.ReportingBaseline:asset",
+               now: now
+             )
+
+    assert detail.freshness.state == :fresh
+
+    assert data_window = Enum.find(detail.data_coverage_timeline, &(&1.value == "2026-05"))
+    assert data_window.status == :covered
+    assert data_window.latest_run_id == "run_reporting_baseline"
+
+    assert refresh_window = Enum.find(detail.refresh_timeline, &(&1.value == "2026-05-19"))
+    assert refresh_window.status == :fresh
+    assert refresh_window.latest_run_id == "run_reporting_baseline"
+  end
+
   test "hourly asset detail timeline uses hours without collapsing same-day freshness" do
     window_spec = WindowSpec.new!(:hour, required: true)
 

--- a/apps/favn_orchestrator/test/run_manager_test.exs
+++ b/apps/favn_orchestrator/test/run_manager_test.exs
@@ -962,7 +962,11 @@ defmodule FavnOrchestrator.RunManagerTest do
     assert run.status == :ok
 
     assert {:ok, page} = FavnOrchestrator.list_logs(%Favn.Log.Filter{run_id: run_id})
-    assert page.items == []
+
+    assert Enum.map(page.items, & &1.message) == [
+             "asset execution started",
+             "asset execution finished"
+           ]
   end
 
   test "accepted success transitions broadcast on both run and global topics in storage order" do

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -17,6 +17,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   alias FavnOrchestrator.Storage.Backfill.BackfillWindowCodec
   alias FavnOrchestrator.Storage.Backfill.CoverageBaselineCodec
   alias FavnOrchestrator.Storage.Freshness.AssetFreshnessStateCodec
+  alias FavnOrchestrator.Storage.JsonSafe
   alias FavnOrchestrator.Storage.LogEntryCodec
   alias FavnOrchestrator.Storage.ManifestCodec
   alias FavnOrchestrator.Storage.RunEventCodec
@@ -1313,7 +1314,7 @@ defmodule Favn.Storage.Adapter.Postgres do
         optional_atom_to_string(entry.source),
         optional_atom_to_string(entry.stream),
         entry.message,
-        Jason.encode!(entry.metadata || %{}),
+        Jason.encode!(JsonSafe.data(entry.metadata || %{})),
         encode_log_entry(entry),
         entry.truncated == true,
         now

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -21,6 +21,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   alias FavnOrchestrator.Storage.IdempotencyResponseCodec
   alias FavnOrchestrator.Storage.LogEntryCodec
   alias FavnOrchestrator.Storage.ManifestCodec
+  alias FavnOrchestrator.Storage.JsonSafe
   alias FavnOrchestrator.Storage.RunEventCodec
   alias FavnOrchestrator.Storage.RunSnapshotCodec
   alias FavnOrchestrator.Storage.RunStateCodec
@@ -1862,7 +1863,7 @@ defmodule Favn.Storage.Adapter.SQLite do
         encode_optional_atom(entry.source),
         encode_optional_atom(entry.stream),
         entry.message,
-        Jason.encode!(entry.metadata || %{}),
+        Jason.encode!(JsonSafe.data(entry.metadata || %{})),
         encode_log_entry(entry),
         entry.truncated == true,
         now

--- a/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
@@ -123,7 +123,11 @@ defmodule Favn.SQLiteStorageTest do
         source: :runner,
         stream: :stdout,
         message: "line one\nline two",
-        metadata: %{password: "secret", keep: "visible"}
+        metadata: %{
+          password: "secret",
+          keep: "visible",
+          node_key: {{Favn.SQLiteStorageTest, :sample_asset}, nil}
+        }
       })
 
     second =
@@ -155,6 +159,12 @@ defmodule Favn.SQLiteStorageTest do
              )
 
     assert Jason.decode!(metadata_blob)["password"] == "[REDACTED]"
+
+    assert Jason.decode!(metadata_blob)["node_key"] == [
+             %{"module" => "Elixir.Favn.SQLiteStorageTest", "name" => "sample_asset"},
+             nil
+           ]
+
     assert Jason.decode!(log_blob)["metadata"]["password"] == "[REDACTED]"
     refute metadata_blob =~ "secret"
     refute log_blob =~ "secret"

--- a/apps/favn_view/lib/favn_view/components/log_viewer.ex
+++ b/apps/favn_view/lib/favn_view/components/log_viewer.ex
@@ -317,7 +317,7 @@ defmodule FavnView.Components.LogViewer do
   def log_row(assigns) do
     ~H"""
     <article
-      class="grid gap-2 text-slate-100/90 sm:grid-cols-[6.5rem_4.5rem_13rem_minmax(0,1fr)]"
+      class="grid gap-2 text-slate-100/90 sm:grid-cols-[9.5rem_4.5rem_13rem_minmax(0,1fr)]"
       data-testid="log-row"
       title={sequence_title(@log)}
     >

--- a/apps/favn_view/lib/favn_view/logs_view_model.ex
+++ b/apps/favn_view/lib/favn_view/logs_view_model.ex
@@ -165,8 +165,8 @@ defmodule FavnView.LogsViewModel do
       {Map.get(entry, :producer_id), Map.get(entry, :producer_sequence)}
   end
 
-  defp time_label(%DateTime{} = value), do: Calendar.strftime(value, "%H:%M:%S")
-  defp time_label(_value), do: "--:--:--"
+  defp time_label(%DateTime{} = value), do: Calendar.strftime(value, "%b %-d %H:%M:%S")
+  defp time_label(_value), do: "--- -- --:--:--"
 
   defp source_label(source), do: source |> normalize_atom() |> String.replace("_", ":")
   defp normalize_atom(value) when is_atom(value), do: Atom.to_string(value)

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -1209,13 +1209,14 @@ defmodule FavnView.PageLiveTest do
   end
 
   test "/logs renders the global log viewer", %{conn: conn} do
-    seed_log!("global boot", source: :system)
+    seed_log!("global boot", source: :system, occurred_at: ~U[2026-05-19 19:24:56Z])
 
     {:ok, view, html} = live(conn, ~p"/logs")
 
     assert html =~ "Live system and run logs"
     assert has_element?(view, ~s([data-testid="log-viewer"][data-log-scope="global"]))
     assert has_element?(view, ~s([data-testid="log-row"]), "global boot")
+    assert has_element?(view, ~s([data-testid="log-row"]), "May 19 19:24:56")
   end
 
   test "/logs loads newest entries when more than one backend page exists", %{conn: conn} do


### PR DESCRIPTION
## Summary
- Mark refresh timeline windows fresh/failed from latest run status when freshness state is window-scoped.
- Persist step lifecycle logs from orchestrator transitions and JSON-safe log metadata for SQLite/Postgres.
- Show date plus time in log rows.

## Verification
- mix format
- mix compile --warnings-as-errors
- mix test