### PR TITLE
Fix run timeline range alignment

### DIFF
--- a/apps/favn_view/assets/js/app.js
+++ b/apps/favn_view/assets/js/app.js
@@ -69,16 +69,21 @@ const Hooks = {
     mounted() {
       this.userPaused = false
       this.followNow()
+      this.syncMinimapViewport()
 
       this.el.addEventListener("scroll", () => {
-        if (this.ignoreScroll || this.el.dataset.liveFollow !== "true") return
-        this.userPaused = true
-        this.pushEvent("timeline_pause_live", {})
+        if (!this.ignoreScroll && this.el.dataset.liveFollow === "true") {
+          this.userPaused = true
+          this.pushEvent("timeline_pause_live", {})
+        }
+
+        this.syncMinimapViewport()
       }, {passive: true})
 
       const minimap = document.getElementById("run-timeline-minimap")
       minimap?.addEventListener("click", event => {
-        const bounds = minimap.getBoundingClientRect()
+        const track = minimap.querySelector("[data-testid='timeline-minimap-track']") || minimap
+        const bounds = track.getBoundingClientRect()
         if (!bounds.width) return
 
         const ratio = Math.max(0, Math.min(1, (event.clientX - bounds.left) / bounds.width))
@@ -89,17 +94,24 @@ const Hooks = {
     },
     updated() {
       this.followNow()
+      this.syncMinimapViewport()
       if (this.pendingFocusRatio !== undefined) {
         const ratio = this.pendingFocusRatio
         this.pendingFocusRatio = undefined
-        window.requestAnimationFrame(() => this.scrollToRatio(ratio))
+        window.requestAnimationFrame(() => {
+          this.scrollToRatio(ratio)
+          this.syncMinimapViewport()
+        })
       }
     },
     scrollToRatio(ratio) {
       const maxScroll = Math.max(this.el.scrollWidth - this.el.clientWidth, 0)
       this.ignoreScroll = true
-      this.el.scrollLeft = Math.max(0, Math.min(maxScroll, ratio * maxScroll))
-      window.requestAnimationFrame(() => { this.ignoreScroll = false })
+      this.el.scrollLeft = Math.max(0, Math.min(maxScroll, this.el.scrollWidth * ratio - this.el.clientWidth / 2))
+      window.requestAnimationFrame(() => {
+        this.ignoreScroll = false
+        this.syncMinimapViewport()
+      })
     },
     followNow() {
       if (this.el.dataset.active !== "true" || this.el.dataset.liveFollow !== "true") return
@@ -111,7 +123,22 @@ const Hooks = {
 
       this.ignoreScroll = true
       this.el.scrollLeft = target
-      window.requestAnimationFrame(() => { this.ignoreScroll = false })
+      window.requestAnimationFrame(() => {
+        this.ignoreScroll = false
+        this.syncMinimapViewport()
+      })
+    },
+    syncMinimapViewport() {
+      const minimap = document.getElementById("run-timeline-minimap")
+      const viewport = minimap?.querySelector("[data-testid='timeline-minimap-viewport']")
+      if (!viewport) return
+
+      const scrollWidth = Math.max(this.el.scrollWidth, this.el.clientWidth, 1)
+      const width = Math.max(0, Math.min(100, this.el.clientWidth / scrollWidth * 100))
+      const left = Math.max(0, Math.min(100 - width, this.el.scrollLeft / scrollWidth * 100))
+
+      viewport.style.left = `${left}%`
+      viewport.style.width = `${width}%`
     }
   }
 }

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/timeline.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/timeline.ex
@@ -48,6 +48,8 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
           data-active={to_string(@timeline.active?)}
           data-live-follow={to_string(@timeline_state.live_follow?)}
           data-now-offset={@timeline.now_offset}
+          data-axis-start-ms={@timeline.axis_start_ms}
+          data-axis-end-ms={@timeline.axis_end_ms}
           data-fit-mode={to_string(@timeline_state.mode == :fit)}
           phx-hook={if(@timeline_hook?, do: "FavnTimeline")}
         >
@@ -60,8 +62,14 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
                 <div class="p-3">Started</div>
                 <div class="p-3">Duration</div>
               </div>
-              <div class="relative grid grid-cols-5 px-4 py-3 text-center">
-                <span :for={tick <- @timeline.ticks}>{tick.label}</span>
+              <div class="relative px-4 py-3">
+                <span
+                  :for={tick <- @timeline.ticks}
+                  class={timeline_tick_label_class(tick.index)}
+                  style={"left: #{tick.offset}%;"}
+                >
+                  {tick.label}
+                </span>
               </div>
             </div>
 
@@ -200,7 +208,10 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
       data-testid="timeline-minimap"
       data-target="run-timeline-scroll"
     >
-      <div class="relative h-full rounded-full bg-base-content/[0.06]">
+      <div
+        class="relative h-full rounded-full bg-base-content/[0.06]"
+        data-testid="timeline-minimap-track"
+      >
         <span
           :for={segment <- @timeline.minimap_segments}
           class={minimap_segment_class(segment.tone)}
@@ -346,7 +357,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
 
     active? = run[:active?] || Enum.any?(all_rows, &(&1.section == "running"))
     now = timeline_now(all_rows)
-    {start_ms, end_ms} = timeline_bounds(all_rows, now)
+    {start_ms, end_ms} = timeline_bounds(all_rows, now, timeline_state)
     span = max(end_ms - start_ms, 1)
     chart_width = timeline_chart_width(span, timeline_state)
 
@@ -377,6 +388,8 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
       ticks: timeline_ticks(start_ms, span),
       minimap_segments: minimap_segments(rows, start_ms, span, now),
       viewport: minimap_viewport(timeline_state),
+      axis_start_ms: start_ms,
+      axis_end_ms: end_ms,
       now: now,
       now_offset: percent(now - start_ms, span),
       chart_width: chart_width
@@ -518,19 +531,28 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
     end
   end
 
-  defp timeline_bounds(rows, now) do
+  defp timeline_bounds(rows, now, timeline_state) do
     real_values =
       rows
       |> Enum.reject(&(&1.section == "queued"))
       |> Enum.flat_map(fn row -> [row.start_ms, row.finish_ms] end)
       |> Enum.reject(&is_nil/1)
 
-    start_ms = Enum.min(real_values ++ [now - 30 * 60 * 1_000])
-    end_ms = Enum.max(real_values ++ [now])
-    padding = max(div(end_ms - start_ms, 12), 60_000)
+    {start_ms, end_ms} =
+      case real_values do
+        [] -> {now - fallback_window_ms(timeline_state), now}
+        values -> {Enum.min(values), Enum.max(values ++ [now])}
+      end
+
+    padding = timeline_padding(end_ms - start_ms)
 
     {start_ms - padding, end_ms + padding}
   end
+
+  defp timeline_padding(span), do: max(div(span, 24), 15_000)
+
+  defp fallback_window_ms(%{zoom: "full"}), do: zoom_ms("30m")
+  defp fallback_window_ms(%{zoom: zoom}), do: zoom_ms(zoom)
 
   defp timeline_chart_width(_span, %{mode: :fit}), do: "100%"
 
@@ -538,14 +560,18 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
     minutes = span / 60_000
     pixels = minutes * 10
 
-    "#{round(max(1216, min(pixels, 12_000)))}px"
+    timeline_chart_width_css(pixels)
   end
 
   defp timeline_chart_width(span, %{zoom: zoom}) do
     zoom_ms = zoom_ms(zoom)
     pixels = span / zoom_ms * 840
 
-    "#{round(max(1216, min(pixels, 12_000)))}px"
+    timeline_chart_width_css(pixels)
+  end
+
+  defp timeline_chart_width_css(pixels) do
+    "max(100%, #{round(max(1216, min(pixels, 12_000)))}px)"
   end
 
   defp zoom_ms("5m"), do: 5 * 60 * 1_000
@@ -590,7 +616,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
   defp timeline_ticks(start_ms, span) do
     for index <- 0..4 do
       tick_ms = start_ms + div(span * index, 4)
-      %{label: time_tick_label(tick_ms), offset: percent(tick_ms - start_ms, span)}
+      %{index: index, label: time_tick_label(tick_ms), offset: percent(tick_ms - start_ms, span)}
     end
   end
 
@@ -645,6 +671,15 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
 
   defp fit_button_class(true), do: "btn btn-sm join-item btn-warning"
   defp fit_button_class(false), do: "btn btn-sm join-item favn-surface-control"
+
+  defp timeline_tick_label_class(0),
+    do: "absolute top-1/2 -translate-y-1/2 whitespace-nowrap text-left"
+
+  defp timeline_tick_label_class(4),
+    do: "absolute top-1/2 -translate-x-full -translate-y-1/2 whitespace-nowrap text-right"
+
+  defp timeline_tick_label_class(_index),
+    do: "absolute top-1/2 -translate-x-1/2 -translate-y-1/2 whitespace-nowrap text-center"
 
   defp minimap_segment_class(:success),
     do: "absolute top-1/2 h-3 -translate-y-1/2 rounded-full bg-success/70"

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -1832,6 +1832,73 @@ defmodule FavnView.PageLiveTest do
     refute has_element?(view, ~s([data-testid="timeline-now-marker"]))
   end
 
+  test "run detail timeline fit bounds use real attempt times" do
+    started_at = ~U[2026-05-20 17:59:00Z]
+    finished_at = ~U[2026-05-20 17:59:20Z]
+
+    run = %{
+      active?: false,
+      windows: [],
+      timeline: [
+        %{
+          timeline_attempt(:ok)
+          | started_at_raw: started_at,
+            finished_at_raw: finished_at,
+            started_at: "May 20, 2026 17:59 UTC",
+            duration: "20s"
+        }
+      ]
+    }
+
+    html =
+      render_component(&Timeline.timeline_panel/1,
+        run: run,
+        timeline_hook?: false,
+        timeline_state: %{
+          mode: :fit,
+          zoom: "full",
+          live_follow?: false,
+          search: "",
+          status: "all",
+          window: "all",
+          failed_only?: false,
+          running_only?: false
+        }
+      )
+
+    [_, axis_start] = Regex.run(~r/data-axis-start-ms="(\d+)"/, html)
+    [_, axis_end] = Regex.run(~r/data-axis-end-ms="(\d+)"/, html)
+
+    assert String.to_integer(axis_start) >= DateTime.to_unix(started_at, :millisecond) - 60_000
+    assert String.to_integer(axis_end) <= DateTime.to_unix(finished_at, :millisecond) + 60_000
+  end
+
+  test "run detail timeline non-fit width still fills wide viewports" do
+    run = %{
+      active?: true,
+      windows: [],
+      timeline: [timeline_attempt(:running)]
+    }
+
+    html =
+      render_component(&Timeline.timeline_panel/1,
+        run: run,
+        timeline_hook?: false,
+        timeline_state: %{
+          mode: :live,
+          zoom: "30m",
+          live_follow?: true,
+          search: "",
+          status: "all",
+          window: "all",
+          failed_only?: false,
+          running_only?: false
+        }
+      )
+
+    assert html =~ "width: max(100%,"
+  end
+
   test "run detail timeline zoom controls update rendered state", %{conn: conn} do
     %{parent_id: parent_id} = seed_run_detail_group!()
 


### PR DESCRIPTION
## Summary
- Align timeline tick labels with the actual grid markers and keep the timeline canvas filling wide viewports.
- Base fit/full timeline bounds on real attempt timestamps instead of synthetic pre-run padding.
- Sync the minimap viewport from actual scroll position and center minimap clicks.

## Verification
- mix format
- mix assets.build
- mix compile --warnings-as-errors
- apps/favn_view: mix test test/favn_view/page_live_test.exs
- apps/favn_view: mix test
- MIX_ENV=test mix do --app favn_local cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser