### PR TITLE
Persist materialization claims as JSON DTOs

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/materialization_claim_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/materialization_claim_codec.ex
@@ -160,6 +160,9 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodec do
   defp node_key_from_dto(%{"type" => "json", "value" => value}), do: {:ok, value}
   defp node_key_from_dto(value), do: {:error, {:invalid_node_key, value}}
 
+  # Keep identity encoding local to this versioned DTO so the persisted shape can
+  # evolve independently. If another storage codec needs this same shape, extract
+  # a private orchestrator storage identity codec instead of copying it again.
   defp node_identity_to_dto(nil), do: nil
 
   defp node_identity_to_dto(%{kind: _kind, start_at_us: _start_at_us, timezone: _timezone} = key) do
@@ -224,7 +227,9 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodec do
 
   # Materialization claims are trusted orchestrator-owned durable state. The
   # current struct still requires atom refs, so JSON decoding recreates only
-  # atoms read from this storage payload; external inputs must not call this path.
+  # atoms read from this storage payload. The long-term fix is string-backed
+  # persisted identities or a richer identity value object, not broader atom
+  # recreation; external inputs must not call this path.
   defp trusted_persisted_atom(value) when is_binary(value), do: {:ok, String.to_atom(value)}
   defp trusted_persisted_atom(value), do: {:error, {:invalid_atom, value}}
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/materialization_claim_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/materialization_claim_codec.ex
@@ -1,7 +1,11 @@
 defmodule FavnOrchestrator.Storage.MaterializationClaimCodec do
   @moduledoc false
 
+  alias Favn.Window.Key, as: WindowKey
   alias FavnOrchestrator.MaterializationClaim
+  alias FavnOrchestrator.Storage.JsonSafe
+
+  @format "favn.materialization_claim.storage.v1"
 
   @spec normalize(MaterializationClaim.t() | map()) ::
           {:ok, MaterializationClaim.t()} | {:error, term()}
@@ -14,7 +18,7 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodec do
   @spec encode(MaterializationClaim.t() | map()) :: {:ok, binary()} | {:error, term()}
   def encode(claim) do
     with {:ok, normalized} <- normalize(claim) do
-      {:ok, Base.encode64(:erlang.term_to_binary(normalized))}
+      Jason.encode(to_dto(normalized))
     end
   rescue
     exception -> {:error, {:invalid_materialization_claim_payload, exception}}
@@ -22,6 +26,94 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodec do
 
   @spec decode(binary()) :: {:ok, MaterializationClaim.t()} | {:error, term()}
   def decode(payload) when is_binary(payload) do
+    decode_json_or_legacy(payload)
+  rescue
+    exception -> {:error, {:invalid_materialization_claim_payload, exception}}
+  end
+
+  def decode(_payload), do: {:error, :invalid_materialization_claim_payload}
+
+  defp decode_json_or_legacy(payload) do
+    case Jason.decode(payload) do
+      {:ok, %{"format" => @format, "schema_version" => 1} = dto} ->
+        from_dto(dto)
+
+      {:ok, %{"format" => @format, "schema_version" => version}} ->
+        {:error, {:unsupported_materialization_claim_schema_version, version}}
+
+      {:ok, other} ->
+        {:error, {:invalid_materialization_claim_dto, other}}
+
+      {:error, reason} ->
+        if json_like?(payload) do
+          {:error, {:invalid_materialization_claim_json, reason}}
+        else
+          decode_legacy_payload(payload)
+        end
+    end
+  end
+
+  defp to_dto(%MaterializationClaim{} = claim) do
+    %{
+      "format" => @format,
+      "schema_version" => 1,
+      "claim_key" => claim.claim_key,
+      "asset_ref_module" => Atom.to_string(claim.asset_ref_module),
+      "asset_ref_name" => Atom.to_string(claim.asset_ref_name),
+      "freshness_key" => claim.freshness_key,
+      "input_fingerprint" => claim.input_fingerprint,
+      "run_id" => claim.run_id,
+      "asset_step_id" => claim.asset_step_id,
+      "node_key" => node_key_to_dto(claim.node_key),
+      "runner_execution_id" => claim.runner_execution_id,
+      "manifest_version_id" => claim.manifest_version_id,
+      "manifest_content_hash" => claim.manifest_content_hash,
+      "freshness_version" => claim.freshness_version,
+      "status" => Atom.to_string(claim.status),
+      "error" => JsonSafe.error(claim.error),
+      "claimed_at" => datetime_to_dto(claim.claimed_at),
+      "heartbeat_at" => datetime_to_dto(claim.heartbeat_at),
+      "expires_at" => datetime_to_dto(claim.expires_at),
+      "finished_at" => datetime_to_dto(claim.finished_at),
+      "metadata" => JsonSafe.data(claim.metadata || %{})
+    }
+  end
+
+  defp from_dto(dto) do
+    with {:ok, asset_ref_module} <- trusted_persisted_atom(Map.get(dto, "asset_ref_module")),
+         {:ok, asset_ref_name} <- trusted_persisted_atom(Map.get(dto, "asset_ref_name")),
+         {:ok, node_key} <- node_key_from_dto(Map.get(dto, "node_key")),
+         {:ok, claimed_at} <- datetime(Map.get(dto, "claimed_at")),
+         {:ok, heartbeat_at} <- optional_datetime(Map.get(dto, "heartbeat_at")),
+         {:ok, expires_at} <- datetime(Map.get(dto, "expires_at")),
+         {:ok, finished_at} <- optional_datetime(Map.get(dto, "finished_at")),
+         {:ok, error} <- error_field(dto, "error"),
+         {:ok, metadata} <- map_field(dto, "metadata") do
+      MaterializationClaim.new(%{
+        claim_key: Map.get(dto, "claim_key"),
+        asset_ref_module: asset_ref_module,
+        asset_ref_name: asset_ref_name,
+        freshness_key: Map.get(dto, "freshness_key"),
+        input_fingerprint: Map.get(dto, "input_fingerprint"),
+        run_id: Map.get(dto, "run_id"),
+        asset_step_id: Map.get(dto, "asset_step_id"),
+        node_key: node_key,
+        runner_execution_id: Map.get(dto, "runner_execution_id"),
+        manifest_version_id: Map.get(dto, "manifest_version_id"),
+        manifest_content_hash: Map.get(dto, "manifest_content_hash"),
+        freshness_version: Map.get(dto, "freshness_version"),
+        status: Map.get(dto, "status"),
+        error: error,
+        claimed_at: claimed_at,
+        heartbeat_at: heartbeat_at,
+        expires_at: expires_at,
+        finished_at: finished_at,
+        metadata: metadata
+      })
+    end
+  end
+
+  defp decode_legacy_payload(payload) do
     with {:ok, binary} <- Base.decode64(payload) do
       binary
       |> decode_trusted_legacy_term()
@@ -29,15 +121,117 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodec do
     else
       :error -> {:error, :invalid_materialization_claim_payload}
     end
-  rescue
-    exception -> {:error, {:invalid_materialization_claim_payload, exception}}
   end
 
-  def decode(_payload), do: {:error, :invalid_materialization_claim_payload}
+  defp json_like?(payload) do
+    payload
+    |> String.trim_leading()
+    |> String.starts_with?(["{", "["])
+  end
+
+  defp node_key_to_dto(nil), do: nil
+
+  defp node_key_to_dto(value) when is_binary(value) do
+    %{"type" => "string", "value" => value}
+  end
+
+  defp node_key_to_dto({ref, identity}) do
+    %{
+      "type" => "asset_node",
+      "ref" => ref_to_dto(ref),
+      "identity" => node_identity_to_dto(identity)
+    }
+  end
+
+  defp node_key_to_dto(value), do: %{"type" => "json", "value" => JsonSafe.data(value)}
+
+  defp node_key_from_dto(nil), do: {:ok, nil}
+
+  defp node_key_from_dto(%{"type" => "string", "value" => value}) when is_binary(value),
+    do: {:ok, value}
+
+  defp node_key_from_dto(%{"type" => "asset_node", "ref" => ref, "identity" => identity}) do
+    with {:ok, decoded_ref} <- ref_from_dto(ref),
+         {:ok, decoded_identity} <- node_identity_from_dto(identity) do
+      {:ok, {decoded_ref, decoded_identity}}
+    end
+  end
+
+  defp node_key_from_dto(%{"type" => "json", "value" => value}), do: {:ok, value}
+  defp node_key_from_dto(value), do: {:error, {:invalid_node_key, value}}
+
+  defp node_identity_to_dto(nil), do: nil
+
+  defp node_identity_to_dto(%{kind: _kind, start_at_us: _start_at_us, timezone: _timezone} = key) do
+    %{"type" => "window_key", "value" => WindowKey.encode(key)}
+  end
+
+  defp node_identity_to_dto(identity), do: %{"type" => "json", "value" => JsonSafe.data(identity)}
+
+  defp node_identity_from_dto(nil), do: {:ok, nil}
+
+  defp node_identity_from_dto(%{"type" => "window_key", "value" => value}),
+    do: WindowKey.decode(value)
+
+  defp node_identity_from_dto(%{"type" => "json", "value" => value}), do: {:ok, value}
+  defp node_identity_from_dto(value), do: {:error, {:invalid_node_identity, value}}
+
+  defp ref_to_dto({module, name}) when is_atom(module) and is_atom(name) do
+    %{"module" => Atom.to_string(module), "name" => Atom.to_string(name)}
+  end
+
+  defp ref_to_dto(_value), do: nil
+
+  defp ref_from_dto(%{"module" => module, "name" => name}) do
+    with {:ok, module_atom} <- trusted_persisted_atom(module),
+         {:ok, name_atom} <- trusted_persisted_atom(name) do
+      {:ok, {module_atom, name_atom}}
+    end
+  end
+
+  defp ref_from_dto(value), do: {:error, {:invalid_ref, value}}
+
+  defp datetime_to_dto(nil), do: nil
+  defp datetime_to_dto(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+
+  defp datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> {:ok, datetime}
+      {:error, reason} -> {:error, {:invalid_datetime, value, reason}}
+    end
+  end
+
+  defp datetime(value), do: {:error, {:invalid_datetime, value}}
+
+  defp optional_datetime(nil), do: {:ok, nil}
+  defp optional_datetime(value), do: datetime(value)
+
+  defp error_field(dto, field) do
+    case Map.fetch(dto, field) do
+      {:ok, value} when is_map(value) or is_nil(value) -> {:ok, value}
+      {:ok, value} -> {:error, {:invalid_dto_field, field, value}}
+      :error -> {:error, {:missing_dto_field, field}}
+    end
+  end
+
+  defp map_field(dto, field) do
+    case Map.fetch(dto, field) do
+      {:ok, value} when is_map(value) -> {:ok, value}
+      {:ok, value} -> {:error, {:invalid_dto_field, field, value}}
+      :error -> {:error, {:missing_dto_field, field}}
+    end
+  end
+
+  # Materialization claims are trusted orchestrator-owned durable state. The
+  # current struct still requires atom refs, so JSON decoding recreates only
+  # atoms read from this storage payload; external inputs must not call this path.
+  defp trusted_persisted_atom(value) when is_binary(value), do: {:ok, String.to_atom(value)}
+  defp trusted_persisted_atom(value), do: {:error, {:invalid_atom, value}}
 
   # Claims are internal durable state written by storage adapters, not external
   # input. Older claim payloads used ETF and may contain consumer module atoms
-  # before those modules are loaded; the fallback recreates those trusted atoms.
+  # before those modules are loaded; keep this trusted compatibility path only
+  # until legacy claim payloads have aged out or been rewritten.
   defp decode_trusted_legacy_term(binary) when is_binary(binary) do
     :erlang.binary_to_term(binary, [:safe])
   rescue

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -281,12 +281,12 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
              Storage.complete_materialization_claim(claim.claim_key, %{
                freshness_version: "freshness-version-1",
                finished_at: DateTime.add(now, 1, :second),
-               metadata: %{rows_written: 10}
+               metadata: %{"rows_written" => 10}
              })
 
     assert completed.status == :succeeded
     assert completed.freshness_version == "freshness-version-1"
-    assert completed.metadata == %{rows_written: 10}
+    assert completed.metadata == %{"rows_written" => 10}
 
     assert {:error, :not_found} =
              Storage.fail_materialization_claim(claim.claim_key, %{status: :failed})
@@ -335,7 +335,7 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
       claimed_at: now,
       heartbeat_at: now,
       expires_at: DateTime.add(now, 5, :second),
-      metadata: %{label: label}
+      metadata: %{"label" => label}
     }
   end
 

--- a/apps/favn_orchestrator/test/storage/materialization_claim_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/materialization_claim_codec_test.exs
@@ -4,27 +4,74 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodecTest do
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Storage.MaterializationClaimCodec
 
+  @format "favn.materialization_claim.storage.v1"
   @external_module_payload "g3QAAAAUdwVlcnJvcncDbmlsdwZzdGF0dXN3CXN1Y2NlZWRlZHcIbWV0YWRhdGF0AAAAAXcNcmVzdWx0X3N0YXR1c3cCb2t3Cl9fc3RydWN0X193LEVsaXhpci5GYXZuT3JjaGVzdHJhdG9yLk1hdGVyaWFsaXphdGlvbkNsYWltdxNtYW5pZmVzdF92ZXJzaW9uX2lkdwNuaWx3BnJ1bl9pZHcDbmlsdxVtYW5pZmVzdF9jb250ZW50X2hhc2h3A25pbHcRZnJlc2huZXNzX3ZlcnNpb253A25pbHcLZmluaXNoZWRfYXR0AAAADXcLbWljcm9zZWNvbmRoAmEAYQB3BnNlY29uZGEAdwhjYWxlbmRhcncTRWxpeGlyLkNhbGVuZGFyLklTT3cFbW9udGhhBXcKX19zdHJ1Y3RfX3cPRWxpeGlyLkRhdGVUaW1ldwNkYXlhFXcEeWVHcmIAAAfqdwZtaW51dGVhAXcEaG91cmEAdwl0aW1lX3pvbmVtAAAAB0V0Yy9VVEN3CXpvbmVfYWJicm0AAAADVVRDdwp1dGNfb2Zmc2V0YQB3CnN0ZF9vZmZzZXRhAHcKZXhwaXJlc19hdHQAAAANdwttaWNyb3NlY29uZGgCYQBhAHcGc2Vjb25kYQB3CGNhbGVuZGFydxNFbGl4aXIuQ2FsZW5kYXIuSVNPdwVtb250aGEFdwpfX3N0cnVjdF9fdw9FbGl4aXIuRGF0ZVRpbWV3A2RheWEVdwR5ZWFyYgAAB+p3Bm1pbnV0ZWEAdwRob3VyYQF3CXRpbWVfem9uZW0AAAAHRXRjL1VUQ3cJem9uZV9hYmJybQAAAANVVEN3CnV0Y19vZmZzZXRhAHcKc3RkX29mZnNldGEAdwpjbGFpbWVkX2F0dAAAAA13C21pY3Jvc2Vjb25kaAJhAGEAdwZzZWNvbmRhAHcIY2FsZW5kYXJ3E0VsaXhpci5DYWxlbmRhci5JU093BW1vbnRoYQV3Cl9fc3RydWN0X193D0VsaXhpci5EYXRlVGltZXcDZGF5YRV3BHllYXJiAAAH6ncGbWludXRlYQB3BGhvdXJhAHcJdGltZV96b25lbQAAAAdFdGMvVVRDdwl6b25lX2FiYnJtAAAAA1VUQ3cKdXRjX29mZnNldGEAdwpzdGRfb2Zmc2V0YQB3CWNsYWltX2tleW0AAAAOZXh0ZXJuYWwtY2xhaW13EGFzc2V0X3JlZl9tb2R1bGV3LEVsaXhpci5FeHRlcm5hbEFwcC5NYXRlcmlhbGl6YXRpb25DbGFpbUFzc2V0dw5hc3NldF9yZWZfbmFtZXcFYXNzZXR3DWZyZXNobmVzc19rZXltAAAAC3dpbmRvdzp0ZXN0dw1hc3NldF9zdGVwX2lkdwNuaWx3CG5vZGVfa2V5aAJoAncsRWxpeGlyLkV4dGVybmFsQXBwLk1hdGVyaWFsaXphdGlvbkNsYWltQXNzZXR3BWFzc2V0dAAAAAF3BndpbmRvd20AAAAEdGVzdHcRaW5wdXRfZmluZ2VycHJpbnRtAAAAC3NoYTI1Njp0ZXN0dxNydW5uZXJfZXhlY3V0aW9uX2lkdwNuaWx3DGhlYXJ0YmVhdF9hdHcDbmls"
 
-  test "round-trips materialization claims" do
-    {:ok, claim} =
-      MaterializationClaim.new(%{
-        claim_key: "claim_codec",
-        asset_ref_module: __MODULE__.Asset,
-        asset_ref_name: :orders,
-        freshness_key: "window:test",
-        input_fingerprint: "sha256:test",
-        status: :succeeded,
-        claimed_at: ~U[2026-05-21 00:00:00Z],
-        expires_at: ~U[2026-05-21 01:00:00Z],
-        finished_at: ~U[2026-05-21 00:01:00Z],
-        metadata: %{result_status: :ok}
-      })
+  test "encodes materialization claims as versioned JSON DTOs" do
+    claim = claim()
 
     assert {:ok, payload} = MaterializationClaimCodec.encode(claim)
+    assert {:ok, dto} = Jason.decode(payload)
+    assert dto["format"] == @format
+    assert dto["schema_version"] == 1
+    assert dto["claim_key"] == claim.claim_key
+    assert dto["asset_ref_module"] == Atom.to_string(claim.asset_ref_module)
+    assert dto["asset_ref_name"] == Atom.to_string(claim.asset_ref_name)
+    assert dto["status"] == "succeeded"
+    assert dto["metadata"] == %{"result_status" => "ok"}
+    assert dto["node_key"] == %{"type" => "string", "value" => "node:claim_codec"}
+
     assert {:ok, restored} = MaterializationClaimCodec.decode(payload)
     assert restored.claim_key == claim.claim_key
     assert restored.status == :succeeded
+    assert restored.metadata == %{"result_status" => "ok"}
+  end
+
+  test "encodes structured node keys without inspect-based tuple payloads" do
+    claim = %{
+      claim()
+      | node_key: {{__MODULE__.Asset, :orders}, %{"window" => "2026-05-21"}}
+    }
+
+    assert {:ok, payload} = MaterializationClaimCodec.encode(claim)
+    assert {:ok, dto} = Jason.decode(payload)
+
+    assert dto["node_key"] == %{
+             "type" => "asset_node",
+             "ref" => %{
+               "module" => "Elixir.FavnOrchestrator.Storage.MaterializationClaimCodecTest.Asset",
+               "name" => "orders"
+             },
+             "identity" => %{"type" => "json", "value" => %{"window" => "2026-05-21"}}
+           }
+
+    assert {:ok, restored} = MaterializationClaimCodec.decode(payload)
+    assert restored.node_key == claim.node_key
+  end
+
+  test "new JSON payloads decode without loading consumer modules" do
+    unloaded_module = String.to_atom("Elixir.ExternalApp.JsonMaterializationClaimAsset")
+    refute Code.ensure_loaded?(unloaded_module)
+
+    claim = %{
+      claim()
+      | asset_ref_module: unloaded_module,
+        node_key: {{unloaded_module, :asset}, nil}
+    }
+
+    assert {:ok, payload} = MaterializationClaimCodec.encode(claim)
+    assert {:ok, restored} = MaterializationClaimCodec.decode(payload)
+    refute Code.ensure_loaded?(unloaded_module)
+    assert restored.asset_ref_module == unloaded_module
+    assert restored.node_key == {{unloaded_module, :asset}, nil}
+  end
+
+  test "decodes legacy Base64 ETF claims" do
+    claim = claim()
+    legacy_payload = Base.encode64(:erlang.term_to_binary(claim))
+
+    assert {:ok, restored} = MaterializationClaimCodec.decode(legacy_payload)
+    assert restored == claim
   end
 
   test "decodes persisted claims containing unloaded consumer module atoms" do
@@ -41,5 +88,50 @@ defmodule FavnOrchestrator.Storage.MaterializationClaimCodecTest do
   test "rejects invalid base64 payloads with tuple error shape" do
     assert {:error, :invalid_materialization_claim_payload} =
              MaterializationClaimCodec.decode("not valid base64")
+  end
+
+  test "rejects malformed JSON with tuple error shape" do
+    assert {:error, {:invalid_materialization_claim_json, %Jason.DecodeError{}}} =
+             MaterializationClaimCodec.decode("{")
+  end
+
+  test "rejects unknown DTO format clearly" do
+    payload = Jason.encode!(%{"format" => "other", "schema_version" => 1})
+
+    assert {:error, {:invalid_materialization_claim_dto, _dto}} =
+             MaterializationClaimCodec.decode(payload)
+  end
+
+  test "rejects unsupported DTO schema versions clearly" do
+    payload = Jason.encode!(%{"format" => @format, "schema_version" => 2})
+
+    assert {:error, {:unsupported_materialization_claim_schema_version, 2}} =
+             MaterializationClaimCodec.decode(payload)
+  end
+
+  defp claim do
+    {:ok, claim} =
+      MaterializationClaim.new(%{
+        claim_key: "claim_codec",
+        asset_ref_module: __MODULE__.Asset,
+        asset_ref_name: :orders,
+        freshness_key: "window:test",
+        input_fingerprint: "sha256:test",
+        run_id: "run_codec",
+        asset_step_id: "step_codec",
+        node_key: "node:claim_codec",
+        runner_execution_id: "runner_codec",
+        manifest_version_id: "manifest_codec",
+        manifest_content_hash: "hash_codec",
+        freshness_version: "freshness_codec",
+        status: :succeeded,
+        claimed_at: ~U[2026-05-21 00:00:00Z],
+        heartbeat_at: ~U[2026-05-21 00:00:30Z],
+        expires_at: ~U[2026-05-21 01:00:00Z],
+        finished_at: ~U[2026-05-21 00:01:00Z],
+        metadata: %{result_status: :ok}
+      })
+
+    claim
   end
 end

--- a/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
@@ -21,6 +21,8 @@ defmodule Favn.SQLiteStorageTest do
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Idempotency
+  alias FavnOrchestrator.MaterializationClaim
+  alias FavnOrchestrator.Repair.RuntimeState
   alias FavnOrchestrator.Storage, as: OrchestratorStorage
   alias FavnOrchestrator.Storage.PayloadCodec
   alias FavnStorageSqlite.Migrations
@@ -105,6 +107,40 @@ defmodule Favn.SQLiteStorageTest do
 
   test "returns :not_found for missing run id" do
     assert {:error, :not_found} = Storage.get_run("missing-sqlite-run")
+  end
+
+  test "runtime repair expires JSON and legacy materialization claim payloads" do
+    now = DateTime.utc_now() |> DateTime.truncate(:second)
+    json_claim = materialization_claim("json", DateTime.add(now, -120, :second))
+    legacy_claim = materialization_claim("legacy", DateTime.add(now, -120, :second))
+
+    assert {:ok, ^json_claim} = OrchestratorStorage.try_acquire_materialization_claim(json_claim)
+    assert :ok = insert_legacy_materialization_claim(legacy_claim)
+
+    assert {:ok, report} = RuntimeState.repair(dry_run: false, freshness: false)
+    assert report.materialization_claims_expired == 2
+
+    assert {:ok, json_expired} =
+             OrchestratorStorage.get_materialization_claim(json_claim.claim_key)
+
+    assert json_expired.status == :expired
+
+    assert {:ok, legacy_expired} =
+             OrchestratorStorage.get_materialization_claim(legacy_claim.claim_key)
+
+    assert legacy_expired.status == :expired
+
+    assert {:ok, %{rows: [[payload]]}} =
+             SQL.query(
+               Repo,
+               "SELECT record_payload FROM favn_materialization_claims WHERE claim_key = ?1",
+               [
+                 legacy_claim.claim_key
+               ]
+             )
+
+    assert {:ok, dto} = Jason.decode(payload)
+    assert dto["format"] == "favn.materialization_claim.storage.v1"
   end
 
   test "persists lists replays and deduplicates log entries" do
@@ -1378,6 +1414,72 @@ defmodule Favn.SQLiteStorageTest do
   end
 
   defp manifest_content_hash, do: manifest_version("manifest_v1").content_hash
+
+  defp materialization_claim(label, claimed_at) do
+    {:ok, claim} =
+      MaterializationClaim.new(%{
+        claim_key: "sqlite_claim_#{label}_#{System.unique_integer([:positive])}",
+        asset_ref_module: Favn.SQLiteStorageTest.Asset,
+        asset_ref_name: :sample_asset,
+        freshness_key: "freshness:#{label}",
+        input_fingerprint: "sha256:#{label}",
+        run_id: "run:#{label}",
+        asset_step_id: "step:#{label}",
+        node_key: "node:#{label}",
+        runner_execution_id: "runner:#{label}",
+        manifest_version_id: "manifest_v1",
+        manifest_content_hash: manifest_content_hash(),
+        status: :claimed,
+        claimed_at: claimed_at,
+        heartbeat_at: claimed_at,
+        expires_at: DateTime.add(claimed_at, 60, :second),
+        metadata: %{"label" => label}
+      })
+
+    claim
+  end
+
+  defp insert_legacy_materialization_claim(%MaterializationClaim{} = claim) do
+    payload = Base.encode64(:erlang.term_to_binary(claim))
+
+    sql = """
+    INSERT INTO favn_materialization_claims (
+      claim_key, asset_ref_module, asset_ref_name, freshness_key, input_fingerprint,
+      run_id, asset_step_id, node_key, runner_execution_id, manifest_version_id,
+      manifest_content_hash, freshness_version, status, claimed_at, heartbeat_at,
+      expires_at, finished_at, record_payload
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
+    """
+
+    params = [
+      claim.claim_key,
+      Atom.to_string(claim.asset_ref_module),
+      Atom.to_string(claim.asset_ref_name),
+      claim.freshness_key,
+      claim.input_fingerprint,
+      claim.run_id,
+      claim.asset_step_id,
+      claim.node_key,
+      claim.runner_execution_id,
+      claim.manifest_version_id,
+      claim.manifest_content_hash,
+      claim.freshness_version,
+      Atom.to_string(claim.status),
+      sqlite_datetime(claim.claimed_at),
+      sqlite_datetime(claim.heartbeat_at),
+      sqlite_datetime(claim.expires_at),
+      sqlite_datetime(claim.finished_at),
+      payload
+    ]
+
+    case SQL.query(Repo, sql, params) do
+      {:ok, _result} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp sqlite_datetime(nil), do: nil
+  defp sqlite_datetime(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
 
   defp configure_router_boundary! do
     previous_tokens = Application.get_env(:favn_orchestrator, :api_service_tokens)


### PR DESCRIPTION
## Summary
- Replace new materialization claim payload writes with a versioned JSON DTO owned by `favn_orchestrator`.
- Keep a clearly marked trusted legacy ETF/Base64 decoder so existing claims, including unloaded consumer module atoms, remain readable.
- Preserve existing SQLite/Postgres normalized columns and indexes; add codec, storage contract, and SQLite repair regression coverage.

## Design
- Chosen option: dual-reader, single-writer codec.
- New writes use `format: favn.materialization_claim.storage.v1` and `schema_version: 1`.
- Legacy ETF decode remains private compatibility code for trusted orchestrator-owned durable state.
- No schema migration is required because filters and expiry continue to use normalized indexed columns.

## Verification
- `mix format`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/storage/materialization_claim_codec_test.exs`
- `MIX_ENV=test mix do --app favn_storage_sqlite cmd mix test test/sqlite_storage_test.exs`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/integration/storage_adapter_contract_test.exs`
- `MIX_ENV=test mix compile --warnings-as-errors`

Note: I started full umbrella `mix test` before the correction to local-only tests; it timed out late in `favn_local` after the changed apps had passed and showed no failures before timeout.