### PR TITLE
Introduce orchestrator runtime config

### DIFF
--- a/apps/favn_orchestrator/lib/favn/storage.ex
+++ b/apps/favn_orchestrator/lib/favn/storage.ex
@@ -11,9 +11,6 @@ defmodule Favn.Storage do
   alias FavnOrchestrator.Projector
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage, as: OrchestratorStorage
-  alias FavnOrchestrator.Storage.Adapter.Memory, as: MemoryAdapter
-
-  @default_adapter MemoryAdapter
 
   @type error :: :not_found | :invalid_opts | {:store_error, term()}
 
@@ -59,12 +56,12 @@ defmodule Favn.Storage do
 
   @spec adapter_module() :: module()
   def adapter_module do
-    Application.get_env(:favn_orchestrator, :storage_adapter, @default_adapter)
+    OrchestratorStorage.adapter_module()
   end
 
   @spec adapter_opts() :: keyword()
   def adapter_opts do
-    Application.get_env(:favn_orchestrator, :storage_adapter_opts, [])
+    OrchestratorStorage.adapter_opts()
   end
 
   @spec validate_adapter(module()) :: :ok | {:error, error()}

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -36,6 +36,7 @@ defmodule FavnOrchestrator do
   alias FavnOrchestrator.RunReadModel
   alias FavnOrchestrator.RunEvent
   alias FavnOrchestrator.RunManager
+  alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.Scheduler.ManifestEntries
   alias FavnOrchestrator.Scheduler.Runtime, as: SchedulerRuntime
   alias FavnOrchestrator.SchedulerEntry
@@ -3169,11 +3170,11 @@ defmodule FavnOrchestrator do
   end
 
   defp configured_runner_client do
-    Application.get_env(:favn_orchestrator, :runner_client, nil)
+    RuntimeConfig.current().runner_client
   end
 
   defp configured_runner_opts do
-    Application.get_env(:favn_orchestrator, :runner_client_opts, [])
+    RuntimeConfig.current().runner_client_opts
   end
 
   defp default_log_filter do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/application.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/application.ex
@@ -10,6 +10,7 @@ defmodule FavnOrchestrator.Application do
   alias FavnOrchestrator.ProductionRuntimeConfig
   alias FavnOrchestrator.RunManager
   alias FavnOrchestrator.RunRecovery
+  alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.Scheduler.Runtime, as: SchedulerRuntime
   alias FavnOrchestrator.Storage
 
@@ -18,19 +19,21 @@ defmodule FavnOrchestrator.Application do
     with :ok <- ProductionRuntimeConfig.apply_from_env_if_configured(),
          _timezone_database <- Favn.Timezone.database!(),
          :ok <- APIConfig.validate(),
-         {:ok, storage_children} <- Storage.child_specs() do
+         runtime_config <- RuntimeConfig.from_app_env(),
+         {:ok, storage_children} <- Storage.child_specs(runtime_config) do
       OperationalEvents.emit(
         :orchestrator_starting,
         %{storage_child_count: length(storage_children)},
         %{
-          storage_adapter: Storage.adapter_module(),
+          storage_adapter: runtime_config.storage_adapter,
           scheduler_enabled?: scheduler_enabled?(),
           api_enabled?: api_enabled?()
         }
       )
 
       children =
-        storage_children ++
+        [{RuntimeConfig, runtime_config}] ++
+          storage_children ++
           [
             {AuthStore, []},
             {Phoenix.PubSub, name: pubsub_name()},

--- a/apps/favn_orchestrator/lib/favn_orchestrator/diagnostics.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/diagnostics.ex
@@ -7,6 +7,7 @@ defmodule FavnOrchestrator.Diagnostics do
   alias FavnOrchestrator.ManifestStore
   alias FavnOrchestrator.OperationalEvents
   alias FavnOrchestrator.Redaction
+  alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Scheduler.Runtime, as: SchedulerRuntime
   alias FavnOrchestrator.Storage
@@ -115,8 +116,9 @@ defmodule FavnOrchestrator.Diagnostics do
   end
 
   defp runner_check do
-    module = Application.get_env(:favn_orchestrator, :runner_client, nil)
-    opts = Application.get_env(:favn_orchestrator, :runner_client_opts, [])
+    runtime_config = RuntimeConfig.current()
+    module = runtime_config.runner_client
+    opts = runtime_config.runner_client_opts
 
     case validate_runner_client(module) do
       :ok ->

--- a/apps/favn_orchestrator/lib/favn_orchestrator/readiness.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/readiness.ex
@@ -6,6 +6,7 @@ defmodule FavnOrchestrator.Readiness do
   alias Favn.Contracts.RunnerClient
   alias FavnOrchestrator.API.Config, as: APIConfig
   alias FavnOrchestrator.Redaction
+  alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.Scheduler.Runtime, as: SchedulerRuntime
   alias FavnOrchestrator.Storage
 
@@ -71,7 +72,7 @@ defmodule FavnOrchestrator.Readiness do
   end
 
   defp runner_check do
-    module = Application.get_env(:favn_orchestrator, :runner_client, nil)
+    module = RuntimeConfig.current().runner_client
 
     with true <- is_atom(module),
          {:module, ^module} <- Code.ensure_loaded(module),
@@ -89,7 +90,7 @@ defmodule FavnOrchestrator.Readiness do
   end
 
   defp runner_runtime_check(FavnOrchestrator.RunnerClient.LocalNode) do
-    runner_opts = Application.get_env(:favn_orchestrator, :runner_client_opts, [])
+    runner_opts = RuntimeConfig.current().runner_client_opts
     runner_module = Keyword.get(runner_opts, :runner_module, Module.concat([FavnRunner]))
 
     with {:module, ^runner_module} <- Code.ensure_loaded(runner_module),

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
@@ -16,6 +16,7 @@ defmodule FavnOrchestrator.RunManager do
   alias FavnOrchestrator.ManifestStore
   alias FavnOrchestrator.OperationalEvents
   alias FavnOrchestrator.RefreshPolicy
+  alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.RunServer
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
@@ -822,8 +823,9 @@ defmodule FavnOrchestrator.RunManager do
   end
 
   defp forward_cancel_result(%RunState{} = run, reason) do
-    runner_client = Application.get_env(:favn_orchestrator, :runner_client, nil)
-    runner_opts = Application.get_env(:favn_orchestrator, :runner_client_opts, [])
+    runtime_config = RuntimeConfig.current()
+    runner_client = runtime_config.runner_client
+    runner_opts = runtime_config.runner_client_opts
     execution_ids = inflight_execution_ids(run)
 
     if execution_ids == [] do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -27,6 +27,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.Redaction
   alias FavnOrchestrator.RefreshPolicy
+  alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.RunnerLogBridge
   alias FavnOrchestrator.RunServer.Cancellation
   alias FavnOrchestrator.RunServer.Execution.AwaitTasks
@@ -2556,11 +2557,11 @@ defmodule FavnOrchestrator.RunServer.Execution do
   end
 
   defp configured_runner_client do
-    Application.get_env(:favn_orchestrator, :runner_client, nil)
+    RuntimeConfig.current().runner_client
   end
 
   defp configured_runner_opts do
-    Application.get_env(:favn_orchestrator, :runner_client_opts, [])
+    RuntimeConfig.current().runner_client_opts
   end
 
   defp validate_runner_client(module) when is_atom(module) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/runtime_config.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/runtime_config.ex
@@ -19,6 +19,7 @@ defmodule FavnOrchestrator.RuntimeConfig do
           storage_adapter_opts: keyword(),
           log_redaction_policy: term()
         }
+  @type error :: {:invalid_runtime_config, {atom(), term()}}
 
   defstruct runner_client: nil,
             runner_client_opts: [],
@@ -35,7 +36,12 @@ defmodule FavnOrchestrator.RuntimeConfig do
   end
 
   def start_link(opts) when is_list(opts) do
-    config = Keyword.get(opts, :config, from_app_env())
+    config =
+      case Keyword.fetch(opts, :config) do
+        {:ok, config} -> normalize!(config)
+        :error -> from_app_env()
+      end
+
     name = Keyword.get(opts, :name, __MODULE__)
     GenServer.start_link(__MODULE__, config, name: name)
   end
@@ -47,7 +53,7 @@ defmodule FavnOrchestrator.RuntimeConfig do
   normalization from application env so unit tests and standalone helper calls
   keep their existing ergonomics.
   """
-  @spec current(GenServer.server()) :: t()
+  @spec current(atom()) :: t()
   def current(name \\ __MODULE__) do
     if dynamic_env_override?(name) do
       from_app_env()
@@ -64,7 +70,7 @@ defmodule FavnOrchestrator.RuntimeConfig do
   """
   @spec from_app_env() :: t()
   def from_app_env do
-    normalize(
+    normalize!(
       runner_client: Application.get_env(:favn_orchestrator, :runner_client, nil),
       runner_client_opts: Application.get_env(:favn_orchestrator, :runner_client_opts, []),
       storage_adapter: Application.get_env(:favn_orchestrator, :storage_adapter, Memory),
@@ -76,8 +82,8 @@ defmodule FavnOrchestrator.RuntimeConfig do
   @doc """
   Normalizes runtime dependency options into a stable struct.
   """
-  @spec normalize(keyword() | map() | t()) :: t()
-  def normalize(%__MODULE__{} = config), do: config
+  @spec normalize(keyword() | map() | t()) :: {:ok, t()} | {:error, error()}
+  def normalize(%__MODULE__{} = config), do: {:ok, config}
 
   def normalize(attrs) when is_map(attrs) do
     attrs
@@ -86,13 +92,39 @@ defmodule FavnOrchestrator.RuntimeConfig do
   end
 
   def normalize(attrs) when is_list(attrs) do
-    %__MODULE__{
-      runner_client: Keyword.get(attrs, :runner_client, nil),
-      runner_client_opts: normalize_keyword(Keyword.get(attrs, :runner_client_opts, [])),
-      storage_adapter: Keyword.get(attrs, :storage_adapter, Memory),
-      storage_adapter_opts: normalize_keyword(Keyword.get(attrs, :storage_adapter_opts, [])),
-      log_redaction_policy: Keyword.get(attrs, :log_redaction_policy)
-    }
+    runner_client = Keyword.get(attrs, :runner_client, nil)
+    runner_client_opts = Keyword.get(attrs, :runner_client_opts, [])
+    storage_adapter = Keyword.get(attrs, :storage_adapter, Memory)
+    storage_adapter_opts = Keyword.get(attrs, :storage_adapter_opts, [])
+
+    with :ok <- validate_module_or_nil(:runner_client, runner_client),
+         {:ok, runner_client_opts} <- validate_keyword(:runner_client_opts, runner_client_opts),
+         :ok <- validate_module(:storage_adapter, storage_adapter),
+         {:ok, storage_adapter_opts} <-
+           validate_keyword(:storage_adapter_opts, storage_adapter_opts) do
+      {:ok,
+       %__MODULE__{
+         runner_client: runner_client,
+         runner_client_opts: runner_client_opts,
+         storage_adapter: storage_adapter,
+         storage_adapter_opts: storage_adapter_opts,
+         log_redaction_policy: Keyword.get(attrs, :log_redaction_policy)
+       }}
+    end
+  end
+
+  @doc """
+  Normalizes runtime dependency options or raises on invalid boot config.
+  """
+  @spec normalize!(keyword() | map() | t()) :: t()
+  def normalize!(attrs) do
+    case normalize(attrs) do
+      {:ok, config} ->
+        config
+
+      {:error, reason} ->
+        raise ArgumentError, "invalid orchestrator runtime config: #{inspect(reason)}"
+    end
   end
 
   @impl true
@@ -107,6 +139,19 @@ defmodule FavnOrchestrator.RuntimeConfig do
 
   defp dynamic_env_override?(_name), do: false
 
-  defp normalize_keyword(opts) when is_list(opts), do: opts
-  defp normalize_keyword(_opts), do: []
+  defp validate_module_or_nil(_field, nil), do: :ok
+  defp validate_module_or_nil(field, module), do: validate_module(field, module)
+
+  defp validate_module(_field, module) when is_atom(module), do: :ok
+  defp validate_module(field, value), do: {:error, {:invalid_runtime_config, {field, value}}}
+
+  defp validate_keyword(field, opts) when is_list(opts) do
+    if Keyword.keyword?(opts) do
+      {:ok, opts}
+    else
+      {:error, {:invalid_runtime_config, {field, opts}}}
+    end
+  end
+
+  defp validate_keyword(field, value), do: {:error, {:invalid_runtime_config, {field, value}}}
 end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/runtime_config.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/runtime_config.ex
@@ -1,0 +1,112 @@
+defmodule FavnOrchestrator.RuntimeConfig do
+  @moduledoc """
+  Normalized runtime dependency contract for the orchestrator process tree.
+
+  Application env remains the boot-time input for deployment and local-dev
+  ergonomics. Once the application starts, hot runtime paths read this explicit
+  struct from the supervised process instead of repeatedly consulting mutable
+  global env.
+  """
+
+  use GenServer
+
+  alias FavnOrchestrator.Storage.Adapter.Memory
+
+  @type t :: %__MODULE__{
+          runner_client: module() | nil,
+          runner_client_opts: keyword(),
+          storage_adapter: module(),
+          storage_adapter_opts: keyword(),
+          log_redaction_policy: term()
+        }
+
+  defstruct runner_client: nil,
+            runner_client_opts: [],
+            storage_adapter: Memory,
+            storage_adapter_opts: [],
+            log_redaction_policy: nil
+
+  @doc """
+  Starts the runtime config holder.
+  """
+  @spec start_link(t() | keyword()) :: GenServer.on_start()
+  def start_link(%__MODULE__{} = config) do
+    GenServer.start_link(__MODULE__, config, name: __MODULE__)
+  end
+
+  def start_link(opts) when is_list(opts) do
+    config = Keyword.get(opts, :config, from_app_env())
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, config, name: name)
+  end
+
+  @doc """
+  Returns the active normalized runtime config.
+
+  If the orchestrator supervision tree is not running, this falls back to a fresh
+  normalization from application env so unit tests and standalone helper calls
+  keep their existing ergonomics.
+  """
+  @spec current(GenServer.server()) :: t()
+  def current(name \\ __MODULE__) do
+    if dynamic_env_override?(name) do
+      from_app_env()
+    else
+      case Process.whereis(name) do
+        nil -> from_app_env()
+        _pid -> GenServer.call(name, :current)
+      end
+    end
+  end
+
+  @doc """
+  Builds the runtime dependency contract from boot-time application env.
+  """
+  @spec from_app_env() :: t()
+  def from_app_env do
+    normalize(
+      runner_client: Application.get_env(:favn_orchestrator, :runner_client, nil),
+      runner_client_opts: Application.get_env(:favn_orchestrator, :runner_client_opts, []),
+      storage_adapter: Application.get_env(:favn_orchestrator, :storage_adapter, Memory),
+      storage_adapter_opts: Application.get_env(:favn_orchestrator, :storage_adapter_opts, []),
+      log_redaction_policy: Application.get_env(:favn_orchestrator, :log_redaction_policy)
+    )
+  end
+
+  @doc """
+  Normalizes runtime dependency options into a stable struct.
+  """
+  @spec normalize(keyword() | map() | t()) :: t()
+  def normalize(%__MODULE__{} = config), do: config
+
+  def normalize(attrs) when is_map(attrs) do
+    attrs
+    |> Map.to_list()
+    |> normalize()
+  end
+
+  def normalize(attrs) when is_list(attrs) do
+    %__MODULE__{
+      runner_client: Keyword.get(attrs, :runner_client, nil),
+      runner_client_opts: normalize_keyword(Keyword.get(attrs, :runner_client_opts, [])),
+      storage_adapter: Keyword.get(attrs, :storage_adapter, Memory),
+      storage_adapter_opts: normalize_keyword(Keyword.get(attrs, :storage_adapter_opts, [])),
+      log_redaction_policy: Keyword.get(attrs, :log_redaction_policy)
+    }
+  end
+
+  @impl true
+  def init(%__MODULE__{} = config), do: {:ok, config}
+
+  @impl true
+  def handle_call(:current, _from, %__MODULE__{} = config), do: {:reply, config, config}
+
+  defp dynamic_env_override?(__MODULE__) do
+    Application.get_env(:favn_orchestrator, :runtime_config_dynamic_env?, false) == true
+  end
+
+  defp dynamic_env_override?(_name), do: false
+
+  defp normalize_keyword(opts) when is_list(opts), do: opts
+  defp normalize_keyword(_opts), do: []
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -492,9 +492,11 @@ defmodule FavnOrchestrator.Storage do
   end
 
   defp redact_log_entries(entries) do
+    policy = RuntimeConfig.current().log_redaction_policy
+
     entries
     |> Enum.reduce_while({:ok, []}, fn entry, {:ok, acc} ->
-      case redact_log_entry(entry) do
+      case redact_log_entry(entry, policy) do
         {:ok, redacted} -> {:cont, {:ok, [redacted | acc]}}
         {:error, reason} -> {:halt, {:error, reason}}
       end
@@ -505,10 +507,10 @@ defmodule FavnOrchestrator.Storage do
     end
   end
 
-  defp redact_log_entry(entry) do
+  defp redact_log_entry(entry, policy) do
     with {:module, Favn.Log.Redactor} <- Code.ensure_loaded(Favn.Log.Redactor),
          true <- function_exported?(Favn.Log.Redactor, :redact, 2) do
-      case Favn.Log.Redactor.redact(entry, log_redaction_policy()) do
+      case Favn.Log.Redactor.redact(entry, policy) do
         {redacted_entry, _redacted?} -> {:ok, redacted_entry}
         redacted_entry -> {:ok, redacted_entry}
       end
@@ -519,10 +521,6 @@ defmodule FavnOrchestrator.Storage do
     error -> {:error, {:invalid_log_entry, error}}
   catch
     kind, reason -> {:error, {:invalid_log_entry, {kind, reason}}}
-  end
-
-  defp log_redaction_policy do
-    RuntimeConfig.current().log_redaction_policy
   end
 
   @spec validate_adapter(module()) :: :ok | {:error, term()}
@@ -538,10 +536,11 @@ defmodule FavnOrchestrator.Storage do
   end
 
   defp adapter_call(fun) when is_function(fun, 2) do
-    adapter = adapter_module()
+    runtime_config = RuntimeConfig.current()
+    adapter = runtime_config.storage_adapter
 
     with :ok <- validate_adapter(adapter) do
-      fun.(adapter, adapter_opts())
+      fun.(adapter, runtime_config.storage_adapter_opts)
     end
   rescue
     error -> {:error, {:raised, error}}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -17,15 +17,18 @@ defmodule FavnOrchestrator.Storage do
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
+  alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.RunState
-  alias FavnOrchestrator.Storage.Adapter.Memory
 
   @spec child_specs() :: {:ok, [Supervisor.child_spec()]} | {:error, term()}
-  def child_specs do
-    adapter = adapter_module()
+  @spec child_specs(RuntimeConfig.t()) :: {:ok, [Supervisor.child_spec()]} | {:error, term()}
+  def child_specs(runtime_config \\ RuntimeConfig.current())
+
+  def child_specs(%RuntimeConfig{} = runtime_config) do
+    adapter = runtime_config.storage_adapter
 
     with :ok <- validate_adapter(adapter),
-         child_spec_result <- adapter.child_spec(adapter_opts()),
+         child_spec_result <- adapter.child_spec(runtime_config.storage_adapter_opts),
          {:ok, child_spec} <- normalize_child_spec_result(child_spec_result) do
       {:ok, maybe_child_to_list(child_spec)}
     end
@@ -480,12 +483,12 @@ defmodule FavnOrchestrator.Storage do
 
   @spec adapter_module() :: module()
   def adapter_module do
-    Application.get_env(:favn_orchestrator, :storage_adapter, Memory)
+    RuntimeConfig.current().storage_adapter
   end
 
   @spec adapter_opts() :: keyword()
   def adapter_opts do
-    Application.get_env(:favn_orchestrator, :storage_adapter_opts, [])
+    RuntimeConfig.current().storage_adapter_opts
   end
 
   defp redact_log_entries(entries) do
@@ -519,7 +522,7 @@ defmodule FavnOrchestrator.Storage do
   end
 
   defp log_redaction_policy do
-    Application.get_env(:favn_orchestrator, :log_redaction_policy)
+    RuntimeConfig.current().log_redaction_policy
   end
 
   @spec validate_adapter(module()) :: :ok | {:error, term()}

--- a/apps/favn_orchestrator/test/runtime_config_test.exs
+++ b/apps/favn_orchestrator/test/runtime_config_test.exs
@@ -1,0 +1,67 @@
+defmodule FavnOrchestrator.RuntimeConfigTest do
+  use ExUnit.Case, async: false
+
+  alias FavnOrchestrator.RuntimeConfig
+  alias FavnOrchestrator.Storage.Adapter.Memory
+
+  defmodule RunnerClientStub do
+    @behaviour Favn.Contracts.RunnerClient
+
+    @impl true
+    def register_manifest(_version, _opts), do: :ok
+
+    @impl true
+    def submit_work(_work, _opts), do: {:ok, "execution"}
+
+    @impl true
+    def await_result(_execution_id, _timeout, _opts), do: {:error, :not_used}
+
+    @impl true
+    def cancel_work(_execution_id, _reason, _opts), do: :ok
+
+    @impl true
+    def inspect_relation(_request, _opts), do: {:error, :not_used}
+  end
+
+  test "normalizes runtime dependency env into one explicit contract" do
+    config =
+      RuntimeConfig.normalize(
+        runner_client: RunnerClientStub,
+        runner_client_opts: [runner_node: :runner@local],
+        storage_adapter: Memory,
+        storage_adapter_opts: [server: __MODULE__.Storage],
+        log_redaction_policy: [fields: [:secret]]
+      )
+
+    assert %RuntimeConfig{
+             runner_client: RunnerClientStub,
+             runner_client_opts: [runner_node: :runner@local],
+             storage_adapter: Memory,
+             storage_adapter_opts: [server: __MODULE__.Storage],
+             log_redaction_policy: [fields: [:secret]]
+           } = config
+  end
+
+  test "supervised runtime config is stable after app env mutation" do
+    name = __MODULE__.RuntimeConfig
+
+    start_supervised!(
+      {RuntimeConfig,
+       config: RuntimeConfig.normalize(runner_client: RunnerClientStub, storage_adapter: Memory),
+       name: name}
+    )
+
+    previous_runner_client = Application.get_env(:favn_orchestrator, :runner_client)
+
+    try do
+      Application.put_env(:favn_orchestrator, :runner_client, :mutated_after_startup)
+
+      assert %RuntimeConfig{runner_client: RunnerClientStub} = RuntimeConfig.current(name)
+    after
+      restore_env(:runner_client, previous_runner_client)
+    end
+  end
+
+  defp restore_env(key, nil), do: Application.delete_env(:favn_orchestrator, key)
+  defp restore_env(key, value), do: Application.put_env(:favn_orchestrator, key, value)
+end

--- a/apps/favn_orchestrator/test/runtime_config_test.exs
+++ b/apps/favn_orchestrator/test/runtime_config_test.exs
@@ -2,6 +2,7 @@ defmodule FavnOrchestrator.RuntimeConfigTest do
   use ExUnit.Case, async: false
 
   alias FavnOrchestrator.RuntimeConfig
+  alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.Adapter.Memory
 
   defmodule RunnerClientStub do
@@ -24,22 +25,33 @@ defmodule FavnOrchestrator.RuntimeConfigTest do
   end
 
   test "normalizes runtime dependency env into one explicit contract" do
-    config =
-      RuntimeConfig.normalize(
-        runner_client: RunnerClientStub,
-        runner_client_opts: [runner_node: :runner@local],
-        storage_adapter: Memory,
-        storage_adapter_opts: [server: __MODULE__.Storage],
-        log_redaction_policy: [fields: [:secret]]
-      )
+    assert {:ok,
+            %RuntimeConfig{
+              runner_client: RunnerClientStub,
+              runner_client_opts: [runner_node: :runner@local],
+              storage_adapter: Memory,
+              storage_adapter_opts: [server: __MODULE__.Storage],
+              log_redaction_policy: [fields: [:secret]]
+            }} =
+             RuntimeConfig.normalize(
+               runner_client: RunnerClientStub,
+               runner_client_opts: [runner_node: :runner@local],
+               storage_adapter: Memory,
+               storage_adapter_opts: [server: __MODULE__.Storage],
+               log_redaction_policy: [fields: [:secret]]
+             )
+  end
 
-    assert %RuntimeConfig{
-             runner_client: RunnerClientStub,
-             runner_client_opts: [runner_node: :runner@local],
-             storage_adapter: Memory,
-             storage_adapter_opts: [server: __MODULE__.Storage],
-             log_redaction_policy: [fields: [:secret]]
-           } = config
+  test "rejects invalid runtime dependency option shapes" do
+    assert {:error, {:invalid_runtime_config, {:runner_client_opts, :bad_opts}}} =
+             RuntimeConfig.normalize(runner_client_opts: :bad_opts)
+
+    assert {:error, {:invalid_runtime_config, {:storage_adapter_opts, %{server: :bad}}}} =
+             RuntimeConfig.normalize(storage_adapter_opts: %{server: :bad})
+
+    assert_raise ArgumentError, ~r/invalid orchestrator runtime config/, fn ->
+      RuntimeConfig.normalize!(storage_adapter_opts: ["server"])
+    end
   end
 
   test "supervised runtime config is stable after app env mutation" do
@@ -47,7 +59,7 @@ defmodule FavnOrchestrator.RuntimeConfigTest do
 
     start_supervised!(
       {RuntimeConfig,
-       config: RuntimeConfig.normalize(runner_client: RunnerClientStub, storage_adapter: Memory),
+       config: RuntimeConfig.normalize!(runner_client: RunnerClientStub, storage_adapter: Memory),
        name: name}
     )
 
@@ -60,6 +72,80 @@ defmodule FavnOrchestrator.RuntimeConfigTest do
     after
       restore_env(:runner_client, previous_runner_client)
     end
+  end
+
+  test "default runtime config freezes storage and runner lookups after startup" do
+    keys = [
+      :runtime_config_dynamic_env?,
+      :runner_client,
+      :runner_client_opts,
+      :storage_adapter,
+      :storage_adapter_opts
+    ]
+
+    previous = Map.new(keys, &{&1, Application.get_env(:favn_orchestrator, &1)})
+
+    try do
+      Application.put_env(:favn_orchestrator, :runtime_config_dynamic_env?, false)
+
+      frozen_config =
+        ensure_default_runtime_config(
+          RuntimeConfig.normalize!(
+            runner_client: RunnerClientStub,
+            runner_client_opts: [runner_node: :frozen_runner],
+            storage_adapter: Memory,
+            storage_adapter_opts: [server: __MODULE__.FrozenMemory]
+          )
+        )
+
+      mutated_runner_client =
+        case frozen_config.runner_client do
+          RunnerClientStub -> nil
+          _other -> RunnerClientStub
+        end
+
+      Application.put_env(:favn_orchestrator, :runner_client, mutated_runner_client)
+      Application.put_env(:favn_orchestrator, :runner_client_opts, runner_node: :mutated)
+      Application.put_env(:favn_orchestrator, :storage_adapter, :mutated_after_startup)
+      Application.put_env(:favn_orchestrator, :storage_adapter_opts, server: :mutated)
+
+      assert Storage.adapter_module() == frozen_config.storage_adapter
+      assert Storage.adapter_opts() == frozen_config.storage_adapter_opts
+
+      assert runner_check_matches_config?(
+               FavnOrchestrator.Readiness.readiness().checks,
+               frozen_config.runner_client
+             )
+    after
+      Enum.each(previous, fn {key, value} -> restore_env(key, value) end)
+    end
+  end
+
+  defp ensure_default_runtime_config(%RuntimeConfig{} = config) do
+    case Process.whereis(RuntimeConfig) do
+      nil ->
+        start_supervised!({RuntimeConfig, config: config})
+        config
+
+      _pid ->
+        RuntimeConfig.current()
+    end
+  end
+
+  defp runner_check_matches_config?(checks, nil) do
+    Enum.any?(checks, fn check ->
+      check.name == :runner and check.status == :error and
+        check.error in [:runner_client_not_available, :nofile]
+    end)
+  end
+
+  defp runner_check_matches_config?(checks, module) when is_atom(module) do
+    expected_module = Atom.to_string(module)
+
+    Enum.any?(checks, fn check ->
+      check.name == :runner and check.status == :ok and
+        get_in(check, [:details, :module]) == expected_module
+    end)
   end
 
   defp restore_env(key, nil), do: Application.delete_env(:favn_orchestrator, key)

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,7 +2,10 @@ import Config
 
 config :logger, level: :error
 
-config :favn_orchestrator, runtime_config_dynamic_env?: true
+config :favn_orchestrator,
+  runtime_config_dynamic_env?: true,
+  runner_client_opts: [],
+  storage_adapter_opts: []
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,6 +2,8 @@ import Config
 
 config :logger, level: :error
 
+config :favn_orchestrator, runtime_config_dynamic_env?: true
+
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :favn_view, FavnView.Endpoint,

--- a/docs/ISSUE_398_RUNTIME_DEPENDENCY_CONTRACT_PLAN.md
+++ b/docs/ISSUE_398_RUNTIME_DEPENDENCY_CONTRACT_PLAN.md
@@ -1,0 +1,54 @@
+# Issue 398 Runtime Dependency Contract Plan
+
+## Goal
+
+Make orchestrator runtime dependencies explicit at the application boundary so
+runner, storage, and log-redaction behavior does not change implicitly after
+startup when application env mutates.
+
+## Current Landing Slice
+
+- Add `FavnOrchestrator.RuntimeConfig` as an internal normalized struct and
+  supervised process.
+- Keep application env as the boot-time input for production config and local-dev
+  launch ergonomics.
+- Start `RuntimeConfig` before storage, run recovery, run manager, scheduler, and
+  API children.
+- Route runner client/options, storage adapter/options, and log-redaction policy
+  reads through `RuntimeConfig.current/1`.
+- Preserve public facade function signatures and adapter callback shapes.
+
+## Design
+
+- `FavnOrchestrator.Application` applies production env config, normalizes one
+  runtime config struct, uses it to build storage child specs, then supervises the
+  same struct for runtime lookups.
+- `FavnOrchestrator.Storage` remains the storage boundary. Its public helper
+  functions now read adapter dependencies from the explicit runtime config.
+- `FavnOrchestrator`, `RunManager`, `RunServer.Execution`, readiness, and
+  diagnostics resolve runner dependencies from the runtime config instead of
+  directly reading application env.
+- The compatibility fallback in `RuntimeConfig.current/1` normalizes from app env
+  when the orchestrator supervision tree is not running, preserving isolated unit
+  test and helper behavior.
+- `config/test.exs` keeps the default runtime config name in dynamic-env mode so
+  existing app-env based tests remain small. Tests that need startup-freeze
+  semantics can start a named `RuntimeConfig` process directly.
+
+## Follow-Up Scope
+
+- Move scheduler and API server options into the same contract if they become hot
+  runtime dependencies or need post-start mutation protection.
+- Convert `FavnOrchestrator.ProductionRuntimeConfig` and `Favn.Dev.RuntimeLaunch`
+  from application env writes to direct runtime-config assembly once launch flows
+  can pass a single boot contract without broad churn.
+- Add a runtime launch acceptance test that starts the local orchestrator and
+  verifies post-start env mutation does not affect active storage/runner calls.
+
+## Tests
+
+- Unit coverage for runtime config normalization.
+- Regression coverage that a supervised runtime config remains stable after app
+  env mutation.
+- Existing readiness, diagnostics, run manager, run server, and storage tests
+  should continue to exercise the same public behavior through the new contract.

--- a/docs/ISSUE_398_RUNTIME_DEPENDENCY_CONTRACT_PLAN.md
+++ b/docs/ISSUE_398_RUNTIME_DEPENDENCY_CONTRACT_PLAN.md
@@ -10,6 +10,8 @@ startup when application env mutates.
 
 - Add `FavnOrchestrator.RuntimeConfig` as an internal normalized struct and
   supervised process.
+- Fail fast on invalid runtime dependency option shapes instead of silently
+  replacing malformed options with defaults.
 - Keep application env as the boot-time input for production config and local-dev
   launch ergonomics.
 - Start `RuntimeConfig` before storage, run recovery, run manager, scheduler, and
@@ -33,7 +35,8 @@ startup when application env mutates.
   test and helper behavior.
 - `config/test.exs` keeps the default runtime config name in dynamic-env mode so
   existing app-env based tests remain small. Tests that need startup-freeze
-  semantics can start a named `RuntimeConfig` process directly.
+  semantics can disable the override and start the default `RuntimeConfig`
+  process directly.
 
 ## Follow-Up Scope
 
@@ -47,8 +50,10 @@ startup when application env mutates.
 
 ## Tests
 
-- Unit coverage for runtime config normalization.
+- Unit coverage for runtime config normalization and invalid option rejection.
 - Regression coverage that a supervised runtime config remains stable after app
   env mutation.
+- Default-name regression coverage showing storage and runner lookups stay frozen
+  when test dynamic-env compatibility is disabled.
 - Existing readiness, diagnostics, run manager, run server, and storage tests
   should continue to exercise the same public behavior through the new contract.

--- a/docs/structure/favn_orchestrator.md
+++ b/docs/structure/favn_orchestrator.md
@@ -24,7 +24,7 @@ Code:
 - preserved public contracts under `apps/favn_orchestrator/lib/favn/`
 - Private API router and DTO boundary under `apps/favn_orchestrator/lib/favn_orchestrator/api/`
 - HTTP contract schemas for private API JSON-safe DTOs under `apps/favn_orchestrator/priv/http_contract/v1/`
-- Production runtime config, readiness, diagnostics, redaction, and operational event modules under `apps/favn_orchestrator/lib/favn_orchestrator/`
+- Production runtime config, normalized runtime dependency config, readiness, diagnostics, redaction, and operational event modules under `apps/favn_orchestrator/lib/favn_orchestrator/`
 - Public facade readiness and diagnostics entrypoints on `FavnOrchestrator`, used
   by same-BEAM web readiness and operator tooling.
 - Command idempotency helpers under `apps/favn_orchestrator/lib/favn_orchestrator/idempotency.ex`
@@ -34,7 +34,7 @@ Tests:
 - API contract tests under `apps/favn_orchestrator/test/api/`
 - HTTP schema shape tests under `apps/favn_orchestrator/test/http_contract/`
 - Auth storage/facade tests under `apps/favn_orchestrator/test/auth/`
-- Production runtime config/readiness/diagnostics tests under `apps/favn_orchestrator/test/production_runtime_config_test.exs`, `apps/favn_orchestrator/test/readiness_test.exs`, and `apps/favn_orchestrator/test/diagnostics_test.exs`
+- Production runtime config/runtime dependency config/readiness/diagnostics tests under `apps/favn_orchestrator/test/production_runtime_config_test.exs`, `apps/favn_orchestrator/test/runtime_config_test.exs`, `apps/favn_orchestrator/test/readiness_test.exs`, and `apps/favn_orchestrator/test/diagnostics_test.exs`
 - storage contract/codec tests under `apps/favn_orchestrator/test/storage/`
 - Freshness decision/query tests under `apps/favn_orchestrator/test/freshness/`
 - cross-app runner integration coverage under `apps/favn_orchestrator/test/orchestrator_runner_integration_test.exs`


### PR DESCRIPTION
## Summary
- Add a supervised `FavnOrchestrator.RuntimeConfig` contract for runner, storage, and log-redaction dependencies.
- Route orchestrator facade, storage, readiness, diagnostics, run manager, and run execution dependency lookups through the normalized runtime config.
- Document the narrow landing slice and follow-up scope for broader launch/runtime config cleanup.

## Verification
- `mix format`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/runtime_config_test.exs test/readiness_test.exs test/diagnostics_test.exs`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser`
- `mix compile --warnings-as-errors`
- `mix test`

Closes #398