### PR TITLE
Normalize asset planner window shapes

### DIFF
--- a/apps/favn_core/lib/favn/assets/planner.ex
+++ b/apps/favn_core/lib/favn/assets/planner.ex
@@ -16,7 +16,7 @@ defmodule Favn.Assets.Planner do
   alias Favn.Plan
   alias Favn.Ref
   alias Favn.TimePeriod
-  alias Favn.Window.{Anchor, Key, Runtime, Spec, Validate}
+  alias Favn.Window.{Anchor, Key, Policy, Runtime, Spec, Validate}
 
   @typedoc """
   Planner options.
@@ -305,7 +305,63 @@ defmodule Favn.Assets.Planner do
 
   defp asset_window_spec(%{window_spec: %Spec{} = spec}), do: spec
   defp asset_window_spec(%{window: %Spec{} = spec}), do: spec
+
+  defp asset_window_spec(%{window: %Policy{kind: kind, timezone: timezone}}) do
+    spec_from_window(kind, timezone: timezone)
+  end
+
+  defp asset_window_spec(%{window: kind}) when is_atom(kind), do: spec_from_window(kind)
+
+  defp asset_window_spec(%{window: %{} = window}) do
+    kind = field_value(window, :kind)
+
+    opts =
+      []
+      |> maybe_put(:lookback, field_value(window, :lookback))
+      |> maybe_put(:refresh_from, field_value(window, :refresh_from))
+      |> maybe_put(:required, field_value(window, :required))
+      |> maybe_put(:timezone, field_value(window, :timezone))
+
+    spec_from_window(kind, opts)
+  end
+
   defp asset_window_spec(_asset), do: nil
+
+  defp spec_from_window(kind, opts \\ []) do
+    case normalize_kind(kind) do
+      {:ok, kind} ->
+        case Spec.new(kind, opts) do
+          {:ok, spec} -> spec
+          {:error, _reason} -> nil
+        end
+
+      {:error, _reason} ->
+        nil
+    end
+  end
+
+  defp normalize_kind(kind) when kind in [:hour, :day, :month, :year], do: {:ok, kind}
+
+  defp normalize_kind(kind) when is_binary(kind) do
+    case Policy.from_value(kind) do
+      {:ok, %Policy{kind: kind}} -> {:ok, kind}
+      {:ok, nil} -> {:error, {:invalid_window_policy_kind, kind}}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp normalize_kind(kind) do
+    case Policy.normalize_kind(kind) do
+      {:ok, kind} -> {:ok, kind}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp field_value(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, _key, ""), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
 
   defp expand_windows(%Anchor{} = anchor_window, %Spec{} = spec) do
     window_count =

--- a/apps/favn_core/lib/favn/assets/planner.ex
+++ b/apps/favn_core/lib/favn/assets/planner.ex
@@ -16,7 +16,7 @@ defmodule Favn.Assets.Planner do
   alias Favn.Plan
   alias Favn.Ref
   alias Favn.TimePeriod
-  alias Favn.Window.{Anchor, Key, Policy, Runtime, Spec, Validate}
+  alias Favn.Window.{Anchor, Key, Runtime, Spec, Validate}
 
   @typedoc """
   Planner options.
@@ -304,64 +304,16 @@ defmodule Favn.Assets.Planner do
   end
 
   defp asset_window_spec(%{window_spec: %Spec{} = spec}), do: spec
-  defp asset_window_spec(%{window: %Spec{} = spec}), do: spec
 
-  defp asset_window_spec(%{window: %Policy{kind: kind, timezone: timezone}}) do
-    spec_from_window(kind, timezone: timezone)
-  end
-
-  defp asset_window_spec(%{window: kind}) when is_atom(kind), do: spec_from_window(kind)
-
-  defp asset_window_spec(%{window: %{} = window}) do
-    kind = field_value(window, :kind)
-
-    opts =
-      []
-      |> maybe_put(:lookback, field_value(window, :lookback))
-      |> maybe_put(:refresh_from, field_value(window, :refresh_from))
-      |> maybe_put(:required, field_value(window, :required))
-      |> maybe_put(:timezone, field_value(window, :timezone))
-
-    spec_from_window(kind, opts)
+  defp asset_window_spec(%{window: window}) do
+    case Spec.from_value(window) do
+      {:ok, %Spec{} = spec} -> spec
+      {:ok, nil} -> nil
+      {:error, _reason} -> nil
+    end
   end
 
   defp asset_window_spec(_asset), do: nil
-
-  defp spec_from_window(kind, opts \\ []) do
-    case normalize_kind(kind) do
-      {:ok, kind} ->
-        case Spec.new(kind, opts) do
-          {:ok, spec} -> spec
-          {:error, _reason} -> nil
-        end
-
-      {:error, _reason} ->
-        nil
-    end
-  end
-
-  defp normalize_kind(kind) when kind in [:hour, :day, :month, :year], do: {:ok, kind}
-
-  defp normalize_kind(kind) when is_binary(kind) do
-    case Policy.from_value(kind) do
-      {:ok, %Policy{kind: kind}} -> {:ok, kind}
-      {:ok, nil} -> {:error, {:invalid_window_policy_kind, kind}}
-      {:error, _reason} = error -> error
-    end
-  end
-
-  defp normalize_kind(kind) do
-    case Policy.normalize_kind(kind) do
-      {:ok, kind} -> {:ok, kind}
-      {:error, _reason} = error -> error
-    end
-  end
-
-  defp field_value(map, key), do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
-
-  defp maybe_put(opts, _key, nil), do: opts
-  defp maybe_put(opts, _key, ""), do: opts
-  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
 
   defp expand_windows(%Anchor{} = anchor_window, %Spec{} = spec) do
     window_count =

--- a/apps/favn_core/lib/favn/manifest/rehydrate.ex
+++ b/apps/favn_core/lib/favn/manifest/rehydrate.ex
@@ -124,31 +124,10 @@ defmodule Favn.Manifest.Rehydrate do
   defp build_window_spec(%Spec{} = value), do: value
 
   defp build_window_spec(value) when is_map(value) do
-    kind = value |> field_value(:kind) |> decode_known_atom([:hour, :day, :month, :year])
-
-    opts = [
-      lookback: field_value(value, :lookback, 0),
-      required: field_value(value, :required, false),
-      timezone: field_value(value, :timezone, "Etc/UTC")
-    ]
-
-    opts =
-      case field_value(value, :refresh_from) do
-        nil ->
-          opts
-
-        refresh_from ->
-          Keyword.put(
-            opts,
-            :refresh_from,
-            decode_known_atom(refresh_from, [:hour, :day, :month, :year])
-          )
-      end
-
-    try do
-      Spec.new!(kind, opts)
-    rescue
-      _error -> plain_map(value)
+    case Spec.from_value(value) do
+      {:ok, %Spec{} = spec} -> spec
+      {:ok, nil} -> nil
+      {:error, _reason} -> plain_map(value)
     end
   end
 

--- a/apps/favn_core/lib/favn/window/spec.ex
+++ b/apps/favn_core/lib/favn/window/spec.ex
@@ -6,6 +6,7 @@ defmodule Favn.Window.Spec do
   particular run request.
   """
 
+  alias Favn.Window.Policy
   alias Favn.Window.Validate
 
   @type kind :: :hour | :day | :month | :year
@@ -70,6 +71,60 @@ defmodule Favn.Window.Spec do
   end
 
   @doc """
+  Normalizes persisted or DSL-shaped values into an asset runtime window spec.
+
+  This accepts the canonical struct, atom/string kind shorthands, persisted maps,
+  and policy-shaped values used by older manifests. Nil and empty option values
+  are omitted so normal `new/2` defaults still apply.
+
+  ## Examples
+
+      iex> Favn.Window.Spec.from_value(%{"kind" => "month", "refresh_from" => "day"})
+      {:ok, %Favn.Window.Spec{kind: :month, lookback: 0, refresh_from: :day, required: false, timezone: "Etc/UTC"}}
+
+      iex> Favn.Window.Spec.from_value(Favn.Window.Policy.new!(:daily))
+      {:ok, %Favn.Window.Spec{kind: :day, lookback: 0, refresh_from: nil, required: false, timezone: "Etc/UTC"}}
+  """
+  @spec from_value(term()) :: {:ok, t() | nil} | {:error, term()}
+  def from_value(nil), do: {:ok, nil}
+
+  def from_value(%__MODULE__{} = spec) do
+    with :ok <- validate(spec), do: {:ok, spec}
+  end
+
+  def from_value(%Policy{kind: kind, timezone: timezone}) do
+    opts = [] |> maybe_put(:timezone, timezone)
+    from_kind_and_opts(kind, opts)
+  end
+
+  def from_value(kind) when is_atom(kind) or is_binary(kind), do: from_kind_and_opts(kind, [])
+
+  def from_value(value) when is_map(value) do
+    kind = field_value(value, :kind)
+
+    with {:ok, refresh_from} <- value |> field_value(:refresh_from) |> normalize_optional_kind() do
+      opts =
+        []
+        |> maybe_put(:lookback, field_value(value, :lookback))
+        |> maybe_put(:required, field_value(value, :required))
+        |> maybe_put(:refresh_from, refresh_from)
+        |> maybe_put(:timezone, field_value(value, :timezone))
+
+      from_kind_and_opts(kind, opts)
+    end
+  end
+
+  def from_value(value) when is_list(value) do
+    if Keyword.keyword?(value) do
+      value |> Map.new() |> from_value()
+    else
+      {:error, {:invalid_window_spec, value}}
+    end
+  end
+
+  def from_value(value), do: {:error, {:invalid_window_spec, value}}
+
+  @doc """
   Validate an existing `%Favn.Window.Spec{}` struct.
   """
   @spec validate(t()) :: :ok | {:error, term()}
@@ -81,6 +136,42 @@ defmodule Favn.Window.Spec do
       Validate.timezone(spec.timezone)
     end
   end
+
+  defp from_kind_and_opts(kind, opts) do
+    with {:ok, kind} <- normalize_kind(kind) do
+      new(kind, opts)
+    end
+  end
+
+  defp normalize_optional_kind(nil), do: {:ok, nil}
+  defp normalize_optional_kind(""), do: {:ok, nil}
+  defp normalize_optional_kind(kind), do: normalize_kind(kind)
+
+  defp normalize_kind(kind) when kind in [:hour, :hourly], do: {:ok, :hour}
+  defp normalize_kind(kind) when kind in [:day, :daily], do: {:ok, :day}
+  defp normalize_kind(kind) when kind in [:month, :monthly], do: {:ok, :month}
+  defp normalize_kind(kind) when kind in [:year, :yearly], do: {:ok, :year}
+  defp normalize_kind(kind) when kind in ["hour", "hourly"], do: {:ok, :hour}
+  defp normalize_kind(kind) when kind in ["day", "daily"], do: {:ok, :day}
+  defp normalize_kind(kind) when kind in ["month", "monthly"], do: {:ok, :month}
+  defp normalize_kind(kind) when kind in ["year", "yearly"], do: {:ok, :year}
+  defp normalize_kind(kind), do: {:error, {:invalid_window_spec_kind, kind}}
+
+  defp field_value(map, key) do
+    string_key = Atom.to_string(key)
+
+    case Map.fetch(map, key) do
+      {:ok, value} ->
+        value
+
+      :error ->
+        Map.get(map, string_key)
+    end
+  end
+
+  defp maybe_put(opts, _key, nil), do: opts
+  defp maybe_put(opts, _key, ""), do: opts
+  defp maybe_put(opts, key, value), do: Keyword.put(opts, key, value)
 
   defp validate_lookback(lookback) when is_integer(lookback) and lookback >= 0, do: :ok
   defp validate_lookback(lookback), do: {:error, {:invalid_lookback, lookback}}

--- a/apps/favn_core/test/assets/planner_window_test.exs
+++ b/apps/favn_core/test/assets/planner_window_test.exs
@@ -72,7 +72,7 @@ defmodule Favn.Assets.PlannerWindowTest do
                  module: MyApp.Monthly,
                  name: :asset,
                  depends_on: [],
-                 window: %{"kind" => "month", "timezone" => "Etc/UTC"}
+                 window: %{"kind" => "month", "refresh_from" => "day", "timezone" => "Etc/UTC"}
                }
              ])
 
@@ -95,6 +95,26 @@ defmodule Favn.Assets.PlannerWindowTest do
                  name: :asset,
                  depends_on: [],
                  window: Policy.new!(:daily, timezone: "Etc/UTC")
+               }
+             ])
+
+    anchor = Anchor.new!(:day, ~U[2026-04-26 00:00:00Z], ~U[2026-04-27 00:00:00Z])
+
+    assert {:ok, plan} = Planner.plan(ref, graph_index: index, anchor_window: anchor)
+    assert [%{window: %{kind: :day, start_at: ~U[2026-04-26 00:00:00Z]}}] = Map.values(plan.nodes)
+  end
+
+  test "expands runtime windows from policy-shaped asset windows with default timezone" do
+    ref = {MyApp.PolicyWindowDefaultTimezone, :asset}
+
+    assert {:ok, index} =
+             GraphIndex.build_index([
+               %{
+                 ref: ref,
+                 module: MyApp.PolicyWindowDefaultTimezone,
+                 name: :asset,
+                 depends_on: [],
+                 window: Policy.new!(:daily)
                }
              ])
 

--- a/apps/favn_core/test/assets/planner_window_test.exs
+++ b/apps/favn_core/test/assets/planner_window_test.exs
@@ -4,6 +4,7 @@ defmodule Favn.Assets.PlannerWindowTest do
   alias Favn.Assets.GraphIndex
   alias Favn.Assets.Planner
   alias Favn.Window.Anchor
+  alias Favn.Window.Policy
   alias Favn.Window.Spec
 
   test "expands planner runtime windows from calendar anchor and lookback" do
@@ -59,6 +60,48 @@ defmodule Favn.Assets.PlannerWindowTest do
 
     assert {:ok, plan} = Planner.plan(ref, graph_index: index)
     assert [%{execution_pool: :github_api}] = Map.values(plan.nodes)
+  end
+
+  test "expands runtime windows from persisted asset window maps" do
+    ref = {MyApp.Monthly, :asset}
+
+    assert {:ok, index} =
+             GraphIndex.build_index([
+               %{
+                 ref: ref,
+                 module: MyApp.Monthly,
+                 name: :asset,
+                 depends_on: [],
+                 window: %{"kind" => "month", "timezone" => "Etc/UTC"}
+               }
+             ])
+
+    anchor = Anchor.new!(:month, ~U[2026-01-01 00:00:00Z], ~U[2026-02-01 00:00:00Z])
+
+    assert {:ok, plan} = Planner.plan(ref, graph_index: index, anchor_window: anchor)
+
+    assert [%{window: %{kind: :month, start_at: ~U[2026-01-01 00:00:00Z]}}] =
+             Map.values(plan.nodes)
+  end
+
+  test "expands runtime windows from policy-shaped asset windows" do
+    ref = {MyApp.PolicyWindow, :asset}
+
+    assert {:ok, index} =
+             GraphIndex.build_index([
+               %{
+                 ref: ref,
+                 module: MyApp.PolicyWindow,
+                 name: :asset,
+                 depends_on: [],
+                 window: Policy.new!(:daily, timezone: "Etc/UTC")
+               }
+             ])
+
+    anchor = Anchor.new!(:day, ~U[2026-04-26 00:00:00Z], ~U[2026-04-27 00:00:00Z])
+
+    assert {:ok, plan} = Planner.plan(ref, graph_index: index, anchor_window: anchor)
+    assert [%{window: %{kind: :day, start_at: ~U[2026-04-26 00:00:00Z]}}] = Map.values(plan.nodes)
   end
 
   defp oslo_datetime!(naive) do

--- a/apps/favn_core/test/window_schedule_test.exs
+++ b/apps/favn_core/test/window_schedule_test.exs
@@ -32,6 +32,17 @@ defmodule Favn.WindowTest do
     assert runtime.anchor_key == anchor.key
   end
 
+  test "normalizes persisted and policy-shaped window specs" do
+    assert {:ok, %Spec{kind: :month, refresh_from: :day, timezone: "Etc/UTC"}} =
+             Spec.from_value(%{"kind" => "month", "refresh_from" => "day"})
+
+    assert {:ok, %Spec{kind: :day, timezone: "Etc/UTC"}} =
+             Spec.from_value(Policy.new!(:daily))
+
+    assert {:ok, %Spec{kind: :hour, timezone: "Europe/Oslo"}} =
+             Spec.from_value(%{kind: :hourly, timezone: "Europe/Oslo"})
+  end
+
   test "encodes and decodes canonical keys" do
     key = Key.new!(:month, ~U[2026-04-01 00:00:00Z], "Etc/UTC")
 

--- a/apps/favn_orchestrator/test/backfill_manager_test.exs
+++ b/apps/favn_orchestrator/test/backfill_manager_test.exs
@@ -204,6 +204,12 @@ defmodule FavnOrchestrator.BackfillManagerTest do
     assert Enum.map(children, & &1.id) == child_run_ids
     assert Enum.all?(children, &(&1.root_run_id == parent_run_id))
     assert Enum.all?(children, &(&1.metadata.refresh_policy.mode == :missing))
+
+    assert Enum.all?(children, fn child ->
+             child.plan.nodes
+             |> Map.values()
+             |> Enum.all?(&match?(%Favn.Window.Runtime{}, &1.window))
+           end)
   end
 
   test "defaults child pipeline submissions to refresh missing" do


### PR DESCRIPTION
## Summary
- Normalize planner asset window handling for persisted maps, atom kinds, and policy-shaped window declarations.
- Add regression coverage so asset backfill child plans include runtime windows instead of reaching execution with missing window context.

## Tests
- MIX_ENV=test mix do --app favn_core cmd mix test test/assets/planner_window_test.exs
- MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/backfill_manager_test.exs
- mix format
- mix compile --warnings-as-errors
- MIX_ENV=test mix do --app favn_view cmd mix test
- MIX_ENV=test mix do --app favn_local cmd mix test --exclude acceptance --exclude slow --exclude browser

## Notes
- Full umbrella `mix test` exceeded tool timeout after passing most apps; `favn_local` full acceptance run separately failed one unrelated production readiness test.