### PR TITLE
Harden backfill run inspection UI

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -1312,6 +1312,16 @@ defmodule FavnOrchestrator do
   end
 
   @doc """
+  Lists persisted events for an execution group, including child/window runs.
+  """
+  @spec list_execution_group_events(run_id(), keyword()) ::
+          {:ok, [RunEvent.t()]} | {:error, term()}
+  def list_execution_group_events(group_id, filters \\ [])
+      when is_binary(group_id) and is_list(filters) do
+    RunReadModel.list_execution_group_events(group_id, filters)
+  end
+
+  @doc """
   Returns public log-page context for one asset step in a run.
   """
   @spec get_asset_step_log_context(run_id(), String.t()) ::

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -1011,6 +1011,8 @@ defmodule FavnOrchestrator.RunReadModel do
     persisted_steps
     |> merge_event_steps(event_steps, run, settling?)
     |> append_waiting_steps(run, event_steps, settling?)
+    |> normalize_step_timings()
+    |> normalize_active_step_statuses(run)
     |> mark_cascade_failures(events)
     |> Enum.sort_by(&{&1.stage || 999_999, &1.asset_ref})
   end
@@ -1253,6 +1255,7 @@ defmodule FavnOrchestrator.RunReadModel do
         |> Enum.find(&step_event_type?(&1, "step_started"))
         |> then(&(&1 && &1.occurred_at)),
       finished_at: event_step_finished_at(latest, events),
+      sequence: latest.sequence,
       attempt: Map.get(data, :attempt) || Map.get(data, "attempt"),
       error: Map.get(data, :error) || Map.get(data, "error"),
       output: nil,
@@ -1260,6 +1263,71 @@ defmodule FavnOrchestrator.RunReadModel do
       failure_role: nil,
       root_failure_asset_ref: nil
     }
+  end
+
+  defp normalize_step_timings(steps) do
+    Enum.map(steps, fn step ->
+      started_at = derived_step_started_at(step) || step.started_at
+      duration_ms = step.duration_ms || duration_ms(started_at, step.finished_at)
+
+      %{step | started_at: started_at, duration_ms: duration_ms}
+    end)
+  end
+
+  defp derived_step_started_at(%{
+         status: status,
+         finished_at: %DateTime{} = finished_at,
+         duration_ms: duration_ms
+       })
+       when is_integer(duration_ms) and duration_ms >= 0 do
+    if terminal_status?(status),
+      do: DateTime.add(finished_at, -duration_ms, :millisecond),
+      else: nil
+  end
+
+  defp derived_step_started_at(_step), do: nil
+
+  defp normalize_active_step_statuses(steps, %RunState{} = run) do
+    max_concurrency = run_max_concurrency(run)
+    running_steps = Enum.filter(steps, &submitted_running_step?/1)
+
+    if length(running_steps) > max_concurrency do
+      running_ids =
+        running_steps
+        |> Enum.sort_by(&submitted_step_sort_key/1)
+        |> Enum.take(max_concurrency)
+        |> MapSet.new(& &1.id)
+
+      Enum.map(steps, fn step ->
+        if submitted_running_step?(step) and not MapSet.member?(running_ids, step.id) do
+          %{
+            step
+            | status: :pending,
+              explanation: "Asset has been submitted and is waiting for runner capacity."
+          }
+        else
+          step
+        end
+      end)
+    else
+      steps
+    end
+  end
+
+  defp run_max_concurrency(%RunState{metadata: metadata}) when is_map(metadata) do
+    case Map.get(metadata, :max_concurrency) || Map.get(metadata, "max_concurrency") do
+      max_concurrency when is_integer(max_concurrency) and max_concurrency > 0 -> max_concurrency
+      _other -> 1
+    end
+  end
+
+  defp run_max_concurrency(_run), do: 1
+
+  defp submitted_running_step?(%{status: :running, finished_at: nil}), do: true
+  defp submitted_running_step?(_step), do: false
+
+  defp submitted_step_sort_key(step) do
+    {datetime_sort_key(step.started_at), Map.get(step, :sequence) || 0, step.id || ""}
   end
 
   defp mark_cascade_failures(steps, events) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -162,7 +162,8 @@ defmodule FavnOrchestrator.RunReadModel do
           required(:child_runs) => [run_summary()],
           required(:windows) => [map()],
           required(:asset_attempts) => [asset_attempt_summary()],
-          required(:timeline) => [timeline_entry()]
+          required(:timeline) => [timeline_entry()],
+          required(:events) => [RunEvent.t()]
         }
 
   @type asset_step_log_context :: %{
@@ -268,8 +269,21 @@ defmodule FavnOrchestrator.RunReadModel do
          child_runs: Enum.map(group.children, &summary/1),
          windows: windows,
          asset_attempts: attempts,
-         timeline: timeline_entries(attempts)
+         timeline: timeline_entries(attempts),
+         events: execution_group_events(group)
        }}
+    end
+  end
+
+  @doc """
+  Lists persisted events for an execution group, including child/window runs.
+  """
+  @spec list_execution_group_events(String.t(), keyword()) ::
+          {:ok, [RunEvent.t()]} | {:error, term()}
+  def list_execution_group_events(group_id, _filters \\ []) when is_binary(group_id) do
+    with {:ok, runs} <- Storage.list_runs(),
+         {:ok, group} <- find_execution_group(runs, group_id) do
+      {:ok, execution_group_events(group)}
     end
   end
 
@@ -743,6 +757,16 @@ defmodule FavnOrchestrator.RunReadModel do
     end
   end
 
+  defp execution_group_events(group) do
+    group.runs
+    |> Enum.flat_map(&run_events(&1.id))
+    |> Enum.sort_by(&event_sort_key/1)
+  end
+
+  defp event_sort_key(%RunEvent{} = event) do
+    {datetime_sort_key(event.occurred_at), event.run_id || "", event.sequence || 0}
+  end
+
   defp event_step_finished_at(latest, events) do
     cond do
       event_step_status(latest.event_type, latest.status) |> terminal_status?() ->
@@ -1012,7 +1036,6 @@ defmodule FavnOrchestrator.RunReadModel do
     |> merge_event_steps(event_steps, run, settling?)
     |> append_waiting_steps(run, event_steps, settling?)
     |> normalize_step_timings()
-    |> normalize_active_step_statuses(run)
     |> mark_cascade_failures(events)
     |> Enum.sort_by(&{&1.stage || 999_999, &1.asset_ref})
   end
@@ -1286,49 +1309,6 @@ defmodule FavnOrchestrator.RunReadModel do
   end
 
   defp derived_step_started_at(_step), do: nil
-
-  defp normalize_active_step_statuses(steps, %RunState{} = run) do
-    max_concurrency = run_max_concurrency(run)
-    running_steps = Enum.filter(steps, &submitted_running_step?/1)
-
-    if length(running_steps) > max_concurrency do
-      running_ids =
-        running_steps
-        |> Enum.sort_by(&submitted_step_sort_key/1)
-        |> Enum.take(max_concurrency)
-        |> MapSet.new(& &1.id)
-
-      Enum.map(steps, fn step ->
-        if submitted_running_step?(step) and not MapSet.member?(running_ids, step.id) do
-          %{
-            step
-            | status: :pending,
-              explanation: "Asset has been submitted and is waiting for runner capacity."
-          }
-        else
-          step
-        end
-      end)
-    else
-      steps
-    end
-  end
-
-  defp run_max_concurrency(%RunState{metadata: metadata}) when is_map(metadata) do
-    case Map.get(metadata, :max_concurrency) || Map.get(metadata, "max_concurrency") do
-      max_concurrency when is_integer(max_concurrency) and max_concurrency > 0 -> max_concurrency
-      _other -> 1
-    end
-  end
-
-  defp run_max_concurrency(_run), do: 1
-
-  defp submitted_running_step?(%{status: :running, finished_at: nil}), do: true
-  defp submitted_running_step?(_step), do: false
-
-  defp submitted_step_sort_key(step) do
-    {datetime_sort_key(step.started_at), Map.get(step, :sequence) || 0, step.id || ""}
-  end
 
   defp mark_cascade_failures(steps, events) do
     cascade = cascade_failure_context(events)

--- a/apps/favn_orchestrator/test/run_read_model_test.exs
+++ b/apps/favn_orchestrator/test/run_read_model_test.exs
@@ -375,45 +375,6 @@ defmodule FavnOrchestrator.RunReadModelTest do
     assert step.duration_ms == 26_800
   end
 
-  test "run detail does not mark every submitted step as running beyond max concurrency" do
-    refs = [
-      {MyApp.Assets.Gold, :asset},
-      {MyApp.Assets.Silver, :asset},
-      {MyApp.Assets.Bronze, :asset}
-    ]
-
-    run =
-      "submitted_step_capacity"
-      |> run(submit_kind: :pipeline)
-      |> Map.put(:metadata, %{max_concurrency: 1})
-      |> Map.put(:target_refs, refs)
-      |> RunState.transition(status: :running)
-
-    assert :ok = Storage.put_run(run)
-
-    refs
-    |> Enum.with_index(1)
-    |> Enum.each(fn {ref, index} ->
-      assert :ok =
-               Storage.append_run_event(run.id, %{
-                 run_id: run.id,
-                 sequence: index,
-                 event_type: :step_started,
-                 occurred_at: ~U[2026-05-20 07:57:13Z],
-                 status: :running,
-                 asset_ref: ref,
-                 stage: 0,
-                 data: %{asset_step_id: "submitted-step-#{index}"}
-               })
-    end)
-
-    assert {:ok, detail} = FavnOrchestrator.get_run_detail(run.id)
-    statuses = Enum.frequencies_by(detail.steps, & &1.status)
-
-    assert statuses.running == 1
-    assert statuses.pending == 2
-  end
-
   test "pipeline success remains active while persisted step results are incomplete" do
     gold_ref = {MyApp.Assets.Gold, :asset}
     silver_ref = {MyApp.Assets.Silver, :asset}
@@ -825,6 +786,40 @@ defmodule FavnOrchestrator.RunReadModelTest do
 
     assert {:ok, timeline} = FavnOrchestrator.list_execution_group_timeline(parent.id)
     assert Enum.map(timeline, & &1.child_run_id) == [earlier_child.id, later_child.id]
+  end
+
+  test "execution group events include child window run events" do
+    parent = run("exec_group_events_parent", submit_kind: :backfill_pipeline)
+    anchor = anchor(~U[2026-07-01 00:00:00Z])
+    child = child_run(parent, "exec_group_events_child", anchor, :running, result_status: nil)
+
+    Enum.each([parent, child], &assert(:ok = Storage.put_run(&1)))
+
+    assert :ok =
+             Storage.append_run_event(parent.id, %{
+               run_id: parent.id,
+               sequence: 1,
+               event_type: :backfill_started,
+               occurred_at: ~U[2026-07-01 00:00:00Z],
+               status: :running
+             })
+
+    assert :ok =
+             Storage.append_run_event(child.id, %{
+               run_id: child.id,
+               sequence: 1,
+               event_type: :step_started,
+               occurred_at: ~U[2026-07-01 00:00:01Z],
+               status: :running,
+               asset_ref: {MyApp.Assets.Gold, :asset},
+               data: %{asset_step_id: "child-step"}
+             })
+
+    assert {:ok, events} = FavnOrchestrator.list_execution_group_events(parent.id)
+    assert Enum.map(events, & &1.run_id) == [parent.id, child.id]
+
+    assert {:ok, detail} = FavnOrchestrator.get_execution_group_detail(parent.id)
+    assert Enum.map(detail.events, & &1.run_id) == [parent.id, child.id]
   end
 
   test "execution group attempt filters apply on orchestrator read model" do

--- a/apps/favn_orchestrator/test/run_read_model_test.exs
+++ b/apps/favn_orchestrator/test/run_read_model_test.exs
@@ -330,6 +330,90 @@ defmodule FavnOrchestrator.RunReadModelTest do
     assert step.explanation == "Failed while executing this asset."
   end
 
+  test "run detail derives terminal step start time from finish and duration" do
+    ref = {MyApp.Assets.Gold, :asset}
+    submitted_at = ~U[2026-05-20 07:57:13Z]
+    finished_at = ~U[2026-05-20 07:57:40Z]
+
+    run =
+      run("derived_terminal_step_start", submit_kind: :pipeline)
+      |> RunState.transition(
+        status: :ok,
+        result: %{
+          node_results: [
+            %{
+              node_key: {ref, nil},
+              ref: ref,
+              stage: 0,
+              status: :ok,
+              finished_at: finished_at,
+              duration_ms: 26_800,
+              asset_step_id: "derived-step"
+            }
+          ]
+        }
+      )
+
+    assert :ok = Storage.put_run(run)
+
+    assert :ok =
+             Storage.append_run_event(run.id, %{
+               run_id: run.id,
+               sequence: 1,
+               event_type: :step_started,
+               occurred_at: submitted_at,
+               status: :running,
+               asset_ref: ref,
+               stage: 0,
+               data: %{asset_step_id: "derived-step"}
+             })
+
+    assert {:ok, detail} = FavnOrchestrator.get_run_detail(run.id)
+    assert [step] = detail.steps
+    assert step.started_at == DateTime.add(finished_at, -26_800, :millisecond)
+    assert step.finished_at == finished_at
+    assert step.duration_ms == 26_800
+  end
+
+  test "run detail does not mark every submitted step as running beyond max concurrency" do
+    refs = [
+      {MyApp.Assets.Gold, :asset},
+      {MyApp.Assets.Silver, :asset},
+      {MyApp.Assets.Bronze, :asset}
+    ]
+
+    run =
+      "submitted_step_capacity"
+      |> run(submit_kind: :pipeline)
+      |> Map.put(:metadata, %{max_concurrency: 1})
+      |> Map.put(:target_refs, refs)
+      |> RunState.transition(status: :running)
+
+    assert :ok = Storage.put_run(run)
+
+    refs
+    |> Enum.with_index(1)
+    |> Enum.each(fn {ref, index} ->
+      assert :ok =
+               Storage.append_run_event(run.id, %{
+                 run_id: run.id,
+                 sequence: index,
+                 event_type: :step_started,
+                 occurred_at: ~U[2026-05-20 07:57:13Z],
+                 status: :running,
+                 asset_ref: ref,
+                 stage: 0,
+                 data: %{asset_step_id: "submitted-step-#{index}"}
+               })
+    end)
+
+    assert {:ok, detail} = FavnOrchestrator.get_run_detail(run.id)
+    statuses = Enum.frequencies_by(detail.steps, & &1.status)
+
+    assert statuses.running == 1
+    assert statuses.pending == 2
+  end
+
   test "pipeline success remains active while persisted step results are incomplete" do
     gold_ref = {MyApp.Assets.Gold, :asset}
     silver_ref = {MyApp.Assets.Silver, :asset}

--- a/apps/favn_view/assets/js/app.js
+++ b/apps/favn_view/assets/js/app.js
@@ -82,12 +82,24 @@ const Hooks = {
         if (!bounds.width) return
 
         const ratio = Math.max(0, Math.min(1, (event.clientX - bounds.left) / bounds.width))
-        this.el.scrollLeft = ratio * Math.max(this.el.scrollWidth - this.el.clientWidth, 0)
-        if (this.el.dataset.liveFollow === "true") this.pushEvent("timeline_pause_live", {})
+        this.pendingFocusRatio = ratio
+        this.pushEvent("timeline_focus", {ratio})
+        this.scrollToRatio(ratio)
       })
     },
     updated() {
       this.followNow()
+      if (this.pendingFocusRatio !== undefined) {
+        const ratio = this.pendingFocusRatio
+        this.pendingFocusRatio = undefined
+        window.requestAnimationFrame(() => this.scrollToRatio(ratio))
+      }
+    },
+    scrollToRatio(ratio) {
+      const maxScroll = Math.max(this.el.scrollWidth - this.el.clientWidth, 0)
+      this.ignoreScroll = true
+      this.el.scrollLeft = Math.max(0, Math.min(maxScroll, ratio * maxScroll))
+      window.requestAnimationFrame(() => { this.ignoreScroll = false })
     },
     followNow() {
       if (this.el.dataset.active !== "true" || this.el.dataset.liveFollow !== "true") return

--- a/apps/favn_view/lib/favn_view/components/app_shell.ex
+++ b/apps/favn_view/lib/favn_view/components/app_shell.ex
@@ -18,6 +18,7 @@ defmodule FavnView.Components.AppShell do
   attr :facts, :list, default: []
   attr :show_header?, :boolean, default: false
   attr :compact_header?, :boolean, default: true
+  attr :content_scroll?, :boolean, default: true
 
   slot :inner_block, required: true
   slot :mode_rail
@@ -29,7 +30,7 @@ defmodule FavnView.Components.AppShell do
       <IconNav.icon_nav items={@nav_items} />
 
       <div class="relative z-10 flex h-screen min-h-0 flex-col px-5 py-3 md:py-4 md:pl-32 md:pr-8 lg:pr-32">
-        <header class="mx-auto flex w-full max-w-[96rem] shrink-0 items-center justify-between gap-3">
+        <header class="mx-auto flex w-full max-w-[120rem] shrink-0 items-center justify-between gap-3">
           <div class="flex min-w-0 items-center gap-3">
             <IconNav.mobile_icon_nav items={@nav_items} />
             <a href={~p"/"} class="btn btn-ghost gap-2 px-2 md:hidden" aria-label="Favn home">
@@ -96,7 +97,8 @@ defmodule FavnView.Components.AppShell do
         </header>
 
         <main class={[
-          "mx-auto flex min-h-0 w-full max-w-[96rem] flex-1 flex-col justify-start overflow-y-auto",
+          "mx-auto flex min-h-0 w-full max-w-[120rem] flex-1 flex-col justify-start",
+          if(@content_scroll?, do: "overflow-y-auto", else: "overflow-hidden"),
           if(@compact_header?, do: "py-2 md:py-3", else: "py-4 md:py-6")
         ]}>
           <dl

--- a/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
@@ -25,7 +25,7 @@ defmodule FavnView.Components.AssetCataloguePage do
       subtitle="Browse and monitor all assets"
       nav_items={@nav_items}
     >
-      <div class="mx-auto w-full max-w-6xl pb-24 lg:pb-0" data-testid="asset-catalogue-page">
+      <div class="mx-auto w-full max-w-[120rem] pb-24 lg:pb-0" data-testid="asset-catalogue-page">
         <.loading_state :if={@loading} />
         <.error_state :if={!@loading && @error} />
 

--- a/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
@@ -164,7 +164,7 @@ defmodule FavnView.Components.AssetDetailPage do
     ~H"""
     <GlassPanel.glass_panel
       id="window-timeline"
-      class="mx-auto w-full max-w-6xl p-6 sm:p-8 lg:p-10"
+      class="mx-auto w-full max-w-[120rem] p-6 sm:p-8 lg:p-10"
       data-testid="window-timeline-panel"
     >
       <div class="flex flex-col gap-10">

--- a/apps/favn_view/lib/favn_view/components/log_viewer.ex
+++ b/apps/favn_view/lib/favn_view/components/log_viewer.ex
@@ -35,7 +35,7 @@ defmodule FavnView.Components.LogViewer do
 
     ~H"""
     <section
-      class="mx-auto flex min-h-0 w-full max-w-6xl flex-1"
+      class="mx-auto flex min-h-0 w-full max-w-[120rem] flex-1"
       data-testid="log-viewer"
       data-log-scope={@scope}
     >

--- a/apps/favn_view/lib/favn_view/components/pipeline_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/pipeline_detail_page.ex
@@ -27,7 +27,10 @@ defmodule FavnView.Components.PipelineDetailPage do
       status_tone={status_tone(@pipeline.status)}
       nav_items={@nav_items}
     >
-      <div class="mx-auto w-full max-w-6xl space-y-4 pb-24 lg:pb-0" data-testid="pipeline-detail-page">
+      <div
+        class="mx-auto w-full max-w-[120rem] space-y-4 pb-24 lg:pb-0"
+        data-testid="pipeline-detail-page"
+      >
         <.summary_panel pipeline={@pipeline} />
         <.actions_panel
           pipeline={@pipeline}

--- a/apps/favn_view/lib/favn_view/components/pipelines_page.ex
+++ b/apps/favn_view/lib/favn_view/components/pipelines_page.ex
@@ -25,7 +25,7 @@ defmodule FavnView.Components.PipelinesPage do
       subtitle="Monitor active manifest pipelines"
       nav_items={@nav_items}
     >
-      <div class="mx-auto w-full max-w-6xl pb-24 lg:pb-0" data-testid="pipelines-page">
+      <div class="mx-auto w-full max-w-[120rem] pb-24 lg:pb-0" data-testid="pipelines-page">
         <.loading_state :if={@loading} />
         <.error_state :if={!@loading && @error} />
 

--- a/apps/favn_view/lib/favn_view/components/run_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page.ex
@@ -73,7 +73,7 @@ defmodule FavnView.Components.RunDetailPage do
 
   def execution_group_page(assigns) do
     ~H"""
-    <div class="mx-auto flex w-full max-w-[96rem] flex-col gap-3" data-testid="run-detail-page">
+    <div class="mx-auto flex w-full max-w-[120rem] flex-col gap-3" data-testid="run-detail-page">
       <Stats.execution_group_stats run={@run} />
 
       <GlassPanel.glass_panel

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/timeline.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/timeline.ex
@@ -91,11 +91,11 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
   def timeline_controls(assigns) do
     ~H"""
     <form
-      class="grid gap-2 rounded-box border border-base-content/10 bg-base-content/[0.025] p-3 xl:grid-cols-[minmax(12rem,1fr)_9rem_10rem_11rem_auto_auto_auto_auto] xl:items-center"
+      class="flex flex-wrap items-center gap-2 rounded-box border border-base-content/10 bg-base-content/[0.025] p-3"
       data-testid="timeline-controls"
       phx-change="timeline_filter"
     >
-      <label class="input input-sm favn-surface-control flex items-center gap-2 rounded-field">
+      <label class="input input-sm favn-surface-control min-w-56 flex-1 items-center gap-2 rounded-field xl:max-w-80">
         <.icon name="hero-magnifying-glass" class="size-4 text-base-content/45" />
         <input
           type="search"
@@ -107,7 +107,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
       </label>
       <select
         name="timeline[status]"
-        class="select select-sm favn-surface-control rounded-field"
+        class="select select-sm favn-surface-control min-w-40 rounded-field"
         aria-label="Status filter"
       >
         <option value="all" selected={@timeline_state.status == "all"}>All statuses</option>
@@ -118,7 +118,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
       </select>
       <select
         name="timeline[window]"
-        class="select select-sm favn-surface-control rounded-field"
+        class="select select-sm favn-surface-control min-w-44 rounded-field"
         aria-label="Window filter"
       >
         <option value="all" selected={@timeline_state.window == "all"}>All windows</option>
@@ -132,29 +132,29 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
       </select>
       <select
         name="timeline[group_by]"
-        class="select select-sm favn-surface-control rounded-field"
+        class="select select-sm favn-surface-control min-w-44 rounded-field"
         aria-label="Group by"
         disabled
       >
         <option>Group by Status</option>
       </select>
-      <label class="flex items-center gap-2 text-xs text-base-content/65">
+      <label class="flex items-center gap-2 text-xs leading-tight text-base-content/65">
         <input
           type="checkbox"
           name="timeline[failed_only]"
           checked={@timeline_state.failed_only?}
           class="toggle toggle-error toggle-xs"
-        /> Show failed only
+        /> <span class="max-w-16">Show failed only</span>
       </label>
-      <label class="flex items-center gap-2 text-xs text-base-content/65">
+      <label class="flex items-center gap-2 text-xs leading-tight text-base-content/65">
         <input
           type="checkbox"
           name="timeline[running_only]"
           checked={@timeline_state.running_only?}
           class="toggle toggle-info toggle-xs"
-        /> Show running only
+        /> <span class="max-w-20">Show running only</span>
       </label>
-      <div class="join justify-self-start xl:justify-self-end" aria-label="Zoom control">
+      <div class="join ml-auto flex shrink-0 flex-wrap justify-end" aria-label="Zoom control">
         <button
           :for={zoom <- timeline_zoom_levels()}
           type="button"
@@ -166,7 +166,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
           {zoom.label}
         </button>
       </div>
-      <div class="join justify-self-start xl:justify-self-end">
+      <div class="join shrink-0">
         <button
           type="button"
           phx-click="timeline_fit"
@@ -408,15 +408,18 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
     search_match? and status_match? and window_match? and failed_match? and running_match?
   end
 
+  defp timeline_attempts(%{timeline: [_ | _] = timeline}),
+    do: Enum.with_index(timeline, &Map.put_new(&1, :timeline_order, &2))
+
+  defp timeline_attempts(%{attempts: attempts}),
+    do: Enum.with_index(attempts, &Map.put_new(&1, :timeline_order, &2))
+
   defp timeline_attempts(%{matrix: %{rows: matrix_rows}}) do
     matrix_rows
     |> Enum.flat_map(& &1.cells)
     |> Enum.with_index()
     |> Enum.map(fn {attempt, index} -> Map.put_new(attempt, :timeline_order, index) end)
   end
-
-  defp timeline_attempts(%{attempts: attempts}),
-    do: Enum.with_index(attempts, &Map.put_new(&1, :timeline_order, &2))
 
   defp timeline_attempts(_run), do: []
 
@@ -426,7 +429,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
     section = timeline_section_for(attempt[:raw_status])
 
     %{
-      attempt_id: attempt[:id],
+      attempt_id: attempt[:attempt_id] || attempt[:id],
       asset_key: attempt[:asset_key] || attempt[:asset_ref] || attempt[:short_asset_name],
       asset_name: attempt[:short_asset_name] || attempt[:asset_name] || attempt[:asset_key],
       window_label: attempt[:window_label] || "No window",

--- a/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
+++ b/apps/favn_view/lib/favn_view/components/run_overview_hud.ex
@@ -14,7 +14,7 @@ defmodule FavnView.Components.RunOverviewHud do
     <GlassPanel.glass_panel
       id="run-overview-panel"
       phx-hook="FavnClipboard"
-      class="mx-auto w-full max-w-[96rem] p-4 sm:p-5 lg:p-6"
+      class="mx-auto w-full max-w-[120rem] p-4 sm:p-5 lg:p-6"
       data-testid="run-overview-panel"
       data-run-active={to_string(@run.active?)}
     >

--- a/apps/favn_view/lib/favn_view/components/runs_list_page.ex
+++ b/apps/favn_view/lib/favn_view/components/runs_list_page.ex
@@ -29,16 +29,20 @@ defmodule FavnView.Components.RunsListPage do
       subtitle="Backfills and runs"
       nav_items={@nav_items}
       show_header?={false}
+      content_scroll?={false}
     >
-      <div class="mx-auto w-full max-w-[92rem] pb-24 lg:pb-0" data-testid="runs-list-page">
+      <div
+        class="mx-auto flex min-h-0 w-full max-w-[120rem] flex-1 flex-col pb-24 lg:pb-0"
+        data-testid="runs-list-page"
+      >
         <.loading_state :if={@loading} />
         <.error_state :if={!@loading && @error} />
 
-        <div :if={!@loading && !@error} class="space-y-2.5 lg:space-y-3">
+        <div :if={!@loading && !@error} class="flex min-h-0 flex-1 flex-col gap-2.5 lg:gap-3">
           <.summary_band summary={@summary} />
 
           <GlassPanel.glass_panel
-            class="overflow-visible p-3 sm:p-4"
+            class="flex min-h-0 flex-1 flex-col overflow-hidden p-3 sm:p-4"
             data-testid="execution-groups-panel"
           >
             <.filters_bar
@@ -301,7 +305,7 @@ defmodule FavnView.Components.RunsListPage do
 
   def execution_groups_table(assigns) do
     ~H"""
-    <div class="hidden overflow-x-auto border-t border-base-content/10 lg:block">
+    <div class="hidden min-h-0 flex-1 overflow-auto border-t border-base-content/10 lg:block">
       <table class="table table-sm" data-testid="execution-groups-table">
         <thead>
           <tr class="border-base-content/10 text-xs text-base-content/55">
@@ -330,7 +334,7 @@ defmodule FavnView.Components.RunsListPage do
           <% end %>
         </tbody>
       </table>
-      <div class="border-t border-base-content/10 px-2 py-3 text-xs text-base-content/55">
+      <div class="sticky bottom-0 border-t border-base-content/10 bg-base-100/80 px-2 py-3 text-xs text-base-content/55 backdrop-blur">
         Showing 1-{length(@groups)} of {length(@groups)} runs
       </div>
     </div>
@@ -379,7 +383,7 @@ defmodule FavnView.Components.RunsListPage do
         </div>
       </td>
       <td class="text-xs text-base-content/75">{@group.trigger}</td>
-      <td class="min-w-56 max-w-80"><.target_cell group={@group} /></td>
+      <td class="min-w-44 max-w-56"><.target_cell group={@group} /></td>
       <td class="min-w-36 text-xs text-base-content/75">
         <p>{@group.window}</p>
         <p class="text-xs text-base-content/45">{@group.window_count_label}</p>
@@ -497,7 +501,9 @@ defmodule FavnView.Components.RunsListPage do
           >
             {@group.short_id}
           </.link>
-          <p class="line-clamp-2 text-sm text-base-content/80">{@group.target}</p>
+          <p class="line-clamp-2 text-sm text-base-content/80" title={@group.target_title}>
+            {@group.target}
+          </p>
         </div>
         <button
           type="button"
@@ -540,7 +546,7 @@ defmodule FavnView.Components.RunsListPage do
 
   def target_cell(%{group: %{targets: [_single]}} = assigns) do
     ~H"""
-    <p class="truncate text-sm font-medium text-base-content" title={@group.target}>
+    <p class="max-w-56 truncate text-sm font-medium text-base-content" title={@group.target_title}>
       {@group.target}
     </p>
     """
@@ -551,7 +557,10 @@ defmodule FavnView.Components.RunsListPage do
     <details class="dropdown dropdown-hover dropdown-bottom">
       <summary class="list-none marker:content-none">
         <span class="inline-flex max-w-full cursor-default items-center gap-2 align-middle">
-          <span class="truncate text-sm font-medium text-base-content" title={@group.target}>
+          <span
+            class="max-w-48 truncate text-sm font-medium text-base-content"
+            title={@group.target_title}
+          >
             {@group.target}
           </span>
           <span class="badge badge-xs badge-soft badge-info shrink-0">

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -226,7 +226,7 @@ defmodule FavnView.RunDetailLive do
     attempts = Enum.map(Map.get(detail, :asset_attempts, []), &attempt_from_public/1)
     legacy_asset_results = Enum.map(Map.get(root_detail, :steps, []), &legacy_step_from_public/1)
     windows = Enum.map(Map.get(detail, :windows, []), &window_from_public/1)
-    events = group_events(root_detail.events, Map.get(detail, :child_runs, []))
+    events = Map.get(detail, :events, root_detail.events)
     child_runs = child_runs_from_public(Map.get(detail, :child_runs, []), attempts, windows)
     timeline = Enum.map(Map.get(detail, :timeline, []), &timeline_from_public(&1, attempts))
     matrix = matrix(attempts, windows)
@@ -293,27 +293,6 @@ defmodule FavnView.RunDetailLive do
       {:ok, detail} -> detail
       {:error, _reason} -> %{events: []}
     end
-  end
-
-  defp group_events(root_events, child_runs) do
-    child_events =
-      child_runs
-      |> Enum.flat_map(fn child ->
-        case FavnOrchestrator.get_run_detail(child.id) do
-          {:ok, detail} -> Map.get(detail, :events, [])
-          {:error, _reason} -> []
-        end
-      end)
-
-    (root_events ++ child_events)
-    |> Enum.sort_by(&event_sort_key/1)
-  end
-
-  defp event_sort_key(event) do
-    occurred_at = Map.get(event, :occurred_at)
-
-    {datetime_sort_key(occurred_at), Map.get(event, :run_id) || "",
-     Map.get(event, :sequence) || 0}
   end
 
   defp maybe_schedule_refresh(%{assigns: %{run: %{active?: true}}} = socket) do
@@ -811,9 +790,6 @@ defmodule FavnView.RunDetailLive do
   defp window_label(_window), do: nil
   defp datetime_iso(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
   defp datetime_iso(_datetime), do: nil
-
-  defp datetime_sort_key(%DateTime{} = datetime), do: DateTime.to_unix(datetime, :microsecond)
-  defp datetime_sort_key(_datetime), do: 0
 
   defp range_label(%DateTime{} = start_at, %DateTime{} = end_at),
     do: "#{Calendar.strftime(start_at, "%b %-d")} - #{Calendar.strftime(end_at, "%b %-d")}"

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -89,6 +89,21 @@ defmodule FavnView.RunDetailLive do
      )}
   end
 
+  def handle_event("timeline_focus", _params, socket) do
+    zoom = socket.assigns.timeline_state.zoom
+
+    {:noreply,
+     patch_run_state(socket,
+       active_mode: :timeline,
+       timeline_state: %{
+         socket.assigns.timeline_state
+         | zoom: if(zoom == "full", do: "30m", else: zoom),
+           mode: :manual,
+           live_follow?: false
+       }
+     )}
+  end
+
   def handle_event("timeline_jump_now", _params, socket) do
     if socket.assigns.run[:active?] do
       {:noreply,
@@ -211,6 +226,7 @@ defmodule FavnView.RunDetailLive do
     attempts = Enum.map(Map.get(detail, :asset_attempts, []), &attempt_from_public/1)
     legacy_asset_results = Enum.map(Map.get(root_detail, :steps, []), &legacy_step_from_public/1)
     windows = Enum.map(Map.get(detail, :windows, []), &window_from_public/1)
+    events = group_events(root_detail.events, Map.get(detail, :child_runs, []))
     child_runs = child_runs_from_public(Map.get(detail, :child_runs, []), attempts, windows)
     timeline = Enum.map(Map.get(detail, :timeline, []), &timeline_from_public(&1, attempts))
     matrix = matrix(attempts, windows)
@@ -258,9 +274,8 @@ defmodule FavnView.RunDetailLive do
       failures: failures,
       child_runs: child_runs,
       timeline: timeline,
-      events: Enum.map(root_detail.events, &event_from_public/1),
-      latest_event_summary:
-        root_detail.events |> Enum.map(&event_from_public/1) |> latest_event_summary(),
+      events: Enum.map(events, &event_from_public/1),
+      latest_event_summary: events |> Enum.map(&event_from_public/1) |> latest_event_summary(),
       waiting_activity?: root_detail.events == [] and active_group?(summary),
       current_activity: current_activity(attempts),
       selected_attempt: nil,
@@ -268,7 +283,8 @@ defmodule FavnView.RunDetailLive do
       back_asset_href:
         existing_back_asset_href || back_asset_href(List.first(summary.target_assets)),
       raw_run: inspect(detail, pretty: true, limit: 50, printable_limit: 2_000),
-      raw_events: inspect(root_detail.events, pretty: true, limit: 50, printable_limit: 2_000)
+      raw_events: inspect(events, pretty: true, limit: 50, printable_limit: 2_000),
+      root_event_sequence: latest_sequence(root_detail.events, nil)
     }
   end
 
@@ -277,6 +293,27 @@ defmodule FavnView.RunDetailLive do
       {:ok, detail} -> detail
       {:error, _reason} -> %{events: []}
     end
+  end
+
+  defp group_events(root_events, child_runs) do
+    child_events =
+      child_runs
+      |> Enum.flat_map(fn child ->
+        case FavnOrchestrator.get_run_detail(child.id) do
+          {:ok, detail} -> Map.get(detail, :events, [])
+          {:error, _reason} -> []
+        end
+      end)
+
+    (root_events ++ child_events)
+    |> Enum.sort_by(&event_sort_key/1)
+  end
+
+  defp event_sort_key(event) do
+    occurred_at = Map.get(event, :occurred_at)
+
+    {datetime_sort_key(occurred_at), Map.get(event, :run_id) || "",
+     Map.get(event, :sequence) || 0}
   end
 
   defp maybe_schedule_refresh(%{assigns: %{run: %{active?: true}}} = socket) do
@@ -330,9 +367,7 @@ defmodule FavnView.RunDetailLive do
     )
   end
 
-  defp run_query_params(:overview, timeline_state) do
-    timeline_query_params(timeline_state)
-  end
+  defp run_query_params(:overview, _timeline_state), do: %{}
 
   defp run_query_params(active_mode, timeline_state) do
     Map.put(timeline_query_params(timeline_state), "view", Atom.to_string(active_mode))
@@ -340,7 +375,11 @@ defmodule FavnView.RunDetailLive do
 
   defp timeline_query_params(timeline_state) do
     %{}
-    |> maybe_put_param("timeline_zoom", timeline_state.zoom, timeline_state.zoom != "30m")
+    |> maybe_put_param(
+      "timeline_zoom",
+      timeline_state.zoom,
+      timeline_state.zoom != "30m" or timeline_state.mode == :manual
+    )
     |> maybe_put_param(
       "timeline_mode",
       Atom.to_string(timeline_state.mode),
@@ -360,7 +399,7 @@ defmodule FavnView.RunDetailLive do
   defp active_mode_from_params(%{"view" => mode}, _current) when mode in @valid_modes,
     do: String.to_existing_atom(mode)
 
-  defp active_mode_from_params(_params, current), do: current
+  defp active_mode_from_params(_params, _current), do: :overview
 
   defp timeline_state_from_params(params, run) do
     default = default_timeline_state(run)
@@ -554,13 +593,16 @@ defmodule FavnView.RunDetailLive do
       end)
       |> Enum.sort_by(& &1.name)
 
-    attempts_by_cell = Map.new(attempts, &{{&1.asset_key, &1.window_id || "none"}, &1})
+    attempts_by_window_id = Map.new(attempts, &{{&1.asset_key, &1.window_id || "none"}, &1})
+    attempts_by_child_run_id = Map.new(attempts, &{{&1.asset_key, &1.child_run_id}, &1})
 
     rows =
       Enum.map(assets, fn asset ->
         cells =
           Enum.map(windows, fn window ->
-            Map.get(attempts_by_cell, {asset.key, window.id}) || pending_cell(asset, window)
+            Map.get(attempts_by_window_id, {asset.key, window.id}) ||
+              Map.get(attempts_by_child_run_id, {asset.key, Map.get(window, :child_run_id)}) ||
+              pending_cell(asset, window)
           end)
 
         Map.put(asset, :cells, cells)
@@ -732,6 +774,10 @@ defmodule FavnView.RunDetailLive do
 
   defp latest_event_sequence(run, fallback \\ nil)
 
+  defp latest_event_sequence(%{root_event_sequence: sequence}, fallback)
+       when is_integer(sequence),
+       do: max(sequence, fallback || 0)
+
   defp latest_event_sequence(%{events: events}, fallback) when is_list(events) do
     events
     |> Enum.map(&Map.get(&1, :sequence))
@@ -765,6 +811,9 @@ defmodule FavnView.RunDetailLive do
   defp window_label(_window), do: nil
   defp datetime_iso(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
   defp datetime_iso(_datetime), do: nil
+
+  defp datetime_sort_key(%DateTime{} = datetime), do: DateTime.to_unix(datetime, :microsecond)
+  defp datetime_sort_key(_datetime), do: 0
 
   defp range_label(%DateTime{} = start_at, %DateTime{} = end_at),
     do: "#{Calendar.strftime(start_at, "%b %-d")} - #{Calendar.strftime(end_at, "%b %-d")}"
@@ -806,6 +855,8 @@ defmodule FavnView.RunDetailLive do
   defp status_tone(status) when status in [:pending, :queued], do: :warning
   defp status_tone(_status), do: :neutral
   defp label(nil), do: "Unknown"
+  defp label(:step_started), do: "Step submitted"
+  defp label("step_started"), do: "Step submitted"
   defp label(value), do: value |> to_string() |> String.replace("_", " ") |> String.capitalize()
 
   defp legacy_step_status_label(_status, :cascade), do: "Cascade failed"

--- a/apps/favn_view/lib/favn_view/runs_list_live.ex
+++ b/apps/favn_view/lib/favn_view/runs_list_live.ex
@@ -202,6 +202,7 @@ defmodule FavnView.RunsListLive do
 
   defp group_from_public(group) do
     targets = targets(Map.get(group, :target_assets, []), nil)
+    target = List.first(targets) || "No target"
     status = display_status(group)
     current_activity = current_activity(Map.get(group, :currently_running_asset_attempts, []))
     window = window_range_label(group)
@@ -211,7 +212,8 @@ defmodule FavnView.RunsListLive do
     %{
       id: group.id,
       short_id: short_id(group.id),
-      target: List.first(targets) || "No target",
+      target: short_target(target),
+      target_title: target,
       targets: targets,
       status: status,
       raw_status: Map.get(group, :root_status),
@@ -251,7 +253,7 @@ defmodule FavnView.RunsListLive do
       short_id: short_id(run.id),
       status: display_run_status(Map.get(run, :status)),
       raw_status: Map.get(run, :status),
-      target: List.first(targets) || "No target",
+      target: short_target(List.first(targets) || "No target"),
       window: window_label(window || Map.get(run, :window)) || "-",
       progress: progress_label(progress, targets),
       started_at: short_timestamp(Map.get(run, :started_at)),
@@ -479,6 +481,13 @@ defmodule FavnView.RunsListLive do
       targets -> targets
     end
   end
+
+  defp short_target("No target"), do: "No target"
+
+  defp short_target(target) when is_binary(target),
+    do: LogsViewModel.display_name(target) || target
+
+  defp short_target(target), do: target
 
   defp window_label(%{label: label}) when is_binary(label), do: label
   defp window_label(%{"label" => label}) when is_binary(label), do: label

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -1507,6 +1507,50 @@ defmodule FavnView.PageLiveTest do
     refute html =~ ~r/data-section="queued".*Blocked/s
   end
 
+  test "run detail timeline prefers authoritative attempts over matrix placeholders" do
+    run = %{
+      active?: false,
+      windows: [],
+      attempts: [timeline_attempt(:ok)],
+      matrix: %{
+        rows: [
+          %{
+            cells: [
+              %{
+                timeline_attempt(:pending)
+                | id: nil,
+                  attempt_id: nil,
+                  raw_status: :pending,
+                  status: "Queued",
+                  started_at_raw: nil,
+                  finished_at_raw: nil
+              }
+            ]
+          }
+        ]
+      }
+    }
+
+    html =
+      render_component(&Timeline.timeline_panel/1,
+        run: run,
+        timeline_hook?: false,
+        timeline_state: %{
+          mode: :fit,
+          zoom: "full",
+          live_follow?: false,
+          search: "",
+          status: "all",
+          window: "all",
+          failed_only?: false,
+          running_only?: false
+        }
+      )
+
+    assert html =~ ~r/data-section="ran".*Ok/s
+    refute html =~ ~r/data-testid="timeline-row"[^>]*data-section="queued"/s
+  end
+
   test "run detail timeline uses started to now bars for running attempts", %{conn: conn} do
     %{parent_id: parent_id} = seed_run_detail_group!()
 
@@ -1557,6 +1601,23 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="timeline-mode-indicator"][data-mode="manual"]))
     assert has_element?(view, ~s([data-testid="timeline-zoom-1h"].btn-info))
     assert has_element?(view, ~s([data-testid="timeline-jump-now"]), "Jump to now")
+  end
+
+  test "run detail timeline focus switches fit view to manual zoom", %{conn: conn} do
+    %{parent_id: parent_id} = seed_run_detail_group!(completed?: true)
+
+    {:ok, view, _html} = live(conn, ~p"/runs/#{parent_id}?view=timeline")
+
+    assert has_element?(view, ~s([data-testid="timeline-mode-indicator"][data-mode="fit"]))
+
+    render_hook(view, "timeline_focus", %{"ratio" => 0.5})
+
+    path = assert_patch(view)
+    assert path =~ "view=timeline"
+    assert path =~ "timeline_mode=manual"
+    assert path =~ "timeline_follow=0"
+    assert has_element?(view, ~s([data-testid="timeline-mode-indicator"][data-mode="manual"]))
+    assert has_element?(view, ~s([data-testid="timeline-zoom-30m"].btn-info))
   end
 
   test "run detail timeline filters remain active after zoom changes", %{conn: conn} do
@@ -1642,6 +1703,20 @@ defmodule FavnView.PageLiveTest do
 
     assert has_element?(view, ~s([data-testid="run-event-timeline"]), "Events")
     refute has_element?(view, ~s([data-testid="run-overview-panel"]))
+  end
+
+  test "run detail overview rail button returns from another mode", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/runs/run_customer_orders_daily?view=timeline")
+
+    refute has_element?(view, ~s([data-testid="run-overview-panel"]))
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Overview"]))
+    |> render_click()
+
+    path = assert_patch(view)
+    assert path == ~p"/runs/run_customer_orders_daily"
+    assert has_element?(view, ~s([data-testid="run-overview-panel"]))
   end
 
   test "run detail right rail exposes expected modes", %{conn: conn} do


### PR DESCRIPTION
## Summary
- Fix run detail timeline and matrix views for multi-window backfills so child-run progress updates consistently.
- Correct timeline semantics for submitted vs running work and derive terminal step timing from result duration.
- Widen Favn pages for large screens, localize runs-list scrolling to the table area, and prevent target text overlap.

## Verification
- MIX_ENV=test mix do --app favn_view cmd mix test test/favn_view/page_live_test.exs
- MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/run_read_model_test.exs
- MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/run_server_test.exs
- MIX_ENV=test mix compile --warnings-as-errors