### PR TITLE
Decode unloaded backfill pipeline modules

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/backfill/backfill_window_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/backfill/backfill_window_codec.ex
@@ -16,7 +16,7 @@ defmodule FavnOrchestrator.Storage.Backfill.BackfillWindowCodec do
   @spec decode(String.t()) :: {:ok, BackfillWindow.t()} | {:error, term()}
   def decode(payload) when is_binary(payload) do
     with {:ok, %{"format" => @format, "schema_version" => 1} = dto} <- Jason.decode(payload),
-         {:ok, pipeline_module} <- existing_atom(Map.get(dto, "pipeline_module")),
+         {:ok, pipeline_module} <- module_atom(Map.get(dto, "pipeline_module")),
          {:ok, window_start_at} <- datetime(Map.get(dto, "window_start_at")),
          {:ok, window_end_at} <- datetime(Map.get(dto, "window_end_at")),
          {:ok, started_at} <- optional_datetime(Map.get(dto, "started_at")),
@@ -105,6 +105,9 @@ defmodule FavnOrchestrator.Storage.Backfill.BackfillWindowCodec do
   end
 
   defp existing_atom(value), do: {:error, {:invalid_atom, value}}
+
+  defp module_atom("Elixir." <> _rest = value), do: {:ok, String.to_atom(value)}
+  defp module_atom(value), do: existing_atom(value)
 
   defp error_field(dto, field) do
     case Map.fetch(dto, field) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/materialization_claim_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/materialization_claim_codec.ex
@@ -22,13 +22,20 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodec do
 
   @spec decode(binary()) :: {:ok, MaterializationClaim.t()} | {:error, term()}
   def decode(payload) when is_binary(payload) do
-    payload
-    |> Base.decode64!()
-    |> :erlang.binary_to_term([:safe])
-    |> normalize()
+    with {:ok, binary} <- Base.decode64(payload) do
+      binary
+      |> decode_term()
+      |> normalize()
+    end
   rescue
     exception -> {:error, {:invalid_materialization_claim_payload, exception}}
   end
 
   def decode(_payload), do: {:error, :invalid_materialization_claim_payload}
+
+  defp decode_term(binary) when is_binary(binary) do
+    :erlang.binary_to_term(binary, [:safe])
+  rescue
+    ArgumentError -> :erlang.binary_to_term(binary)
+  end
 end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/materialization_claim_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/materialization_claim_codec.ex
@@ -24,8 +24,10 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodec do
   def decode(payload) when is_binary(payload) do
     with {:ok, binary} <- Base.decode64(payload) do
       binary
-      |> decode_term()
+      |> decode_trusted_legacy_term()
       |> normalize()
+    else
+      :error -> {:error, :invalid_materialization_claim_payload}
     end
   rescue
     exception -> {:error, {:invalid_materialization_claim_payload, exception}}
@@ -33,7 +35,10 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodec do
 
   def decode(_payload), do: {:error, :invalid_materialization_claim_payload}
 
-  defp decode_term(binary) when is_binary(binary) do
+  # Claims are internal durable state written by storage adapters, not external
+  # input. Older claim payloads used ETF and may contain consumer module atoms
+  # before those modules are loaded; the fallback recreates those trusted atoms.
+  defp decode_trusted_legacy_term(binary) when is_binary(binary) do
     :erlang.binary_to_term(binary, [:safe])
   rescue
     ArgumentError -> :erlang.binary_to_term(binary)

--- a/apps/favn_orchestrator/test/storage/backfill_read_model_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/backfill_read_model_codec_test.exs
@@ -84,6 +84,18 @@ defmodule FavnOrchestrator.Storage.BackfillReadModelCodecTest do
     assert restored.metadata["source"] == "backfill"
   end
 
+  test "backfill window codec restores unloaded pipeline module identities" do
+    pipeline_module =
+      "Elixir.FavnOrchestrator.Test.UnloadedPipeline#{System.unique_integer([:positive])}"
+
+    assert {:ok, restored} =
+             encoded_backfill_window_payload()
+             |> put_payload_field("pipeline_module", pipeline_module)
+             |> BackfillWindowCodec.decode()
+
+    assert Atom.to_string(restored.pipeline_module) == pipeline_module
+  end
+
   test "asset window state codec preserves identity fields and JSON-shaped payloads" do
     {:ok, state} =
       AssetWindowState.new(%{

--- a/apps/favn_orchestrator/test/storage/materialization_claim_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/materialization_claim_codec_test.exs
@@ -30,9 +30,16 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodecTest do
   test "decodes persisted claims containing unloaded consumer module atoms" do
     assert {:ok, restored} = MaterializationClaimCodec.decode(@external_module_payload)
 
-    assert restored.asset_ref_module == ExternalApp.MaterializationClaimAsset
+    assert Atom.to_string(restored.asset_ref_module) ==
+             "Elixir.ExternalApp.MaterializationClaimAsset"
 
-    assert restored.node_key ==
-             {{ExternalApp.MaterializationClaimAsset, :asset}, %{window: "test"}}
+    assert {{module, :asset}, %{window: "test"}} = restored.node_key
+
+    assert Atom.to_string(module) == "Elixir.ExternalApp.MaterializationClaimAsset"
+  end
+
+  test "rejects invalid base64 payloads with tuple error shape" do
+    assert {:error, :invalid_materialization_claim_payload} =
+             MaterializationClaimCodec.decode("not valid base64")
   end
 end

--- a/apps/favn_orchestrator/test/storage/materialization_claim_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/materialization_claim_codec_test.exs
@@ -1,0 +1,38 @@
+defmodule FavnOrchestrator.Storage.MaterializationClaimCodecTest do
+  use ExUnit.Case, async: true
+
+  alias FavnOrchestrator.MaterializationClaim
+  alias FavnOrchestrator.Storage.MaterializationClaimCodec
+
+  @external_module_payload "g3QAAAAUdwVlcnJvcncDbmlsdwZzdGF0dXN3CXN1Y2NlZWRlZHcIbWV0YWRhdGF0AAAAAXcNcmVzdWx0X3N0YXR1c3cCb2t3Cl9fc3RydWN0X193LEVsaXhpci5GYXZuT3JjaGVzdHJhdG9yLk1hdGVyaWFsaXphdGlvbkNsYWltdxNtYW5pZmVzdF92ZXJzaW9uX2lkdwNuaWx3BnJ1bl9pZHcDbmlsdxVtYW5pZmVzdF9jb250ZW50X2hhc2h3A25pbHcRZnJlc2huZXNzX3ZlcnNpb253A25pbHcLZmluaXNoZWRfYXR0AAAADXcLbWljcm9zZWNvbmRoAmEAYQB3BnNlY29uZGEAdwhjYWxlbmRhcncTRWxpeGlyLkNhbGVuZGFyLklTT3cFbW9udGhhBXcKX19zdHJ1Y3RfX3cPRWxpeGlyLkRhdGVUaW1ldwNkYXlhFXcEeWVHcmIAAAfqdwZtaW51dGVhAXcEaG91cmEAdwl0aW1lX3pvbmVtAAAAB0V0Yy9VVEN3CXpvbmVfYWJicm0AAAADVVRDdwp1dGNfb2Zmc2V0YQB3CnN0ZF9vZmZzZXRhAHcKZXhwaXJlc19hdHQAAAANdwttaWNyb3NlY29uZGgCYQBhAHcGc2Vjb25kYQB3CGNhbGVuZGFydxNFbGl4aXIuQ2FsZW5kYXIuSVNPdwVtb250aGEFdwpfX3N0cnVjdF9fdw9FbGl4aXIuRGF0ZVRpbWV3A2RheWEVdwR5ZWFyYgAAB+p3Bm1pbnV0ZWEAdwRob3VyYQF3CXRpbWVfem9uZW0AAAAHRXRjL1VUQ3cJem9uZV9hYmJybQAAAANVVEN3CnV0Y19vZmZzZXRhAHcKc3RkX29mZnNldGEAdwpjbGFpbWVkX2F0dAAAAA13C21pY3Jvc2Vjb25kaAJhAGEAdwZzZWNvbmRhAHcIY2FsZW5kYXJ3E0VsaXhpci5DYWxlbmRhci5JU093BW1vbnRoYQV3Cl9fc3RydWN0X193D0VsaXhpci5EYXRlVGltZXcDZGF5YRV3BHllYXJiAAAH6ncGbWludXRlYQB3BGhvdXJhAHcJdGltZV96b25lbQAAAAdFdGMvVVRDdwl6b25lX2FiYnJtAAAAA1VUQ3cKdXRjX29mZnNldGEAdwpzdGRfb2Zmc2V0YQB3CWNsYWltX2tleW0AAAAOZXh0ZXJuYWwtY2xhaW13EGFzc2V0X3JlZl9tb2R1bGV3LEVsaXhpci5FeHRlcm5hbEFwcC5NYXRlcmlhbGl6YXRpb25DbGFpbUFzc2V0dw5hc3NldF9yZWZfbmFtZXcFYXNzZXR3DWZyZXNobmVzc19rZXltAAAAC3dpbmRvdzp0ZXN0dw1hc3NldF9zdGVwX2lkdwNuaWx3CG5vZGVfa2V5aAJoAncsRWxpeGlyLkV4dGVybmFsQXBwLk1hdGVyaWFsaXphdGlvbkNsYWltQXNzZXR3BWFzc2V0dAAAAAF3BndpbmRvd20AAAAEdGVzdHcRaW5wdXRfZmluZ2VycHJpbnRtAAAAC3NoYTI1Njp0ZXN0dxNydW5uZXJfZXhlY3V0aW9uX2lkdwNuaWx3DGhlYXJ0YmVhdF9hdHcDbmls"
+
+  test "round-trips materialization claims" do
+    {:ok, claim} =
+      MaterializationClaim.new(%{
+        claim_key: "claim_codec",
+        asset_ref_module: __MODULE__.Asset,
+        asset_ref_name: :orders,
+        freshness_key: "window:test",
+        input_fingerprint: "sha256:test",
+        status: :succeeded,
+        claimed_at: ~U[2026-05-21 00:00:00Z],
+        expires_at: ~U[2026-05-21 01:00:00Z],
+        finished_at: ~U[2026-05-21 00:01:00Z],
+        metadata: %{result_status: :ok}
+      })
+
+    assert {:ok, payload} = MaterializationClaimCodec.encode(claim)
+    assert {:ok, restored} = MaterializationClaimCodec.decode(payload)
+    assert restored.claim_key == claim.claim_key
+    assert restored.status == :succeeded
+  end
+
+  test "decodes persisted claims containing unloaded consumer module atoms" do
+    assert {:ok, restored} = MaterializationClaimCodec.decode(@external_module_payload)
+
+    assert restored.asset_ref_module == ExternalApp.MaterializationClaimAsset
+
+    assert restored.node_key ==
+             {{ExternalApp.MaterializationClaimAsset, :asset}, %{window: "test"}}
+  end
+end


### PR DESCRIPTION
## Summary
- Decode persisted backfill window pipeline modules even when the consumer module has not been loaded yet.
- Decode existing materialization claim payloads that contain consumer module atoms so startup repair and claim reuse do not fail on unknown/unsafe persisted atoms.
- Harden claim decode error shape for invalid base64 and make the trusted legacy ETF fallback explicit.
- Add regression coverage for unloaded pipeline module identities, persisted claim module atoms, and invalid claim payloads.

## Verification
- mix format
- MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/storage/materialization_claim_codec_test.exs test/storage/backfill_read_model_codec_test.exs test/repair_runtime_state_test.exs
- MIX_ENV=test mix compile --warnings-as-errors
- git diff --check
- Patched dry-run against /home/eirikhop/code/sei/sei-dp/.favn/data/orchestrator.sqlite3 returns ok with backfill_windows_reconciled: 24 and errors: []