### PR TITLE
Fix Mix fallback module discovery

### DIFF
--- a/apps/favn_authoring/test/module_discovery_test.exs
+++ b/apps/favn_authoring/test/module_discovery_test.exs
@@ -84,6 +84,38 @@ defmodule FavnAuthoring.ModuleDiscoveryTest do
              ModuleDiscovery.discover(:assets, apps: [app])
   end
 
+  test "discovers Mix app modules from BEAM artifacts when .app metadata is missing" do
+    unique = System.unique_integer([:positive])
+    app = String.to_atom("favn_discovery_missing_app_#{unique}")
+    module = Module.concat([FavnDiscoveryMissingApp, "Connection#{unique}"])
+    ebin_path = Path.join([Mix.Project.build_path(), "lib", Atom.to_string(app), "ebin"])
+
+    File.rm_rf!(ebin_path)
+    File.mkdir_p!(ebin_path)
+
+    on_exit(fn -> File.rm_rf!(ebin_path) end)
+
+    [{^module, beam}] =
+      Code.compile_string("""
+      defmodule #{inspect(module)} do
+        @behaviour Favn.Connection
+
+        @impl true
+        def definition do
+          %Favn.Connection.Definition{
+            name: :fallback_warehouse,
+            adapter: __MODULE__.Adapter,
+            config_schema: []
+          }
+        end
+      end
+      """)
+
+    File.write!(Path.join(ebin_path, "#{module}.beam"), beam)
+
+    assert {:ok, [^module]} = ModuleDiscovery.discover(:connections, apps: [app])
+  end
+
   test "explicit manifest module inputs override discovery" do
     app = load_test_app!([DiscoveryAsset, DiscoveryPipeline])
     Application.put_env(:favn, :discovery, apps: [app], assets: :all, pipelines: :all)

--- a/apps/favn_authoring/test/module_discovery_test.exs
+++ b/apps/favn_authoring/test/module_discovery_test.exs
@@ -93,7 +93,10 @@ defmodule FavnAuthoring.ModuleDiscoveryTest do
     File.rm_rf!(ebin_path)
     File.mkdir_p!(ebin_path)
 
-    on_exit(fn -> File.rm_rf!(ebin_path) end)
+    on_exit(fn ->
+      Code.delete_path(ebin_path)
+      File.rm_rf!(ebin_path)
+    end)
 
     [{^module, beam}] =
       Code.compile_string("""
@@ -113,7 +116,12 @@ defmodule FavnAuthoring.ModuleDiscoveryTest do
 
     File.write!(Path.join(ebin_path, "#{module}.beam"), beam)
 
+    :code.purge(module)
+    :code.delete(module)
+    refute Code.loaded?(module)
+
     assert {:ok, [^module]} = ModuleDiscovery.discover(:connections, apps: [app])
+    assert Code.loaded?(module)
   end
 
   test "explicit manifest module inputs override discovery" do

--- a/apps/favn_core/lib/favn/module_discovery.ex
+++ b/apps/favn_core/lib/favn/module_discovery.ex
@@ -1,10 +1,12 @@
 defmodule Favn.ModuleDiscovery do
   @moduledoc """
-  Discovers Favn-authored modules from compiled OTP application metadata.
+  Discovers Favn-authored modules from compiled application artifacts.
 
   Discovery is intentionally app-scoped. It reads the module list from each
-  configured OTP application instead of scanning source files, which keeps the
-  behavior compatible with releases and deterministic for manifest generation.
+  configured OTP application when `.app` metadata is available. In Mix projects,
+  it can fall back to compiled BEAM files for the configured app when the `.app`
+  artifact is unavailable, keeping local dev tasks usable without scanning
+  source files.
 
   ## Config
 
@@ -44,7 +46,7 @@ defmodule Favn.ModuleDiscovery do
   def discover(_kind, config), do: {:error, {:invalid_discovery_config, config}}
 
   @doc """
-  Returns all modules declared by the configured OTP applications.
+  Returns all modules declared by configured application artifacts.
   """
   @spec app_modules([atom()]) :: {:ok, [module()]} | {:error, error()}
   def app_modules(apps) when is_list(apps) do
@@ -90,7 +92,43 @@ defmodule Favn.ModuleDiscovery do
         end
 
       error ->
-        {:error, {:app_modules_unavailable, app, error}}
+        case fetch_mix_app_modules(app) do
+          {:ok, modules} -> {:ok, modules}
+          :error -> {:error, {:app_modules_unavailable, app, error}}
+        end
+    end
+  end
+
+  defp fetch_mix_app_modules(app) do
+    with true <- Code.ensure_loaded?(Mix.Project),
+         build_path when is_binary(build_path) <- Mix.Project.build_path(),
+         ebin_path <- Path.join([build_path, "lib", Atom.to_string(app), "ebin"]),
+         {:ok, modules} <- beam_modules(ebin_path),
+         true <- modules != [] do
+      Code.prepend_path(String.to_charlist(ebin_path))
+      {:ok, modules}
+    else
+      _other -> :error
+    end
+  rescue
+    _error -> :error
+  end
+
+  defp beam_modules(ebin_path) do
+    with {:ok, entries} <- File.ls(ebin_path) do
+      modules =
+        entries
+        |> Enum.filter(&String.ends_with?(&1, ".beam"))
+        |> Enum.reduce([], fn entry, acc ->
+          beam_path = Path.join(ebin_path, entry)
+
+          case :beam_lib.info(String.to_charlist(beam_path))[:module] do
+            module when is_atom(module) -> [module | acc]
+            _other -> acc
+          end
+        end)
+
+      {:ok, modules}
     end
   end
 

--- a/apps/favn_core/lib/favn/module_discovery.ex
+++ b/apps/favn_core/lib/favn/module_discovery.ex
@@ -105,7 +105,7 @@ defmodule Favn.ModuleDiscovery do
          ebin_path <- Path.join([build_path, "lib", Atom.to_string(app), "ebin"]),
          {:ok, modules} <- beam_modules(ebin_path),
          true <- modules != [] do
-      Code.prepend_path(String.to_charlist(ebin_path))
+      Code.prepend_path(ebin_path)
       {:ok, modules}
     else
       _other -> :error


### PR DESCRIPTION
## Summary
- Fall back to compiled BEAM artifacts when OTP `.app` metadata is unavailable during Favn module discovery.
- Keep app-scoped discovery behavior while allowing local Mix tasks like `mix favn.query` to resolve connection modules before opening a connection.
- Add regression coverage for missing `.app` metadata.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_authoring cmd mix test --no-compile test/module_discovery_test.exs`
- `mix test` attempted, but exceeded the 120s tool timeout after passing through `favn_authoring`.