### PR TITLE
Refine skipped run timeline handling

### DIFF
--- a/apps/favn_view/lib/favn_view/components/run_detail_page/attempt_drawer.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/attempt_drawer.ex
@@ -70,7 +70,24 @@ defmodule FavnView.Components.RunDetailPage.AttemptDrawer do
         />
 
         <div
-          :if={@attempt.error_summary}
+          :if={skipped_attempt?(@attempt)}
+          class="mt-3 rounded-box border border-base-content/10 bg-base-content/[0.035] p-3 text-sm text-base-content/75"
+        >
+          <p class="font-medium text-base-content">Skipped asset</p>
+          <p class="mt-1">
+            Window already ran{skipped_at(@attempt)}.
+            <.link
+              :if={attempt_run_href(@attempt)}
+              navigate={attempt_run_href(@attempt)}
+              class="ml-1 font-medium text-info underline-offset-2 hover:underline"
+            >
+              Open run
+            </.link>
+          </p>
+        </div>
+
+        <div
+          :if={@attempt.error_summary && !skipped_attempt?(@attempt)}
           class="mt-3 rounded-box border border-error/30 bg-error/10 p-3 text-sm text-error"
         >
           {@attempt.error_summary}
@@ -103,4 +120,22 @@ defmodule FavnView.Components.RunDetailPage.AttemptDrawer do
     </div>
     """
   end
+
+  defp skipped_attempt?(%{raw_status: status})
+       when status in [:skipped, :skipped_fresh, "skipped", "skipped_fresh"],
+       do: true
+
+  defp skipped_attempt?(_attempt), do: false
+
+  defp skipped_at(%{finished_at: finished_at}) when is_binary(finished_at) and finished_at != "-",
+    do: " on #{finished_at}"
+
+  defp skipped_at(%{started_at: started_at}) when is_binary(started_at) and started_at != "-",
+    do: " on #{started_at}"
+
+  defp skipped_at(_attempt), do: ""
+
+  defp attempt_run_href(%{child_run_id: run_id}) when is_binary(run_id), do: "/runs/#{run_id}"
+  defp attempt_run_href(%{run_id: run_id}) when is_binary(run_id), do: "/runs/#{run_id}"
+  defp attempt_run_href(_attempt), do: nil
 end

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/samples.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/samples.ex
@@ -293,6 +293,17 @@ defmodule FavnView.Components.RunDetailPage.Samples do
         error_summary: nil
       }),
       sample_attempt(%{
+        id: "returns-mar",
+        asset: "returns",
+        window: Enum.at(windows, 2),
+        status: :skipped_fresh,
+        duration: "0 ms",
+        start_min: 24,
+        duration_min: 0,
+        child_run_id: "run_sales_mar",
+        error_summary: "existing_success"
+      }),
+      sample_attempt(%{
         id: "taxes-apr",
         asset: "taxes",
         window: Enum.at(windows, 3),
@@ -366,13 +377,12 @@ defmodule FavnView.Components.RunDetailPage.Samples do
       completed_windows: 3,
       failed_windows: length(failures),
       total_asset_attempts: length(attempts),
-      completed_asset_attempts: Enum.count(attempts, &(&1.status_tone in [:success, :error])),
+      completed_asset_attempts: completed_sample_attempts(attempts),
       succeeded_asset_attempts: Enum.count(attempts, &(&1.status_tone == :success)),
       failed_asset_attempts: length(failures),
       running_asset_attempts: length(running),
       queued_asset_attempts: Enum.count(attempts, &(&1.status_tone == :warning)),
-      progress_label:
-        "#{Enum.count(attempts, &(&1.status_tone in [:success, :error]))} / #{length(attempts)}",
+      progress_label: "#{completed_sample_attempts(attempts)} / #{length(attempts)}",
       matrix: matrix,
       assets: matrix.assets,
       windows: windows,
@@ -429,7 +439,7 @@ defmodule FavnView.Components.RunDetailPage.Samples do
         finished_at: "May 19, 2026 17:00 UTC",
         duration: "36m",
         elapsed_duration: "36m",
-        completed_asset_attempts: Enum.count(attempts, &(&1.status_tone in [:success, :error])),
+        completed_asset_attempts: completed_sample_attempts(attempts),
         succeeded_asset_attempts: Enum.count(attempts, &(&1.status_tone == :success)),
         failed_asset_attempts: length(failures),
         running_asset_attempts: 0,
@@ -755,8 +765,7 @@ defmodule FavnView.Components.RunDetailPage.Samples do
         window_label: window.label,
         status: child_status(child_attempts),
         status_tone: child_tone(child_attempts),
-        progress:
-          "#{Enum.count(child_attempts, &(&1.status_tone in [:success, :error]))} / #{length(child_attempts)}",
+        progress: "#{completed_sample_attempts(child_attempts)} / #{length(child_attempts)}",
         started_at: "May 19, 2026 16:26 UTC",
         finished_at: "-",
         duration: "5m 41s",
@@ -785,6 +794,10 @@ defmodule FavnView.Components.RunDetailPage.Samples do
       Enum.any?(attempts, &(&1.status_tone == :warning)) -> :warning
       true -> :success
     end
+  end
+
+  defp completed_sample_attempts(attempts) do
+    Enum.count(attempts, &(&1.status_tone not in [:info, :warning]))
   end
 
   defp sample_events(status) do

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/timeline.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/timeline.ex
@@ -122,6 +122,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
         <option value="running" selected={@timeline_state.status == "running"}>Running</option>
         <option value="succeeded" selected={@timeline_state.status == "succeeded"}>Succeeded</option>
         <option value="failed" selected={@timeline_state.status == "failed"}>Failed</option>
+        <option value="skipped" selected={@timeline_state.status == "skipped"}>Skipped</option>
         <option value="queued" selected={@timeline_state.status == "queued"}>Queued</option>
       </select>
       <select
@@ -303,6 +304,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
       data-attempt-id={@row.attempt_id}
       data-window-label={@row.window_label}
       data-start-sort={@row.start_sort || "none"}
+      data-completed-sort={@row.completed_sort || "none"}
       data-time-mode={@row.time_mode}
     >
       <div class="sticky left-0 z-20 grid grid-cols-[minmax(0,1.4fr)_8rem_7rem_8rem_7rem] items-center border-r border-base-content/10 bg-base-300/80 text-sm backdrop-blur group-hover:bg-base-300/95">
@@ -352,8 +354,15 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
     running =
       rows |> Enum.filter(&(&1.section == "running")) |> Enum.sort_by(&(&1.start_sort || 0))
 
-    ran = rows |> Enum.filter(&(&1.section == "ran")) |> Enum.sort_by(&(&1.start_sort || 0))
+    ran =
+      rows
+      |> Enum.filter(&(&1.section == "ran"))
+      |> Enum.sort_by(&(&1.completed_sort || 0), :desc)
+
     queued = Enum.filter(rows, &(&1.section == "queued"))
+
+    skipped =
+      rows |> Enum.filter(&(&1.section == "skipped")) |> Enum.sort_by(&(&1.start_sort || 0))
 
     active? = run[:active?] || Enum.any?(all_rows, &(&1.section == "running"))
     now = timeline_now(all_rows)
@@ -379,6 +388,12 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
         label: "Queued",
         hint: "Queued work is shown without fabricated scheduled bars.",
         rows: Enum.map(queued, &position_timeline_row(&1, start_ms, span, now))
+      },
+      %{
+        id: "skipped",
+        label: "Skipped",
+        hint: "Skipped assets already had successful work for this window.",
+        rows: Enum.map(skipped, &position_timeline_row(&1, start_ms, span, now))
       }
     ]
 
@@ -410,6 +425,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
         "running" -> row.section == "running"
         "succeeded" -> row.status_tone == :success
         "failed" -> row.status_tone == :error
+        "skipped" -> row.section == "skipped"
         "queued" -> row.section == "queued"
         _status -> true
       end
@@ -446,7 +462,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
       asset_key: attempt[:asset_key] || attempt[:asset_ref] || attempt[:short_asset_name],
       asset_name: attempt[:short_asset_name] || attempt[:asset_name] || attempt[:asset_key],
       window_label: attempt[:window_label] || "No window",
-      status: attempt[:status] || status_label(attempt[:raw_status]),
+      status: timeline_status_label(attempt),
       raw_status: attempt[:raw_status],
       status_tone: attempt[:status_tone],
       started_at: attempt[:started_at] || "-",
@@ -456,13 +472,24 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
       start_ms: start_ms,
       finish_ms: finish_ms,
       start_sort: start_ms || attempt[:timeline_order],
+      completed_sort: finish_ms || start_ms || attempt[:timeline_order],
       order: attempt[:timeline_order] || 0,
       time_mode: timeline_time_mode(section, start_ms, finish_ms),
       has_real_bar?: not is_nil(start_ms) and section != "queued"
     }
   end
 
+  defp timeline_status_label(%{raw_status: status})
+       when status in [:skipped, :skipped_fresh, "skipped", "skipped_fresh"],
+       do: "Skipped"
+
+  defp timeline_status_label(attempt), do: attempt[:status] || status_label(attempt[:raw_status])
+
   defp timeline_section_for(status) when status in [:running, :retrying], do: "running"
+
+  defp timeline_section_for(status)
+       when status in [:skipped_fresh, :skipped, "skipped_fresh", "skipped"],
+       do: "skipped"
 
   defp timeline_section_for(status)
        when status in [
@@ -472,9 +499,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
               :failed,
               :timed_out,
               :cancelled,
-              :blocked,
-              :skipped_fresh,
-              :skipped
+              :blocked
             ],
        do: "ran"
 
@@ -484,6 +509,9 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
     do: "started-to-now"
 
   defp timeline_time_mode("ran", start_ms, finish_ms)
+       when is_integer(start_ms) and is_integer(finish_ms), do: "started-to-finished"
+
+  defp timeline_time_mode("skipped", start_ms, finish_ms)
        when is_integer(start_ms) and is_integer(finish_ms), do: "started-to-finished"
 
   defp timeline_time_mode("queued", nil, _finish_ms), do: "no-start"
@@ -646,6 +674,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
   defp timeline_empty_label("running"), do: "No attempts are running."
   defp timeline_empty_label("ran"), do: "No attempts have completed yet."
   defp timeline_empty_label("queued"), do: "No queued attempts."
+  defp timeline_empty_label("skipped"), do: "No skipped attempts."
 
   defp timeline_zoom_levels do
     [
@@ -700,10 +729,12 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
   defp timeline_section_icon("running"), do: "hero-arrow-path"
   defp timeline_section_icon("ran"), do: "hero-check-circle"
   defp timeline_section_icon("queued"), do: "hero-clock"
+  defp timeline_section_icon("skipped"), do: "hero-minus-circle"
 
   defp timeline_section_icon_class("running"), do: "size-4 text-info"
   defp timeline_section_icon_class("ran"), do: "size-4 text-success"
   defp timeline_section_icon_class("queued"), do: "size-4 text-warning"
+  defp timeline_section_icon_class("skipped"), do: "size-4 text-base-content/50"
 
   defp timeline_bar_class(:success),
     do:

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/ui.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/ui.ex
@@ -9,6 +9,7 @@ defmodule FavnView.Components.RunDetailPage.Ui do
   def status_label(:cancelled), do: "Cancelled"
   def status_label(:timed_out), do: "Timed out"
   def status_label(:skipped), do: "Skipped"
+  def status_label(:skipped_fresh), do: "Skipped"
   def status_label(nil), do: "Pending"
 
   def status_label(status),

--- a/apps/favn_view/lib/favn_view/components/runs_list_page.ex
+++ b/apps/favn_view/lib/favn_view/components/runs_list_page.ex
@@ -930,7 +930,7 @@ defmodule FavnView.Components.RunsListPage do
   defp status_label(:error), do: "Failed"
   defp status_label(:blocked), do: "Blocked"
   defp status_label(:cancelled), do: "Cancelled"
-  defp status_label(:skipped_fresh), do: "Skipped fresh"
+  defp status_label(:skipped_fresh), do: "Skipped"
   defp status_label(:timed_out), do: "Timed out"
   defp status_label(_status), do: "Unknown"
 

--- a/apps/favn_view/lib/favn_view/logs_view_model.ex
+++ b/apps/favn_view/lib/favn_view/logs_view_model.ex
@@ -105,7 +105,7 @@ defmodule FavnView.LogsViewModel do
   def status_label(status) when status in [:error, "error"], do: "Failed"
   def status_label(status) when status in [:blocked, "blocked"], do: "Blocked"
   def status_label(status) when status in [:cancelled, "cancelled"], do: "Cancelled"
-  def status_label(status) when status in [:skipped_fresh, "skipped_fresh"], do: "Skipped fresh"
+  def status_label(status) when status in [:skipped_fresh, "skipped_fresh"], do: "Skipped"
   def status_label(status) when status in [:timed_out, "timed_out"], do: "Timed out"
   def status_label(nil), do: "Unknown"
   def status_label(status), do: humanize(status)

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -857,7 +857,7 @@ defmodule FavnView.RunDetailLive do
   defp status_label(:running), do: "Running"
   defp status_label(:retrying), do: "Retrying"
   defp status_label(:skipped), do: "Skipped"
-  defp status_label(:skipped_fresh), do: "Skipped fresh"
+  defp status_label(:skipped_fresh), do: "Skipped"
   defp status_label(:blocked), do: "Blocked"
   defp status_label(:partial), do: "Partial"
   defp status_label(nil), do: "Pending"

--- a/apps/favn_view/storybook/components/run_detail_timeline_page.story.exs
+++ b/apps/favn_view/storybook/components/run_detail_timeline_page.story.exs
@@ -57,6 +57,25 @@ defmodule FavnView.Storybook.Components.RunDetailTimelinePage do
             running_only?: false
           }
         }
+      },
+      %Variation{
+        id: :skipped_filter,
+        attributes: %{
+          run: RunDetailPage.sample_completed_timeline_run(),
+          run_id: "run_sales_backfill_timeline_done",
+          nav_items: RunDetailPage.sample_nav_items(),
+          active_mode: :timeline,
+          timeline_state: %{
+            mode: :fit,
+            zoom: "full",
+            live_follow?: false,
+            search: "",
+            status: "skipped",
+            window: "all",
+            failed_only?: false,
+            running_only?: false
+          }
+        }
       }
     ]
   end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -12,6 +12,7 @@ defmodule FavnView.PageLiveTest do
   alias Favn.Window.Policy
   alias Favn.Window.Spec, as: WindowSpec
   alias FavnView.Components.AssetDetailPage
+  alias FavnView.Components.RunDetailPage.AttemptDrawer
   alias FavnView.Components.RunDetailPage.Timeline
   alias FavnView.Auth.BrowserSessionStore
   alias FavnOrchestrator.Auth
@@ -935,7 +936,7 @@ defmodule FavnView.PageLiveTest do
   test "run detail prefers node results for execution rows", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/runs/run_node_results")
 
-    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Skipped fresh")
+    assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Skipped")
     assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Retrying")
     assert has_element?(view, ~s([data-testid="run-asset-result-row"]), "Blocked")
     assert has_element?(view, ~s([data-testid="run-asset-result-row"][data-asset-step-id]))
@@ -1683,7 +1684,7 @@ defmodule FavnView.PageLiveTest do
            )
   end
 
-  test "run detail timeline groups attempts into running ran and queued", %{conn: conn} do
+  test "run detail timeline groups attempts into running ran queued and skipped", %{conn: conn} do
     %{parent_id: parent_id} = seed_run_detail_group!()
 
     {:ok, view, _html} = live(conn, ~p"/runs/#{parent_id}")
@@ -1707,9 +1708,15 @@ defmodule FavnView.PageLiveTest do
              ~s([data-testid="timeline-section"][data-section="queued"]),
              "Queued"
            )
+
+    assert has_element?(
+             view,
+             ~s([data-testid="timeline-section"][data-section="skipped"]),
+             "Skipped"
+           )
   end
 
-  test "run detail timeline sorts started groups by start time", %{conn: conn} do
+  test "run detail timeline sorts completed rows latest first", %{conn: conn} do
     %{parent_id: parent_id} = seed_run_detail_group!()
 
     {:ok, view, _html} = live(conn, ~p"/runs/#{parent_id}")
@@ -1717,7 +1724,7 @@ defmodule FavnView.PageLiveTest do
     html = render_click(view, "set_mode", %{"mode" => "timeline"})
 
     assert html =~
-             ~r/data-section="ran".*customer_orders_daily.*Jan 2026.*stg_payments.*Jan 2026.*customer_orders_daily.*Feb 2026/s
+             ~r/data-section="ran".*customer_orders_daily.*Feb 2026.*stg_payments.*Feb 2026.*customer_orders_daily.*Jan 2026/s
   end
 
   test "run detail timeline shows window labels on every row", %{conn: conn} do
@@ -1743,7 +1750,7 @@ defmodule FavnView.PageLiveTest do
     assert html =~ ~r/data-section="ran".*customer_orders_daily.*Feb 2026.*Failed/s
   end
 
-  test "run detail timeline puts blocked skipped fresh and partial attempts in ran" do
+  test "run detail timeline separates skipped attempts at the bottom" do
     run = %{
       active?: false,
       windows: [],
@@ -1776,8 +1783,41 @@ defmodule FavnView.PageLiveTest do
         }
       )
 
-    assert html =~ ~r/data-section="ran".*Blocked.*Skipped fresh.*Partial/s
+    assert html =~ ~r/data-section="ran".*Blocked.*Partial/s
+    assert html =~ ~r/data-section="skipped".*Skipped/s
     refute html =~ ~r/data-section="queued".*Blocked/s
+  end
+
+  test "run detail timeline filters skipped attempts" do
+    run = %{
+      active?: false,
+      windows: [],
+      timeline: [
+        timeline_attempt(:ok),
+        timeline_attempt(:skipped_fresh),
+        timeline_attempt(:queued)
+      ]
+    }
+
+    html =
+      render_component(&Timeline.timeline_panel/1,
+        run: run,
+        timeline_hook?: false,
+        timeline_state: %{
+          mode: :fit,
+          zoom: "full",
+          live_follow?: false,
+          search: "",
+          status: "skipped",
+          window: "all",
+          failed_only?: false,
+          running_only?: false
+        }
+      )
+
+    assert html =~ ~r/data-section="skipped".*asset_skipped_fresh.*Skipped/s
+    refute html =~ ~r/data-testid="timeline-row"[^>]+data-section="ran"/s
+    refute html =~ ~r/data-testid="timeline-row"[^>]+data-section="queued"/s
   end
 
   test "run detail timeline prefers authoritative attempts over matrix placeholders" do
@@ -2095,6 +2135,24 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="output-metadata"]), "Output metadata")
     assert has_element?(view, ~s([data-testid="output-metadata"]), "Rows written")
     assert has_element?(view, ~s([data-testid="output-metadata"]), "0")
+  end
+
+  test "run detail attempt drawer describes skipped attempts without error styling" do
+    attempt = %{
+      timeline_attempt(:skipped_fresh)
+      | status: "Skipped",
+        error_summary: "existing_success",
+        finished_at: "May 20, 2026 19:51 UTC",
+        child_run_id: "run_existing_window"
+    }
+
+    html = render_component(&AttemptDrawer.attempt_drawer/1, attempt: attempt)
+
+    assert html =~ "Skipped asset"
+    assert html =~ "Window already ran on May 20, 2026 19:51 UTC"
+    assert html =~ ~s(href="/runs/run_existing_window")
+    refute html =~ "existing_success"
+    refute html =~ "border-error"
   end
 
   test "run detail mode rail changes to events mode", %{conn: conn} do
@@ -2674,10 +2732,15 @@ defmodule FavnView.PageLiveTest do
     %{
       id: "attempt-#{status}",
       attempt_id: "attempt-#{status}",
+      root_execution_group_id: "run_backfill_test",
+      child_run_id: "run_window_test",
+      run_id: "run_window_test",
       asset_key: "asset_#{status}",
       asset_ref: "asset_#{status}",
       asset_name: "asset_#{status}",
       short_asset_name: "asset_#{status}",
+      stage_label: "Stage 0",
+      attempt_number: 0,
       window_label: "May 2026",
       raw_status: status,
       status: label,
@@ -2685,8 +2748,10 @@ defmodule FavnView.PageLiveTest do
       started_at_raw: ~U[2026-05-01 00:00:00Z],
       finished_at_raw: ~U[2026-05-01 00:00:10Z],
       started_at: "May 1, 2026 00:00 UTC",
+      finished_at: "May 1, 2026 00:00 UTC",
       duration: "10s",
-      error_summary: nil
+      error_summary: nil,
+      logs_href: "/runs/run_window_test/assets/attempt-#{status}/logs"
     }
   end
 


### PR DESCRIPTION
## Summary
- Move skipped asset attempts into a dedicated bottom timeline section with a Skipped filter.
- Normalize skipped-fresh labels to Skipped and show neutral skipped details instead of an error-looking reason.
- Sort completed timeline rows newest-first so the latest completion appears on top.

## Verification
- mix format
- cd apps/favn_view && mix test test/favn_view/page_live_test.exs
- cd apps/favn_view && mix compile --warnings-as-errors
- cd apps/favn_view && mix test