### PR TITLE
Fix local dev execution pool propagation

### DIFF
--- a/apps/favn_local/lib/favn/dev/consumer_config_transport.ex
+++ b/apps/favn_local/lib/favn/dev/consumer_config_transport.ex
@@ -7,6 +7,7 @@ defmodule Favn.Dev.ConsumerConfigTransport do
     :discovery,
     :connection_modules,
     :connections,
+    :execution_pools,
     :runner_plugins,
     :duckdb_in_process_client,
     :duckdb_adbc
@@ -30,6 +31,7 @@ defmodule Favn.Dev.ConsumerConfigTransport do
     "discovery" => :discovery,
     "connection_modules" => :connection_modules,
     "connections" => :connections,
+    "execution_pools" => :execution_pools,
     "runner_plugins" => :runner_plugins,
     "duckdb_in_process_client" => :duckdb_in_process_client,
     "duckdb_adbc" => :duckdb_adbc
@@ -114,6 +116,7 @@ defmodule Favn.Dev.ConsumerConfigTransport do
         "discovery" => :discovery,
         "connection_modules" => :connection_modules,
         "connections" => :connections,
+        "execution_pools" => :execution_pools,
         "runner_plugins" => :runner_plugins,
         "duckdb_in_process_client" => :duckdb_in_process_client,
         "duckdb_adbc" => :duckdb_adbc

--- a/apps/favn_local/lib/favn/dev/consumer_config_transport.ex
+++ b/apps/favn_local/lib/favn/dev/consumer_config_transport.ex
@@ -330,7 +330,16 @@ defmodule Favn.Dev.ConsumerConfigTransport do
 
   defp collect_keys(collect_opts) do
     case Keyword.get(collect_opts, :only, @supported_keys) do
-      keys when is_list(keys) -> Enum.filter(@supported_keys, &(&1 in keys))
+      keys when is_list(keys) ->
+        unsupported = keys -- @supported_keys
+
+        if unsupported == [] do
+          Enum.filter(@supported_keys, &(&1 in keys))
+        else
+          raise ArgumentError,
+                "unsupported Favn consumer config transport keys: #{inspect(unsupported)}"
+        end
+
       _other -> @supported_keys
     end
   end

--- a/apps/favn_local/lib/favn/dev/consumer_config_transport.ex
+++ b/apps/favn_local/lib/favn/dev/consumer_config_transport.ex
@@ -43,10 +43,11 @@ defmodule Favn.Dev.ConsumerConfigTransport do
   def supported_keys, do: @supported_keys
 
   @spec collect(keyword()) :: keyword()
-  def collect(opts) when is_list(opts) do
+  @spec collect(keyword(), keyword()) :: keyword()
+  def collect(opts, collect_opts \\ []) when is_list(opts) and is_list(collect_opts) do
     root_dir = Paths.root_dir(opts)
 
-    @supported_keys
+    collect_keys(collect_opts)
     |> Enum.flat_map(fn key ->
       case Application.fetch_env(:favn, key) do
         {:ok, value} -> [{key, normalize_config(key, value, root_dir)}]
@@ -64,7 +65,9 @@ defmodule Favn.Dev.ConsumerConfigTransport do
   end
 
   @spec collect_and_encode(keyword()) :: String.t()
-  def collect_and_encode(opts) when is_list(opts), do: opts |> collect() |> encode()
+  @spec collect_and_encode(keyword(), keyword()) :: String.t()
+  def collect_and_encode(opts, collect_opts \\ []) when is_list(opts) and is_list(collect_opts),
+    do: opts |> collect(collect_opts) |> encode()
 
   @spec decode(String.t()) :: {:ok, keyword()} | {:error, transport_error()}
   def decode(encoded) when is_binary(encoded) do
@@ -323,6 +326,13 @@ defmodule Favn.Dev.ConsumerConfigTransport do
       end)
 
     %{"schema_version" => @schema_version, "entries" => entries}
+  end
+
+  defp collect_keys(collect_opts) do
+    case Keyword.get(collect_opts, :only, @supported_keys) do
+      keys when is_list(keys) -> Enum.filter(@supported_keys, &(&1 in keys))
+      _other -> @supported_keys
+    end
   end
 
   defp encode_value(value) when is_boolean(value) or is_nil(value), do: value

--- a/apps/favn_local/lib/favn/dev/runtime_launch.ex
+++ b/apps/favn_local/lib/favn/dev/runtime_launch.ex
@@ -244,7 +244,8 @@ defmodule Favn.Dev.RuntimeLaunch do
           "FAVN_VIEW_SECRET_KEY_BASE" => secrets["web_session_secret"],
           "FAVN_VIEW_ORCHESTRATOR_SERVICE_TOKEN" => secrets["service_token"],
           "FAVN_VIEW_LOCAL_DEV_TRUSTED_AUTH" => "1",
-          "FAVN_DEV_CONSUMER_FAVN_CONFIG" => ConsumerConfigTransport.collect_and_encode(opts)
+          "FAVN_DEV_CONSUMER_FAVN_CONFIG" =>
+            ConsumerConfigTransport.collect_and_encode(opts, only: [:execution_pools])
         })
     }
   end

--- a/apps/favn_local/lib/favn/dev/runtime_launch.ex
+++ b/apps/favn_local/lib/favn/dev/runtime_launch.ex
@@ -87,8 +87,10 @@ defmodule Favn.Dev.RuntimeLaunch do
     sqlite_path = Path.expand(config.sqlite_path, Paths.root_dir(opts))
     distribution = local_distribution!(opts)
 
-    code =
-      """
+      code =
+        """
+      #{ConsumerConfigTransport.bootstrap_eval_snippet()}
+
       storage = System.fetch_env!("FAVN_DEV_STORAGE")
 
       api_bind_ip =
@@ -241,7 +243,8 @@ defmodule Favn.Dev.RuntimeLaunch do
           "FAVN_VIEW_PUBLIC_ORIGIN" => config.web_base_url,
           "FAVN_VIEW_SECRET_KEY_BASE" => secrets["web_session_secret"],
           "FAVN_VIEW_ORCHESTRATOR_SERVICE_TOKEN" => secrets["service_token"],
-          "FAVN_VIEW_LOCAL_DEV_TRUSTED_AUTH" => "1"
+          "FAVN_VIEW_LOCAL_DEV_TRUSTED_AUTH" => "1",
+          "FAVN_DEV_CONSUMER_FAVN_CONFIG" => ConsumerConfigTransport.collect_and_encode(opts)
         })
     }
   end

--- a/apps/favn_local/test/dev_consumer_config_transport_test.exs
+++ b/apps/favn_local/test/dev_consumer_config_transport_test.exs
@@ -129,6 +129,14 @@ defmodule Favn.Dev.ConsumerConfigTransportTest do
     assert connection[:database] == "/tmp/consumer/data/warehouse.duckdb"
   end
 
+  test "collect raises for unsupported only keys" do
+    assert_raise ArgumentError,
+                 ~r/unsupported Favn consumer config transport keys: \[:execution_pool\]/,
+                 fn ->
+                   ConsumerConfigTransport.collect([root_dir: "/tmp/consumer"], only: [:execution_pool])
+                 end
+  end
+
   test "apply_encoded applies decoded config to favn application env" do
     encoded = ConsumerConfigTransport.encode(connection_modules: [MyApp.Connections.Warehouse])
 

--- a/apps/favn_local/test/dev_consumer_config_transport_test.exs
+++ b/apps/favn_local/test/dev_consumer_config_transport_test.exs
@@ -34,6 +34,7 @@ defmodule Favn.Dev.ConsumerConfigTransportTest do
       connections: [
         warehouse: [adapter: Favn.SQL.Adapter.DuckDB, database: "/tmp/warehouse.duckdb"]
       ],
+      execution_pools: [global: [max_concurrency: 5], mercatus_api: [max_concurrency: 2]],
       runner_plugins: [{FavnDuckdb, [execution_mode: :in_process]}],
       duckdb_in_process_client: [pool: MyApp.DuckPool, enabled: true, note: nil],
       duckdb_adbc: [driver: "/opt/duckdb/1.5.2/libduckdb.so", entrypoint: "duckdb_adbc_init"]
@@ -159,7 +160,7 @@ defmodule Favn.Dev.ConsumerConfigTransportTest do
              ConsumerConfigTransport.decode(
                encode_payload(%{
                   "schema_version" => 1,
-                  "entries" => duplicate_entries(7)
+                   "entries" => duplicate_entries(8)
                 })
               )
 
@@ -282,6 +283,7 @@ defmodule Favn.Dev.ConsumerConfigTransportTest do
     encoded =
       ConsumerConfigTransport.encode(
         connection_modules: [MyApp.Connections.Warehouse],
+        execution_pools: [global: [max_concurrency: 5], mercatus_api: [max_concurrency: 2]],
         runner_plugins: [{FavnDuckdb, [execution_mode: :in_process]}],
         duckdb_adbc: [driver: "/opt/duckdb/1.5.2/libduckdb.so", entrypoint: "duckdb_adbc_init"]
       )
@@ -291,6 +293,11 @@ defmodule Favn.Dev.ConsumerConfigTransportTest do
     purge_bootstrap_module()
     assert {:ok, _bindings} = Code.eval_string(ConsumerConfigTransport.bootstrap_eval_snippet())
     assert Application.get_env(:favn, :connection_modules) == [MyApp.Connections.Warehouse]
+
+    assert Application.get_env(:favn, :execution_pools) == [
+             global: [max_concurrency: 5],
+             mercatus_api: [max_concurrency: 2]
+           ]
 
     assert Application.get_env(:favn, :runner_plugins) == [
              {FavnDuckdb, [execution_mode: :in_process]}

--- a/apps/favn_local/test/dev_runtime_launch_test.exs
+++ b/apps/favn_local/test/dev_runtime_launch_test.exs
@@ -351,14 +351,29 @@ defmodule Favn.Dev.RuntimeLaunchTest do
       "web_session_secret" => String.duplicate("s", 64)
     }
 
+    previous_connections = Application.get_env(:favn, :connections)
+    previous_duckdb_adbc = Application.get_env(:favn, :duckdb_adbc)
+    previous_duckdb_in_process_client = Application.get_env(:favn, :duckdb_in_process_client)
     previous_execution_pools = Application.get_env(:favn, :execution_pools)
+    previous_runner_plugins = Application.get_env(:favn, :runner_plugins)
 
+    Application.put_env(:favn, :connections, warehouse: [database: "warehouse.duckdb"])
+    Application.put_env(:favn, :duckdb_adbc, driver: "/opt/duckdb/1.5.2/libduckdb.so")
+    Application.put_env(:favn, :duckdb_in_process_client, enabled: true)
     Application.put_env(:favn, :execution_pools,
       global: [max_concurrency: 5],
       mercatus_api: [max_concurrency: 2]
     )
 
-    on_exit(fn -> restore_env(:execution_pools, previous_execution_pools) end)
+    Application.put_env(:favn, :runner_plugins, [{FavnDuckdb, execution_mode: :in_process}])
+
+    on_exit(fn ->
+      restore_env(:connections, previous_connections)
+      restore_env(:duckdb_adbc, previous_duckdb_adbc)
+      restore_env(:duckdb_in_process_client, previous_duckdb_in_process_client)
+      restore_env(:execution_pools, previous_execution_pools)
+      restore_env(:runner_plugins, previous_runner_plugins)
+    end)
 
     operator = RuntimeLaunch.operator_spec(runtime, config, distribution_opts(), node_names, secrets)
     code = eval_code!(operator)
@@ -369,6 +384,11 @@ defmodule Favn.Dev.RuntimeLaunchTest do
 
     assert {:execution_pools, [global: [max_concurrency: 5], mercatus_api: [max_concurrency: 2]]} in
              decoded_config
+
+    refute Keyword.has_key?(decoded_config, :connections)
+    refute Keyword.has_key?(decoded_config, :duckdb_adbc)
+    refute Keyword.has_key?(decoded_config, :duckdb_in_process_client)
+    refute Keyword.has_key?(decoded_config, :runner_plugins)
 
     assert before?(
              code,

--- a/apps/favn_local/test/dev_runtime_launch_test.exs
+++ b/apps/favn_local/test/dev_runtime_launch_test.exs
@@ -260,15 +260,22 @@ defmodule Favn.Dev.RuntimeLaunchTest do
 
     previous_connection_modules = Application.get_env(:favn, :connection_modules)
     previous_connections = Application.get_env(:favn, :connections)
+    previous_execution_pools = Application.get_env(:favn, :execution_pools)
     previous_runner_plugins = Application.get_env(:favn, :runner_plugins)
 
     Application.put_env(:favn, :connection_modules, [MyApp.Connections.Warehouse])
     Application.put_env(:favn, :connections, warehouse: [database: "warehouse.duckdb"])
+    Application.put_env(:favn, :execution_pools,
+      global: [max_concurrency: 5],
+      mercatus_api: [max_concurrency: 2]
+    )
+
     Application.put_env(:favn, :runner_plugins, [{FavnDuckdb, execution_mode: :in_process}])
 
     on_exit(fn ->
       restore_env(:connection_modules, previous_connection_modules)
       restore_env(:connections, previous_connections)
+      restore_env(:execution_pools, previous_execution_pools)
       restore_env(:runner_plugins, previous_runner_plugins)
     end)
 
@@ -289,6 +296,9 @@ defmodule Favn.Dev.RuntimeLaunchTest do
     assert {:connection_modules, [MyApp.Connections.Warehouse]} in decoded_config
 
     assert {:connections, [warehouse: [database: "/tmp/consumer/warehouse.duckdb"]]} in decoded_config
+
+    assert {:execution_pools, [global: [max_concurrency: 5], mercatus_api: [max_concurrency: 2]]} in
+             decoded_config
 
     assert {:runner_plugins, [{FavnDuckdb, [execution_mode: :in_process]}]} in decoded_config
     assert code =~ "FAVN_DEV_CONSUMER_FAVN_CONFIG"
@@ -324,6 +334,47 @@ defmodule Favn.Dev.RuntimeLaunchTest do
 
     assert code =~ "validate_runner_node_name!"
     assert before?(code, "validate_runner_node_name!", "String.to_atom()")
+  end
+
+  test "operator spec applies transported consumer config before orchestrator starts" do
+    runtime = %{"orchestrator_root" => "/tmp/favn_runtime"}
+    config = Config.resolve([])
+
+    node_names = %{
+      runner_full: "favn_runner_test@host",
+      orchestrator_short: "favn_orchestrator_test"
+    }
+
+    secrets = %{
+      "rpc_cookie" => "cookie",
+      "service_token" => "token",
+      "web_session_secret" => String.duplicate("s", 64)
+    }
+
+    previous_execution_pools = Application.get_env(:favn, :execution_pools)
+
+    Application.put_env(:favn, :execution_pools,
+      global: [max_concurrency: 5],
+      mercatus_api: [max_concurrency: 2]
+    )
+
+    on_exit(fn -> restore_env(:execution_pools, previous_execution_pools) end)
+
+    operator = RuntimeLaunch.operator_spec(runtime, config, distribution_opts(), node_names, secrets)
+    code = eval_code!(operator)
+
+    decoded_config =
+      ConsumerConfigTransport.decode(operator.env["FAVN_DEV_CONSUMER_FAVN_CONFIG"])
+      |> then(fn {:ok, config} -> config end)
+
+    assert {:execution_pools, [global: [max_concurrency: 5], mercatus_api: [max_concurrency: 2]]} in
+             decoded_config
+
+    assert before?(
+             code,
+             "Application.put_env(:favn, key, value)",
+             "Application.ensure_all_started(:favn_orchestrator)"
+           )
   end
 
   test "orchestrator spec disables scheduler by default" do

--- a/apps/favn_view/lib/favn_view/components/run_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page.ex
@@ -176,7 +176,7 @@ defmodule FavnView.Components.RunDetailPage do
         id: :failures,
         label: "Failures",
         icon: "hero-exclamation-triangle",
-        count: run[:failed_asset_attempts]
+        count: failed_count(run)
       },
       %{
         id: :windows,
@@ -201,6 +201,10 @@ defmodule FavnView.Components.RunDetailPage do
   defp page_title(_run, run_id), do: "Run #{short_id(run_id)}"
   defp page_subtitle(%{found?: true, subtitle: subtitle}), do: subtitle
   defp page_subtitle(_run), do: "Run detail"
+
+  defp failed_count(run),
+    do: (run[:failed_asset_attempts] || 0) + (run[:backfill_failure_count] || 0)
+
   defp short_id(id) when is_binary(id) and byte_size(id) > 18, do: String.slice(id, 0, 18)
   defp short_id(id), do: to_string(id)
 end

--- a/apps/favn_view/lib/favn_view/components/run_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page.ex
@@ -28,12 +28,12 @@ defmodule FavnView.Components.RunDetailPage do
   attr :selected_attempt_id, :string, default: nil
 
   def run_detail_page(assigns) do
+    run = normalize_run(assigns.run)
+
     assigns =
-      assign(
-        assigns,
-        :selected_attempt,
-        selected_attempt(assigns.run, assigns.selected_attempt_id)
-      )
+      assigns
+      |> assign(:run, run)
+      |> assign(:selected_attempt, selected_attempt(run, assigns.selected_attempt_id))
 
     ~H"""
     <AppShell.app_shell
@@ -114,6 +114,7 @@ defmodule FavnView.Components.RunDetailPage do
   defdelegate sample_single_window_run(), to: Samples
   defdelegate sample_timeline_run(), to: Samples
   defdelegate sample_completed_timeline_run(), to: Samples
+  defdelegate sample_admission_failed_backfill(), to: Samples
   defdelegate not_found_run(), to: Samples
   defdelegate sample_execution_group(status \\ :running), to: Samples
 
@@ -121,6 +122,13 @@ defmodule FavnView.Components.RunDetailPage do
     do: Enum.find(attempts, &(&1.id == attempt_id))
 
   defp selected_attempt(_run, _attempt_id), do: nil
+
+  defp normalize_run(run) when is_map(run) do
+    run
+    |> Map.put_new(:failures, [])
+    |> Map.put_new(:backfill_failures, [])
+    |> Map.put_new(:backfill_failure_count, 0)
+  end
 
   defp default_timeline_state(%{active?: true}) do
     live_timeline_state()

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/failures.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/failures.ex
@@ -5,6 +5,13 @@ defmodule FavnView.Components.RunDetailPage.Failures do
   attr :run, :map, required: true
 
   def failures_panel(assigns) do
+    assigns =
+      assign(
+        assigns,
+        :failure_count,
+        length(assigns.run.failures) + length(assigns.run.backfill_failures)
+      )
+
     ~H"""
     <section data-testid="failures-view">
       <div class="mb-4 flex items-center justify-between gap-3">
@@ -14,18 +21,22 @@ defmodule FavnView.Components.RunDetailPage.Failures do
             Failed asset attempts with retry-relevant context.
           </p>
         </div>
-        <span class="badge badge-error badge-soft">{length(@run.failures)} failed</span>
+        <span class="badge badge-error badge-soft">{@failure_count} failed</span>
       </div>
 
       <div
-        :if={@run.failures == []}
+        :if={@failure_count == 0}
         class="rounded-box border border-dashed border-base-content/15 p-5 text-sm text-base-content/55"
       >
-        No failed asset attempts in this run.
+        No failed asset attempts or window runs in this run.
       </div>
 
       <div :if={@run.failures != []} class="space-y-2">
         <.failure_row :for={attempt <- @run.failures} attempt={attempt} />
+      </div>
+
+      <div :if={@run.backfill_failures != []} class="space-y-2">
+        <.window_failure_row :for={failure <- @run.backfill_failures} failure={failure} />
       </div>
     </section>
     """
@@ -53,6 +64,28 @@ defmodule FavnView.Components.RunDetailPage.Failures do
       <p class="text-sm">Attempt {@attempt.attempt_number || "-"}</p>
       <p class="text-sm">{@attempt.duration}</p>
     </button>
+    """
+  end
+
+  attr :failure, :map, required: true
+
+  def window_failure_row(assigns) do
+    ~H"""
+    <div
+      class="grid w-full gap-3 rounded-box border border-error/30 bg-error/10 p-3 text-left lg:grid-cols-[minmax(0,1fr)_8rem_10rem_6rem_8rem]"
+      data-testid="window-failure-row"
+    >
+      <div class="min-w-0">
+        <p class="truncate font-medium text-error">{@failure.short_asset_name}</p>
+        <p class="truncate text-xs text-base-content/55">
+          {@failure.error_summary || "No error summary"}
+        </p>
+      </div>
+      <p class="text-sm">{@failure.window_label}</p>
+      <p class="font-mono text-xs text-base-content/60">{@failure.child_run_id || "-"}</p>
+      <p class="text-sm">Attempt {@failure.attempt_count || "-"}</p>
+      <p class="text-sm">{@failure.duration}</p>
+    </div>
     """
   end
 end

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/failures.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/failures.ex
@@ -5,12 +5,12 @@ defmodule FavnView.Components.RunDetailPage.Failures do
   attr :run, :map, required: true
 
   def failures_panel(assigns) do
+    backfill_failure_count = backfill_failure_count(assigns.run)
+
     assigns =
-      assign(
-        assigns,
-        :failure_count,
-        length(assigns.run.failures) + length(assigns.run.backfill_failures)
-      )
+      assigns
+      |> assign(:backfill_failure_count, backfill_failure_count)
+      |> assign(:failure_count, length(assigns.run.failures) + backfill_failure_count)
 
     ~H"""
     <section data-testid="failures-view">
@@ -36,6 +36,12 @@ defmodule FavnView.Components.RunDetailPage.Failures do
       </div>
 
       <div :if={@run.backfill_failures != []} class="space-y-2">
+        <p
+          :if={@backfill_failure_count > length(@run.backfill_failures)}
+          class="text-xs text-base-content/55"
+        >
+          Showing {length(@run.backfill_failures)} of {@backfill_failure_count} failed window runs.
+        </p>
         <.window_failure_row :for={failure <- @run.backfill_failures} failure={failure} />
       </div>
     </section>
@@ -71,21 +77,41 @@ defmodule FavnView.Components.RunDetailPage.Failures do
 
   def window_failure_row(assigns) do
     ~H"""
+    <.link
+      :if={@failure.child_run_id}
+      navigate={~p"/runs/#{@failure.child_run_id}"}
+      class="grid w-full gap-3 rounded-box border border-error/30 bg-error/10 p-3 text-left transition hover:border-error/60 lg:grid-cols-[minmax(0,1fr)_8rem_10rem_6rem_8rem]"
+      data-testid="window-failure-row"
+    >
+      <.window_failure_row_content failure={@failure} />
+    </.link>
     <div
+      :if={is_nil(@failure.child_run_id)}
       class="grid w-full gap-3 rounded-box border border-error/30 bg-error/10 p-3 text-left lg:grid-cols-[minmax(0,1fr)_8rem_10rem_6rem_8rem]"
       data-testid="window-failure-row"
     >
-      <div class="min-w-0">
-        <p class="truncate font-medium text-error">{@failure.short_asset_name}</p>
-        <p class="truncate text-xs text-base-content/55">
-          {@failure.error_summary || "No error summary"}
-        </p>
-      </div>
-      <p class="text-sm">{@failure.window_label}</p>
-      <p class="font-mono text-xs text-base-content/60">{@failure.child_run_id || "-"}</p>
-      <p class="text-sm">Attempt {@failure.attempt_count || "-"}</p>
-      <p class="text-sm">{@failure.duration}</p>
+      <.window_failure_row_content failure={@failure} />
     </div>
     """
   end
+
+  attr :failure, :map, required: true
+
+  def window_failure_row_content(assigns) do
+    ~H"""
+    <div class="min-w-0">
+      <p class="truncate font-medium text-error">{@failure.short_asset_name}</p>
+      <p class="truncate text-xs text-base-content/55">
+        {@failure.error_summary || "No error summary"}
+      </p>
+    </div>
+    <p class="text-sm">{@failure.window_label}</p>
+    <p class="font-mono text-xs text-base-content/60">{@failure.child_run_id || "-"}</p>
+    <p class="text-sm">Attempt {@failure.attempt_count || "-"}</p>
+    <p class="text-sm">{@failure.duration}</p>
+    """
+  end
+
+  defp backfill_failure_count(run),
+    do: Map.get(run, :backfill_failure_count, length(Map.get(run, :backfill_failures, [])))
 end

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/overview.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/overview.ex
@@ -58,9 +58,12 @@ defmodule FavnView.Components.RunDetailPage.Overview do
         <span :for={attempt <- @run.failures}>
           {attempt.short_asset_name} {attempt.error_summary}
         </span>
+        <span :for={failure <- @run.backfill_failures}>
+          {failure.short_asset_name} {failure.window_label} {failure.error_summary}
+        </span>
         <span>{@run.latest_event_summary}</span>
         <button
-          :if={@run.failures != []}
+          :if={@run.failures != [] or @run.backfill_failures != []}
           type="button"
           class="sr-only"
           data-testid="asset-error-copy-button"
@@ -70,16 +73,16 @@ defmodule FavnView.Components.RunDetailPage.Overview do
       </div>
 
       <div
-        :if={@run.failed_windows > 0 and @run.failures != []}
+        :if={@run.failed_windows > 0 and @run.backfill_failures != []}
         class="sr-only"
         data-testid="backfill-failure-list"
       >
-        Failed backfill window Showing {length(@run.failures)} of {@run.failed_windows}
-        <div :for={attempt <- @run.failures} data-testid="backfill-failure-row">
-          {attempt.short_asset_name} {attempt.window_label} {attempt.error_summary}
+        Failed backfill window Showing {length(@run.backfill_failures)} of {@run.backfill_failure_count}
+        <div :for={failure <- @run.backfill_failures} data-testid="backfill-failure-row">
+          {failure.short_asset_name} {failure.window_label} {failure.error_summary}
           <.link
-            :if={attempt.child_run_id}
-            navigate={~p"/runs/#{@run.id}?view=windows&child_run_id=#{attempt.child_run_id}"}
+            :if={failure.child_run_id}
+            navigate={~p"/runs/#{@run.id}?view=windows&child_run_id=#{failure.child_run_id}"}
           >
             Open window run
           </.link>

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/samples.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/samples.ex
@@ -445,6 +445,72 @@ defmodule FavnView.Components.RunDetailPage.Samples do
     }
   end
 
+  def sample_admission_failed_backfill do
+    run = sample_execution_group(:error)
+    window = List.first(run.windows)
+
+    failure = %{
+      id: "run_backfill_unknown_pool_jan",
+      child_run_id: "run_backfill_unknown_pool_jan",
+      asset_ref: nil,
+      short_asset_name: "Window run",
+      window: window,
+      window_id: window.id,
+      window_label: window.label,
+      status: "Failed",
+      raw_status: :error,
+      status_tone: :error,
+      error_summary: "{:unknown_execution_pool, :mercatus_api}",
+      attempt_count: 1,
+      started_at: "May 19, 2026 16:26 UTC",
+      finished_at: "May 19, 2026 16:26 UTC",
+      duration: "0.0 s"
+    }
+
+    Map.merge(run, %{
+      raw_status: :error,
+      active?: false,
+      status: "Failed",
+      status_tone: :error,
+      failed_windows: 1,
+      total_asset_attempts: 0,
+      completed_asset_attempts: 0,
+      succeeded_asset_attempts: 0,
+      failed_asset_attempts: 0,
+      running_asset_attempts: 0,
+      queued_asset_attempts: 0,
+      progress_label: "0 / 0",
+      matrix: %{assets: [], windows: [window], rows: []},
+      assets: [],
+      windows: [window],
+      attempts: [],
+      failures: [],
+      backfill_failures: [failure],
+      backfill_failure_count: 1,
+      child_runs: [
+        %{
+          id: "run_backfill_unknown_pool_jan",
+          window: window,
+          window_label: window.label,
+          status: "Failed",
+          raw_status: :error,
+          status_tone: :error,
+          progress: "0 / 0",
+          started_at: "May 19, 2026 16:26 UTC",
+          finished_at: "May 19, 2026 16:26 UTC",
+          duration: "0.0 s",
+          succeeded_count: 0,
+          failed_count: 0,
+          running_count: 0,
+          queued_count: 0,
+          attempts: []
+        }
+      ],
+      timeline: [],
+      latest_event_summary: "Backfill failed"
+    })
+  end
+
   def not_found_run do
     %{
       found?: false,

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -231,6 +231,10 @@ defmodule FavnView.RunDetailLive do
     timeline = Enum.map(Map.get(detail, :timeline, []), &timeline_from_public(&1, attempts))
     matrix = matrix(attempts, windows)
     failures = Enum.filter(attempts, &(&1.status_tone == :error))
+
+    backfill_failures =
+      Enum.map(Map.get(root_detail, :backfill_failures, []), &backfill_failure_from_public/1)
+
     target = target_label(summary.target_assets)
     status = group_status(summary)
 
@@ -272,6 +276,9 @@ defmodule FavnView.RunDetailLive do
       legacy_asset_results: legacy_asset_results,
       legacy_asset_text: legacy_asset_text(legacy_asset_results),
       failures: failures,
+      backfill_failures: backfill_failures,
+      backfill_failure_count:
+        Map.get(root_detail, :backfill_failure_count, length(backfill_failures)),
       child_runs: child_runs,
       timeline: timeline,
       events: Enum.map(events, &event_from_public/1),
@@ -508,6 +515,33 @@ defmodule FavnView.RunDetailLive do
       started_at: LogsViewModel.timestamp_label(Map.get(window, :started_at)),
       finished_at: LogsViewModel.timestamp_label(Map.get(window, :finished_at)),
       duration: LogsViewModel.duration_ms_label(Map.get(window, :duration_ms))
+    }
+  end
+
+  defp backfill_failure_from_public(failure) do
+    window = window_from_public(Map.get(failure, :window))
+    status = Map.get(failure, :status)
+    asset_ref = Map.get(failure, :asset_ref)
+    child_run_id = Map.get(failure, :child_run_id)
+
+    %{
+      id: child_run_id || "backfill-window-#{window_identity(window)}",
+      child_run_id: child_run_id,
+      asset_ref: asset_ref,
+      short_asset_name:
+        LogsViewModel.display_name(asset_ref) || LogsViewModel.ref_label(asset_ref) ||
+          "Window run",
+      window: window,
+      window_id: window_identity(window),
+      window_label: window_label(window) || "No window",
+      status: status_label(status),
+      raw_status: status,
+      status_tone: status_tone(status),
+      error_summary: error_summary(Map.get(failure, :error)),
+      attempt_count: Map.get(failure, :attempt_count),
+      started_at: LogsViewModel.timestamp_label(Map.get(failure, :started_at)),
+      finished_at: LogsViewModel.timestamp_label(Map.get(failure, :finished_at)),
+      duration: LogsViewModel.duration_ms_label(Map.get(failure, :duration_ms))
     }
   end
 

--- a/apps/favn_view/storybook/components/run_detail_failures_page.story.exs
+++ b/apps/favn_view/storybook/components/run_detail_failures_page.story.exs
@@ -19,6 +19,15 @@ defmodule FavnView.Storybook.Components.RunDetailFailuresPage do
           nav_items: RunDetailPage.sample_nav_items(),
           active_mode: :failures
         }
+      },
+      %Variation{
+        id: :admission_failure,
+        attributes: %{
+          run: RunDetailPage.sample_admission_failed_backfill(),
+          run_id: "run_backfill_unknown_pool",
+          nav_items: RunDetailPage.sample_nav_items(),
+          active_mode: :failures
+        }
       }
     ]
   end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -1423,6 +1423,86 @@ defmodule FavnView.PageLiveTest do
            )
   end
 
+  test "backfill parent surfaces child admission failure without asset results", %{conn: conn} do
+    parent_id = "run_backfill_parent_unknown_pool"
+    child_id = "run_backfill_child_unknown_pool"
+    failed_ref = {__MODULE__.Assets, :inventory_by_day}
+    started_at = ~U[2026-05-01 00:00:00Z]
+    window_key = "day:2026-05-01"
+    error = {:unknown_execution_pool, :mercatus_api}
+
+    parent =
+      RunState.new(
+        id: parent_id,
+        manifest_version_id: "mv_view_assets",
+        manifest_content_hash: "hash_view_assets",
+        asset_ref: failed_ref,
+        target_refs: [failed_ref],
+        submit_kind: :backfill_pipeline,
+        trigger: %{kind: :backfill, pipeline_module: __MODULE__.Pipelines.DailyOrders},
+        metadata: %{pipeline_submit_ref: __MODULE__.Pipelines.DailyOrders}
+      )
+      |> RunState.transition(status: :error, error: :failed, result: %{status: :error})
+
+    child =
+      RunState.new(
+        id: child_id,
+        manifest_version_id: "mv_view_assets",
+        manifest_content_hash: "hash_view_assets",
+        asset_ref: failed_ref,
+        target_refs: [failed_ref],
+        submit_kind: :pipeline,
+        parent_run_id: parent_id,
+        root_run_id: parent_id,
+        lineage_depth: 1,
+        trigger: %{
+          kind: :backfill,
+          backfill_run_id: parent_id,
+          pipeline_module: __MODULE__.Pipelines.DailyOrders,
+          window_key: window_key
+        },
+        metadata: %{pipeline_submit_ref: __MODULE__.Pipelines.DailyOrders}
+      )
+      |> RunState.transition(status: :error, error: error, result: %{status: :error})
+
+    {:ok, window} =
+      BackfillWindow.new(%{
+        backfill_run_id: parent_id,
+        child_run_id: child_id,
+        latest_attempt_run_id: child_id,
+        pipeline_module: __MODULE__.Pipelines.DailyOrders,
+        manifest_version_id: "mv_view_assets",
+        window_kind: :day,
+        window_start_at: started_at,
+        window_end_at: DateTime.add(started_at, 1, :day),
+        timezone: "Etc/UTC",
+        window_key: window_key,
+        status: :error,
+        attempt_count: 1,
+        last_error: error,
+        started_at: started_at,
+        finished_at: started_at,
+        updated_at: started_at
+      })
+
+    assert :ok = Storage.put_run(parent)
+    assert :ok = Storage.put_run(child)
+    assert :ok = Storage.put_backfill_window(window)
+
+    {:ok, view, _html} = live(conn, ~p"/runs/#{parent_id}")
+
+    assert has_element?(view, ~s([data-testid="run-failure-summary"]), "1 backfill window failed")
+    assert has_element?(view, ~s([data-testid="backfill-failure-row"]), "unknown_execution_pool")
+    assert has_element?(view, ~s([data-testid="backfill-failure-row"]), "mercatus_api")
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Failures"]))
+    |> render_click()
+
+    assert has_element?(view, ~s([data-testid="window-failure-row"]), "unknown_execution_pool")
+    assert has_element?(view, ~s([data-testid="window-failure-row"]), "mercatus_api")
+  end
+
   test "run detail renders execution group header for backfill", %{conn: conn} do
     %{parent_id: parent_id} = seed_run_detail_group!()
 

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -1503,6 +1503,65 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="window-failure-row"]), "mercatus_api")
   end
 
+  test "run detail failures view counts all failed windows when details are capped", %{conn: conn} do
+    parent_id = "run_backfill_parent_many_window_failures"
+    failed_ref = {__MODULE__.Assets, :inventory_by_day}
+    started_at = ~U[2026-05-01 00:00:00Z]
+
+    parent =
+      RunState.new(
+        id: parent_id,
+        manifest_version_id: "mv_view_assets",
+        manifest_content_hash: "hash_view_assets",
+        asset_ref: failed_ref,
+        target_refs: [failed_ref],
+        submit_kind: :backfill_pipeline,
+        trigger: %{kind: :backfill, pipeline_module: __MODULE__.Pipelines.DailyOrders},
+        metadata: %{pipeline_submit_ref: __MODULE__.Pipelines.DailyOrders}
+      )
+      |> RunState.transition(status: :error, error: :failed, result: %{status: :error})
+
+    assert :ok = Storage.put_run(parent)
+
+    for day <- 1..12 do
+      window_start = DateTime.add(started_at, (day - 1) * 86_400, :second)
+
+      {:ok, window} =
+        BackfillWindow.new(%{
+          backfill_run_id: parent_id,
+          pipeline_module: __MODULE__.Pipelines.DailyOrders,
+          manifest_version_id: "mv_view_assets",
+          window_kind: :day,
+          window_start_at: window_start,
+          window_end_at: DateTime.add(window_start, 1, :day),
+          timezone: "Etc/UTC",
+          window_key: "day:2026-05-#{String.pad_leading(Integer.to_string(day), 2, "0")}",
+          status: :error,
+          attempt_count: 1,
+          last_error: {:unknown_execution_pool, :mercatus_api},
+          started_at: window_start,
+          finished_at: window_start,
+          updated_at: window_start
+        })
+
+      assert :ok = Storage.put_backfill_window(window)
+    end
+
+    {:ok, view, _html} = live(conn, ~p"/runs/#{parent_id}")
+
+    view
+    |> element(~s([data-testid="view-mode-rail"] button[aria-label="Failures"]))
+    |> render_click()
+
+    assert has_element?(view, ~s([data-testid="failures-view"]), "12 failed")
+
+    assert has_element?(
+             view,
+             ~s([data-testid="failures-view"]),
+             "Showing 10 of 12 failed window runs"
+           )
+  end
+
   test "run detail renders execution group header for backfill", %{conn: conn} do
     %{parent_id: parent_id} = seed_run_detail_group!()
 


### PR DESCRIPTION
## Summary
- Transport consumer `config :favn, :execution_pools` into local dev runtime processes.
- Apply transported consumer config before the local operator starts `:favn_orchestrator`.
- Surface child/window admission failures on top-level backfill run detail pages.

## Verification
- `mix format --check-formatted`
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_local cmd mix test --no-compile test/dev_consumer_config_transport_test.exs test/dev_runtime_launch_test.exs`
- `MIX_ENV=test mix do --app favn_view cmd mix test --no-compile test/favn_view/page_live_test.exs`