### PR TITLE
Refill pipeline concurrency during stage execution

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,4 @@ favn-*.tar
 /.playwright-mcp/
 .favn/
 .env
+.vscode/

--- a/apps/favn_orchestrator/lib/favn_orchestrator/materialization_claims.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/materialization_claims.ex
@@ -1,0 +1,179 @@
+defmodule FavnOrchestrator.MaterializationClaims do
+  @moduledoc """
+  Orchestrator-owned materialization claim lifecycle helpers.
+
+  This module owns persisted claim acquire/complete/fail transitions used by run
+  scheduling. It does not execute assets, decide freshness, or manage runner
+  processes.
+  """
+
+  alias Favn.Contracts.RunnerResult
+  alias Favn.Contracts.RunnerWork
+  alias Favn.Manifest.Version
+  alias FavnOrchestrator.AssetFreshnessState
+  alias FavnOrchestrator.Freshness.Staleness
+  alias FavnOrchestrator.MaterializationClaim.Identity
+  alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage
+
+  @materialization_claim_timeout_buffer_ms 60_000
+
+  @type claim :: map()
+  @type node_key :: Favn.Plan.node_key()
+
+  @spec acquire(RunState.t(), Version.t(), node_key(), map(), map(), RunnerWork.t()) ::
+          {:ok, claim()}
+          | {:already_succeeded, claim()}
+          | {:already_claimed, claim()}
+          | {:error, term()}
+  def acquire(
+        %RunState{} = run_state,
+        %Version{} = version,
+        node_key,
+        decisions,
+        freshness_context,
+        %RunnerWork{} = work
+      )
+      when is_map(decisions) and is_map(freshness_context) do
+    node = Map.fetch!(run_state.plan.nodes, node_key)
+    {module, name} = node.ref
+    now = DateTime.utc_now()
+    freshness_key = decision_freshness_key(decisions, node_key)
+
+    input_versions =
+      Staleness.consumed_input_versions(node, current_upstream_states(node, freshness_context))
+
+    input_fingerprint = Identity.input_fingerprint(input_versions)
+    producer_identity = producer_identity(run_state, version, node_key, decisions)
+
+    claim = %{
+      claim_key:
+        Identity.claim_key(node.ref, freshness_key, input_fingerprint, producer_identity),
+      run_id: run_state.id,
+      asset_step_id: Map.fetch!(work.metadata, :asset_step_id),
+      node_key: node_key,
+      asset_ref_module: module,
+      asset_ref_name: name,
+      freshness_key: freshness_key,
+      input_fingerprint: input_fingerprint,
+      input_versions: input_versions,
+      manifest_version_id: version.manifest_version_id,
+      manifest_content_hash: version.content_hash,
+      status: :claimed,
+      claimed_at: now,
+      heartbeat_at: now,
+      expires_at: DateTime.add(now, ttl_ms(run_state), :millisecond)
+    }
+
+    case Storage.try_acquire_materialization_claim(claim) do
+      {:ok, claim} -> {:ok, claim}
+      {:already_succeeded, claim} -> {:already_succeeded, claim}
+      {:already_claimed, claim} -> {:already_claimed, claim}
+      {:error, {:already_succeeded, claim}} -> {:already_succeeded, claim}
+      {:error, {:already_claimed, claim}} -> {:already_claimed, claim}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec complete(claim() | nil, RunnerResult.t(), AssetFreshnessState.t()) ::
+          :ok | {:error, term()}
+  def complete(nil, %RunnerResult{}, %AssetFreshnessState{}), do: :ok
+
+  def complete(claim, %RunnerResult{} = result, %AssetFreshnessState{} = freshness_state)
+      when is_map(claim) do
+    case Storage.complete_materialization_claim(key(claim), %{
+           finished_at: DateTime.utc_now(),
+           freshness_version: freshness_state.freshness_version,
+           metadata: %{result_status: result.status}
+         }) do
+      :ok -> :ok
+      {:ok, _claim} -> :ok
+      {:error, reason} -> {:error, {:complete_materialization_claim_failed, reason}}
+    end
+  end
+
+  @spec fail(claim() | nil, term()) :: :ok | {:error, term()}
+  def fail(nil, _reason), do: :ok
+
+  def fail(claim, reason) when is_map(claim) do
+    case Storage.fail_materialization_claim(key(claim), %{
+           status: failure_status(reason),
+           finished_at: DateTime.utc_now(),
+           error: reason
+         }) do
+      :ok -> :ok
+      {:ok, _claim} -> :ok
+      {:error, reason} -> {:error, {:fail_materialization_claim_failed, reason}}
+    end
+  end
+
+  @spec fail_entry(map(), term()) :: :ok | {:error, term()}
+  def fail_entry(%{materialization_claim: claim}, reason), do: fail(claim, reason)
+  def fail_entry(_entry, _reason), do: :ok
+
+  @spec scope(claim()) :: map()
+  def scope(claim) when is_map(claim), do: %{kind: :materialization_claim, key: key(claim)}
+
+  @spec skip_reason(claim()) :: :concurrent_materialization_succeeded | :existing_success
+  def skip_reason(claim) when is_map(claim) do
+    case Map.get(claim, :status) || Map.get(claim, "status") do
+      status when status in [:succeeded, "succeeded", :ok, "ok"] ->
+        :concurrent_materialization_succeeded
+
+      _other ->
+        :existing_success
+    end
+  end
+
+  @spec reusable_success?(map(), node_key()) :: boolean()
+  def reusable_success?(decisions, node_key) when is_map(decisions) do
+    decisions
+    |> Map.get(node_key, %{})
+    |> Map.get(:reason)
+    |> reusable_reason?()
+  end
+
+  @spec key(claim()) :: String.t() | nil
+  def key(claim) when is_map(claim), do: Map.get(claim, :claim_key) || Map.get(claim, "claim_key")
+
+  defp reusable_reason?(reason) when reason in [:upstream_refreshed, :upstream_version_changed],
+    do: true
+
+  defp reusable_reason?(_reason), do: false
+
+  defp producer_identity(%RunState{} = run_state, %Version{} = version, node_key, decisions) do
+    base = version.content_hash || version.manifest_version_id || "unknown_manifest"
+
+    if reusable_success?(decisions, node_key) do
+      base
+    else
+      node_token = node_key |> :erlang.term_to_binary() |> Base.encode16(case: :lower)
+      Enum.join([base, run_state.id, node_token], ":")
+    end
+  end
+
+  defp current_upstream_states(%{upstream: upstream}, freshness_context) do
+    Map.new(upstream, fn upstream_node_key ->
+      {upstream_node_key, Map.get(freshness_context.current_states, upstream_node_key)}
+    end)
+  end
+
+  defp decision_freshness_key(decisions, node_key) when is_map(decisions) do
+    decisions
+    |> Map.get(node_key, %{})
+    |> Map.get(:freshness_key, Favn.Freshness.Key.latest())
+  end
+
+  defp ttl_ms(%RunState{timeout_ms: timeout_ms}) when is_integer(timeout_ms) and timeout_ms > 0,
+    do: timeout_ms + @materialization_claim_timeout_buffer_ms
+
+  defp ttl_ms(%RunState{}), do: 360_000
+
+  defp failure_status(:timeout), do: :timed_out
+  defp failure_status(:await_timeout), do: :timed_out
+  defp failure_status(:external_cancel), do: :cancelled
+  defp failure_status(:stopped_pending_await), do: :cancelled
+  defp failure_status(:cancelled), do: :cancelled
+  defp failure_status(:timed_out), do: :timed_out
+  defp failure_status(_reason), do: :failed
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/cancellation.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/cancellation.ex
@@ -1,0 +1,53 @@
+defmodule FavnOrchestrator.RunServer.Cancellation do
+  @moduledoc """
+  Shared runner cancellation payload and dispatch helpers for run-server paths.
+
+  This module owns the runner cancellation envelope contract only. Callers remain
+  responsible for any local run-state cleanup after dispatching cancellation.
+  """
+
+  alias FavnOrchestrator.RunState
+
+  @type execution_id :: String.t()
+  @type reason :: term()
+  @type envelope :: %{
+          required(:run_id) => String.t(),
+          required(:reason) => reason(),
+          required(:requested_at) => DateTime.t()
+        }
+
+  @doc """
+  Wraps a runner cancellation reason in the control-plane cancellation envelope.
+  """
+  @spec envelope(RunState.t(), reason()) :: envelope()
+  def envelope(%RunState{id: run_id}, reason) do
+    %{run_id: run_id, reason: reason, requested_at: DateTime.utc_now()}
+  end
+
+  @doc """
+  Cancels unique runner execution ids and returns the ids that were dispatched.
+
+  Cancellation dispatch is best-effort; individual runner-client errors are
+  intentionally ignored to preserve the existing run-server cleanup semantics.
+  """
+  @spec cancel_runner_work(RunState.t(), [term()], reason(), module(), keyword()) :: [
+          execution_id()
+        ]
+  def cancel_runner_work(
+        %RunState{} = run_state,
+        execution_ids,
+        reason,
+        runner_client,
+        runner_opts
+      )
+      when is_list(execution_ids) do
+    unique_ids = execution_ids |> Enum.filter(&is_binary/1) |> Enum.uniq()
+    envelope = envelope(run_state, reason)
+
+    Enum.each(unique_ids, fn execution_id ->
+      _ = runner_client.cancel_work(execution_id, envelope, runner_opts)
+    end)
+
+    unique_ids
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -28,6 +28,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
   alias FavnOrchestrator.Redaction
   alias FavnOrchestrator.RefreshPolicy
   alias FavnOrchestrator.RunnerLogBridge
+  alias FavnOrchestrator.RunServer.Cancellation
   alias FavnOrchestrator.RunServer.Execution.AwaitTasks
   alias FavnOrchestrator.RunServer.Execution.StageAdmission
   alias FavnOrchestrator.RunServer.Execution.StageAttemptState
@@ -1652,16 +1653,14 @@ defmodule FavnOrchestrator.RunServer.Execution do
          runner_opts
        )
        when is_list(execution_ids) do
-    unique_ids = execution_ids |> Enum.filter(&is_binary/1) |> Enum.uniq()
-
-    Enum.each(unique_ids, fn execution_id ->
-      _ =
-        runner_client.cancel_work(
-          execution_id,
-          %{run_id: run_state.id, reason: reason, requested_at: DateTime.utc_now()},
-          runner_opts
-        )
-    end)
+    unique_ids =
+      Cancellation.cancel_runner_work(
+        run_state,
+        execution_ids,
+        reason,
+        runner_client,
+        runner_opts
+      )
 
     clear_inflight_executions(run_state, unique_ids)
   end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -23,20 +23,21 @@ defmodule FavnOrchestrator.RunServer.Execution do
   alias FavnOrchestrator.ExecutionAdmission
   alias FavnOrchestrator.Freshness.Decider
   alias FavnOrchestrator.Freshness.StateWriter
-  alias FavnOrchestrator.Freshness.Staleness
-  alias FavnOrchestrator.MaterializationClaim.Identity, as: MaterializationClaimIdentity
+  alias FavnOrchestrator.MaterializationClaims
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.Redaction
   alias FavnOrchestrator.RefreshPolicy
   alias FavnOrchestrator.RunnerLogBridge
+  alias FavnOrchestrator.RunServer.Execution.AwaitTasks
+  alias FavnOrchestrator.RunServer.Execution.StageAdmission
+  alias FavnOrchestrator.RunServer.Execution.StageAttemptState
   alias FavnOrchestrator.RunServer.Persistence
   alias FavnOrchestrator.RunServer.Snapshots
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
 
-  @await_task_timeout_buffer_ms 2_000
+  @stage_admission_timeout_buffer_ms 2_000
   @stage_admission_retry_ms 100
-  @materialization_claim_timeout_buffer_ms 60_000
 
   def execute_plan(%RunState{submit_kind: :pipeline} = run_state, %Version{} = version),
     do: execute_pipeline_parallel_once(run_state, version)
@@ -417,7 +418,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
         {:ok, run_after_submit, entries, deferred_node_keys, queued_steps} ->
           result =
             process_stage_attempt_results(
-              stage_attempt_state(
+              StageAttemptState.new(
                 run_after_submit,
                 acc_results,
                 entries,
@@ -571,395 +572,18 @@ defmodule FavnOrchestrator.RunServer.Execution do
          runner_opts,
          queued_steps
        ) do
-    submit_stage_entries(
-      node_keys,
-      run_state,
-      version,
-      stage,
-      decisions,
-      freshness_context,
-      attempt,
-      runner_client,
-      runner_opts,
-      [],
-      queued_steps
-    )
-  end
-
-  defp submit_stage_entries(
-         [],
-         %RunState{} = run_state,
-         _version,
-         _stage,
-         _decisions,
-         _freshness_context,
-         _attempt,
-         _runner_client,
-         _runner_opts,
-         entries,
-         queued_steps
-       ) do
-    {:ok, run_state, entries, [], queued_steps}
-  end
-
-  defp submit_stage_entries(
-         [node_key | rest] = node_keys,
-         %RunState{} = current_run,
-         %Version{} = version,
-         stage,
-         decisions,
-         freshness_context,
-         attempt,
-         runner_client,
-         runner_opts,
-         acc,
-         queued_steps
-       ) do
-    if Persistence.externally_cancelled?(current_run.id) do
-      {:error, Snapshots.cancelled_snapshot(current_run), [], Enum.map(acc, & &1.node_key)}
-    else
-      work = stage_work(current_run, version, node_key, stage, attempt)
-      asset_step_id = Map.fetch!(work.metadata, :asset_step_id)
-
-      case ExecutionAdmission.acquire(current_run, %{
-             asset_step_id: asset_step_id,
-             execution_pool: Map.get(work.metadata, :execution_pool)
-           }) do
-        {:ok, lease} ->
-          case acquire_materialization_claim(
-                 current_run,
-                 version,
-                 node_key,
-                 decisions,
-                 freshness_context,
-                 work
-               ) do
-            {:ok, claim} ->
-              submit_admitted_stage_entry(
-                rest,
-                current_run,
-                version,
-                stage,
-                decisions,
-                freshness_context,
-                attempt,
-                runner_client,
-                runner_opts,
-                acc,
-                queued_steps,
-                node_key,
-                work,
-                lease,
-                claim
-              )
-
-            {:already_succeeded, claim} ->
-              :ok = release_entry_lease(%{lease: lease})
-
-              if reusable_materialization_success?(decisions, node_key) do
-                decision =
-                  decisions
-                  |> Map.get(node_key, %{})
-                  |> Map.merge(%{
-                    decision: :skipped_fresh,
-                    reason: materialization_skip_reason(claim)
-                  })
-
-                case persist_decision_result(
-                       current_run,
-                       version,
-                       node_key,
-                       stage,
-                       :skipped_fresh,
-                       decision
-                     ) do
-                  {:ok, skipped_run} ->
-                    submit_stage_entries(
-                      rest,
-                      skipped_run,
-                      version,
-                      stage,
-                      decisions,
-                      freshness_context,
-                      attempt,
-                      runner_client,
-                      runner_opts,
-                      acc,
-                      queued_steps
-                    )
-
-                  {:error, :external_cancel} ->
-                    {:error, Snapshots.cancelled_snapshot(current_run), [],
-                     Enum.map(acc, & &1.node_key)}
-
-                  {:error, reason} ->
-                    failed = RunState.transition(current_run, status: :error, error: reason)
-                    {:error, failed, [], Enum.map(acc, & &1.node_key)}
-                end
-              else
-                failed =
-                  RunState.transition(current_run,
-                    status: :error,
-                    error:
-                      {:non_reusable_materialization_claim_succeeded,
-                       materialization_claim_key(claim)}
-                  )
-
-                {:error, failed, [], Enum.map(acc, & &1.node_key)}
-              end
-
-            {:already_claimed, claim} ->
-              :ok = release_entry_lease(%{lease: lease})
-              queue_reason = :materialization_claim
-              scope = materialization_claim_scope(claim)
-              queue_signature = queue_signature(asset_step_id, queue_reason, scope)
-
-              case maybe_persist_step_queued(
-                     queued_steps,
-                     queue_signature,
-                     current_run,
-                     work,
-                     stage,
-                     attempt,
-                     queue_reason,
-                     scope
-                   ) do
-                {:ok, queued_run, next_queued_steps} when acc == [] ->
-                  {:ok, queued_run, [], node_keys, next_queued_steps}
-
-                {:ok, queued_run, next_queued_steps} ->
-                  {:ok, queued_run, acc, node_keys, next_queued_steps}
-
-                {:error, :external_cancel} ->
-                  {:error, Snapshots.cancelled_snapshot(current_run), [],
-                   Enum.map(acc, & &1.node_key)}
-
-                {:error, reason} ->
-                  failed = RunState.transition(current_run, status: :error, error: reason)
-                  {:error, failed, [], Enum.map(acc, & &1.node_key)}
-              end
-
-            {:error, reason} ->
-              :ok = release_entry_lease(%{lease: lease})
-              failed = RunState.transition(current_run, status: :error, error: reason)
-              {:error, failed, [], Enum.map(acc, & &1.node_key)}
-          end
-
-        {:queued, queue_reason, scope} ->
-          queue_signature = queue_signature(asset_step_id, queue_reason, scope)
-
-          case maybe_persist_step_queued(
-                 queued_steps,
-                 queue_signature,
-                 current_run,
-                 work,
-                 stage,
-                 attempt,
-                 queue_reason,
-                 scope
-               ) do
-            {:ok, queued_run, next_queued_steps} when acc == [] ->
-              {:ok, queued_run, [], node_keys, next_queued_steps}
-
-            {:ok, queued_run, next_queued_steps} ->
-              {:ok, queued_run, acc, node_keys, next_queued_steps}
-
-            {:error, :external_cancel} ->
-              {:error, Snapshots.cancelled_snapshot(current_run), [],
-               Enum.map(acc, & &1.node_key)}
-
-            {:error, reason} ->
-              failed = RunState.transition(current_run, status: :error, error: reason)
-              {:error, failed, [], Enum.map(acc, & &1.node_key)}
-          end
-
-        {:error, reason} ->
-          failed = RunState.transition(current_run, status: :error, error: reason)
-          {:error, failed, [], Enum.map(acc, & &1.node_key)}
-      end
-    end
-  end
-
-  defp submit_admitted_stage_entry(
-         rest,
-         current_run,
-         version,
-         stage,
-         decisions,
-         freshness_context,
-         attempt,
-         runner_client,
-         runner_opts,
-         acc,
-         queued_steps,
-         node_key,
-         work,
-         lease,
-         materialization_claim
-       ) do
-    asset_ref = work.asset_ref
-    asset_step_id = Map.fetch!(work.metadata, :asset_step_id)
-
-    case runner_client.submit_work(work, runner_opts) do
-      {:ok, execution_id} ->
-        updated_run = with_inflight_execution(current_run, execution_id, work.metadata)
-
-        case Persistence.persist_run_step(updated_run, :step_started, %{
-               asset_ref: asset_ref,
-               runner_execution_id: execution_id,
-               asset_step_id: asset_step_id,
-               window: Map.get(work.metadata, :window),
-               stage: stage,
-               attempt: attempt,
-               max_attempts: current_run.max_attempts,
-               execution_pool: Map.get(work.metadata, :execution_pool),
-               freshness_key: decision_freshness_key(decisions, node_key)
-             }) do
-          :ok ->
-            entry = %{
-              run_id: current_run.id,
-              asset_step_id: asset_step_id,
-              asset_ref: asset_ref,
-              node_key: node_key,
-              window: Map.get(work.metadata, :window),
-              execution_id: execution_id,
-              runner_execution_id: execution_id,
-              version: version,
-              decision: Map.get(decisions, node_key, %{}),
-              freshness_context: freshness_context,
-              attempt: attempt,
-              stage: stage,
-              lease: lease,
-              materialization_claim: materialization_claim,
-              execution_pool: Map.get(work.metadata, :execution_pool),
-              freshness_key: decision_freshness_key(decisions, node_key)
-            }
-
-            submit_stage_entries(
-              rest,
-              updated_run,
-              version,
-              stage,
-              decisions,
-              freshness_context,
-              attempt,
-              runner_client,
-              runner_opts,
-              acc ++ [entry],
-              queued_steps
-            )
-
-          {:error, :external_cancel} ->
-            :ok = release_entry_lease(%{lease: lease})
-            :ok = fail_materialization_claim(materialization_claim, :external_cancel)
-            :ok = release_entry_leases(acc)
-
-            cancelled =
-              cancel_execution_ids(
-                updated_run,
-                [execution_id],
-                %{kind: :external_cancel, asset_ref: asset_ref, stage: stage, attempt: attempt},
-                runner_client,
-                runner_opts
-              )
-
-            attempted = Enum.map(acc, & &1.node_key) ++ [node_key]
-            {:error, Snapshots.cancelled_snapshot(cancelled), [], attempted}
-        end
-
-      {:error, reason} ->
-        :ok = release_entry_lease(%{lease: lease})
-        :ok = fail_materialization_claim(materialization_claim, reason)
-        :ok = release_entry_leases(acc)
-
-        cancelled =
-          cancel_execution_ids(
-            current_run,
-            Enum.map(acc, & &1.execution_id),
-            %{kind: :submit_failure, asset_ref: asset_ref, error: reason},
-            runner_client,
-            runner_opts
-          )
-
-        failed =
-          RunState.transition(cancelled,
-            status: :error,
-            error: reason,
-            runner_execution_id: nil
-          )
-
-        case Persistence.persist_run_step(failed, :step_failed, %{
-               asset_ref: asset_ref,
-               error: reason,
-               node_key: Map.get(work.metadata, :node_key),
-               asset_step_id: Map.get(work.metadata, :asset_step_id),
-               window: Map.get(work.metadata, :window),
-               stage: stage,
-               attempt: attempt,
-               max_attempts: current_run.max_attempts,
-               execution_pool: Map.get(work.metadata, :execution_pool)
-             }) do
-          :ok ->
-            attempted = Enum.map(acc, & &1.node_key)
-            {:error, failed, [], attempted}
-
-          {:error, :external_cancel} ->
-            attempted = Enum.map(acc, & &1.node_key)
-            {:error, Snapshots.cancelled_snapshot(failed), [], attempted}
-        end
-    end
-  end
-
-  defp entry_node_keys(entries), do: Enum.map(entries, & &1.node_key)
-
-  defp stage_attempt_state(run_state, acc_results, entries, deferred_node_keys, queued_steps) do
-    %{
+    StageAdmission.submit(%{
       run: run_state,
-      results: acc_results,
-      retry_refs: [],
-      terminal_failure: nil,
-      pending_ids: pending_execution_ids(entries),
-      deferred_node_keys: deferred_node_keys,
-      queued_steps: queued_steps,
-      initial_entries: entries,
-      attempted_node_keys: entry_node_keys(entries)
-    }
-  end
-
-  defp start_await_tasks(entries, timeout_ms, runner_client, runner_opts) do
-    parent = self()
-
-    entries
-    |> Enum.reduce(%{replies: %{}, monitors: %{}}, fn entry, acc ->
-      reply_ref = make_ref()
-
-      {pid, monitor_ref} =
-        spawn_monitor(fn ->
-          send(
-            parent,
-            {reply_ref, await_runner_result(entry, timeout_ms, runner_client, runner_opts)}
-          )
-        end)
-
-      await = %{
-        pid: pid,
-        monitor_ref: monitor_ref,
-        deadline_ms: await_deadline(timeout_ms),
-        entry: entry
-      }
-
-      %{
-        replies: Map.put(acc.replies, reply_ref, await),
-        monitors: Map.put(acc.monitors, monitor_ref, reply_ref)
-      }
-    end)
-  end
-
-  defp merge_pending_tasks(left, right) do
-    %{
-      replies: Map.merge(left.replies, right.replies),
-      monitors: Map.merge(left.monitors, right.monitors)
-    }
+      version: version,
+      stage: stage,
+      node_keys: node_keys,
+      decisions: decisions,
+      freshness_context: freshness_context,
+      attempt: attempt,
+      runner_client: runner_client,
+      runner_opts: runner_opts,
+      queued_steps: queued_steps
+    })
   end
 
   defp await_runner_result(entry, timeout_ms, runner_client, runner_opts) do
@@ -985,23 +609,17 @@ defmodule FavnOrchestrator.RunServer.Execution do
       {:error, %{type: :await_task_failed, kind: kind, reason: inspect(reason)}}
   end
 
-  defp await_deadline(timeout_ms),
-    do: System.monotonic_time(:millisecond) + timeout_ms + @await_task_timeout_buffer_ms
-
-  defp flush_await_reply(reply_ref) do
-    receive do
-      {^reply_ref, _result} -> :ok
-    after
-      0 -> :ok
-    end
+  defp start_await_tasks(entries, timeout_ms, runner_client, runner_opts) do
+    AwaitTasks.start(entries, timeout_ms, fn entry ->
+      await_runner_result(entry, timeout_ms, runner_client, runner_opts)
+    end)
   end
 
-  defp await_exit_to_error(reason) do
-    {:error, %{type: :await_task_failed, kind: :exit, reason: inspect(reason)}}
-  end
+  defp stage_admission_deadline(timeout_ms),
+    do: System.monotonic_time(:millisecond) + timeout_ms + @stage_admission_timeout_buffer_ms
 
   defp process_stage_attempt_results(
-         %{run: %RunState{} = run_state} = state,
+         %StageAttemptState{run: %RunState{} = run_state} = state,
          stage,
          attempt,
          version,
@@ -1013,7 +631,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
     state.initial_entries
     |> start_await_tasks(run_state.timeout_ms, runner_client, runner_opts)
     |> collect_stage_attempt_results(
-      await_deadline(run_state.timeout_ms),
+      stage_admission_deadline(run_state.timeout_ms),
       state,
       stage,
       attempt,
@@ -1026,7 +644,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
   end
 
   defp collect_stage_attempt_results(
-         %{replies: replies} = pending_tasks,
+         %AwaitTasks{} = pending_tasks,
          deadline,
          state,
          stage,
@@ -1036,9 +654,55 @@ defmodule FavnOrchestrator.RunServer.Execution do
          freshness_context,
          runner_client,
          runner_opts
-       )
-       when map_size(replies) == 0 do
-    if state.terminal_failure == nil and state.deferred_node_keys != [] do
+       ) do
+    if AwaitTasks.empty?(pending_tasks) do
+      collect_idle_stage_attempt(
+        pending_tasks,
+        deadline,
+        state,
+        stage,
+        attempt,
+        version,
+        decisions,
+        freshness_context,
+        runner_client,
+        runner_opts
+      )
+    else
+      {:events, events, next_pending_tasks} =
+        AwaitTasks.receive_next(pending_tasks, &release_entry_lease/1)
+
+      {available_events, drained_pending_tasks} = AwaitTasks.drain_available(next_pending_tasks)
+
+      process_stage_attempt_result_batch(
+        events ++ available_events,
+        drained_pending_tasks,
+        deadline,
+        state,
+        stage,
+        attempt,
+        version,
+        decisions,
+        freshness_context,
+        runner_client,
+        runner_opts
+      )
+    end
+  end
+
+  defp collect_idle_stage_attempt(
+         pending_tasks,
+         deadline,
+         %StageAttemptState{} = state,
+         stage,
+         attempt,
+         version,
+         decisions,
+         freshness_context,
+         runner_client,
+         runner_opts
+       ) do
+    if not StageAttemptState.terminal_failure?(state) and StageAttemptState.deferred?(state) do
       case wait_for_stage_admission_retry(deadline) do
         :ok ->
           case refill_stage_attempt_capacity(
@@ -1078,88 +742,11 @@ defmodule FavnOrchestrator.RunServer.Execution do
     end
   end
 
-  defp collect_stage_attempt_results(
-         %{replies: replies, monitors: monitors} = pending_tasks,
-         deadline,
-         state,
-         stage,
-         attempt,
-         version,
-         decisions,
-         freshness_context,
-         runner_client,
-         runner_opts
-       ) do
-    receive_timeout_ms = next_await_receive_timeout_ms(pending_tasks)
-
-    receive do
-      {reply_ref, result} when is_map_key(replies, reply_ref) ->
-        {%{monitor_ref: monitor_ref, entry: entry}, next_replies} = Map.pop!(replies, reply_ref)
-        Process.demonitor(monitor_ref, [:flush])
-
-        next_pending_tasks = %{
-          replies: next_replies,
-          monitors: Map.delete(monitors, monitor_ref)
-        }
-
-        handle_stage_attempt_result(
-          next_pending_tasks,
-          deadline,
-          state,
-          {entry, result},
-          stage,
-          attempt,
-          version,
-          decisions,
-          freshness_context,
-          runner_client,
-          runner_opts
-        )
-
-      {:DOWN, monitor_ref, :process, _pid, reason} when is_map_key(monitors, monitor_ref) ->
-        {reply_ref, next_monitors} = Map.pop!(monitors, monitor_ref)
-        {%{entry: entry}, next_replies} = Map.pop!(replies, reply_ref)
-
-        next_pending_tasks = %{replies: next_replies, monitors: next_monitors}
-
-        handle_stage_attempt_result(
-          next_pending_tasks,
-          deadline,
-          state,
-          {entry, await_exit_to_error(reason)},
-          stage,
-          attempt,
-          version,
-          decisions,
-          freshness_context,
-          runner_client,
-          runner_opts
-        )
-    after
-      receive_timeout_ms ->
-        {timed_out, next_pending_tasks} = timeout_expired_await_tasks(pending_tasks)
-
-        process_stage_attempt_result_list(
-          timed_out,
-          next_pending_tasks,
-          deadline,
-          state,
-          stage,
-          attempt,
-          version,
-          decisions,
-          freshness_context,
-          runner_client,
-          runner_opts
-        )
-    end
-  end
-
-  defp handle_stage_attempt_result(
+  defp process_stage_attempt_result_batch(
+         events,
          pending_tasks,
          deadline,
          state,
-         {entry, await_result},
          stage,
          attempt,
          version,
@@ -1167,11 +754,12 @@ defmodule FavnOrchestrator.RunServer.Execution do
          freshness_context,
          runner_client,
          runner_opts
-       ) do
-    case process_stage_attempt_result(
+       )
+       when is_list(events) do
+    case process_stage_attempt_result_list(
+           events,
+           pending_tasks,
            state,
-           entry,
-           await_result,
            stage,
            attempt,
            runner_client,
@@ -1209,48 +797,27 @@ defmodule FavnOrchestrator.RunServer.Execution do
         end
 
       {:halt, result} ->
-        stop_pending_await_tasks(pending_tasks)
         result
     end
   end
 
   defp process_stage_attempt_result_list(
          [],
-         pending_tasks,
-         deadline,
+         _pending_tasks,
          state,
-         stage,
-         attempt,
-         version,
-         decisions,
-         freshness_context,
-         runner_client,
-         runner_opts
-       ) do
-    collect_stage_attempt_results(
-      pending_tasks,
-      deadline,
-      state,
-      stage,
-      attempt,
-      version,
-      decisions,
-      freshness_context,
-      runner_client,
-      runner_opts
-    )
-  end
+         _stage,
+         _attempt,
+         _runner_client,
+         _runner_opts
+       ),
+       do: {:cont, state}
 
   defp process_stage_attempt_result_list(
          [{entry, await_result} | rest],
          pending_tasks,
-         deadline,
          state,
          stage,
          attempt,
-         version,
-         decisions,
-         freshness_context,
          runner_client,
          runner_opts
        ) do
@@ -1264,49 +831,27 @@ defmodule FavnOrchestrator.RunServer.Execution do
            runner_opts
          ) do
       {:cont, next_state} ->
-        case refill_stage_attempt_capacity(
-               pending_tasks,
-               next_state,
-               stage,
-               attempt,
-               version,
-               decisions,
-               freshness_context,
-               runner_client,
-               runner_opts
-             ) do
-          {:cont, next_pending_tasks, refilled_state} ->
-            process_stage_attempt_result_list(
-              rest,
-              next_pending_tasks,
-              deadline,
-              refilled_state,
-              stage,
-              attempt,
-              version,
-              decisions,
-              freshness_context,
-              runner_client,
-              runner_opts
-            )
-
-          {:halt, result} ->
-            fail_unprocessed_stage_attempt_results(rest)
-            stop_pending_await_tasks(pending_tasks)
-            result
-        end
+        process_stage_attempt_result_list(
+          rest,
+          pending_tasks,
+          next_state,
+          stage,
+          attempt,
+          runner_client,
+          runner_opts
+        )
 
       {:halt, result} ->
         fail_unprocessed_stage_attempt_results(rest)
         stop_pending_await_tasks(pending_tasks)
-        result
+        {:halt, result}
     end
   end
 
   defp fail_unprocessed_stage_attempt_results(results) when is_list(results) do
     Enum.each(results, fn
       {entry, {:error, :timeout}} ->
-        :ok = fail_entry_materialization_claim(entry, :await_timeout)
+        :ok = MaterializationClaims.fail_entry(entry, :await_timeout)
 
       {_entry, _result} ->
         :ok
@@ -1315,7 +860,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
 
   defp refill_stage_attempt_capacity(
          pending_tasks,
-         %{terminal_failure: terminal_failure} = state,
+         %StageAttemptState{terminal_failure: terminal_failure} = state,
          _stage,
          _attempt,
          _version,
@@ -1330,7 +875,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
 
   defp refill_stage_attempt_capacity(
          pending_tasks,
-         %{deferred_node_keys: []} = state,
+         %StageAttemptState{deferred_node_keys: []} = state,
          _stage,
          _attempt,
          _version,
@@ -1344,7 +889,8 @@ defmodule FavnOrchestrator.RunServer.Execution do
 
   defp refill_stage_attempt_capacity(
          pending_tasks,
-         %{run: %RunState{} = run_state, deferred_node_keys: deferred_node_keys} = state,
+         %StageAttemptState{run: %RunState{} = run_state, deferred_node_keys: deferred_node_keys} =
+           state,
          stage,
          attempt,
          version,
@@ -1367,41 +913,32 @@ defmodule FavnOrchestrator.RunServer.Execution do
          ) do
       {:ok, next_run, [], next_deferred_node_keys, next_queued_steps} ->
         {:cont, pending_tasks,
-         %{
-           state
-           | run: next_run,
-             deferred_node_keys: next_deferred_node_keys,
-             queued_steps: next_queued_steps
-         }}
+         StageAttemptState.defer_only(
+           state,
+           next_run,
+           next_deferred_node_keys,
+           next_queued_steps
+         )}
 
       {:ok, next_run, entries, next_deferred_node_keys, next_queued_steps} ->
         next_pending_tasks =
           entries
           |> start_await_tasks(next_run.timeout_ms, runner_client, runner_opts)
-          |> then(&merge_pending_tasks(pending_tasks, &1))
-
-        next_pending_ids =
-          entries
-          |> pending_execution_ids()
-          |> MapSet.union(state.pending_ids)
-
-        next_attempted_node_keys =
-          Enum.uniq(state.attempted_node_keys ++ entry_node_keys(entries))
+          |> then(&AwaitTasks.merge(pending_tasks, &1))
 
         {:cont, next_pending_tasks,
-         %{
-           state
-           | run: next_run,
-             pending_ids: next_pending_ids,
-             deferred_node_keys: next_deferred_node_keys,
-             queued_steps: next_queued_steps,
-             attempted_node_keys: next_attempted_node_keys
-         }}
+         StageAttemptState.add_entries(
+           state,
+           entries,
+           next_run,
+           next_deferred_node_keys,
+           next_queued_steps
+         )}
 
       {:error, failed_run, step_results, attempted_node_keys} ->
         {:halt,
          {:error, failed_run, state.results ++ step_results,
-          Enum.uniq(state.attempted_node_keys ++ attempted_node_keys)}}
+          Enum.uniq(StageAttemptState.attempted_node_keys(state) ++ attempted_node_keys)}}
     end
   end
 
@@ -1429,11 +966,11 @@ defmodule FavnOrchestrator.RunServer.Execution do
         runner_execution_id: nil
       )
 
-    {:error, timed_out, state.results, state.attempted_node_keys}
+    {:error, timed_out, state.results, StageAttemptState.attempted_node_keys(state)}
   end
 
   defp process_stage_attempt_result(
-         %{
+         %StageAttemptState{
            run: current_run,
            results: current_results,
            retry_refs: retry_refs,
@@ -1457,11 +994,11 @@ defmodule FavnOrchestrator.RunServer.Execution do
           runner_opts
         )
 
-      :ok = fail_entry_materialization_claim(entry, :external_cancel)
+      :ok = MaterializationClaims.fail_entry(entry, :external_cancel)
 
       {:halt,
        {:error, Snapshots.cancelled_terminal(cancelled, current_results), current_results,
-        state.attempted_node_keys}}
+        StageAttemptState.attempted_node_keys(state)}}
     else
       {next_run, outcome, step_results} =
         process_one_stage_attempt_result(
@@ -1494,7 +1031,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
     end
   end
 
-  defp finalize_stage_attempt_state(%{
+  defp finalize_stage_attempt_state(%StageAttemptState{
          run: next_run,
          results: next_results,
          retry_refs: retry_refs,
@@ -1504,7 +1041,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
     {:ok, next_run, next_results, retry_refs, attempted_node_keys}
   end
 
-  defp finalize_stage_attempt_state(%{
+  defp finalize_stage_attempt_state(%StageAttemptState{
          run: next_run,
          results: next_results,
          terminal_failure: terminal_failure,
@@ -1514,259 +1051,12 @@ defmodule FavnOrchestrator.RunServer.Execution do
     {:error, failed_run, next_results, attempted_node_keys}
   end
 
-  defp next_await_receive_timeout_ms(%{replies: replies}) do
-    now = System.monotonic_time(:millisecond)
-
-    replies
-    |> Map.values()
-    |> Enum.map(& &1.deadline_ms)
-    |> Enum.min(fn -> now end)
-    |> Kernel.-(now)
-    |> max(0)
-  end
-
-  defp timeout_expired_await_tasks(%{replies: replies, monitors: monitors}) do
-    now = System.monotonic_time(:millisecond)
-
-    {timed_out, next_replies, next_monitors} =
-      Enum.reduce(replies, {[], %{}, monitors}, fn {reply_ref, await},
-                                                   {timed_out, next_replies, next_monitors} ->
-        if await.deadline_ms <= now do
-          Process.exit(await.pid, :kill)
-          Process.demonitor(await.monitor_ref, [:flush])
-          flush_await_reply(reply_ref)
-          :ok = release_entry_lease(await.entry)
-
-          {[{await.entry, {:error, :timeout}} | timed_out], next_replies,
-           Map.delete(next_monitors, await.monitor_ref)}
-        else
-          {timed_out, Map.put(next_replies, reply_ref, await), next_monitors}
-        end
-      end)
-
-    {Enum.reverse(timed_out), %{replies: next_replies, monitors: next_monitors}}
-  end
-
-  defp stop_pending_await_tasks(%{replies: replies}) do
-    Enum.each(replies, fn {reply_ref, %{pid: pid, monitor_ref: monitor_ref, entry: entry}} ->
-      Process.exit(pid, :kill)
-      Process.demonitor(monitor_ref, [:flush])
-      flush_await_reply(reply_ref)
+  defp stop_pending_await_tasks(%AwaitTasks{} = pending_tasks) do
+    AwaitTasks.stop(pending_tasks, fn entry ->
       :ok = release_entry_lease(entry)
-      :ok = fail_entry_materialization_claim(entry, :stopped_pending_await)
+      :ok = MaterializationClaims.fail_entry(entry, :stopped_pending_await)
     end)
   end
-
-  defp persist_step_queued(run_state, work, stage, attempt, queue_reason, scope) do
-    queued_run = RunState.transition(run_state, status: :running, error: nil)
-
-    case Persistence.persist_run_step(queued_run, :step_queued, %{
-           asset_ref: work.asset_ref,
-           node_key: Map.get(work.metadata, :node_key),
-           asset_step_id: Map.get(work.metadata, :asset_step_id),
-           window: Map.get(work.metadata, :window),
-           stage: stage,
-           attempt: attempt,
-           max_attempts: run_state.max_attempts,
-           execution_pool: Map.get(work.metadata, :execution_pool),
-           queue_reason: queue_reason,
-           admission_scope: scope
-         }) do
-      :ok -> {:ok, queued_run}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp maybe_persist_step_queued(
-         queued_steps,
-         queue_signature,
-         %RunState{} = run_state,
-         work,
-         stage,
-         attempt,
-         queue_reason,
-         scope
-       ) do
-    if MapSet.member?(queued_steps, queue_signature) do
-      {:ok, run_state, queued_steps}
-    else
-      case persist_step_queued(run_state, work, stage, attempt, queue_reason, scope) do
-        {:ok, queued_run} -> {:ok, queued_run, MapSet.put(queued_steps, queue_signature)}
-        {:error, reason} -> {:error, reason}
-      end
-    end
-  end
-
-  defp queue_signature(asset_step_id, queue_reason, scope) do
-    scope_kind = Map.get(scope, :kind) || Map.get(scope, "kind")
-    scope_key = Map.get(scope, :key) || Map.get(scope, "key")
-
-    {asset_step_id, queue_reason, scope_kind, scope_key}
-  end
-
-  defp acquire_materialization_claim(
-         %RunState{} = run_state,
-         %Version{} = version,
-         node_key,
-         decisions,
-         freshness_context,
-         %RunnerWork{} = work
-       ) do
-    node = Map.fetch!(run_state.plan.nodes, node_key)
-    {module, name} = node.ref
-    now = DateTime.utc_now()
-    freshness_key = decision_freshness_key(decisions, node_key)
-
-    input_versions =
-      Staleness.consumed_input_versions(node, current_upstream_states(node, freshness_context))
-
-    input_fingerprint = MaterializationClaimIdentity.input_fingerprint(input_versions)
-    producer_identity = materialization_producer_identity(run_state, version, node_key, decisions)
-
-    claim_key =
-      MaterializationClaimIdentity.claim_key(
-        node.ref,
-        freshness_key,
-        input_fingerprint,
-        producer_identity
-      )
-
-    asset_step_id = Map.fetch!(work.metadata, :asset_step_id)
-
-    claim = %{
-      claim_key: claim_key,
-      run_id: run_state.id,
-      asset_step_id: asset_step_id,
-      node_key: node_key,
-      asset_ref_module: module,
-      asset_ref_name: name,
-      freshness_key: freshness_key,
-      input_fingerprint: input_fingerprint,
-      input_versions: input_versions,
-      manifest_version_id: version.manifest_version_id,
-      manifest_content_hash: version.content_hash,
-      status: :claimed,
-      claimed_at: now,
-      heartbeat_at: now,
-      expires_at: DateTime.add(now, materialization_claim_ttl_ms(run_state), :millisecond)
-    }
-
-    case Storage.try_acquire_materialization_claim(claim) do
-      {:ok, claim} -> {:ok, claim}
-      {:already_succeeded, claim} -> {:already_succeeded, claim}
-      {:already_claimed, claim} -> {:already_claimed, claim}
-      {:error, {:already_succeeded, claim}} -> {:already_succeeded, claim}
-      {:error, {:already_claimed, claim}} -> {:already_claimed, claim}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  defp materialization_claim_scope(claim) when is_map(claim) do
-    %{
-      kind: :materialization_claim,
-      key: materialization_claim_key(claim)
-    }
-  end
-
-  defp materialization_skip_reason(claim) when is_map(claim) do
-    case Map.get(claim, :status) || Map.get(claim, "status") do
-      status when status in [:succeeded, "succeeded", :ok, "ok"] ->
-        :concurrent_materialization_succeeded
-
-      _other ->
-        :existing_success
-    end
-  end
-
-  defp reusable_materialization_success?(decisions, node_key) when is_map(decisions) do
-    decisions
-    |> Map.get(node_key, %{})
-    |> Map.get(:reason)
-    |> reusable_materialization_reason?()
-  end
-
-  defp reusable_materialization_reason?(reason)
-       when reason in [:upstream_refreshed, :upstream_version_changed],
-       do: true
-
-  defp reusable_materialization_reason?(_reason), do: false
-
-  defp materialization_producer_identity(
-         %RunState{} = run_state,
-         %Version{} = version,
-         node_key,
-         decisions
-       ) do
-    base = version.content_hash || version.manifest_version_id || "unknown_manifest"
-
-    if reusable_materialization_success?(decisions, node_key) do
-      base
-    else
-      node_token = node_key |> :erlang.term_to_binary() |> Base.encode16(case: :lower)
-      Enum.join([base, run_state.id, node_token], ":")
-    end
-  end
-
-  defp materialization_claim_ttl_ms(%RunState{timeout_ms: timeout_ms})
-       when is_integer(timeout_ms) and timeout_ms > 0 do
-    timeout_ms + @materialization_claim_timeout_buffer_ms
-  end
-
-  defp materialization_claim_ttl_ms(%RunState{}), do: 360_000
-
-  defp release_entry_leases(entries) when is_list(entries) do
-    Enum.each(entries, &release_entry_lease/1)
-    :ok
-  end
-
-  defp fail_entry_materialization_claim(%{materialization_claim: claim}, reason),
-    do: fail_materialization_claim(claim, reason)
-
-  defp fail_entry_materialization_claim(_entry, _reason), do: :ok
-
-  defp complete_materialization_claim(nil, _result, _freshness_state), do: :ok
-
-  defp complete_materialization_claim(claim, result, %AssetFreshnessState{} = freshness_state)
-       when is_map(claim) do
-    claim_id = materialization_claim_key(claim)
-
-    case Storage.complete_materialization_claim(claim_id, %{
-           finished_at: DateTime.utc_now(),
-           freshness_version: freshness_state.freshness_version,
-           metadata: %{result_status: result.status}
-         }) do
-      :ok -> :ok
-      {:ok, _claim} -> :ok
-      {:error, reason} -> {:error, {:complete_materialization_claim_failed, reason}}
-    end
-  end
-
-  defp fail_materialization_claim(nil, _reason), do: :ok
-
-  defp fail_materialization_claim(claim, reason) when is_map(claim) do
-    claim_id = materialization_claim_key(claim)
-
-    case Storage.fail_materialization_claim(claim_id, %{
-           status: materialization_failure_status(reason),
-           finished_at: DateTime.utc_now(),
-           error: reason
-         }) do
-      :ok -> :ok
-      {:ok, _claim} -> :ok
-      {:error, reason} -> {:error, {:fail_materialization_claim_failed, reason}}
-    end
-  end
-
-  defp materialization_failure_status(:timeout), do: :timed_out
-  defp materialization_failure_status(:await_timeout), do: :timed_out
-  defp materialization_failure_status(:external_cancel), do: :cancelled
-  defp materialization_failure_status(:stopped_pending_await), do: :cancelled
-  defp materialization_failure_status(:cancelled), do: :cancelled
-  defp materialization_failure_status(:timed_out), do: :timed_out
-  defp materialization_failure_status(_reason), do: :failed
-
-  defp materialization_claim_key(claim) when is_map(claim),
-    do: Map.get(claim, :claim_key) || Map.get(claim, "claim_key")
 
   defp record_stage_attempt_freshness(%RunState{} = run_state, entry, :ok) do
     StateWriter.put_success_state(
@@ -1812,14 +1102,14 @@ defmodule FavnOrchestrator.RunServer.Execution do
          _context
        ) do
     {:cont,
-     %{
-       state
-       | run: next_run,
-         results: next_results,
-         retry_refs: retry_refs,
-         terminal_failure: terminal_failure,
-         pending_ids: pending_ids
-     }}
+     StageAttemptState.record_result(
+       state,
+       next_run,
+       next_results,
+       retry_refs,
+       terminal_failure,
+       pending_ids
+     )}
   end
 
   defp reduce_stage_attempt_outcome(
@@ -1838,14 +1128,14 @@ defmodule FavnOrchestrator.RunServer.Execution do
       if terminal_failure == nil, do: retry_refs ++ [entry.node_key], else: retry_refs
 
     {:cont,
-     %{
-       state
-       | run: next_run,
-         results: next_results,
-         retry_refs: next_retry_refs,
-         terminal_failure: terminal_failure,
-         pending_ids: pending_ids
-     }}
+     StageAttemptState.record_result(
+       state,
+       next_run,
+       next_results,
+       next_retry_refs,
+       terminal_failure,
+       pending_ids
+     )}
   end
 
   defp reduce_stage_attempt_outcome(
@@ -1859,7 +1149,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
        ) do
     {:halt,
      {:error, Snapshots.cancelled_terminal(next_run, next_results), next_results,
-      state.attempted_node_keys}}
+      StageAttemptState.attempted_node_keys(state)}}
   end
 
   defp reduce_stage_attempt_outcome(
@@ -1877,27 +1167,20 @@ defmodule FavnOrchestrator.RunServer.Execution do
     case remember_stage_failure(next_run, terminal_failure, entry, stage, attempt, pending_ids) do
       {:ok, failure_run, next_terminal_failure} ->
         {:cont,
-         %{
-           state
-           | run: failure_run,
-             results: next_results,
-             retry_refs: retry_refs,
-             terminal_failure: next_terminal_failure,
-             pending_ids: pending_ids
-         }}
+         StageAttemptState.record_result(
+           state,
+           failure_run,
+           next_results,
+           retry_refs,
+           next_terminal_failure,
+           pending_ids
+         )}
 
       {:error, cancelled} ->
         {:halt,
          {:error, Snapshots.cancelled_terminal(cancelled, next_results), next_results,
-          state.attempted_node_keys}}
+          StageAttemptState.attempted_node_keys(state)}}
     end
-  end
-
-  defp pending_execution_ids(entries) when is_list(entries) do
-    entries
-    |> Enum.map(& &1.execution_id)
-    |> Enum.filter(&is_binary/1)
-    |> MapSet.new()
   end
 
   defp remember_stage_failure(run_state, terminal_failure, entry, stage, attempt, pending_ids)
@@ -2135,7 +1418,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
   defp persist_post_step_state(%RunState{} = step_state, entry, :ok, %RunnerResult{} = result) do
     with {:ok, freshness_state} <- record_stage_attempt_freshness(step_state, entry, :ok),
          :ok <-
-           complete_materialization_claim(
+           MaterializationClaims.complete(
              Map.get(entry, :materialization_claim),
              result,
              freshness_state
@@ -2148,7 +1431,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
 
   defp persist_post_step_state(%RunState{} = step_state, entry, status, failure_reason) do
     with {:ok, _state} <- record_stage_attempt_freshness(step_state, entry, status),
-         :ok <- fail_entry_materialization_claim(entry, failure_reason) do
+         :ok <- MaterializationClaims.fail_entry(entry, failure_reason) do
       :ok
     else
       {:error, reason} -> {:error, reason}
@@ -2306,36 +1589,6 @@ defmodule FavnOrchestrator.RunServer.Execution do
     end
   end
 
-  defp stage_work(%RunState{} = run_state, %Version{} = version, node_key, stage, attempt) do
-    node = Map.fetch!(run_state.plan.nodes, node_key)
-    asset_ref = node.ref
-    asset_step_id = AssetStepIdentity.asset_step_id(run_state.id, node_key, asset_ref)
-
-    %RunnerWork{
-      run_id: run_state.id,
-      manifest_version_id: version.manifest_version_id,
-      manifest_content_hash: version.content_hash,
-      asset_ref: asset_ref,
-      asset_refs: [asset_ref],
-      planned_asset_refs: planned_asset_refs(run_state),
-      params: run_state.params,
-      trigger:
-        run_state.trigger
-        |> Map.put(:window, node.window)
-        |> maybe_put_pipeline_trigger(Map.get(run_state.metadata, :pipeline_context)),
-      metadata:
-        Map.merge(work_metadata(run_state.metadata), %{
-          attempt: attempt,
-          asset_step_id: asset_step_id,
-          max_attempts: run_state.max_attempts,
-          stage: stage,
-          node_key: node_key,
-          window: node.window,
-          execution_pool: effective_execution_pool(run_state, node_key)
-        })
-    }
-  end
-
   defp effective_execution_pool(%RunState{} = run_state, node_key) do
     node_pool =
       case run_state.plan do
@@ -2357,25 +1610,6 @@ defmodule FavnOrchestrator.RunServer.Execution do
   end
 
   defp pipeline_default_execution_pool(%RunState{}), do: nil
-
-  defp maybe_put_pipeline_trigger(trigger, pipeline_context) when is_map(pipeline_context),
-    do: Map.put(trigger, :pipeline, pipeline_context)
-
-  defp maybe_put_pipeline_trigger(trigger, _pipeline_context), do: trigger
-
-  defp with_inflight_execution(%RunState{} = run_state, execution_id, metadata) do
-    ids =
-      run_state
-      |> inflight_ids_from_metadata()
-      |> Kernel.++([execution_id])
-      |> Enum.filter(&is_binary/1)
-      |> Enum.uniq()
-
-    RunState.transition(run_state,
-      runner_execution_id: execution_id,
-      metadata: Map.put(metadata, :in_flight_execution_ids, ids)
-    )
-  end
 
   defp clear_inflight_execution(%RunState{} = run_state, execution_id) do
     ids =
@@ -2639,20 +1873,8 @@ defmodule FavnOrchestrator.RunServer.Execution do
     |> node_result_status()
   end
 
-  defp current_upstream_states(%{upstream: upstream}, freshness_context) do
-    Map.new(upstream, fn upstream_node_key ->
-      {upstream_node_key, Map.get(freshness_context.current_states, upstream_node_key)}
-    end)
-  end
-
   defp state_asset_ref(%AssetFreshnessState{} = state) do
     {state.asset_ref_module, state.asset_ref_name}
-  end
-
-  defp decision_freshness_key(decisions, node_key) when is_map(decisions) do
-    decisions
-    |> Map.get(node_key, %{})
-    |> Map.get(:freshness_key, Favn.Freshness.Key.latest())
   end
 
   defp existing_node_results(%RunState{result: %{node_results: results}}) when is_list(results),

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -1264,24 +1264,53 @@ defmodule FavnOrchestrator.RunServer.Execution do
            runner_opts
          ) do
       {:cont, next_state} ->
-        process_stage_attempt_result_list(
-          rest,
-          pending_tasks,
-          deadline,
-          next_state,
-          stage,
-          attempt,
-          version,
-          decisions,
-          freshness_context,
-          runner_client,
-          runner_opts
-        )
+        case refill_stage_attempt_capacity(
+               pending_tasks,
+               next_state,
+               stage,
+               attempt,
+               version,
+               decisions,
+               freshness_context,
+               runner_client,
+               runner_opts
+             ) do
+          {:cont, next_pending_tasks, refilled_state} ->
+            process_stage_attempt_result_list(
+              rest,
+              next_pending_tasks,
+              deadline,
+              refilled_state,
+              stage,
+              attempt,
+              version,
+              decisions,
+              freshness_context,
+              runner_client,
+              runner_opts
+            )
+
+          {:halt, result} ->
+            fail_unprocessed_stage_attempt_results(rest)
+            stop_pending_await_tasks(pending_tasks)
+            result
+        end
 
       {:halt, result} ->
+        fail_unprocessed_stage_attempt_results(rest)
         stop_pending_await_tasks(pending_tasks)
         result
     end
+  end
+
+  defp fail_unprocessed_stage_attempt_results(results) when is_list(results) do
+    Enum.each(results, fn
+      {entry, {:error, :timeout}} ->
+        :ok = fail_entry_materialization_claim(entry, :await_timeout)
+
+      {_entry, _result} ->
+        :ok
+    end)
   end
 
   defp refill_stage_attempt_capacity(
@@ -1428,6 +1457,8 @@ defmodule FavnOrchestrator.RunServer.Execution do
           runner_opts
         )
 
+      :ok = fail_entry_materialization_claim(entry, :external_cancel)
+
       {:halt,
        {:error, Snapshots.cancelled_terminal(cancelled, current_results), current_results,
         state.attempted_node_keys}}
@@ -1505,7 +1536,6 @@ defmodule FavnOrchestrator.RunServer.Execution do
           Process.demonitor(await.monitor_ref, [:flush])
           flush_await_reply(reply_ref)
           :ok = release_entry_lease(await.entry)
-          :ok = fail_entry_materialization_claim(await.entry, :await_timeout)
 
           {[{await.entry, {:error, :timeout}} | timed_out], next_replies,
            Map.delete(next_monitors, await.monitor_ref)}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -35,6 +35,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
   alias FavnOrchestrator.Storage
 
   @await_task_timeout_buffer_ms 2_000
+  @stage_admission_retry_ms 100
   @materialization_claim_timeout_buffer_ms 60_000
 
   def execute_plan(%RunState{submit_kind: :pipeline} = run_state, %Version{} = version),
@@ -413,42 +414,35 @@ defmodule FavnOrchestrator.RunServer.Execution do
              runner_client,
              runner_opts
            ) do
-        {:ok, run_after_submit, entries, deferred_node_keys} ->
-          attempted_node_keys = entry_node_keys(entries)
-
+        {:ok, run_after_submit, entries, deferred_node_keys, queued_steps} ->
           result =
             process_stage_attempt_results(
-              run_after_submit,
-              entries,
+              stage_attempt_state(
+                run_after_submit,
+                acc_results,
+                entries,
+                deferred_node_keys,
+                queued_steps
+              ),
               stage,
               attempt,
-              acc_results,
+              version,
+              decisions,
+              freshness_context,
               runner_client,
               runner_opts
             )
 
           case result do
-            {:ok, next_run, next_acc_results, []} ->
-              continue_deferred_stage_attempt(
-                next_run,
-                version,
-                stage,
-                deferred_node_keys,
-                decisions,
-                freshness_context,
-                attempt,
-                runner_client,
-                runner_opts,
-                next_acc_results,
-                attempted_node_keys
-              )
+            {:ok, next_run, next_acc_results, [], _attempted_node_keys} ->
+              {:ok, next_run, next_acc_results}
 
-            {:ok, next_run, next_acc_results, retry_refs} ->
+            {:ok, next_run, next_acc_results, retry_refs, attempted_node_keys} ->
               continue_retry_stage_attempt(
                 next_run,
                 version,
                 stage,
-                deferred_node_keys,
+                [],
                 retry_refs,
                 decisions,
                 freshness_context,
@@ -459,63 +453,13 @@ defmodule FavnOrchestrator.RunServer.Execution do
                 attempted_node_keys
               )
 
-            {:error, failed_run, next_acc_results} ->
+            {:error, failed_run, next_acc_results, attempted_node_keys} ->
               {:error, failed_run, next_acc_results, attempted_node_keys}
           end
 
         {:error, failed_run, step_results, attempted_node_keys} ->
           {:error, failed_run, step_results, attempted_node_keys}
       end
-    end
-  end
-
-  defp continue_deferred_stage_attempt(
-         next_run,
-         _version,
-         _stage,
-         [],
-         _decisions,
-         _freshness_context,
-         _attempt,
-         _runner_client,
-         _runner_opts,
-         next_acc_results,
-         _attempted_node_keys
-       ) do
-    {:ok, next_run, next_acc_results}
-  end
-
-  defp continue_deferred_stage_attempt(
-         next_run,
-         version,
-         stage,
-         deferred_node_keys,
-         decisions,
-         freshness_context,
-         attempt,
-         runner_client,
-         runner_opts,
-         next_acc_results,
-         attempted_node_keys
-       ) do
-    case run_stage_attempt(
-           next_run,
-           version,
-           stage,
-           deferred_node_keys,
-           decisions,
-           freshness_context,
-           attempt,
-           runner_client,
-           runner_opts,
-           next_acc_results
-         ) do
-      {:ok, deferred_run, deferred_results} ->
-        {:ok, deferred_run, deferred_results}
-
-      {:error, deferred_failed_run, deferred_results, deferred_attempted_node_keys} ->
-        {:error, deferred_failed_run, deferred_results,
-         Enum.uniq(attempted_node_keys ++ deferred_attempted_node_keys)}
     end
   end
 
@@ -602,6 +546,32 @@ defmodule FavnOrchestrator.RunServer.Execution do
          runner_opts
        ) do
     submit_stage_entries(
+      run_state,
+      version,
+      stage,
+      node_keys,
+      decisions,
+      freshness_context,
+      attempt,
+      runner_client,
+      runner_opts,
+      MapSet.new()
+    )
+  end
+
+  defp submit_stage_entries(
+         %RunState{} = run_state,
+         %Version{} = version,
+         stage,
+         node_keys,
+         decisions,
+         freshness_context,
+         attempt,
+         runner_client,
+         runner_opts,
+         queued_steps
+       ) do
+    submit_stage_entries(
       node_keys,
       run_state,
       version,
@@ -612,7 +582,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
       runner_client,
       runner_opts,
       [],
-      MapSet.new()
+      queued_steps
     )
   end
 
@@ -627,9 +597,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
          _runner_client,
          _runner_opts,
          entries,
-         _queued_steps
+         queued_steps
        ) do
-    {:ok, run_state, entries, []}
+    {:ok, run_state, entries, [], queued_steps}
   end
 
   defp submit_stage_entries(
@@ -755,24 +725,10 @@ defmodule FavnOrchestrator.RunServer.Execution do
                      scope
                    ) do
                 {:ok, queued_run, next_queued_steps} when acc == [] ->
-                  Process.sleep(100)
+                  {:ok, queued_run, [], node_keys, next_queued_steps}
 
-                  submit_stage_entries(
-                    node_keys,
-                    queued_run,
-                    version,
-                    stage,
-                    decisions,
-                    freshness_context,
-                    attempt,
-                    runner_client,
-                    runner_opts,
-                    acc,
-                    next_queued_steps
-                  )
-
-                {:ok, queued_run, _next_queued_steps} ->
-                  {:ok, queued_run, acc, node_keys}
+                {:ok, queued_run, next_queued_steps} ->
+                  {:ok, queued_run, acc, node_keys, next_queued_steps}
 
                 {:error, :external_cancel} ->
                   {:error, Snapshots.cancelled_snapshot(current_run), [],
@@ -803,24 +759,10 @@ defmodule FavnOrchestrator.RunServer.Execution do
                  scope
                ) do
             {:ok, queued_run, next_queued_steps} when acc == [] ->
-              Process.sleep(100)
+              {:ok, queued_run, [], node_keys, next_queued_steps}
 
-              submit_stage_entries(
-                node_keys,
-                queued_run,
-                version,
-                stage,
-                decisions,
-                freshness_context,
-                attempt,
-                runner_client,
-                runner_opts,
-                acc,
-                next_queued_steps
-              )
-
-            {:ok, queued_run, _next_queued_steps} ->
-              {:ok, queued_run, acc, node_keys}
+            {:ok, queued_run, next_queued_steps} ->
+              {:ok, queued_run, acc, node_keys, next_queued_steps}
 
             {:error, :external_cancel} ->
               {:error, Snapshots.cancelled_snapshot(current_run), [],
@@ -970,6 +912,20 @@ defmodule FavnOrchestrator.RunServer.Execution do
 
   defp entry_node_keys(entries), do: Enum.map(entries, & &1.node_key)
 
+  defp stage_attempt_state(run_state, acc_results, entries, deferred_node_keys, queued_steps) do
+    %{
+      run: run_state,
+      results: acc_results,
+      retry_refs: [],
+      terminal_failure: nil,
+      pending_ids: pending_execution_ids(entries),
+      deferred_node_keys: deferred_node_keys,
+      queued_steps: queued_steps,
+      initial_entries: entries,
+      attempted_node_keys: entry_node_keys(entries)
+    }
+  end
+
   defp start_await_tasks(entries, timeout_ms, runner_client, runner_opts) do
     parent = self()
 
@@ -992,6 +948,13 @@ defmodule FavnOrchestrator.RunServer.Execution do
         monitors: Map.put(acc.monitors, monitor_ref, reply_ref)
       }
     end)
+  end
+
+  defp merge_pending_tasks(left, right) do
+    %{
+      replies: Map.merge(left.replies, right.replies),
+      monitors: Map.merge(left.monitors, right.monitors)
+    }
   end
 
   defp await_runner_result(entry, timeout_ms, runner_client, runner_opts) do
@@ -1033,39 +996,77 @@ defmodule FavnOrchestrator.RunServer.Execution do
   end
 
   defp process_stage_attempt_results(
-         %RunState{} = run_state,
-         entries,
+         %{run: %RunState{} = run_state} = state,
          stage,
          attempt,
-         acc_results,
+         version,
+         decisions,
+         freshness_context,
          runner_client,
          runner_opts
        ) do
-    pending_ids = pending_execution_ids(entries)
-
-    entries
+    state.initial_entries
     |> start_await_tasks(run_state.timeout_ms, runner_client, runner_opts)
     |> collect_stage_attempt_results(
       await_deadline(run_state.timeout_ms),
-      {:ok, run_state, acc_results, [], nil, pending_ids},
+      state,
       stage,
       attempt,
+      version,
+      decisions,
+      freshness_context,
       runner_client,
       runner_opts
     )
   end
 
   defp collect_stage_attempt_results(
-         %{replies: replies},
-         _deadline,
+         %{replies: replies} = pending_tasks,
+         deadline,
          state,
-         _stage,
-         _attempt,
-         _runner_client,
-         _runner_opts
+         stage,
+         attempt,
+         version,
+         decisions,
+         freshness_context,
+         runner_client,
+         runner_opts
        )
        when map_size(replies) == 0 do
-    finalize_stage_attempt_state(state)
+    if state.terminal_failure == nil and state.deferred_node_keys != [] do
+      wait_for_stage_admission_retry()
+
+      case refill_stage_attempt_capacity(
+             pending_tasks,
+             state,
+             stage,
+             attempt,
+             version,
+             decisions,
+             freshness_context,
+             runner_client,
+             runner_opts
+           ) do
+        {:cont, next_pending_tasks, next_state} ->
+          collect_stage_attempt_results(
+            next_pending_tasks,
+            deadline,
+            next_state,
+            stage,
+            attempt,
+            version,
+            decisions,
+            freshness_context,
+            runner_client,
+            runner_opts
+          )
+
+        {:halt, result} ->
+          result
+      end
+    else
+      finalize_stage_attempt_state(state)
+    end
   end
 
   defp collect_stage_attempt_results(
@@ -1074,6 +1075,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
          state,
          stage,
          attempt,
+         version,
+         decisions,
+         freshness_context,
          runner_client,
          runner_opts
        ) do
@@ -1096,6 +1100,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
           {entry, result},
           stage,
           attempt,
+          version,
+          decisions,
+          freshness_context,
           runner_client,
           runner_opts
         )
@@ -1113,6 +1120,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
           {entry, await_exit_to_error(reason)},
           stage,
           attempt,
+          version,
+          decisions,
+          freshness_context,
           runner_client,
           runner_opts
         )
@@ -1126,6 +1136,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
           state,
           stage,
           attempt,
+          version,
+          decisions,
+          freshness_context,
           runner_client,
           runner_opts
         )
@@ -1139,6 +1152,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
          {entry, await_result},
          stage,
          attempt,
+         version,
+         decisions,
+         freshness_context,
          runner_client,
          runner_opts
        ) do
@@ -1152,15 +1168,35 @@ defmodule FavnOrchestrator.RunServer.Execution do
            runner_opts
          ) do
       {:cont, next_state} ->
-        collect_stage_attempt_results(
-          pending_tasks,
-          deadline,
-          next_state,
-          stage,
-          attempt,
-          runner_client,
-          runner_opts
-        )
+        case refill_stage_attempt_capacity(
+               pending_tasks,
+               next_state,
+               stage,
+               attempt,
+               version,
+               decisions,
+               freshness_context,
+               runner_client,
+               runner_opts
+             ) do
+          {:cont, next_pending_tasks, refilled_state} ->
+            collect_stage_attempt_results(
+              next_pending_tasks,
+              deadline,
+              refilled_state,
+              stage,
+              attempt,
+              version,
+              decisions,
+              freshness_context,
+              runner_client,
+              runner_opts
+            )
+
+          {:halt, result} ->
+            stop_pending_await_tasks(pending_tasks)
+            result
+        end
 
       {:halt, result} ->
         stop_pending_await_tasks(pending_tasks)
@@ -1175,6 +1211,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
          state,
          stage,
          attempt,
+         version,
+         decisions,
+         freshness_context,
          runner_client,
          runner_opts
        ) do
@@ -1184,6 +1223,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
       state,
       stage,
       attempt,
+      version,
+      decisions,
+      freshness_context,
       runner_client,
       runner_opts
     )
@@ -1196,6 +1238,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
          state,
          stage,
          attempt,
+         version,
+         decisions,
+         freshness_context,
          runner_client,
          runner_opts
        ) do
@@ -1216,6 +1261,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
           next_state,
           stage,
           attempt,
+          version,
+          decisions,
+          freshness_context,
           runner_client,
           runner_opts
         )
@@ -1226,8 +1274,115 @@ defmodule FavnOrchestrator.RunServer.Execution do
     end
   end
 
+  defp refill_stage_attempt_capacity(
+         pending_tasks,
+         %{terminal_failure: terminal_failure} = state,
+         _stage,
+         _attempt,
+         _version,
+         _decisions,
+         _freshness_context,
+         _runner_client,
+         _runner_opts
+       )
+       when not is_nil(terminal_failure) do
+    {:cont, pending_tasks, state}
+  end
+
+  defp refill_stage_attempt_capacity(
+         pending_tasks,
+         %{deferred_node_keys: []} = state,
+         _stage,
+         _attempt,
+         _version,
+         _decisions,
+         _freshness_context,
+         _runner_client,
+         _runner_opts
+       ) do
+    {:cont, pending_tasks, state}
+  end
+
+  defp refill_stage_attempt_capacity(
+         pending_tasks,
+         %{run: %RunState{} = run_state, deferred_node_keys: deferred_node_keys} = state,
+         stage,
+         attempt,
+         version,
+         decisions,
+         freshness_context,
+         runner_client,
+         runner_opts
+       ) do
+    case submit_stage_entries(
+           run_state,
+           version,
+           stage,
+           deferred_node_keys,
+           decisions,
+           freshness_context,
+           attempt,
+           runner_client,
+           runner_opts,
+           state.queued_steps
+         ) do
+      {:ok, next_run, [], next_deferred_node_keys, next_queued_steps} ->
+        {:cont, pending_tasks,
+         %{
+           state
+           | run: next_run,
+             deferred_node_keys: next_deferred_node_keys,
+             queued_steps: next_queued_steps
+         }}
+
+      {:ok, next_run, entries, next_deferred_node_keys, next_queued_steps} ->
+        next_pending_tasks =
+          entries
+          |> start_await_tasks(next_run.timeout_ms, runner_client, runner_opts)
+          |> then(&merge_pending_tasks(pending_tasks, &1))
+
+        next_pending_ids =
+          entries
+          |> pending_execution_ids()
+          |> MapSet.union(state.pending_ids)
+
+        next_attempted_node_keys =
+          Enum.uniq(state.attempted_node_keys ++ entry_node_keys(entries))
+
+        {:cont, next_pending_tasks,
+         %{
+           state
+           | run: next_run,
+             pending_ids: next_pending_ids,
+             deferred_node_keys: next_deferred_node_keys,
+             queued_steps: next_queued_steps,
+             attempted_node_keys: next_attempted_node_keys
+         }}
+
+      {:error, failed_run, step_results, attempted_node_keys} ->
+        {:halt,
+         {:error, failed_run, state.results ++ step_results,
+          Enum.uniq(state.attempted_node_keys ++ attempted_node_keys)}}
+    end
+  end
+
+  defp wait_for_stage_admission_retry do
+    retry_ref = make_ref()
+    Process.send_after(self(), {:retry_stage_admission, retry_ref}, @stage_admission_retry_ms)
+
+    receive do
+      {:retry_stage_admission, ^retry_ref} -> :ok
+    end
+  end
+
   defp process_stage_attempt_result(
-         {:ok, current_run, current_results, retry_refs, terminal_failure, pending_ids},
+         %{
+           run: current_run,
+           results: current_results,
+           retry_refs: retry_refs,
+           terminal_failure: terminal_failure,
+           pending_ids: pending_ids
+         } = state,
          entry,
          await_result,
          stage,
@@ -1245,7 +1400,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
           runner_opts
         )
 
-      {:halt, {:error, Snapshots.cancelled_terminal(cancelled, current_results), current_results}}
+      {:halt,
+       {:error, Snapshots.cancelled_terminal(cancelled, current_results), current_results,
+        state.attempted_node_keys}}
     else
       {next_run, outcome, step_results} =
         process_one_stage_attempt_result(
@@ -1266,6 +1423,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
       reduce_stage_attempt_outcome(
         outcome,
         %{
+          state: state,
           run: next_run,
           results: next_results,
           retry_refs: retry_refs,
@@ -1277,15 +1435,24 @@ defmodule FavnOrchestrator.RunServer.Execution do
     end
   end
 
-  defp finalize_stage_attempt_state({:ok, next_run, next_results, retry_refs, nil, _pending_ids}) do
-    {:ok, next_run, next_results, retry_refs}
+  defp finalize_stage_attempt_state(%{
+         run: next_run,
+         results: next_results,
+         retry_refs: retry_refs,
+         terminal_failure: nil,
+         attempted_node_keys: attempted_node_keys
+       }) do
+    {:ok, next_run, next_results, retry_refs, attempted_node_keys}
   end
 
-  defp finalize_stage_attempt_state(
-         {:ok, next_run, next_results, _retry_refs, terminal_failure, _pending_ids}
-       ) do
+  defp finalize_stage_attempt_state(%{
+         run: next_run,
+         results: next_results,
+         terminal_failure: terminal_failure,
+         attempted_node_keys: attempted_node_keys
+       }) do
     failed_run = failed_stage_terminal_state(next_run, terminal_failure)
-    {:error, failed_run, next_results}
+    {:error, failed_run, next_results, attempted_node_keys}
   end
 
   defp timeout_pending_await_tasks(%{replies: replies}) do
@@ -1554,6 +1721,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
   defp reduce_stage_attempt_outcome(
          :ok,
          %{
+           state: state,
            run: %RunState{} = next_run,
            results: next_results,
            retry_refs: retry_refs,
@@ -1562,12 +1730,21 @@ defmodule FavnOrchestrator.RunServer.Execution do
          },
          _context
        ) do
-    {:cont, {:ok, next_run, next_results, retry_refs, terminal_failure, pending_ids}}
+    {:cont,
+     %{
+       state
+       | run: next_run,
+         results: next_results,
+         retry_refs: retry_refs,
+         terminal_failure: terminal_failure,
+         pending_ids: pending_ids
+     }}
   end
 
   defp reduce_stage_attempt_outcome(
          :retry,
          %{
+           state: state,
            run: %RunState{} = next_run,
            results: next_results,
            retry_refs: retry_refs,
@@ -1579,20 +1756,35 @@ defmodule FavnOrchestrator.RunServer.Execution do
     next_retry_refs =
       if terminal_failure == nil, do: retry_refs ++ [entry.node_key], else: retry_refs
 
-    {:cont, {:ok, next_run, next_results, next_retry_refs, terminal_failure, pending_ids}}
-  end
-
-  defp reduce_stage_attempt_outcome(
-         :error,
-         %{run: %RunState{status: :cancelled} = next_run, results: next_results},
-         _context
-       ) do
-    {:halt, {:error, Snapshots.cancelled_terminal(next_run, next_results), next_results}}
+    {:cont,
+     %{
+       state
+       | run: next_run,
+         results: next_results,
+         retry_refs: next_retry_refs,
+         terminal_failure: terminal_failure,
+         pending_ids: pending_ids
+     }}
   end
 
   defp reduce_stage_attempt_outcome(
          :error,
          %{
+           state: state,
+           run: %RunState{status: :cancelled} = next_run,
+           results: next_results
+         },
+         _context
+       ) do
+    {:halt,
+     {:error, Snapshots.cancelled_terminal(next_run, next_results), next_results,
+      state.attempted_node_keys}}
+  end
+
+  defp reduce_stage_attempt_outcome(
+         :error,
+         %{
+           state: state,
            run: %RunState{} = next_run,
            results: next_results,
            retry_refs: retry_refs,
@@ -1603,10 +1795,20 @@ defmodule FavnOrchestrator.RunServer.Execution do
        ) do
     case remember_stage_failure(next_run, terminal_failure, entry, stage, attempt, pending_ids) do
       {:ok, failure_run, next_terminal_failure} ->
-        {:cont, {:ok, failure_run, next_results, retry_refs, next_terminal_failure, pending_ids}}
+        {:cont,
+         %{
+           state
+           | run: failure_run,
+             results: next_results,
+             retry_refs: retry_refs,
+             terminal_failure: next_terminal_failure,
+             pending_ids: pending_ids
+         }}
 
       {:error, cancelled} ->
-        {:halt, {:error, Snapshots.cancelled_terminal(cancelled, next_results), next_results}}
+        {:halt,
+         {:error, Snapshots.cancelled_terminal(cancelled, next_results), next_results,
+          state.attempted_node_keys}}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -941,7 +941,12 @@ defmodule FavnOrchestrator.RunServer.Execution do
           )
         end)
 
-      await = %{pid: pid, monitor_ref: monitor_ref, entry: entry}
+      await = %{
+        pid: pid,
+        monitor_ref: monitor_ref,
+        deadline_ms: await_deadline(timeout_ms),
+        entry: entry
+      }
 
       %{
         replies: Map.put(acc.replies, reply_ref, await),
@@ -1034,35 +1039,39 @@ defmodule FavnOrchestrator.RunServer.Execution do
        )
        when map_size(replies) == 0 do
     if state.terminal_failure == nil and state.deferred_node_keys != [] do
-      wait_for_stage_admission_retry()
+      case wait_for_stage_admission_retry(deadline) do
+        :ok ->
+          case refill_stage_attempt_capacity(
+                 pending_tasks,
+                 state,
+                 stage,
+                 attempt,
+                 version,
+                 decisions,
+                 freshness_context,
+                 runner_client,
+                 runner_opts
+               ) do
+            {:cont, next_pending_tasks, next_state} ->
+              collect_stage_attempt_results(
+                next_pending_tasks,
+                deadline,
+                next_state,
+                stage,
+                attempt,
+                version,
+                decisions,
+                freshness_context,
+                runner_client,
+                runner_opts
+              )
 
-      case refill_stage_attempt_capacity(
-             pending_tasks,
-             state,
-             stage,
-             attempt,
-             version,
-             decisions,
-             freshness_context,
-             runner_client,
-             runner_opts
-           ) do
-        {:cont, next_pending_tasks, next_state} ->
-          collect_stage_attempt_results(
-            next_pending_tasks,
-            deadline,
-            next_state,
-            stage,
-            attempt,
-            version,
-            decisions,
-            freshness_context,
-            runner_client,
-            runner_opts
-          )
+            {:halt, result} ->
+              result
+          end
 
-        {:halt, result} ->
-          result
+        :timeout ->
+          timeout_deferred_stage_attempt(state)
       end
     else
       finalize_stage_attempt_state(state)
@@ -1081,7 +1090,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
          runner_client,
          runner_opts
        ) do
-    receive_timeout_ms = max(deadline - System.monotonic_time(:millisecond), 0)
+    receive_timeout_ms = next_await_receive_timeout_ms(pending_tasks)
 
     receive do
       {reply_ref, result} when is_map_key(replies, reply_ref) ->
@@ -1128,10 +1137,11 @@ defmodule FavnOrchestrator.RunServer.Execution do
         )
     after
       receive_timeout_ms ->
-        pending_tasks
-        |> timeout_pending_await_tasks()
-        |> process_stage_attempt_result_list(
-          %{replies: %{}, monitors: %{}},
+        {timed_out, next_pending_tasks} = timeout_expired_await_tasks(pending_tasks)
+
+        process_stage_attempt_result_list(
+          timed_out,
+          next_pending_tasks,
           deadline,
           state,
           stage,
@@ -1366,13 +1376,31 @@ defmodule FavnOrchestrator.RunServer.Execution do
     end
   end
 
-  defp wait_for_stage_admission_retry do
-    retry_ref = make_ref()
-    Process.send_after(self(), {:retry_stage_admission, retry_ref}, @stage_admission_retry_ms)
+  defp wait_for_stage_admission_retry(deadline) do
+    now = System.monotonic_time(:millisecond)
+    wait_ms = min(@stage_admission_retry_ms, max(deadline - now, 0))
 
-    receive do
-      {:retry_stage_admission, ^retry_ref} -> :ok
+    if wait_ms == 0 do
+      :timeout
+    else
+      retry_ref = make_ref()
+      Process.send_after(self(), {:retry_stage_admission, retry_ref}, wait_ms)
+
+      receive do
+        {:retry_stage_admission, ^retry_ref} -> :ok
+      end
     end
+  end
+
+  defp timeout_deferred_stage_attempt(%{run: %RunState{} = run_state} = state) do
+    timed_out =
+      RunState.transition(run_state,
+        status: :timed_out,
+        error: :timeout,
+        runner_execution_id: nil
+      )
+
+    {:error, timed_out, state.results, state.attempted_node_keys}
   end
 
   defp process_stage_attempt_result(
@@ -1455,15 +1483,38 @@ defmodule FavnOrchestrator.RunServer.Execution do
     {:error, failed_run, next_results, attempted_node_keys}
   end
 
-  defp timeout_pending_await_tasks(%{replies: replies}) do
-    Enum.map(replies, fn {reply_ref, %{pid: pid, monitor_ref: monitor_ref, entry: entry}} ->
-      Process.exit(pid, :kill)
-      Process.demonitor(monitor_ref, [:flush])
-      flush_await_reply(reply_ref)
-      :ok = fail_entry_materialization_claim(entry, :await_timeout)
+  defp next_await_receive_timeout_ms(%{replies: replies}) do
+    now = System.monotonic_time(:millisecond)
 
-      {entry, {:error, :timeout}}
-    end)
+    replies
+    |> Map.values()
+    |> Enum.map(& &1.deadline_ms)
+    |> Enum.min(fn -> now end)
+    |> Kernel.-(now)
+    |> max(0)
+  end
+
+  defp timeout_expired_await_tasks(%{replies: replies, monitors: monitors}) do
+    now = System.monotonic_time(:millisecond)
+
+    {timed_out, next_replies, next_monitors} =
+      Enum.reduce(replies, {[], %{}, monitors}, fn {reply_ref, await},
+                                                   {timed_out, next_replies, next_monitors} ->
+        if await.deadline_ms <= now do
+          Process.exit(await.pid, :kill)
+          Process.demonitor(await.monitor_ref, [:flush])
+          flush_await_reply(reply_ref)
+          :ok = release_entry_lease(await.entry)
+          :ok = fail_entry_materialization_claim(await.entry, :await_timeout)
+
+          {[{await.entry, {:error, :timeout}} | timed_out], next_replies,
+           Map.delete(next_monitors, await.monitor_ref)}
+        else
+          {timed_out, Map.put(next_replies, reply_ref, await), next_monitors}
+        end
+      end)
+
+    {Enum.reverse(timed_out), %{replies: next_replies, monitors: next_monitors}}
   end
 
   defp stop_pending_await_tasks(%{replies: replies}) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/await_tasks.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/await_tasks.ex
@@ -1,0 +1,195 @@
+defmodule FavnOrchestrator.RunServer.Execution.AwaitTasks do
+  @moduledoc """
+  BEAM process bookkeeping for runner await workers.
+
+  This module owns spawn/monitor/ref tracking, per-await deadlines, stale reply
+  flushing, and worker termination. It does not know about pipeline stages,
+  retries, admission policy, or materialization claim semantics; callers provide
+  cleanup callbacks for killed entries.
+  """
+
+  @await_task_timeout_buffer_ms 2_000
+
+  @type entry :: map()
+  @type await_result :: term()
+  @type event :: {entry(), await_result()}
+  @type cleanup_fun :: (entry() -> :ok)
+
+  @type await :: %{
+          required(:pid) => pid(),
+          required(:monitor_ref) => reference(),
+          required(:deadline_ms) => integer(),
+          required(:entry) => entry()
+        }
+
+  @type t :: %__MODULE__{
+          replies: %{optional(reference()) => await()},
+          monitors: %{optional(reference()) => reference()}
+        }
+
+  defstruct replies: %{}, monitors: %{}
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @spec start([entry()], pos_integer(), (entry() -> await_result())) :: t()
+  def start(entries, timeout_ms, await_fun)
+      when is_list(entries) and is_integer(timeout_ms) and timeout_ms > 0 and
+             is_function(await_fun, 1) do
+    parent = self()
+
+    Enum.reduce(entries, new(), fn entry, %__MODULE__{} = acc ->
+      reply_ref = make_ref()
+
+      {pid, monitor_ref} =
+        spawn_monitor(fn ->
+          send(parent, {reply_ref, await_fun.(entry)})
+        end)
+
+      await = %{
+        pid: pid,
+        monitor_ref: monitor_ref,
+        deadline_ms: await_deadline(timeout_ms),
+        entry: entry
+      }
+
+      %{
+        acc
+        | replies: Map.put(acc.replies, reply_ref, await),
+          monitors: Map.put(acc.monitors, monitor_ref, reply_ref)
+      }
+    end)
+  end
+
+  @spec empty?(t()) :: boolean()
+  def empty?(%__MODULE__{replies: replies}), do: map_size(replies) == 0
+
+  @spec merge(t(), t()) :: t()
+  def merge(%__MODULE__{} = left, %__MODULE__{} = right) do
+    %__MODULE__{
+      replies: Map.merge(left.replies, right.replies),
+      monitors: Map.merge(left.monitors, right.monitors)
+    }
+  end
+
+  @spec receive_next(t(), cleanup_fun()) :: {:events, [event()], t()}
+  def receive_next(%__MODULE__{replies: replies, monitors: monitors} = tasks, timeout_cleanup_fun)
+      when is_function(timeout_cleanup_fun, 1) do
+    receive_timeout_ms = next_receive_timeout_ms(tasks)
+
+    receive do
+      {reply_ref, result} when is_map_key(replies, reply_ref) ->
+        {%{monitor_ref: monitor_ref, entry: entry}, next_replies} = Map.pop!(replies, reply_ref)
+        Process.demonitor(monitor_ref, [:flush])
+
+        {:events, [{entry, result}],
+         %{tasks | replies: next_replies, monitors: Map.delete(monitors, monitor_ref)}}
+
+      {:DOWN, monitor_ref, :process, _pid, reason} when is_map_key(monitors, monitor_ref) ->
+        {reply_ref, next_monitors} = Map.pop!(monitors, monitor_ref)
+        {%{entry: entry}, next_replies} = Map.pop!(replies, reply_ref)
+
+        {:events, [{entry, await_exit_to_error(reason)}],
+         %{tasks | replies: next_replies, monitors: next_monitors}}
+    after
+      receive_timeout_ms ->
+        timeout_expired(tasks, timeout_cleanup_fun)
+    end
+  end
+
+  @spec drain_available(t()) :: {[event()], t()}
+  def drain_available(%__MODULE__{} = tasks), do: drain_available(tasks, [])
+
+  @spec timeout_expired(t(), cleanup_fun()) :: {:events, [event()], t()}
+  def timeout_expired(%__MODULE__{replies: replies, monitors: monitors} = tasks, cleanup_fun)
+      when is_function(cleanup_fun, 1) do
+    now = System.monotonic_time(:millisecond)
+
+    {timed_out, next_replies, next_monitors} =
+      Enum.reduce(replies, {[], %{}, monitors}, fn {reply_ref, await},
+                                                   {timed_out, next_replies, next_monitors} ->
+        if await.deadline_ms <= now do
+          Process.exit(await.pid, :kill)
+          Process.demonitor(await.monitor_ref, [:flush])
+          flush_reply(reply_ref)
+          :ok = cleanup_fun.(await.entry)
+
+          {[{await.entry, {:error, :timeout}} | timed_out], next_replies,
+           Map.delete(next_monitors, await.monitor_ref)}
+        else
+          {timed_out, Map.put(next_replies, reply_ref, await), next_monitors}
+        end
+      end)
+
+    {:events, Enum.reverse(timed_out), %{tasks | replies: next_replies, monitors: next_monitors}}
+  end
+
+  @spec stop(t(), cleanup_fun()) :: :ok
+  def stop(%__MODULE__{replies: replies}, cleanup_fun) when is_function(cleanup_fun, 1) do
+    Enum.each(replies, fn {reply_ref, %{pid: pid, monitor_ref: monitor_ref, entry: entry}} ->
+      Process.exit(pid, :kill)
+      Process.demonitor(monitor_ref, [:flush])
+      flush_reply(reply_ref)
+      :ok = cleanup_fun.(entry)
+    end)
+  end
+
+  @spec fail_unprocessed_timeout_results([event()], cleanup_fun()) :: :ok
+  def fail_unprocessed_timeout_results(results, cleanup_fun)
+      when is_list(results) and is_function(cleanup_fun, 1) do
+    Enum.each(results, fn
+      {entry, {:error, :timeout}} -> :ok = cleanup_fun.(entry)
+      {_entry, _result} -> :ok
+    end)
+  end
+
+  defp drain_available(%__MODULE__{replies: replies, monitors: monitors} = tasks, acc) do
+    receive do
+      {reply_ref, result} when is_map_key(replies, reply_ref) ->
+        {%{monitor_ref: monitor_ref, entry: entry}, next_replies} = Map.pop!(replies, reply_ref)
+        Process.demonitor(monitor_ref, [:flush])
+
+        drain_available(
+          %{tasks | replies: next_replies, monitors: Map.delete(monitors, monitor_ref)},
+          [{entry, result} | acc]
+        )
+
+      {:DOWN, monitor_ref, :process, _pid, reason} when is_map_key(monitors, monitor_ref) ->
+        {reply_ref, next_monitors} = Map.pop!(monitors, monitor_ref)
+        {%{entry: entry}, next_replies} = Map.pop!(replies, reply_ref)
+
+        drain_available(
+          %{tasks | replies: next_replies, monitors: next_monitors},
+          [{entry, await_exit_to_error(reason)} | acc]
+        )
+    after
+      0 -> {Enum.reverse(acc), tasks}
+    end
+  end
+
+  defp next_receive_timeout_ms(%__MODULE__{replies: replies}) do
+    now = System.monotonic_time(:millisecond)
+
+    replies
+    |> Map.values()
+    |> Enum.map(& &1.deadline_ms)
+    |> Enum.min(fn -> now end)
+    |> Kernel.-(now)
+    |> max(0)
+  end
+
+  defp await_deadline(timeout_ms),
+    do: System.monotonic_time(:millisecond) + timeout_ms + @await_task_timeout_buffer_ms
+
+  defp flush_reply(reply_ref) do
+    receive do
+      {^reply_ref, _result} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  defp await_exit_to_error(reason) do
+    {:error, %{type: :await_task_failed, kind: :exit, reason: inspect(reason)}}
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/await_tasks.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/await_tasks.ex
@@ -134,15 +134,6 @@ defmodule FavnOrchestrator.RunServer.Execution.AwaitTasks do
     end)
   end
 
-  @spec fail_unprocessed_timeout_results([event()], cleanup_fun()) :: :ok
-  def fail_unprocessed_timeout_results(results, cleanup_fun)
-      when is_list(results) and is_function(cleanup_fun, 1) do
-    Enum.each(results, fn
-      {entry, {:error, :timeout}} -> :ok = cleanup_fun.(entry)
-      {_entry, _result} -> :ok
-    end)
-  end
-
   defp drain_available(%__MODULE__{replies: replies, monitors: monitors} = tasks, acc) do
     receive do
       {reply_ref, result} when is_map_key(replies, reply_ref) ->

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
@@ -616,7 +616,12 @@ defmodule FavnOrchestrator.RunServer.Execution.StageAdmission do
     |> Enum.filter(&is_binary/1)
     |> Enum.uniq()
     |> Enum.each(fn execution_id ->
-      runner_client.cancel_work(execution_id, reason, runner_opts)
+      _ =
+        runner_client.cancel_work(
+          execution_id,
+          %{run_id: run_state.id, reason: reason, requested_at: DateTime.utc_now()},
+          runner_opts
+        )
     end)
 
     clear_inflight_executions(run_state, execution_ids)

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
@@ -15,6 +15,7 @@ defmodule FavnOrchestrator.RunServer.Execution.StageAdmission do
   alias FavnOrchestrator.ExecutionAdmission
   alias FavnOrchestrator.Freshness.StateWriter
   alias FavnOrchestrator.MaterializationClaims
+  alias FavnOrchestrator.RunServer.Cancellation
   alias FavnOrchestrator.RunServer.Persistence
   alias FavnOrchestrator.RunServer.Snapshots
   alias FavnOrchestrator.RunState
@@ -612,19 +613,16 @@ defmodule FavnOrchestrator.RunServer.Execution.StageAdmission do
          runner_client,
          runner_opts
        ) do
-    execution_ids
-    |> Enum.filter(&is_binary/1)
-    |> Enum.uniq()
-    |> Enum.each(fn execution_id ->
-      _ =
-        runner_client.cancel_work(
-          execution_id,
-          %{run_id: run_state.id, reason: reason, requested_at: DateTime.utc_now()},
-          runner_opts
-        )
-    end)
+    unique_ids =
+      Cancellation.cancel_runner_work(
+        run_state,
+        execution_ids,
+        reason,
+        runner_client,
+        runner_opts
+      )
 
-    clear_inflight_executions(run_state, execution_ids)
+    clear_inflight_executions(run_state, unique_ids)
   end
 
   defp clear_inflight_executions(%RunState{} = run_state, execution_ids)

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
@@ -1,0 +1,639 @@
+defmodule FavnOrchestrator.RunServer.Execution.StageAdmission do
+  @moduledoc """
+  Admission and runner submission for one pipeline stage attempt.
+
+  This module owns stage-local submit/defer decisions: execution admission
+  leases, materialization claims, queued-step dedupe, `:step_queued`, and
+  `:step_started` persistence. It does not await runner results or decide retry
+  and failure-drain behavior.
+  """
+
+  alias Favn.Contracts.RunnerWork
+  alias Favn.Manifest.Version
+  alias Favn.Run.NodeResult
+  alias FavnOrchestrator.AssetStepIdentity
+  alias FavnOrchestrator.ExecutionAdmission
+  alias FavnOrchestrator.Freshness.StateWriter
+  alias FavnOrchestrator.MaterializationClaims
+  alias FavnOrchestrator.RunServer.Persistence
+  alias FavnOrchestrator.RunServer.Snapshots
+  alias FavnOrchestrator.RunState
+
+  @type node_key :: Favn.Plan.node_key()
+  @type entry :: map()
+  @type result ::
+          {:ok, RunState.t(), [entry()], [node_key()], MapSet.t(term())}
+          | {:error, RunState.t(), [term()], [node_key()]}
+
+  @spec submit(map()) :: result()
+  def submit(%{queued_steps: queued_steps} = request) when is_map(request) do
+    do_submit(
+      request.node_keys,
+      request.run,
+      request.version,
+      request.stage,
+      request.decisions,
+      request.freshness_context,
+      request.attempt,
+      request.runner_client,
+      request.runner_opts,
+      [],
+      queued_steps
+    )
+  end
+
+  def submit(%{
+        run: %RunState{} = run_state,
+        version: %Version{} = version,
+        stage: stage,
+        node_keys: node_keys,
+        decisions: decisions,
+        freshness_context: freshness_context,
+        attempt: attempt,
+        runner_client: runner_client,
+        runner_opts: runner_opts
+      })
+      when is_list(node_keys) and is_map(decisions) and is_map(freshness_context) do
+    submit(%{
+      run: run_state,
+      version: version,
+      stage: stage,
+      node_keys: node_keys,
+      decisions: decisions,
+      freshness_context: freshness_context,
+      attempt: attempt,
+      runner_client: runner_client,
+      runner_opts: runner_opts,
+      queued_steps: MapSet.new()
+    })
+  end
+
+  defp do_submit(
+         [],
+         %RunState{} = run_state,
+         _version,
+         _stage,
+         _decisions,
+         _freshness_context,
+         _attempt,
+         _runner_client,
+         _runner_opts,
+         entries,
+         queued_steps
+       ) do
+    {:ok, run_state, entries, [], queued_steps}
+  end
+
+  defp do_submit(
+         [node_key | rest] = node_keys,
+         %RunState{} = current_run,
+         %Version{} = version,
+         stage,
+         decisions,
+         freshness_context,
+         attempt,
+         runner_client,
+         runner_opts,
+         acc,
+         queued_steps
+       ) do
+    if Persistence.externally_cancelled?(current_run.id) do
+      {:error, Snapshots.cancelled_snapshot(current_run), [], Enum.map(acc, & &1.node_key)}
+    else
+      work = stage_work(current_run, version, node_key, stage, attempt)
+      asset_step_id = Map.fetch!(work.metadata, :asset_step_id)
+
+      case ExecutionAdmission.acquire(current_run, %{
+             asset_step_id: asset_step_id,
+             execution_pool: Map.get(work.metadata, :execution_pool)
+           }) do
+        {:ok, lease} ->
+          handle_admitted_entry(%{
+            rest: rest,
+            node_keys: node_keys,
+            current_run: current_run,
+            version: version,
+            stage: stage,
+            decisions: decisions,
+            freshness_context: freshness_context,
+            attempt: attempt,
+            runner_client: runner_client,
+            runner_opts: runner_opts,
+            acc: acc,
+            queued_steps: queued_steps,
+            node_key: node_key,
+            work: work,
+            lease: lease
+          })
+
+        {:queued, queue_reason, scope} ->
+          persist_or_defer_queued_entry(%{
+            queued_steps: queued_steps,
+            queue_signature: queue_signature(asset_step_id, queue_reason, scope),
+            current_run: current_run,
+            work: work,
+            stage: stage,
+            attempt: attempt,
+            queue_reason: queue_reason,
+            scope: scope,
+            acc: acc,
+            node_keys: node_keys
+          })
+
+        {:error, reason} ->
+          failed = RunState.transition(current_run, status: :error, error: reason)
+          {:error, failed, [], Enum.map(acc, & &1.node_key)}
+      end
+    end
+  end
+
+  defp handle_admitted_entry(
+         %{current_run: current_run, version: version, node_key: node_key} = ctx
+       ) do
+    case MaterializationClaims.acquire(
+           current_run,
+           version,
+           node_key,
+           ctx.decisions,
+           ctx.freshness_context,
+           ctx.work
+         ) do
+      {:ok, claim} ->
+        submit_admitted_entry(Map.put(ctx, :materialization_claim, claim))
+
+      {:already_succeeded, claim} ->
+        :ok = release_entry_lease(%{lease: ctx.lease})
+        maybe_skip_succeeded_claim(ctx, claim)
+
+      {:already_claimed, claim} ->
+        :ok = release_entry_lease(%{lease: ctx.lease})
+        queue_reason = :materialization_claim
+        scope = MaterializationClaims.scope(claim)
+
+        persist_or_defer_queued_entry(%{
+          queued_steps: ctx.queued_steps,
+          queue_signature:
+            queue_signature(Map.fetch!(ctx.work.metadata, :asset_step_id), queue_reason, scope),
+          current_run: current_run,
+          work: ctx.work,
+          stage: ctx.stage,
+          attempt: ctx.attempt,
+          queue_reason: queue_reason,
+          scope: scope,
+          acc: ctx.acc,
+          node_keys: ctx.node_keys
+        })
+
+      {:error, reason} ->
+        :ok = release_entry_lease(%{lease: ctx.lease})
+        failed = RunState.transition(current_run, status: :error, error: reason)
+        {:error, failed, [], Enum.map(ctx.acc, & &1.node_key)}
+    end
+  end
+
+  defp maybe_skip_succeeded_claim(ctx, claim) do
+    if MaterializationClaims.reusable_success?(ctx.decisions, ctx.node_key) do
+      decision =
+        ctx.decisions
+        |> Map.get(ctx.node_key, %{})
+        |> Map.merge(%{
+          decision: :skipped_fresh,
+          reason: MaterializationClaims.skip_reason(claim)
+        })
+
+      case persist_decision_result(
+             ctx.current_run,
+             ctx.version,
+             ctx.node_key,
+             ctx.stage,
+             :skipped_fresh,
+             decision
+           ) do
+        {:ok, skipped_run} ->
+          do_submit(
+            ctx.rest,
+            skipped_run,
+            ctx.version,
+            ctx.stage,
+            ctx.decisions,
+            ctx.freshness_context,
+            ctx.attempt,
+            ctx.runner_client,
+            ctx.runner_opts,
+            ctx.acc,
+            ctx.queued_steps
+          )
+
+        {:error, :external_cancel} ->
+          {:error, Snapshots.cancelled_snapshot(ctx.current_run), [],
+           Enum.map(ctx.acc, & &1.node_key)}
+
+        {:error, reason} ->
+          failed = RunState.transition(ctx.current_run, status: :error, error: reason)
+          {:error, failed, [], Enum.map(ctx.acc, & &1.node_key)}
+      end
+    else
+      failed =
+        RunState.transition(ctx.current_run,
+          status: :error,
+          error: {:non_reusable_materialization_claim_succeeded, MaterializationClaims.key(claim)}
+        )
+
+      {:error, failed, [], Enum.map(ctx.acc, & &1.node_key)}
+    end
+  end
+
+  defp persist_or_defer_queued_entry(ctx) do
+    case maybe_persist_step_queued(
+           ctx.queued_steps,
+           ctx.queue_signature,
+           ctx.current_run,
+           ctx.work,
+           ctx.stage,
+           ctx.attempt,
+           ctx.queue_reason,
+           ctx.scope
+         ) do
+      {:ok, queued_run, next_queued_steps} when ctx.acc == [] ->
+        {:ok, queued_run, [], ctx.node_keys, next_queued_steps}
+
+      {:ok, queued_run, next_queued_steps} ->
+        {:ok, queued_run, ctx.acc, ctx.node_keys, next_queued_steps}
+
+      {:error, :external_cancel} ->
+        {:error, Snapshots.cancelled_snapshot(ctx.current_run), [],
+         Enum.map(ctx.acc, & &1.node_key)}
+
+      {:error, reason} ->
+        failed = RunState.transition(ctx.current_run, status: :error, error: reason)
+        {:error, failed, [], Enum.map(ctx.acc, & &1.node_key)}
+    end
+  end
+
+  defp submit_admitted_entry(ctx) do
+    asset_ref = ctx.work.asset_ref
+    asset_step_id = Map.fetch!(ctx.work.metadata, :asset_step_id)
+
+    case ctx.runner_client.submit_work(ctx.work, ctx.runner_opts) do
+      {:ok, execution_id} ->
+        updated_run = with_inflight_execution(ctx.current_run, execution_id, ctx.work.metadata)
+
+        case Persistence.persist_run_step(updated_run, :step_started, %{
+               asset_ref: asset_ref,
+               runner_execution_id: execution_id,
+               asset_step_id: asset_step_id,
+               window: Map.get(ctx.work.metadata, :window),
+               stage: ctx.stage,
+               attempt: ctx.attempt,
+               max_attempts: ctx.current_run.max_attempts,
+               execution_pool: Map.get(ctx.work.metadata, :execution_pool),
+               freshness_key: decision_freshness_key(ctx.decisions, ctx.node_key)
+             }) do
+          :ok ->
+            entry = %{
+              run_id: ctx.current_run.id,
+              asset_step_id: asset_step_id,
+              asset_ref: asset_ref,
+              node_key: ctx.node_key,
+              window: Map.get(ctx.work.metadata, :window),
+              execution_id: execution_id,
+              runner_execution_id: execution_id,
+              version: ctx.version,
+              decision: Map.get(ctx.decisions, ctx.node_key, %{}),
+              freshness_context: ctx.freshness_context,
+              attempt: ctx.attempt,
+              stage: ctx.stage,
+              lease: ctx.lease,
+              materialization_claim: ctx.materialization_claim,
+              execution_pool: Map.get(ctx.work.metadata, :execution_pool),
+              freshness_key: decision_freshness_key(ctx.decisions, ctx.node_key)
+            }
+
+            do_submit(
+              ctx.rest,
+              updated_run,
+              ctx.version,
+              ctx.stage,
+              ctx.decisions,
+              ctx.freshness_context,
+              ctx.attempt,
+              ctx.runner_client,
+              ctx.runner_opts,
+              ctx.acc ++ [entry],
+              ctx.queued_steps
+            )
+
+          {:error, :external_cancel} ->
+            :ok = release_entry_lease(%{lease: ctx.lease})
+            :ok = MaterializationClaims.fail(ctx.materialization_claim, :external_cancel)
+            :ok = release_entry_leases(ctx.acc)
+
+            cancelled =
+              cancel_execution_ids(
+                updated_run,
+                [execution_id],
+                %{
+                  kind: :external_cancel,
+                  asset_ref: asset_ref,
+                  stage: ctx.stage,
+                  attempt: ctx.attempt
+                },
+                ctx.runner_client,
+                ctx.runner_opts
+              )
+
+            {:error, Snapshots.cancelled_snapshot(cancelled), [],
+             Enum.map(ctx.acc, & &1.node_key) ++ [ctx.node_key]}
+        end
+
+      {:error, reason} ->
+        :ok = release_entry_lease(%{lease: ctx.lease})
+        :ok = MaterializationClaims.fail(ctx.materialization_claim, reason)
+        :ok = release_entry_leases(ctx.acc)
+
+        cancelled =
+          cancel_execution_ids(
+            ctx.current_run,
+            Enum.map(ctx.acc, & &1.execution_id),
+            %{kind: :submit_failure, asset_ref: asset_ref, error: reason},
+            ctx.runner_client,
+            ctx.runner_opts
+          )
+
+        failed =
+          RunState.transition(cancelled, status: :error, error: reason, runner_execution_id: nil)
+
+        case Persistence.persist_run_step(failed, :step_failed, %{
+               asset_ref: asset_ref,
+               error: reason,
+               node_key: Map.get(ctx.work.metadata, :node_key),
+               asset_step_id: Map.get(ctx.work.metadata, :asset_step_id),
+               window: Map.get(ctx.work.metadata, :window),
+               stage: ctx.stage,
+               attempt: ctx.attempt,
+               max_attempts: ctx.current_run.max_attempts,
+               execution_pool: Map.get(ctx.work.metadata, :execution_pool)
+             }) do
+          :ok ->
+            {:error, failed, [], Enum.map(ctx.acc, & &1.node_key)}
+
+          {:error, :external_cancel} ->
+            {:error, Snapshots.cancelled_snapshot(failed), [], Enum.map(ctx.acc, & &1.node_key)}
+        end
+    end
+  end
+
+  defp persist_step_queued(run_state, work, stage, attempt, queue_reason, scope) do
+    queued_run = RunState.transition(run_state, status: :running, error: nil)
+
+    case Persistence.persist_run_step(queued_run, :step_queued, %{
+           asset_ref: work.asset_ref,
+           node_key: Map.get(work.metadata, :node_key),
+           asset_step_id: Map.get(work.metadata, :asset_step_id),
+           window: Map.get(work.metadata, :window),
+           stage: stage,
+           attempt: attempt,
+           max_attempts: run_state.max_attempts,
+           execution_pool: Map.get(work.metadata, :execution_pool),
+           queue_reason: queue_reason,
+           admission_scope: scope
+         }) do
+      :ok -> {:ok, queued_run}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp maybe_persist_step_queued(
+         queued_steps,
+         queue_signature,
+         run_state,
+         work,
+         stage,
+         attempt,
+         queue_reason,
+         scope
+       ) do
+    if MapSet.member?(queued_steps, queue_signature) do
+      {:ok, run_state, queued_steps}
+    else
+      case persist_step_queued(run_state, work, stage, attempt, queue_reason, scope) do
+        {:ok, queued_run} -> {:ok, queued_run, MapSet.put(queued_steps, queue_signature)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  defp queue_signature(asset_step_id, queue_reason, scope) do
+    scope_kind = Map.get(scope, :kind) || Map.get(scope, "kind")
+    scope_key = Map.get(scope, :key) || Map.get(scope, "key")
+
+    {asset_step_id, queue_reason, scope_kind, scope_key}
+  end
+
+  defp persist_decision_result(
+         %RunState{} = run_state,
+         %Version{} = version,
+         node_key,
+         stage,
+         status,
+         decision
+       ) do
+    node = Map.fetch!(run_state.plan.nodes, node_key)
+    now = DateTime.utc_now()
+    freshness_key = Map.get(decision, :freshness_key, Favn.Freshness.Key.latest())
+    asset_step_id = AssetStepIdentity.asset_step_id(run_state.id, node_key, node.ref)
+
+    result =
+      NodeResult.new(%{
+        node_key: node_key,
+        ref: node.ref,
+        window: node.window,
+        stage: stage,
+        execution_pool: effective_execution_pool(run_state, node_key),
+        status: status,
+        started_at: now,
+        finished_at: now,
+        duration_ms: 0,
+        reason: decision.reason,
+        freshness_key: freshness_key,
+        input_versions: [],
+        attempt_count: 0,
+        max_attempts: run_state.max_attempts,
+        meta: decision_metadata(decision),
+        error: if(status == :blocked, do: decision.reason, else: nil),
+        asset_step_id: asset_step_id
+      })
+
+    next_run = put_node_result(run_state, result)
+    event_type = if status == :skipped_fresh, do: :step_skipped_fresh, else: :step_blocked
+
+    case Persistence.persist_run_step(next_run, event_type, %{
+           asset_ref: node.ref,
+           node_key: node_key,
+           window: node.window,
+           asset_step_id: asset_step_id,
+           stage: stage,
+           execution_pool: effective_execution_pool(run_state, node_key),
+           reason: decision.reason,
+           freshness_key: freshness_key
+         }) do
+      :ok ->
+        case StateWriter.put_attempt_state(
+               next_run,
+               version,
+               node_key,
+               status,
+               freshness_key,
+               decision
+             ) do
+          {:ok, _state} -> {:ok, next_run}
+          {:error, reason} -> {:error, {:freshness_state_write_failed, reason}}
+        end
+
+      {:error, :external_cancel} ->
+        {:error, :external_cancel}
+    end
+  end
+
+  defp decision_metadata(decision) when is_map(decision),
+    do: Map.drop(decision, [:decision, :node_key, :reason, :freshness_key])
+
+  defp put_node_result(%RunState{} = run_state, %NodeResult{} = result) do
+    node_results = existing_node_results(run_state) ++ [result]
+    result_map = Map.merge(run_state.result || %{}, %{node_results: node_results})
+    RunState.transition(run_state, result: result_map)
+  end
+
+  defp existing_node_results(%RunState{result: %{node_results: results}}) when is_list(results),
+    do: results
+
+  defp existing_node_results(_run_state), do: []
+
+  defp stage_work(%RunState{} = run_state, %Version{} = version, node_key, stage, attempt) do
+    node = Map.fetch!(run_state.plan.nodes, node_key)
+    asset_ref = node.ref
+    asset_step_id = AssetStepIdentity.asset_step_id(run_state.id, node_key, asset_ref)
+
+    %RunnerWork{
+      run_id: run_state.id,
+      manifest_version_id: version.manifest_version_id,
+      manifest_content_hash: version.content_hash,
+      asset_ref: asset_ref,
+      asset_refs: [asset_ref],
+      planned_asset_refs: planned_asset_refs(run_state),
+      params: run_state.params,
+      trigger:
+        run_state.trigger
+        |> Map.put(:window, node.window)
+        |> maybe_put_pipeline_trigger(Map.get(run_state.metadata, :pipeline_context)),
+      metadata:
+        Map.merge(work_metadata(run_state.metadata), %{
+          attempt: attempt,
+          asset_step_id: asset_step_id,
+          max_attempts: run_state.max_attempts,
+          stage: stage,
+          node_key: node_key,
+          window: node.window,
+          execution_pool: effective_execution_pool(run_state, node_key)
+        })
+    }
+  end
+
+  defp planned_asset_refs(%RunState{target_refs: refs}) when is_list(refs), do: refs
+  defp planned_asset_refs(_run_state), do: []
+
+  defp effective_execution_pool(%RunState{} = run_state, node_key) do
+    node_pool =
+      case run_state.plan do
+        %Favn.Plan{nodes: nodes} when is_map(nodes) ->
+          nodes |> Map.get(node_key, %{}) |> Map.get(:execution_pool)
+
+        _other ->
+          nil
+      end
+
+    node_pool || pipeline_default_execution_pool(run_state)
+  end
+
+  defp pipeline_default_execution_pool(%RunState{metadata: %{pipeline_execution_policy: policy}})
+       when is_map(policy) do
+    Map.get(policy, :execution_pool) || Map.get(policy, "execution_pool")
+  end
+
+  defp pipeline_default_execution_pool(%RunState{}), do: nil
+
+  defp maybe_put_pipeline_trigger(trigger, pipeline_context) when is_map(pipeline_context),
+    do: Map.put(trigger, :pipeline, pipeline_context)
+
+  defp maybe_put_pipeline_trigger(trigger, _pipeline_context), do: trigger
+
+  defp work_metadata(metadata) when is_map(metadata), do: Map.delete(metadata, :runner_metadata)
+
+  defp with_inflight_execution(%RunState{} = run_state, execution_id, metadata) do
+    ids =
+      run_state
+      |> inflight_ids_from_metadata()
+      |> Kernel.++([execution_id])
+      |> Enum.filter(&is_binary/1)
+      |> Enum.uniq()
+
+    RunState.transition(run_state,
+      runner_execution_id: execution_id,
+      metadata: Map.put(metadata, :in_flight_execution_ids, ids)
+    )
+  end
+
+  defp inflight_ids_from_metadata(%RunState{} = run_state) do
+    case Map.get(run_state.metadata, :in_flight_execution_ids, []) do
+      ids when is_list(ids) -> ids
+      _other -> []
+    end
+  end
+
+  defp release_entry_leases(entries) when is_list(entries) do
+    Enum.each(entries, &release_entry_lease/1)
+    :ok
+  end
+
+  defp release_entry_lease(%{lease: lease}), do: release_entry_lease(lease)
+  defp release_entry_lease(nil), do: :ok
+
+  defp release_entry_lease(lease) when is_map(lease) do
+    case ExecutionAdmission.release(lease) do
+      :ok -> :ok
+      {:error, _reason} -> :ok
+    end
+  end
+
+  defp cancel_execution_ids(
+         %RunState{} = run_state,
+         execution_ids,
+         reason,
+         runner_client,
+         runner_opts
+       ) do
+    execution_ids
+    |> Enum.filter(&is_binary/1)
+    |> Enum.uniq()
+    |> Enum.each(fn execution_id ->
+      runner_client.cancel_work(execution_id, reason, runner_opts)
+    end)
+
+    clear_inflight_executions(run_state, execution_ids)
+  end
+
+  defp clear_inflight_executions(%RunState{} = run_state, execution_ids)
+       when is_list(execution_ids) do
+    ids = inflight_ids_from_metadata(run_state) -- Enum.filter(execution_ids, &is_binary/1)
+
+    RunState.transition(run_state,
+      metadata: Map.put(run_state.metadata, :in_flight_execution_ids, ids)
+    )
+  end
+
+  defp decision_freshness_key(decisions, node_key) when is_map(decisions) do
+    decisions
+    |> Map.get(node_key, %{})
+    |> Map.get(:freshness_key, Favn.Freshness.Key.latest())
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_attempt_state.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_attempt_state.ex
@@ -1,0 +1,131 @@
+defmodule FavnOrchestrator.RunServer.Execution.StageAttemptState do
+  @moduledoc """
+  Explicit state for one pipeline stage attempt.
+
+  This struct owns scheduler bookkeeping for admitted, deferred, retryable, and
+  completed same-stage work. It does not acquire leases, start runner work, or
+  persist run events.
+  """
+
+  alias FavnOrchestrator.RunState
+
+  @type entry :: map()
+  @type node_key :: Favn.Plan.node_key()
+  @type terminal_failure :: %{required(:status) => RunState.status(), required(:error) => term()}
+
+  @type t :: %__MODULE__{
+          run: RunState.t(),
+          results: [term()],
+          retry_refs: [node_key()],
+          terminal_failure: terminal_failure() | nil,
+          pending_ids: MapSet.t(String.t()),
+          deferred_node_keys: [node_key()],
+          queued_steps: MapSet.t(term()),
+          initial_entries: [entry()],
+          attempted_node_keys: [node_key()]
+        }
+
+  defstruct run: nil,
+            results: [],
+            retry_refs: [],
+            terminal_failure: nil,
+            pending_ids: MapSet.new(),
+            deferred_node_keys: [],
+            queued_steps: MapSet.new(),
+            initial_entries: [],
+            attempted_node_keys: []
+
+  @spec new(RunState.t(), [term()], [entry()], [node_key()], MapSet.t(term())) :: t()
+  def new(%RunState{} = run, results, entries, deferred_node_keys, queued_steps)
+      when is_list(results) and is_list(entries) and is_list(deferred_node_keys) do
+    %__MODULE__{
+      run: run,
+      results: results,
+      pending_ids: pending_execution_ids(entries),
+      deferred_node_keys: deferred_node_keys,
+      queued_steps: queued_steps,
+      initial_entries: entries,
+      attempted_node_keys: entry_node_keys(entries)
+    }
+  end
+
+  @spec terminal_failure?(t()) :: boolean()
+  def terminal_failure?(%__MODULE__{terminal_failure: nil}), do: false
+  def terminal_failure?(%__MODULE__{}), do: true
+
+  @spec deferred?(t()) :: boolean()
+  def deferred?(%__MODULE__{deferred_node_keys: []}), do: false
+  def deferred?(%__MODULE__{}), do: true
+
+  @spec add_entries(t(), [entry()], RunState.t(), [node_key()], MapSet.t(term())) :: t()
+  def add_entries(
+        %__MODULE__{} = state,
+        entries,
+        %RunState{} = run,
+        deferred_node_keys,
+        queued_steps
+      )
+      when is_list(entries) and is_list(deferred_node_keys) do
+    %{
+      state
+      | run: run,
+        pending_ids: MapSet.union(state.pending_ids, pending_execution_ids(entries)),
+        deferred_node_keys: deferred_node_keys,
+        queued_steps: queued_steps,
+        attempted_node_keys: Enum.uniq(state.attempted_node_keys ++ entry_node_keys(entries))
+    }
+  end
+
+  @spec defer_only(t(), RunState.t(), [node_key()], MapSet.t(term())) :: t()
+  def defer_only(%__MODULE__{} = state, %RunState{} = run, deferred_node_keys, queued_steps)
+      when is_list(deferred_node_keys) do
+    %{state | run: run, deferred_node_keys: deferred_node_keys, queued_steps: queued_steps}
+  end
+
+  @spec record_result(
+          t(),
+          RunState.t(),
+          [term()],
+          [node_key()],
+          terminal_failure() | nil,
+          MapSet.t(String.t())
+        ) :: t()
+  def record_result(
+        %__MODULE__{} = state,
+        %RunState{} = run,
+        results,
+        retry_refs,
+        terminal_failure,
+        pending_ids
+      )
+      when is_list(results) and is_list(retry_refs) do
+    %{
+      state
+      | run: run,
+        results: results,
+        retry_refs: retry_refs,
+        terminal_failure: terminal_failure,
+        pending_ids: pending_ids
+    }
+  end
+
+  @spec mark_terminal_failure(t(), terminal_failure()) :: t()
+  def mark_terminal_failure(%__MODULE__{} = state, terminal_failure)
+      when is_map(terminal_failure),
+      do: %{state | terminal_failure: terminal_failure}
+
+  @spec attempted_node_keys(t()) :: [node_key()]
+  def attempted_node_keys(%__MODULE__{attempted_node_keys: attempted_node_keys}),
+    do: attempted_node_keys
+
+  @spec pending_execution_ids([entry()]) :: MapSet.t(String.t())
+  def pending_execution_ids(entries) when is_list(entries) do
+    entries
+    |> Enum.map(&Map.get(&1, :execution_id))
+    |> Enum.filter(&is_binary/1)
+    |> MapSet.new()
+  end
+
+  @spec entry_node_keys([entry()]) :: [node_key()]
+  def entry_node_keys(entries) when is_list(entries), do: Enum.map(entries, & &1.node_key)
+end

--- a/apps/favn_orchestrator/test/run_server_test.exs
+++ b/apps/favn_orchestrator/test/run_server_test.exs
@@ -143,6 +143,95 @@ defmodule FavnOrchestrator.RunServerTest do
     end
   end
 
+  defmodule RunnerClientBlockingStub do
+    @behaviour Favn.Contracts.RunnerClient
+
+    @impl true
+    def register_manifest(_version, _opts), do: :ok
+
+    @impl true
+    def submit_work(work, opts) do
+      parent = Keyword.fetch!(opts, :parent)
+      execution_id = execution_id(work)
+      send(parent, {:submitted, work.asset_ref, execution_id})
+      {:ok, execution_id}
+    end
+
+    @impl true
+    def await_result(execution_id, _timeout, opts) do
+      parent = Keyword.fetch!(opts, :parent)
+      asset_ref = execution_ref(execution_id)
+      send(parent, {:awaiting, execution_id, asset_ref, self()})
+
+      receive do
+        {:release_runner_result, ^execution_id, status} ->
+          {:ok,
+           %RunnerResult{
+             status: status,
+             error: if(status == :ok, do: nil, else: :runner_failed),
+             asset_results: [asset_result(execution_id, status)],
+             metadata: %{}
+           }}
+      end
+    end
+
+    @impl true
+    def cancel_work(_execution_id, _reason, _opts), do: :ok
+
+    @impl true
+    def inspect_relation(_request, _opts), do: {:error, :not_supported}
+
+    defp execution_id(work) do
+      {module, name} = work.asset_ref
+
+      encoded_node_key =
+        work.metadata.node_key |> :erlang.term_to_binary() |> Base.encode16(case: :lower)
+
+      Enum.join(
+        [
+          "blocking_exec",
+          work.run_id,
+          Atom.to_string(module),
+          Atom.to_string(name),
+          encoded_node_key
+        ],
+        ":"
+      )
+    end
+
+    defp execution_ref(execution_id) do
+      [_prefix, _run_id, module, name | _rest] = String.split(execution_id, ":")
+      {String.to_existing_atom(module), String.to_existing_atom(name)}
+    end
+
+    defp execution_node_key(execution_id) do
+      execution_id
+      |> String.split(":")
+      |> List.last()
+      |> Base.decode16!(case: :lower)
+      |> :erlang.binary_to_term()
+    end
+
+    defp asset_result(execution_id, status) do
+      ref = execution_ref(execution_id)
+      node_key = execution_node_key(execution_id)
+
+      %Favn.Run.AssetResult{
+        ref: ref,
+        stage: 0,
+        status: status,
+        started_at: DateTime.utc_now(),
+        finished_at: DateTime.utc_now(),
+        duration_ms: 0,
+        meta: %{node_key: node_key},
+        error: if(status == :ok, do: nil, else: :runner_failed),
+        attempt_count: 1,
+        max_attempts: 1,
+        attempts: []
+      }
+    end
+  end
+
   setup do
     previous_client = Application.get_env(:favn_orchestrator, :runner_client)
     previous_opts = Application.get_env(:favn_orchestrator, :runner_client_opts)
@@ -446,6 +535,101 @@ defmodule FavnOrchestrator.RunServerTest do
     assert statuses[{silver_b, nil}] == :ok
   end
 
+  test "pipeline max concurrency refills same-stage work as executions complete" do
+    Application.put_env(:favn_orchestrator, :runner_client, RunnerClientBlockingStub)
+    Application.put_env(:favn_orchestrator, :runner_client_opts, parent: self())
+
+    refs =
+      Enum.map(1..6, fn index ->
+        {Module.concat([MyApp.Assets.PipelineRefill, "Asset#{index}"]), :asset}
+      end)
+
+    plan = same_stage_plan(refs)
+    version = manifest_version_for_refs("mv_pipeline_sliding_window_refill", refs)
+
+    run_state =
+      "run_pipeline_sliding_window_refill"
+      |> pipeline_run_state(version, plan, refs)
+      |> RunState.transition(metadata: %{pipeline_execution_policy: %{max_concurrency: 5}})
+
+    assert :ok = Storage.put_run(run_state)
+
+    assert {:ok, pid} = RunServer.start_link(%{run_state: run_state, version: version})
+    ref = Process.monitor(pid)
+
+    initial_submissions = receive_submissions(5)
+    refute_received {:submitted, _, _}
+
+    awaiters = receive_awaiters(initial_submissions)
+
+    {first_execution_id, first_awaiter} =
+      awaiter_for_submission(hd(initial_submissions), awaiters)
+
+    send(first_awaiter, {:release_runner_result, first_execution_id, :ok})
+
+    assert_receive {:submitted, sixth_ref, sixth_execution_id}, 1_000
+    assert sixth_ref == List.last(refs)
+
+    awaiters = Map.merge(awaiters, receive_awaiters([{sixth_ref, sixth_execution_id}]))
+
+    initial_submissions
+    |> tl()
+    |> Enum.each(fn submission -> release_submission(submission, awaiters) end)
+
+    release_submission({sixth_ref, sixth_execution_id}, awaiters)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+    assert {:ok, stored} = Storage.get_run(run_state.id)
+    assert stored.status == :ok
+  end
+
+  test "pipeline max concurrency does not refill same-stage work after terminal failure" do
+    Application.put_env(:favn_orchestrator, :runner_client, RunnerClientBlockingStub)
+    Application.put_env(:favn_orchestrator, :runner_client_opts, parent: self())
+
+    refs =
+      Enum.map(1..3, fn index ->
+        {Module.concat([MyApp.Assets.PipelineFailureDrain, "Asset#{index}"]), :asset}
+      end)
+
+    plan = same_stage_plan(refs)
+    version = manifest_version_for_refs("mv_pipeline_failure_does_not_refill", refs)
+
+    run_state =
+      "run_pipeline_failure_does_not_refill"
+      |> pipeline_run_state(version, plan, refs)
+      |> RunState.transition(metadata: %{pipeline_execution_policy: %{max_concurrency: 2}})
+
+    assert :ok = Storage.put_run(run_state)
+
+    assert {:ok, pid} = RunServer.start_link(%{run_state: run_state, version: version})
+    ref = Process.monitor(pid)
+
+    initial_submissions = receive_submissions(2)
+    refute_received {:submitted, _, _}
+
+    awaiters = receive_awaiters(initial_submissions)
+    release_submission(hd(initial_submissions), awaiters, :error)
+
+    last_ref = List.last(refs)
+    refute_receive {:submitted, ^last_ref, _execution_id}, 200
+
+    initial_submissions
+    |> tl()
+    |> Enum.each(fn submission -> release_submission(submission, awaiters) end)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+    assert {:ok, stored} = Storage.get_run(run_state.id)
+    assert stored.status == :error
+
+    assert {:ok, events} = Storage.list_run_events(run_state.id)
+
+    started_refs =
+      events |> Enum.filter(&(&1.event_type == :step_started)) |> Enum.map(& &1.asset_ref)
+
+    refute last_ref in started_refs
+  end
+
   test "actual upstream success refreshes downstream in same pipeline" do
     {:ok, submit_log} = Agent.start_link(fn -> [] end)
     Application.put_env(:favn_orchestrator, :runner_client, RunnerClientRecordingStub)
@@ -735,6 +919,52 @@ defmodule FavnOrchestrator.RunServerTest do
     statuses = Map.new(stored.result.node_results, &{&1.node_key, &1.status})
     assert statuses[node_one] == :ok
     assert statuses[node_two] == :error
+  end
+
+  defp receive_submissions(count) do
+    Enum.map(1..count, fn _index ->
+      assert_receive {:submitted, asset_ref, execution_id}, 1_000
+      {asset_ref, execution_id}
+    end)
+  end
+
+  defp receive_awaiters(submissions) do
+    submissions
+    |> Map.new(fn {asset_ref, execution_id} ->
+      assert_receive {:awaiting, ^execution_id, ^asset_ref, awaiter}, 1_000
+      {execution_id, awaiter}
+    end)
+  end
+
+  defp awaiter_for_submission({_asset_ref, execution_id}, awaiters) do
+    {execution_id, Map.fetch!(awaiters, execution_id)}
+  end
+
+  defp release_submission(submission, awaiters) do
+    release_submission(submission, awaiters, :ok)
+  end
+
+  defp release_submission({_asset_ref, execution_id} = submission, awaiters, status) do
+    {_execution_id, awaiter} = awaiter_for_submission(submission, awaiters)
+    send(awaiter, {:release_runner_result, execution_id, status})
+  end
+
+  defp same_stage_plan(refs) do
+    node_keys = Enum.map(refs, &{&1, nil})
+
+    nodes =
+      Map.new(Enum.zip(refs, node_keys), fn {ref, node_key} ->
+        {node_key, plan_node(ref, node_key, stage: 0)}
+      end)
+
+    %Plan{
+      target_refs: refs,
+      target_node_keys: node_keys,
+      nodes: nodes,
+      topo_order: refs,
+      stages: [refs],
+      node_stages: [node_keys]
+    }
   end
 
   defp manifest_version(manifest_version_id, opts \\ []) do

--- a/apps/favn_orchestrator/test/run_server_test.exs
+++ b/apps/favn_orchestrator/test/run_server_test.exs
@@ -232,6 +232,45 @@ defmodule FavnOrchestrator.RunServerTest do
     end
   end
 
+  defmodule RunnerClientSubmitFailureStub do
+    @behaviour Favn.Contracts.RunnerClient
+
+    @impl true
+    def register_manifest(_version, _opts), do: :ok
+
+    @impl true
+    def submit_work(work, opts) do
+      parent = Keyword.fetch!(opts, :parent)
+      execution_id = execution_id(work)
+      send(parent, {:submitted, work.asset_ref, execution_id})
+
+      if work.asset_ref == Keyword.fetch!(opts, :fail_ref) do
+        {:error, :submit_failed}
+      else
+        {:ok, execution_id}
+      end
+    end
+
+    @impl true
+    def await_result(_execution_id, _timeout, _opts) do
+      raise "await_result/3 should not be called after submit failure cancels admitted work"
+    end
+
+    @impl true
+    def cancel_work(execution_id, reason, opts) do
+      send(Keyword.fetch!(opts, :parent), {:cancelled, execution_id, reason})
+      :ok
+    end
+
+    @impl true
+    def inspect_relation(_request, _opts), do: {:error, :not_supported}
+
+    defp execution_id(work) do
+      encoded_ref = work.asset_ref |> :erlang.term_to_binary() |> Base.encode16(case: :lower)
+      "submit_failure_exec:#{work.run_id}:#{encoded_ref}"
+    end
+  end
+
   setup do
     previous_client = Application.get_env(:favn_orchestrator, :runner_client)
     previous_opts = Application.get_env(:favn_orchestrator, :runner_client_opts)
@@ -629,6 +668,50 @@ defmodule FavnOrchestrator.RunServerTest do
       events |> Enum.filter(&(&1.event_type == :step_started)) |> Enum.map(& &1.asset_ref)
 
     refute last_ref in started_refs
+  end
+
+  test "pipeline submit failure cancels admitted same-stage work with wrapped reason" do
+    [first_ref, fail_ref] =
+      Enum.map(1..2, fn index ->
+        {Module.concat([MyApp.Assets.PipelineSubmitFailure, "Asset#{index}"]), :asset}
+      end)
+
+    Application.put_env(:favn_orchestrator, :runner_client, RunnerClientSubmitFailureStub)
+
+    Application.put_env(:favn_orchestrator, :runner_client_opts,
+      parent: self(),
+      fail_ref: fail_ref
+    )
+
+    refs = [first_ref, fail_ref]
+    plan = same_stage_plan(refs)
+    version = manifest_version_for_refs("mv_pipeline_submit_failure_cancel_reason", refs)
+
+    run_state =
+      pipeline_run_state("run_pipeline_submit_failure_cancel_reason", version, plan, refs)
+
+    assert :ok = Storage.put_run(run_state)
+
+    assert {:ok, pid} = RunServer.start_link(%{run_state: run_state, version: version})
+    ref = Process.monitor(pid)
+
+    assert_receive {:submitted, ^first_ref, first_execution_id}, 1_000
+    assert_receive {:submitted, ^fail_ref, _failed_execution_id}, 1_000
+
+    assert_receive {:cancelled, ^first_execution_id, cancellation_reason}, 1_000
+    assert cancellation_reason.run_id == run_state.id
+    assert %DateTime{} = cancellation_reason.requested_at
+
+    assert %{
+             kind: :submit_failure,
+             asset_ref: ^fail_ref,
+             error: :submit_failed
+           } = cancellation_reason.reason
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+
+    assert {:ok, stored} = Storage.get_run(run_state.id)
+    assert stored.status == :error
   end
 
   test "actual upstream success refreshes downstream in same pipeline" do

--- a/apps/favn_orchestrator/test/run_server_test.exs
+++ b/apps/favn_orchestrator/test/run_server_test.exs
@@ -612,7 +612,6 @@ defmodule FavnOrchestrator.RunServerTest do
     release_submission(hd(initial_submissions), awaiters, :error)
 
     last_ref = List.last(refs)
-    refute_receive {:submitted, ^last_ref, _execution_id}, 200
 
     initial_submissions
     |> tl()

--- a/apps/favn_orchestrator/test/run_server_test.exs
+++ b/apps/favn_orchestrator/test/run_server_test.exs
@@ -612,6 +612,8 @@ defmodule FavnOrchestrator.RunServerTest do
     release_submission(hd(initial_submissions), awaiters, :error)
 
     last_ref = List.last(refs)
+    assert {:ok, _event} = wait_for_run_event(run_state.id, :stage_draining_after_failure)
+    refute_received {:submitted, ^last_ref, _execution_id}
 
     initial_submissions
     |> tl()
@@ -946,6 +948,28 @@ defmodule FavnOrchestrator.RunServerTest do
   defp release_submission({_asset_ref, execution_id} = submission, awaiters, status) do
     {_execution_id, awaiter} = awaiter_for_submission(submission, awaiters)
     send(awaiter, {:release_runner_result, execution_id, status})
+  end
+
+  defp wait_for_run_event(run_id, event_type, timeout_ms \\ 1_000) do
+    deadline = System.monotonic_time(:millisecond) + timeout_ms
+    wait_for_run_event_until(run_id, event_type, deadline)
+  end
+
+  defp wait_for_run_event_until(run_id, event_type, deadline) do
+    {:ok, events} = Storage.list_run_events(run_id)
+
+    case Enum.find(events, &(&1.event_type == event_type)) do
+      nil ->
+        if System.monotonic_time(:millisecond) >= deadline do
+          {:error, :timeout}
+        else
+          Process.sleep(10)
+          wait_for_run_event_until(run_id, event_type, deadline)
+        end
+
+      event ->
+        {:ok, event}
+    end
   end
 
   defp same_stage_plan(refs) do


### PR DESCRIPTION
## Summary
- Change pipeline stage execution from fixed batches to sliding-window refill when an admitted asset completes.
- Remove capacity polling sleeps from stage admission and preserve queued-step deduplication across refill attempts.
- Add deterministic RunServer unit coverage for same-stage refill and no-refill-after-failure behavior.

## Tests
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile test/run_server_test.exs`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile test/execution_admission_test.exs`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser`

## Notes
- The existing local `.gitignore` modification was left uncommitted.