### PR TITLE
Fix pipeline history window labels

### DIFF
--- a/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
@@ -286,6 +286,10 @@ defmodule FavnView.PipelineDetailLive do
   defp scope_label(nil), do: "-"
   defp scope_label(value) when is_binary(value), do: value
 
+  defp scope_label(%{type: :window} = value) do
+    labelled_scope_value(value) || window_scope_label(value)
+  end
+
   defp scope_label(%{type: :range} = value) do
     [
       Map.get(value, :kind),
@@ -301,11 +305,34 @@ defmodule FavnView.PipelineDetailLive do
   end
 
   defp scope_label(value) when is_map(value) do
-    Map.get(value, :label) || Map.get(value, "label") || Map.get(value, :id) ||
-      Map.get(value, "id") || Map.get(value, :key) || Map.get(value, "key") || inspect(value)
+    labelled_scope_value(value) || inspect(value)
   end
 
   defp scope_label(value), do: inspect(value)
+
+  defp labelled_scope_value(value) do
+    [:label, "label", :id, "id", :key, "key"]
+    |> Enum.find_value(fn key ->
+      case Map.get(value, key) do
+        label when is_binary(label) -> label
+        label when is_atom(label) -> Atom.to_string(label)
+        label when is_integer(label) -> Integer.to_string(label)
+        _other -> nil
+      end
+    end)
+  end
+
+  defp window_scope_label(value) do
+    kind = Map.get(value, :kind) || Map.get(value, "kind")
+    timezone = Map.get(value, :timezone) || Map.get(value, "timezone")
+
+    case {kind, timezone} do
+      {nil, nil} -> inspect(value)
+      {nil, timezone} -> timezone
+      {kind, nil} -> humanize(kind)
+      {kind, timezone} -> "#{humanize(kind)} #{timezone}"
+    end
+  end
 
   defp range_boundary_label(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
   defp range_boundary_label(value), do: value

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -32,7 +32,7 @@ defmodule FavnView.PageLiveTest do
     version = manifest_version()
     assert :ok = FavnOrchestrator.register_manifest(version)
     assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
-    assert :ok = Storage.put_run(run_state(:customer_orders_daily, :ok, -600))
+    assert :ok = Storage.put_run(run_state(:customer_orders_daily, :ok, -650))
     assert :ok = Storage.put_run(run_state(:raw_payments, :running, -30))
     assert :ok = Storage.put_run(pipeline_run_state())
 

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -266,6 +266,30 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="pipeline-runs-table"]), "run_daily_orders")
   end
 
+  test "pipeline detail renders run history when window keys are maps", %{conn: conn} do
+    assert :ok =
+             Storage.put_run(
+               pipeline_run_state(
+                 id: "run_daily_orders_windowed",
+                 metadata: %{
+                   selected_window: %{
+                     kind: :month,
+                     key: %{
+                       "kind" => "month",
+                       "start_at_us" => 1_772_323_200_000_000,
+                       "timezone" => "Etc/UTC"
+                     },
+                     timezone: "Etc/UTC"
+                   }
+                 }
+               )
+             )
+
+    {:ok, view, _html} = live(conn, pipeline_detail_path())
+
+    assert has_element?(view, ~s([data-testid="pipeline-runs-table"]), "run_daily...ndowed")
+  end
+
   test "pipeline detail does not invent an implicit window for normal pipeline runs", %{
     conn: conn
   } do
@@ -2635,23 +2659,30 @@ defmodule FavnView.PageLiveTest do
     |> RunState.with_snapshot_hash()
   end
 
-  defp pipeline_run_state do
+  defp pipeline_run_state(opts \\ []) do
     ref = {__MODULE__.Assets, :customer_orders_daily}
     finished_at = DateTime.add(DateTime.utc_now(), -900, :second)
     started_at = DateTime.add(finished_at, -5, :second)
+    id = Keyword.get(opts, :id, "run_daily_orders")
+
+    metadata =
+      Map.merge(
+        %{
+          pipeline_submit_ref: __MODULE__.Pipelines.DailyOrders,
+          pipeline_target_refs: [ref],
+          pipeline_dependencies: :all
+        },
+        Keyword.get(opts, :metadata, %{})
+      )
 
     RunState.new(
-      id: "run_daily_orders",
+      id: id,
       manifest_version_id: "mv_view_assets",
       manifest_content_hash: "hash_view_assets",
       asset_ref: ref,
       target_refs: [ref],
       submit_kind: :pipeline,
-      metadata: %{
-        pipeline_submit_ref: __MODULE__.Pipelines.DailyOrders,
-        pipeline_target_refs: [ref],
-        pipeline_dependencies: :all
-      }
+      metadata: metadata
     )
     |> RunState.transition(
       status: :ok,


### PR DESCRIPTION
## Summary
- Prevent pipeline run history from rendering raw map-valued window keys in HEEx.
- Add a LiveView regression test covering selected window metadata with encoded map keys.

## Verification
- `mix format`
- `MIX_ENV=test mix do --app favn_view cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser test/favn_view/page_live_test.exs`
- `mix compile --warnings-as-errors`

Note: skipped full `mix test` per request; CI will run the broader suite.