### PR TITLE
Make manifest graph the runtime planning contract

### DIFF
--- a/apps/favn_authoring/lib/favn.ex
+++ b/apps/favn_authoring/lib/favn.ex
@@ -27,6 +27,7 @@ defmodule FavnAuthoring do
   alias Favn.Manifest.Build
   alias Favn.Manifest.Compatibility
   alias Favn.Manifest.Generator
+  alias Favn.Manifest.Index
   alias Favn.Manifest.Serializer
   alias Favn.Manifest.Version
   alias Favn.ModuleDiscovery
@@ -270,8 +271,15 @@ defmodule FavnAuthoring do
   @spec plan_asset_run(asset_ref() | [asset_ref()], keyword()) ::
           {:ok, Favn.Plan.t()} | {:error, term()}
   def plan_asset_run(target_refs, opts \\ []) do
-    with {:ok, asset_modules} <- default_asset_modules() do
-      opts = Keyword.put_new(opts, :asset_modules, asset_modules)
+    with {:ok, default_asset_modules} <- default_asset_modules(),
+         asset_modules <- Keyword.get(opts, :asset_modules, default_asset_modules),
+         {:ok, manifest} <- Generator.generate(asset_modules: asset_modules),
+         {:ok, index} <- Index.build(manifest) do
+      opts =
+        opts
+        |> Keyword.delete(:asset_modules)
+        |> Keyword.put(:planning_index, index.planning_index)
+
       Planner.plan(target_refs, opts)
     end
   end

--- a/apps/favn_core/lib/favn/assets/planner.ex
+++ b/apps/favn_core/lib/favn/assets/planner.ex
@@ -13,6 +13,7 @@ defmodule Favn.Assets.Planner do
   """
 
   alias Favn.Assets.GraphIndex
+  alias Favn.Manifest.PlanningIndex
   alias Favn.Plan
   alias Favn.Ref
   alias Favn.TimePeriod
@@ -39,6 +40,7 @@ defmodule Favn.Assets.Planner do
           anchor_windows: [Anchor.t()],
           anchor_ranges: [backfill_anchor_range()],
           exact_windows: %{optional(Ref.t()) => [Runtime.t()]},
+          planning_index: PlanningIndex.t() | nil,
           graph_index: GraphIndex.t() | nil,
           asset_modules: [module()]
         ]
@@ -50,6 +52,7 @@ defmodule Favn.Assets.Planner do
     anchor_windows = Keyword.get(opts, :anchor_windows, [])
     anchor_ranges = Keyword.get(opts, :anchor_ranges, [])
     exact_windows = Keyword.get(opts, :exact_windows, %{})
+    planning_index = Keyword.get(opts, :planning_index)
     graph_index = Keyword.get(opts, :graph_index)
     asset_modules = Keyword.get(opts, :asset_modules)
 
@@ -58,7 +61,7 @@ defmodule Favn.Assets.Planner do
          :ok <- validate_dependencies_mode(dependencies),
          {:ok, anchors} <- normalize_anchors(anchor_window, anchor_windows, anchor_ranges),
          :ok <- validate_exact_windows(exact_windows),
-         {:ok, index} <- resolve_graph_index(graph_index, asset_modules),
+         {:ok, index} <- resolve_index(planning_index, graph_index, asset_modules),
          :ok <- validate_target_refs(index, target_refs),
          {:ok, refs} <- selected_refs(index, target_refs, dependencies),
          {:ok, projected_index} <- projected_index(index, refs),
@@ -106,6 +109,7 @@ defmodule Favn.Assets.Planner do
         :anchor_windows,
         :anchor_ranges,
         :exact_windows,
+        :planning_index,
         :graph_index,
         :asset_modules
       ])
@@ -194,14 +198,20 @@ defmodule Favn.Assets.Planner do
 
   defp anchor_sort_key(%Anchor{key: key}), do: Key.encode(key)
 
-  defp resolve_graph_index(%GraphIndex{} = index, _asset_modules), do: {:ok, index}
+  defp resolve_index(%PlanningIndex{} = index, _graph_index, _asset_modules), do: {:ok, index}
 
-  defp resolve_graph_index(nil, modules) when is_list(modules),
+  defp resolve_index(invalid_planning_index, _graph_index, _asset_modules)
+       when not is_nil(invalid_planning_index),
+       do: {:error, :invalid_planning_index}
+
+  defp resolve_index(nil, %GraphIndex{} = index, _asset_modules), do: {:ok, index}
+
+  defp resolve_index(nil, nil, modules) when is_list(modules),
     do: GraphIndex.index_for_modules(modules)
 
-  defp resolve_graph_index(nil, nil), do: {:error, :missing_graph_index_input}
-  defp resolve_graph_index(nil, _other), do: {:error, :invalid_asset_modules}
-  defp resolve_graph_index(_other, _asset_modules), do: {:error, :invalid_graph_index}
+  defp resolve_index(nil, nil, nil), do: {:error, :missing_graph_index_input}
+  defp resolve_index(nil, nil, _other), do: {:error, :invalid_asset_modules}
+  defp resolve_index(nil, _other, _asset_modules), do: {:error, :invalid_graph_index}
 
   defp validate_target_refs(index, refs) do
     case Enum.find(refs, &(not Map.has_key?(index.assets_by_ref, &1))) do
@@ -226,6 +236,12 @@ defmodule Favn.Assets.Planner do
   end
 
   defp projected_index(index, refs) do
+    project_index(index, refs)
+  end
+
+  defp project_index(%PlanningIndex{} = index, refs), do: PlanningIndex.project(index, refs)
+
+  defp project_index(%GraphIndex{} = index, refs) do
     refs
     |> Enum.map(&Map.fetch!(index.assets_by_ref, &1))
     |> project_assets(refs)

--- a/apps/favn_core/lib/favn/assets/planner.ex
+++ b/apps/favn_core/lib/favn/assets/planner.ex
@@ -1,6 +1,10 @@
 defmodule Favn.Assets.Planner do
   @moduledoc """
-  Build deterministic execution plans from the global graph index.
+  Build deterministic execution plans from an explicit planning index.
+
+  Runtime callers should pass `:planning_index` built from a pinned manifest.
+  `:graph_index` and `:asset_modules` remain authoring conveniences for local
+  developer paths and tests.
 
   The planner produces a deduplicated run graph for one or more targets and
   groups plan nodes into topological stages for parallel execution.

--- a/apps/favn_core/lib/favn/manifest/index.ex
+++ b/apps/favn_core/lib/favn/manifest/index.ex
@@ -3,9 +3,9 @@ defmodule Favn.Manifest.Index do
   Deterministic lookup/index helpers built from a persisted manifest payload.
   """
 
-  alias Favn.Assets.GraphIndex
   alias Favn.Manifest
   alias Favn.Manifest.Asset
+  alias Favn.Manifest.PlanningIndex
   alias Favn.Manifest.Pipeline
   alias Favn.Manifest.Schedule
   alias Favn.Manifest.Version
@@ -14,7 +14,7 @@ defmodule Favn.Manifest.Index do
 
   @type t :: %__MODULE__{
           manifest: Manifest.t(),
-          graph_index: GraphIndex.t(),
+          planning_index: PlanningIndex.t(),
           assets_by_ref: %{required(ref()) => Asset.t()},
           pipelines_by_ref: %{required(ref()) => Pipeline.t()},
           schedules_by_ref: %{required(ref()) => Schedule.t()}
@@ -28,11 +28,11 @@ defmodule Favn.Manifest.Index do
           | {:duplicate_asset_ref, ref()}
           | {:duplicate_pipeline_ref, ref()}
           | {:duplicate_schedule_ref, ref()}
-          | GraphIndex.error()
+          | PlanningIndex.error()
 
   defstruct [
     :manifest,
-    :graph_index,
+    :planning_index,
     assets_by_ref: %{},
     pipelines_by_ref: %{},
     schedules_by_ref: %{}
@@ -41,13 +41,13 @@ defmodule Favn.Manifest.Index do
   @spec build(Manifest.t()) :: {:ok, t()} | {:error, error()}
   def build(%Manifest{} = manifest) do
     with {:ok, assets_by_ref} <- build_assets_by_ref(manifest.assets),
-         {:ok, graph_index} <- GraphIndex.build_index(Map.values(assets_by_ref)),
+         {:ok, planning_index} <- PlanningIndex.build(manifest),
          {:ok, pipelines_by_ref} <- build_pipelines_by_ref(manifest.pipelines),
          {:ok, schedules_by_ref} <- build_schedules_by_ref(manifest.schedules) do
       {:ok,
        %__MODULE__{
          manifest: manifest,
-         graph_index: graph_index,
+         planning_index: planning_index,
          assets_by_ref: assets_by_ref,
          pipelines_by_ref: pipelines_by_ref,
          schedules_by_ref: schedules_by_ref

--- a/apps/favn_core/lib/favn/manifest/planning_index.ex
+++ b/apps/favn_core/lib/favn/manifest/planning_index.ex
@@ -34,7 +34,9 @@ defmodule Favn.Manifest.PlanningIndex do
           :invalid_manifest
           | {:invalid_asset_ref, term()}
           | {:duplicate_asset_ref, Ref.t()}
+          | {:missing_manifest_graph, :non_empty_assets}
           | {:manifest_graph_mismatch, :nodes | :edges | :topo_order}
+          | {:unknown_projection_ref, Ref.t()}
           | Graph.error()
 
   defstruct assets_by_ref: %{},
@@ -59,6 +61,10 @@ defmodule Favn.Manifest.PlanningIndex do
   Builds a planning index from an explicit manifest graph and asset list.
   """
   @spec build(Graph.t(), [Asset.t()]) :: {:ok, t()} | {:error, error()}
+  def build(%Graph{nodes: [], edges: [], topo_order: []}, assets)
+      when is_list(assets) and assets != [],
+      do: {:error, {:missing_manifest_graph, :non_empty_assets}}
+
   def build(%Graph{} = graph, assets) when is_list(assets) do
     with {:ok, assets_by_ref} <- build_assets_by_ref(assets),
          {:ok, expected_graph} <- Graph.build(assets),
@@ -89,16 +95,26 @@ defmodule Favn.Manifest.PlanningIndex do
   """
   @spec project(t(), MapSet.t(Ref.t())) :: {:ok, t()} | {:error, error()}
   def project(%__MODULE__{} = index, %MapSet{} = refs) do
-    assets =
-      refs
-      |> Enum.map(&Map.fetch!(index.assets_by_ref, &1))
-      |> Enum.map(fn %Asset{} = asset ->
-        %{asset | depends_on: Enum.filter(asset.depends_on, &MapSet.member?(refs, &1))}
-      end)
-
-    with {:ok, graph} <- Graph.build(assets) do
+    with :ok <- validate_projection_refs(index, refs),
+         assets <- project_assets(index, refs),
+         {:ok, graph} <- Graph.build(assets) do
       build(graph, assets)
     end
+  end
+
+  defp validate_projection_refs(%__MODULE__{} = index, %MapSet{} = refs) do
+    case Enum.find(refs, &(not Map.has_key?(index.assets_by_ref, &1))) do
+      nil -> :ok
+      ref -> {:error, {:unknown_projection_ref, ref}}
+    end
+  end
+
+  defp project_assets(%__MODULE__{} = index, %MapSet{} = refs) do
+    refs
+    |> Enum.map(&Map.fetch!(index.assets_by_ref, &1))
+    |> Enum.map(fn %Asset{} = asset ->
+      %{asset | depends_on: Enum.filter(asset.depends_on, &MapSet.member?(refs, &1))}
+    end)
   end
 
   defp build_assets_by_ref(assets) do

--- a/apps/favn_core/lib/favn/manifest/planning_index.ex
+++ b/apps/favn_core/lib/favn/manifest/planning_index.ex
@@ -1,0 +1,174 @@
+defmodule Favn.Manifest.PlanningIndex do
+  @moduledoc """
+  Pure runtime planning index built from a pinned manifest graph.
+
+  The planning index is the in-memory query shape used by planners after a
+  `%Favn.Manifest{}` has been built, persisted, and pinned in a manifest
+  version. It validates that manifest assets and the embedded
+  `%Favn.Manifest.Graph{}` agree before exposing adjacency, transitive closure,
+  and topological rank data.
+  """
+
+  alias Favn.Manifest
+  alias Favn.Manifest.Asset
+  alias Favn.Manifest.Graph
+  alias Favn.Ref
+
+  @typedoc """
+  Manifest-derived dependency index for runtime planning.
+  """
+  @type t :: %__MODULE__{
+          assets_by_ref: %{Ref.t() => Asset.t()},
+          upstream: %{Ref.t() => MapSet.t(Ref.t())},
+          downstream: %{Ref.t() => MapSet.t(Ref.t())},
+          transitive_upstream: %{Ref.t() => MapSet.t(Ref.t())},
+          transitive_downstream: %{Ref.t() => MapSet.t(Ref.t())},
+          topo_order: [Ref.t()],
+          topo_rank: %{Ref.t() => non_neg_integer()}
+        }
+
+  @typedoc """
+  Planning index construction errors.
+  """
+  @type error ::
+          :invalid_manifest
+          | {:invalid_asset_ref, term()}
+          | {:duplicate_asset_ref, Ref.t()}
+          | {:manifest_graph_mismatch, :nodes | :edges | :topo_order}
+          | Graph.error()
+
+  defstruct assets_by_ref: %{},
+            upstream: %{},
+            downstream: %{},
+            transitive_upstream: %{},
+            transitive_downstream: %{},
+            topo_order: [],
+            topo_rank: %{}
+
+  @doc """
+  Builds a planning index from a canonical manifest.
+  """
+  @spec build(Manifest.t()) :: {:ok, t()} | {:error, error()}
+  def build(%Manifest{assets: assets, graph: %Graph{} = graph}) do
+    build(graph, assets)
+  end
+
+  def build(_other), do: {:error, :invalid_manifest}
+
+  @doc """
+  Builds a planning index from an explicit manifest graph and asset list.
+  """
+  @spec build(Graph.t(), [Asset.t()]) :: {:ok, t()} | {:error, error()}
+  def build(%Graph{} = graph, assets) when is_list(assets) do
+    with {:ok, assets_by_ref} <- build_assets_by_ref(assets),
+         {:ok, expected_graph} <- Graph.build(assets),
+         :ok <- validate_graph(graph, expected_graph),
+         {upstream, downstream} <- build_adjacency(graph),
+         transitive_upstream <- build_transitive_index(upstream),
+         transitive_downstream <- build_transitive_index(downstream) do
+      {:ok,
+       %__MODULE__{
+         assets_by_ref: assets_by_ref,
+         upstream: upstream,
+         downstream: downstream,
+         transitive_upstream: transitive_upstream,
+         transitive_downstream: transitive_downstream,
+         topo_order: graph.topo_order,
+         topo_rank: build_topo_rank(graph.topo_order)
+       }}
+    end
+  end
+
+  def build(%Graph{}, invalid), do: {:error, {:invalid_assets_input, invalid}}
+
+  @doc """
+  Projects an existing planning index to a selected ref set.
+
+  Dependencies outside the selected set are removed before rebuilding the
+  manifest graph/index contract for the projected plan.
+  """
+  @spec project(t(), MapSet.t(Ref.t())) :: {:ok, t()} | {:error, error()}
+  def project(%__MODULE__{} = index, %MapSet{} = refs) do
+    assets =
+      refs
+      |> Enum.map(&Map.fetch!(index.assets_by_ref, &1))
+      |> Enum.map(fn %Asset{} = asset ->
+        %{asset | depends_on: Enum.filter(asset.depends_on, &MapSet.member?(refs, &1))}
+      end)
+
+    with {:ok, graph} <- Graph.build(assets) do
+      build(graph, assets)
+    end
+  end
+
+  defp build_assets_by_ref(assets) do
+    Enum.reduce_while(assets, {:ok, %{}}, fn
+      %Asset{ref: {module, name}} = asset, {:ok, acc}
+      when is_atom(module) and is_atom(name) and not is_nil(module) and not is_nil(name) ->
+        if Map.has_key?(acc, asset.ref) do
+          {:halt, {:error, {:duplicate_asset_ref, asset.ref}}}
+        else
+          {:cont, {:ok, Map.put(acc, asset.ref, asset)}}
+        end
+
+      %Asset{ref: ref}, _acc ->
+        {:halt, {:error, {:invalid_asset_ref, ref}}}
+
+      other, _acc ->
+        {:halt, {:error, {:invalid_asset_ref, other}}}
+    end)
+  end
+
+  defp validate_graph(%Graph{} = graph, %Graph{} = expected_graph) do
+    cond do
+      graph.nodes != expected_graph.nodes ->
+        {:error, {:manifest_graph_mismatch, :nodes}}
+
+      graph.edges != expected_graph.edges ->
+        {:error, {:manifest_graph_mismatch, :edges}}
+
+      graph.topo_order != expected_graph.topo_order ->
+        {:error, {:manifest_graph_mismatch, :topo_order}}
+
+      true ->
+        :ok
+    end
+  end
+
+  defp build_adjacency(%Graph{} = graph) do
+    empty_sets = Map.new(graph.nodes, &{&1, MapSet.new()})
+
+    Enum.reduce(graph.edges, {empty_sets, empty_sets}, fn %{from: from, to: to},
+                                                          {upstream, downstream} ->
+      {
+        Map.update!(upstream, to, &MapSet.put(&1, from)),
+        Map.update!(downstream, from, &MapSet.put(&1, to))
+      }
+    end)
+  end
+
+  defp build_transitive_index(adjacency) do
+    Map.new(adjacency, fn {ref, _neighbors} ->
+      reachable = reachable_from_map(ref, adjacency, %{})
+      {ref, reachable |> Map.keys() |> MapSet.new()}
+    end)
+  end
+
+  defp reachable_from_map(ref, adjacency, visited) do
+    adjacency
+    |> Map.fetch!(ref)
+    |> Enum.reduce(visited, fn neighbor, acc ->
+      if Map.has_key?(acc, neighbor) do
+        acc
+      else
+        reachable_from_map(neighbor, adjacency, Map.put(acc, neighbor, true))
+      end
+    end)
+  end
+
+  defp build_topo_rank(order) do
+    order
+    |> Enum.with_index()
+    |> Map.new(fn {ref, index} -> {ref, index} end)
+  end
+end

--- a/apps/favn_core/lib/favn/manifest/rehydrate.ex
+++ b/apps/favn_core/lib/favn/manifest/rehydrate.ex
@@ -58,13 +58,16 @@ defmodule Favn.Manifest.Rehydrate do
   def manifest(other), do: {:error, {:invalid_manifest_input, other}}
 
   defp build_manifest(value) do
+    assets = value |> field_value(:assets, []) |> build_assets()
+    graph = value |> field_value(:graph, %Graph{}) |> build_graph() |> normalize_graph(assets)
+
     %Manifest{
       schema_version: field_value(value, :schema_version),
       runner_contract_version: field_value(value, :runner_contract_version),
-      assets: value |> field_value(:assets, []) |> build_assets(),
+      assets: assets,
       pipelines: value |> field_value(:pipelines, []) |> build_pipelines(),
       schedules: value |> field_value(:schedules, []) |> build_schedules(),
-      graph: value |> field_value(:graph, %Graph{}) |> build_graph(),
+      graph: graph,
       metadata: value |> field_value(:metadata, %{}) |> plain_map()
     }
   end
@@ -630,6 +633,15 @@ defmodule Favn.Manifest.Rehydrate do
   end
 
   defp build_graph(_other), do: %Graph{}
+
+  defp normalize_graph(%Graph{nodes: [], edges: [], topo_order: []}, assets) when assets != [] do
+    case Graph.build(assets) do
+      {:ok, graph} -> graph
+      {:error, reason} -> raise ArgumentError, "invalid manifest graph: #{inspect(reason)}"
+    end
+  end
+
+  defp normalize_graph(%Graph{} = graph, _assets), do: graph
 
   defp build_edges(values) when is_list(values) do
     Enum.map(values, fn

--- a/apps/favn_core/lib/favn/plan/node_identity.ex
+++ b/apps/favn_core/lib/favn/plan/node_identity.ex
@@ -1,0 +1,55 @@
+defmodule Favn.Plan.NodeIdentity do
+  @moduledoc """
+  Manifest/planning-owned identity for one planned node.
+
+  This struct deliberately contains only data produced from a pinned manifest
+  version and a plan. Runner lifecycle data such as execution IDs, attempts, and
+  storage state belongs outside this contract.
+  """
+
+  alias Favn.Plan
+  alias Favn.Ref
+
+  @type node_key :: Plan.node_key()
+
+  @type t :: %__MODULE__{
+          manifest_version_id: String.t(),
+          node_key: node_key(),
+          target_refs: [Ref.t()],
+          planned_asset_refs: [Ref.t()],
+          window: Favn.Window.Runtime.t() | nil,
+          execution_pool: atom() | nil
+        }
+
+  defstruct [
+    :manifest_version_id,
+    :node_key,
+    target_refs: [],
+    planned_asset_refs: [],
+    window: nil,
+    execution_pool: nil
+  ]
+
+  @doc """
+  Builds node identity from a pinned manifest version id and plan node key.
+  """
+  @spec from_plan(String.t(), Plan.t(), node_key()) :: {:ok, t()} | {:error, :plan_node_not_found}
+  def from_plan(manifest_version_id, %Plan{} = plan, node_key)
+      when is_binary(manifest_version_id) do
+    case Map.fetch(plan.nodes, node_key) do
+      {:ok, node} ->
+        {:ok,
+         %__MODULE__{
+           manifest_version_id: manifest_version_id,
+           node_key: node_key,
+           target_refs: plan.target_refs,
+           planned_asset_refs: plan.topo_order,
+           window: Map.get(node, :window),
+           execution_pool: Map.get(node, :execution_pool)
+         }}
+
+      :error ->
+        {:error, :plan_node_not_found}
+    end
+  end
+end

--- a/apps/favn_core/test/manifest/index_test.exs
+++ b/apps/favn_core/test/manifest/index_test.exs
@@ -3,6 +3,7 @@ defmodule Favn.Manifest.IndexTest do
 
   alias Favn.Manifest
   alias Favn.Manifest.Asset
+  alias Favn.Manifest.Graph
   alias Favn.Manifest.Index
   alias Favn.Manifest.Pipeline
   alias Favn.Manifest.Schedule
@@ -20,7 +21,7 @@ defmodule Favn.Manifest.IndexTest do
     assert {:ok, %Schedule{name: :daily}} =
              Index.fetch_schedule(index, {MyApp.Schedules, :daily})
 
-    assert index.graph_index.topo_order == [{MyApp.Raw, :asset}, {MyApp.Gold, :asset}]
+    assert index.planning_index.topo_order == [{MyApp.Raw, :asset}, {MyApp.Gold, :asset}]
   end
 
   test "fails when pipeline refs are duplicated" do
@@ -65,8 +66,8 @@ defmodule Favn.Manifest.IndexTest do
   end
 
   defp sample_manifest do
-    %Manifest{
-      assets: [
+    assets =
+      [
         %Asset{
           ref: {MyApp.Gold, :asset},
           module: MyApp.Gold,
@@ -74,7 +75,13 @@ defmodule Favn.Manifest.IndexTest do
           depends_on: [{MyApp.Raw, :asset}]
         },
         %Asset{ref: {MyApp.Raw, :asset}, module: MyApp.Raw, name: :asset, depends_on: []}
-      ],
+      ]
+
+    {:ok, graph} = Graph.build(assets)
+
+    %Manifest{
+      assets: assets,
+      graph: graph,
       pipelines: [
         %Pipeline{
           module: MyApp.Pipelines.Daily,

--- a/apps/favn_core/test/manifest/pipeline_resolver_test.exs
+++ b/apps/favn_core/test/manifest/pipeline_resolver_test.exs
@@ -3,6 +3,7 @@ defmodule Favn.Manifest.PipelineResolverTest do
 
   alias Favn.Manifest
   alias Favn.Manifest.Asset
+  alias Favn.Manifest.Graph
   alias Favn.Manifest.Index
   alias Favn.Manifest.Pipeline
   alias Favn.Manifest.PipelineResolver
@@ -54,8 +55,8 @@ defmodule Favn.Manifest.PipelineResolverTest do
   end
 
   defp sample_manifest do
-    %Manifest{
-      assets: [
+    assets =
+      [
         %Asset{
           ref: {MyApp.Gold, :asset},
           module: MyApp.Gold,
@@ -70,7 +71,13 @@ defmodule Favn.Manifest.PipelineResolverTest do
           depends_on: [],
           metadata: %{tags: [:daily], category: :raw}
         }
-      ],
+      ]
+
+    {:ok, graph} = Graph.build(assets)
+
+    %Manifest{
+      assets: assets,
+      graph: graph,
       pipelines: [
         %Pipeline{
           module: MyApp.Pipelines.Daily,

--- a/apps/favn_core/test/manifest/planner_contract_test.exs
+++ b/apps/favn_core/test/manifest/planner_contract_test.exs
@@ -1,0 +1,45 @@
+defmodule Favn.Manifest.PlannerContractTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Assets.Planner
+  alias Favn.Manifest
+  alias Favn.Manifest.Asset
+  alias Favn.Manifest.Graph
+  alias Favn.Manifest.PlanningIndex
+
+  test "planner can plan solely from a manifest planning index" do
+    assets = [
+      %Asset{ref: {MyApp.Raw, :asset}, module: MyApp.Raw, name: :asset, depends_on: []},
+      %Asset{
+        ref: {MyApp.Gold, :asset},
+        module: MyApp.Gold,
+        name: :asset,
+        depends_on: [{MyApp.Raw, :asset}]
+      }
+    ]
+
+    assert {:ok, graph} = Graph.build(assets)
+    assert {:ok, index} = PlanningIndex.build(%Manifest{assets: assets, graph: graph})
+
+    assert {:ok, plan} =
+             Planner.plan({MyApp.Gold, :asset}, planning_index: index, dependencies: :all)
+
+    assert plan.topo_order == [{MyApp.Raw, :asset}, {MyApp.Gold, :asset}]
+    assert plan.stages == [[{MyApp.Raw, :asset}], [{MyApp.Gold, :asset}]]
+  end
+
+  test "manifest planning does not load authoring modules" do
+    module = Module.concat([MyApp, "ManifestOnly#{System.unique_integer([:positive])}"])
+    ref = {module, :asset}
+    assets = [%Asset{ref: ref, module: module, name: :asset, depends_on: []}]
+
+    refute Code.ensure_loaded?(module)
+
+    assert {:ok, graph} = Graph.build(assets)
+    assert {:ok, index} = PlanningIndex.build(%Manifest{assets: assets, graph: graph})
+    assert {:ok, plan} = Planner.plan(ref, planning_index: index)
+
+    assert plan.topo_order == [ref]
+    refute Code.ensure_loaded?(module)
+  end
+end

--- a/apps/favn_core/test/manifest/planning_index_test.exs
+++ b/apps/favn_core/test/manifest/planning_index_test.exs
@@ -38,6 +38,11 @@ defmodule Favn.Manifest.PlanningIndexTest do
              PlanningIndex.build(%Manifest{assets: sample_assets(), graph: graph})
   end
 
+  test "fails clearly when non-empty assets have no manifest graph" do
+    assert {:error, {:missing_manifest_graph, :non_empty_assets}} =
+             PlanningIndex.build(%Manifest{assets: sample_assets()})
+  end
+
   test "fails when manifest graph edges differ from manifest asset dependencies" do
     assert {:ok, graph} = Graph.build(sample_assets())
     graph = %{graph | edges: []}
@@ -65,6 +70,14 @@ defmodule Favn.Manifest.PlanningIndexTest do
     assert projected.topo_order == [{MyApp.Stage, :asset}, {MyApp.Gold, :asset}]
     assert projected.upstream[{MyApp.Gold, :asset}] == MapSet.new([{MyApp.Stage, :asset}])
     assert projected.upstream[{MyApp.Stage, :asset}] == MapSet.new()
+  end
+
+  test "returns deterministic errors for unknown projection refs" do
+    assert {:ok, graph} = Graph.build(sample_assets())
+    assert {:ok, index} = PlanningIndex.build(%Manifest{assets: sample_assets(), graph: graph})
+
+    assert {:error, {:unknown_projection_ref, {MyApp.Missing, :asset}}} =
+             PlanningIndex.project(index, MapSet.new([{MyApp.Missing, :asset}]))
   end
 
   defp sample_assets do

--- a/apps/favn_core/test/manifest/planning_index_test.exs
+++ b/apps/favn_core/test/manifest/planning_index_test.exs
@@ -1,0 +1,87 @@
+defmodule Favn.Manifest.PlanningIndexTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Manifest
+  alias Favn.Manifest.Asset
+  alias Favn.Manifest.Graph
+  alias Favn.Manifest.PlanningIndex
+
+  test "builds manifest-derived adjacency, transitive closures, and topo ranks" do
+    assert {:ok, graph} = Graph.build(sample_assets())
+    manifest = %Manifest{assets: sample_assets(), graph: graph}
+
+    assert {:ok, index} = PlanningIndex.build(manifest)
+
+    assert index.topo_order == [{MyApp.Raw, :asset}, {MyApp.Stage, :asset}, {MyApp.Gold, :asset}]
+
+    assert index.topo_rank == %{
+             {MyApp.Raw, :asset} => 0,
+             {MyApp.Stage, :asset} => 1,
+             {MyApp.Gold, :asset} => 2
+           }
+
+    assert index.upstream[{MyApp.Gold, :asset}] == MapSet.new([{MyApp.Stage, :asset}])
+    assert index.downstream[{MyApp.Raw, :asset}] == MapSet.new([{MyApp.Stage, :asset}])
+
+    assert index.transitive_upstream[{MyApp.Gold, :asset}] ==
+             MapSet.new([{MyApp.Raw, :asset}, {MyApp.Stage, :asset}])
+
+    assert index.transitive_downstream[{MyApp.Raw, :asset}] ==
+             MapSet.new([{MyApp.Stage, :asset}, {MyApp.Gold, :asset}])
+  end
+
+  test "fails when manifest graph nodes differ from manifest assets" do
+    assert {:ok, graph} = Graph.build(sample_assets())
+    graph = %{graph | nodes: [{MyApp.Raw, :asset}]}
+
+    assert {:error, {:manifest_graph_mismatch, :nodes}} =
+             PlanningIndex.build(%Manifest{assets: sample_assets(), graph: graph})
+  end
+
+  test "fails when manifest graph edges differ from manifest asset dependencies" do
+    assert {:ok, graph} = Graph.build(sample_assets())
+    graph = %{graph | edges: []}
+
+    assert {:error, {:manifest_graph_mismatch, :edges}} =
+             PlanningIndex.build(%Manifest{assets: sample_assets(), graph: graph})
+  end
+
+  test "fails deterministically for duplicate asset refs" do
+    assets = [%Asset{ref: {MyApp.Raw, :asset}}, %Asset{ref: {MyApp.Raw, :asset}}]
+    assert {:ok, graph} = Graph.build(assets)
+
+    assert {:error, {:duplicate_asset_ref, {MyApp.Raw, :asset}}} =
+             PlanningIndex.build(%Manifest{assets: assets, graph: graph})
+  end
+
+  test "projects selected refs through the manifest graph contract" do
+    assert {:ok, graph} = Graph.build(sample_assets())
+    assert {:ok, index} = PlanningIndex.build(%Manifest{assets: sample_assets(), graph: graph})
+
+    refs = MapSet.new([{MyApp.Stage, :asset}, {MyApp.Gold, :asset}])
+
+    assert {:ok, projected} = PlanningIndex.project(index, refs)
+
+    assert projected.topo_order == [{MyApp.Stage, :asset}, {MyApp.Gold, :asset}]
+    assert projected.upstream[{MyApp.Gold, :asset}] == MapSet.new([{MyApp.Stage, :asset}])
+    assert projected.upstream[{MyApp.Stage, :asset}] == MapSet.new()
+  end
+
+  defp sample_assets do
+    [
+      %Asset{
+        ref: {MyApp.Gold, :asset},
+        module: MyApp.Gold,
+        name: :asset,
+        depends_on: [{MyApp.Stage, :asset}]
+      },
+      %Asset{ref: {MyApp.Raw, :asset}, module: MyApp.Raw, name: :asset, depends_on: []},
+      %Asset{
+        ref: {MyApp.Stage, :asset},
+        module: MyApp.Stage,
+        name: :asset,
+        depends_on: [{MyApp.Raw, :asset}]
+      }
+    ]
+  end
+end

--- a/apps/favn_core/test/manifest/version_test.exs
+++ b/apps/favn_core/test/manifest/version_test.exs
@@ -269,6 +269,29 @@ defmodule Favn.Manifest.VersionTest do
     assert roundtrip.content_hash == original.content_hash
   end
 
+  test "upconverts missing manifest graph at version boundary" do
+    raw = {MyApp.Assets.LegacyRaw, :asset}
+    gold = {MyApp.Assets.LegacyGold, :asset}
+
+    manifest = %Manifest{
+      schema_version: 2,
+      runner_contract_version: 2,
+      assets: [
+        %Asset{ref: raw, module: elem(raw, 0), name: :asset, depends_on: []},
+        %Asset{ref: gold, module: elem(gold, 0), name: :asset, depends_on: [raw]}
+      ],
+      pipelines: [],
+      schedules: [],
+      metadata: %{}
+    }
+
+    assert {:ok, version} = Version.new(manifest, manifest_version_id: "mv_missing_graph")
+
+    assert version.manifest.graph.nodes == [gold, raw]
+    assert version.manifest.graph.edges == [%{from: raw, to: gold}]
+    assert version.manifest.graph.topo_order == [raw, gold]
+  end
+
   test "rehydrates known manifest module atoms without loading user modules" do
     manifest = %{
       "schema_version" => 2,

--- a/apps/favn_core/test/plan/node_identity_test.exs
+++ b/apps/favn_core/test/plan/node_identity_test.exs
@@ -1,0 +1,37 @@
+defmodule Favn.Plan.NodeIdentityTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Plan
+  alias Favn.Plan.NodeIdentity
+
+  test "builds identity from manifest version id and plan node" do
+    node_key = {{MyApp.Gold, :asset}, nil}
+
+    plan = %Plan{
+      target_refs: [{MyApp.Gold, :asset}],
+      topo_order: [{MyApp.Raw, :asset}, {MyApp.Gold, :asset}],
+      nodes: %{
+        node_key => %{
+          ref: {MyApp.Gold, :asset},
+          node_key: node_key,
+          window: nil,
+          execution_pool: :warehouse
+        }
+      }
+    }
+
+    assert {:ok, identity} = NodeIdentity.from_plan("manifest-v1", plan, node_key)
+
+    assert identity.manifest_version_id == "manifest-v1"
+    assert identity.node_key == node_key
+    assert identity.target_refs == [{MyApp.Gold, :asset}]
+    assert identity.planned_asset_refs == [{MyApp.Raw, :asset}, {MyApp.Gold, :asset}]
+    assert identity.window == nil
+    assert identity.execution_pool == :warehouse
+  end
+
+  test "returns an explicit error for unknown plan nodes" do
+    assert {:error, :plan_node_not_found} =
+             NodeIdentity.from_plan("manifest-v1", %Plan{}, {{MyApp.Missing, :asset}, nil})
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -1943,7 +1943,7 @@ defmodule FavnOrchestrator do
 
   defp asset_freshness_plan(asset, version, now) do
     with {:ok, index} <- Index.build_from_version(version) do
-      opts = [dependencies: :all, graph_index: index.graph_index]
+      opts = [dependencies: :all, planning_index: index.planning_index]
 
       opts =
         case asset_current_anchor_window(asset, now) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
@@ -313,7 +313,7 @@ defmodule FavnOrchestrator.RunManager do
          {:ok, _asset} <- Index.fetch_asset(index, asset_ref),
          {:ok, plan} <-
            Planner.plan(asset_ref,
-             graph_index: index.graph_index,
+             planning_index: index.planning_index,
              dependencies: dependencies,
              anchor_window: anchor_window,
              exact_windows: exact_windows
@@ -370,7 +370,7 @@ defmodule FavnOrchestrator.RunManager do
          :ok <- ensure_assets_exist(index, target_refs),
          {:ok, plan} <-
            Planner.plan(target_refs,
-             graph_index: index.graph_index,
+             planning_index: index.planning_index,
              dependencies: dependencies,
              anchor_window: anchor_window
            ) do
@@ -551,7 +551,7 @@ defmodule FavnOrchestrator.RunManager do
          :ok <- validate_anchor_window(anchor_window),
          {:ok, plan} <-
            Planner.plan(rerun_targets,
-             graph_index: index.graph_index,
+             planning_index: index.planning_index,
              dependencies: rerun_dependencies,
              anchor_window: anchor_window
            ) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
@@ -10,6 +10,7 @@ defmodule FavnOrchestrator.RunServer.Execution.StageAdmission do
 
   alias Favn.Contracts.RunnerWork
   alias Favn.Manifest.Version
+  alias Favn.Plan.NodeIdentity
   alias Favn.Run.NodeResult
   alias FavnOrchestrator.AssetStepIdentity
   alias FavnOrchestrator.ExecutionAdmission
@@ -515,17 +516,20 @@ defmodule FavnOrchestrator.RunServer.Execution.StageAdmission do
     asset_ref = node.ref
     asset_step_id = AssetStepIdentity.asset_step_id(run_state.id, node_key, asset_ref)
 
+    {:ok, identity} =
+      NodeIdentity.from_plan(version.manifest_version_id, run_state.plan, node_key)
+
     %RunnerWork{
       run_id: run_state.id,
-      manifest_version_id: version.manifest_version_id,
+      manifest_version_id: identity.manifest_version_id,
       manifest_content_hash: version.content_hash,
       asset_ref: asset_ref,
       asset_refs: [asset_ref],
-      planned_asset_refs: planned_asset_refs(run_state),
+      planned_asset_refs: identity.planned_asset_refs,
       params: run_state.params,
       trigger:
         run_state.trigger
-        |> Map.put(:window, node.window)
+        |> Map.put(:window, identity.window)
         |> maybe_put_pipeline_trigger(Map.get(run_state.metadata, :pipeline_context)),
       metadata:
         Map.merge(work_metadata(run_state.metadata), %{
@@ -533,15 +537,12 @@ defmodule FavnOrchestrator.RunServer.Execution.StageAdmission do
           asset_step_id: asset_step_id,
           max_attempts: run_state.max_attempts,
           stage: stage,
-          node_key: node_key,
-          window: node.window,
+          node_key: identity.node_key,
+          window: identity.window,
           execution_pool: effective_execution_pool(run_state, node_key)
         })
     }
   end
-
-  defp planned_asset_refs(%RunState{target_refs: refs}) when is_list(refs), do: refs
-  defp planned_asset_refs(_run_state), do: []
 
   defp effective_execution_pool(%RunState{} = run_state, node_key) do
     node_pool =

--- a/apps/favn_orchestrator/test/orchestrator_runner_integration_test.exs
+++ b/apps/favn_orchestrator/test/orchestrator_runner_integration_test.exs
@@ -208,7 +208,7 @@ defmodule FavnOrchestrator.RunnerIntegrationTest do
       }
     ]
 
-    refs = Enum.map(assets, & &1.ref)
+    {:ok, graph} = Graph.build(assets)
 
     manifest = %Manifest{
       schema_version: 1,
@@ -225,7 +225,7 @@ defmodule FavnOrchestrator.RunnerIntegrationTest do
         }
       ],
       schedules: [],
-      graph: %Graph{nodes: refs, edges: [], topo_order: refs},
+      graph: graph,
       metadata: %{}
     }
 
@@ -254,6 +254,7 @@ defmodule FavnOrchestrator.RunnerIntegrationTest do
     ]
 
     refs = Enum.map(assets, & &1.ref)
+    {:ok, graph} = Graph.build(assets)
 
     manifest = %Manifest{
       schema_version: 2,
@@ -268,7 +269,7 @@ defmodule FavnOrchestrator.RunnerIntegrationTest do
           max_concurrency: 1
         }
       ],
-      graph: %Graph{nodes: refs, edges: [], topo_order: refs}
+      graph: graph
     }
 
     {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)

--- a/apps/favn_orchestrator/test/run_manager_test.exs
+++ b/apps/favn_orchestrator/test/run_manager_test.exs
@@ -5,6 +5,7 @@ defmodule FavnOrchestrator.RunManagerTest do
 
   alias Favn.Contracts.RunnerResult
   alias Favn.Manifest
+  alias Favn.Manifest.Graph
   alias Favn.Manifest.Version
   alias FavnOrchestrator
   alias FavnOrchestrator.AssetStepIdentity
@@ -2521,27 +2522,32 @@ defmodule FavnOrchestrator.RunManagerTest do
   end
 
   defp manifest_version(manifest_version_id, opts \\ []) do
+    assets = [
+      %Favn.Manifest.Asset{
+        ref: {MyApp.Assets.Raw, :asset},
+        module: MyApp.Assets.Raw,
+        name: :asset
+      },
+      %Favn.Manifest.Asset{
+        ref: {MyApp.Assets.Gold, :asset},
+        module: MyApp.Assets.Gold,
+        name: :asset,
+        depends_on: [{MyApp.Assets.Raw, :asset}]
+      },
+      %Favn.Manifest.Asset{
+        ref: {MyApp.Assets.Silver, :asset},
+        module: MyApp.Assets.Silver,
+        name: :asset,
+        depends_on: []
+      }
+    ]
+
+    {:ok, graph} = Graph.build(assets)
+
     manifest =
       %Manifest{
-        assets: [
-          %Favn.Manifest.Asset{
-            ref: {MyApp.Assets.Raw, :asset},
-            module: MyApp.Assets.Raw,
-            name: :asset
-          },
-          %Favn.Manifest.Asset{
-            ref: {MyApp.Assets.Gold, :asset},
-            module: MyApp.Assets.Gold,
-            name: :asset,
-            depends_on: [{MyApp.Assets.Raw, :asset}]
-          },
-          %Favn.Manifest.Asset{
-            ref: {MyApp.Assets.Silver, :asset},
-            module: MyApp.Assets.Silver,
-            name: :asset,
-            depends_on: []
-          }
-        ],
+        assets: assets,
+        graph: graph,
         pipelines: [
           %Favn.Manifest.Pipeline{
             module: MyApp.Pipelines.Daily,

--- a/apps/favn_sql_runtime/test/sql/admission_test.exs
+++ b/apps/favn_sql_runtime/test/sql/admission_test.exs
@@ -73,7 +73,8 @@ defmodule FavnSQLRuntime.SQLAdmissionTest do
 
       bump_active(tracker, -1)
 
-      {:ok, %Result{kind: :execute, command: IO.iodata_to_binary(statement), rows: [], columns: []}}
+      {:ok,
+       %Result{kind: :execute, command: IO.iodata_to_binary(statement), rows: [], columns: []}}
     end
 
     def transaction(conn, fun, opts) do
@@ -111,7 +112,7 @@ defmodule FavnSQLRuntime.SQLAdmissionTest do
       receive do
         :release_materialize -> :ok
       after
-        50 -> :ok
+        1_000 -> :ok
       end
 
       bump_active(tracker, -1)
@@ -458,8 +459,11 @@ defmodule FavnSQLRuntime.SQLAdmissionTest do
         required_catalogs: ["raw"]
       )
 
-    first = Task.async(fn -> Client.execute(session, "insert into raw.main.events select 1", []) end)
-    second = Task.async(fn -> Client.execute(session, "insert into raw.main.events select 2", []) end)
+    first =
+      Task.async(fn -> Client.execute(session, "insert into raw.main.events select 1", []) end)
+
+    second =
+      Task.async(fn -> Client.execute(session, "insert into raw.main.events select 2", []) end)
 
     assert_receive {:execute_started, first_pid}, 500
     assert_receive {:execute_started, second_pid}, 500
@@ -479,7 +483,10 @@ defmodule FavnSQLRuntime.SQLAdmissionTest do
 
     first =
       Task.async(fn ->
-        Client.execute(session, "insert into raw.main.events select ?", params: [1], admission: [catalog: "raw"])
+        Client.execute(session, "insert into raw.main.events select ?",
+          params: [1],
+          admission: [catalog: "raw"]
+        )
       end)
 
     second =
@@ -544,7 +551,9 @@ defmodule FavnSQLRuntime.SQLAdmissionTest do
       Task.async(fn ->
         Client.transaction(
           session,
-          fn tx_session -> Client.execute(tx_session, "insert into raw.main.events select 1", []) end,
+          fn tx_session ->
+            Client.execute(tx_session, "insert into raw.main.events select 1", [])
+          end,
           admission: [required_catalogs: ["raw"]]
         )
       end)
@@ -553,7 +562,9 @@ defmodule FavnSQLRuntime.SQLAdmissionTest do
       Task.async(fn ->
         Client.transaction(
           session,
-          fn tx_session -> Client.execute(tx_session, "insert into mart.main.events select 1", []) end,
+          fn tx_session ->
+            Client.execute(tx_session, "insert into mart.main.events select 1", [])
+          end,
           admission: [required_catalogs: ["mart"]]
         )
       end)
@@ -577,7 +588,9 @@ defmodule FavnSQLRuntime.SQLAdmissionTest do
         required_catalogs: ["raw"]
       )
 
-    raw_holder = Task.async(fn -> Client.execute(session, "insert into raw.main.events select 1", []) end)
+    raw_holder =
+      Task.async(fn -> Client.execute(session, "insert into raw.main.events select 1", []) end)
+
     assert_receive {:execute_started, raw_pid}, 500
 
     mart = Task.async(fn -> Client.materialize(session, write_plan("mart"), []) end)

--- a/docs/ISSUE_396_MANIFEST_GRAPH_INDEX_PLAN.md
+++ b/docs/ISSUE_396_MANIFEST_GRAPH_INDEX_PLAN.md
@@ -31,6 +31,9 @@ cache state.
   code. A suitable module name is `Favn.Manifest.PlanningIndex`.
 - Build the planning index only from `%Favn.Manifest{}` or from an explicit
   `%Favn.Manifest.Graph{}` plus manifest assets.
+- Keep missing legacy graph upconversion at the manifest rehydration/version
+  boundary. `PlanningIndex` must not rebuild a missing graph during runtime
+  planning; it should fail clearly if it receives non-empty assets with no graph.
 - Store manifest assets in the planning index as `%Favn.Manifest.Asset{}` values,
   not compiled authoring asset maps.
 - Validate that manifest assets and manifest graph agree exactly: same asset refs,

--- a/docs/ISSUE_396_MANIFEST_GRAPH_INDEX_PLAN.md
+++ b/docs/ISSUE_396_MANIFEST_GRAPH_INDEX_PLAN.md
@@ -1,0 +1,125 @@
+# Issue 396 Manifest Graph/Index Planning Contract Plan
+
+## Goal
+
+Make the pinned manifest graph/index the single runtime planning contract. Runtime
+planning should derive from the stored `%Favn.Manifest.Version{}` payload and must
+not rebuild an equivalent-but-separate asset graph from authoring modules or global
+cache state.
+
+## Current State
+
+- `Favn.Manifest.Graph` is the graph embedded in canonical manifests, but it only
+  stores nodes, edges, and topological order.
+- `Favn.Manifest.Index` validates manifest lookup tables, then rebuilds an
+  `Favn.Assets.GraphIndex` from manifest assets.
+- `Favn.Assets.GraphIndex` currently mixes four concerns: compiling authored
+  asset modules, global `:persistent_term` caching, pure graph indexing, and graph
+  query support for planning.
+- `Favn.Assets.Planner` can plan from `asset_modules` or an `Assets.GraphIndex`.
+  Orchestrator call sites pass `index.graph_index`, so runtime planning is pinned
+  to the manifest version envelope but not directly to the manifest graph.
+- Developer ergonomics such as `Favn.plan_asset_run/2`, `GraphIndex.load/1`, and
+  graph inspection APIs still need an authoring-module entry point, but that path
+  should stay outside runtime planning.
+
+## Design
+
+- Keep `Favn.Manifest.Graph` as the canonical persisted graph contract and make
+  it authoritative for runtime validation.
+- Add a pure manifest planning index in `favn_core`, owned by manifest/planning
+  code. A suitable module name is `Favn.Manifest.PlanningIndex`.
+- Build the planning index only from `%Favn.Manifest{}` or from an explicit
+  `%Favn.Manifest.Graph{}` plus manifest assets.
+- Store manifest assets in the planning index as `%Favn.Manifest.Asset{}` values,
+  not compiled authoring asset maps.
+- Validate that manifest assets and manifest graph agree exactly: same asset refs,
+  same dependency edges, same deterministic topological order, no duplicates, no
+  missing dependencies, and deterministic cycle errors.
+- Move adjacency, transitive closure, topological rank, subgraph projection, and
+  selected-ref behavior needed by planning into the pure manifest planning index.
+- Keep authoring-module compilation and global cache mechanics in
+  `Favn.Assets.GraphIndex` or a small authoring-facing wrapper. That wrapper may
+  compile modules, run dependency inference, build a manifest, and delegate to the
+  manifest planning contract, but runtime callers should not use it.
+- Extract the planner implementation behind a manifest-index-first API, for
+  example `Favn.Plan.Builder.plan(index, targets, opts)` or
+  `Favn.Manifest.Planner.plan(index, targets, opts)`. The API should accept only a
+  manifest planning/index contract plus target/window options.
+- Keep `Favn.Assets.Planner` as an authoring convenience only if needed by public
+  developer ergonomics. Its module-compilation path should delegate through
+  `Favn.Manifest.Generator` and the manifest planning index instead of building an
+  `Assets.GraphIndex` directly.
+- Replace orchestrator planning call sites so they build `Favn.Manifest.Index`
+  from the pinned `Favn.Manifest.Version` and pass the manifest planning contract
+  into the planner.
+- Introduce `Favn.Plan.NodeIdentity` as a small `favn_core` seam for planned-node
+  identity with only manifest/planning-owned fields: `manifest_version_id`,
+  `node_key`, `target_refs`, `planned_asset_refs`, `window`, and
+  `execution_pool`.
+- Produce `NodeIdentity` from the pinned manifest/index and plan. Do not add
+  runner lifecycle state, run attempt state, execution IDs, storage IDs, or runner
+  callbacks to this contract.
+- Preserve the runner-facing `Favn.Contracts.RunnerWork` contract. Orchestrator
+  may translate plan/node identity into existing `RunnerWork` fields and metadata,
+  but this issue should not change runner API shape.
+
+## Landing Slices
+
+1. Add manifest planning index tests first.
+2. Introduce `Favn.Manifest.PlanningIndex` with pure construction from manifest
+   assets and graph.
+3. Change `Favn.Manifest.Index` to own a `planning_index` instead of rebuilding an
+   `Favn.Assets.GraphIndex`.
+4. Extract planner internals to a manifest-index-first module while preserving the
+   current plan output shape.
+5. Move orchestrator planning call sites to the manifest planning contract.
+6. Rework `Favn.plan_asset_run/2` and any remaining authoring conveniences so
+   module compilation happens before manifest planning, not inside runtime
+   planning.
+7. Add `Favn.Plan.NodeIdentity` and have orchestrator/runtime admission derive it
+   from the plan where identity is needed, without changing `RunnerWork`.
+8. Remove or narrow runtime-facing uses of `Favn.Assets.GraphIndex` once all
+   planning paths use the manifest contract.
+9. Update docs and module docs to describe the split between authoring graph
+   conveniences and manifest runtime planning.
+
+## Tests
+
+- Core manifest graph/index parity: building a planning index from a manifest with
+  valid assets and graph preserves nodes, edges, topological order, adjacency,
+  transitive upstream/downstream closures, and rank ordering.
+- Contract validation: mismatched graph nodes, graph edges, duplicate asset refs,
+  missing dependencies, and cycles fail with deterministic error shapes.
+- Planner contract: planning succeeds with only a manifest planning index and does
+  not require `asset_modules` or global cached graph state.
+- Runtime safety: planning from a persisted manifest containing valid module atoms
+  does not `Code.ensure_loaded/1` authoring modules.
+- Orchestrator planning: manual run, pipeline run, rerun, and freshness planning
+  call through `Favn.Manifest.Index` and the manifest planning contract.
+- Authoring ergonomics: `Favn.plan_asset_run/2` still works from configured or
+  discovered modules by generating a manifest first.
+- Runner boundary: `RunnerWork` struct fields and runner submit APIs remain
+  unchanged.
+
+## Risks And Tradeoffs
+
+- This is a foundational refactor and should land in small slices because graph
+  construction, planner behavior, and orchestrator run submission are tightly
+  connected.
+- Renaming or replacing `graph_index` on `Favn.Manifest.Index` is a breaking
+  internal/public-core change, but the project is pre-v1 and the clearer runtime
+  contract is worth the churn.
+- Keeping `Favn.Assets.GraphIndex` as an authoring convenience avoids unnecessary
+  developer-facing breakage while still removing it from runtime planning.
+- Issue #334 should remain separate. This plan should not redefine atom/string
+  rehydration semantics, but tests should avoid relying on implicit atomization
+  beyond the current manifest contract.
+
+## Non-Goals
+
+- Do not change `Favn.Contracts.RunnerWork`.
+- Do not move orchestrator scheduling, storage, retry, or runner lifecycle state
+  into `favn_core`.
+- Do not use `Favn.Assets.GraphIndex` cache state to satisfy runtime planning.
+- Do not solve manifest atom/string rehydration semantics from issue #334 here.


### PR DESCRIPTION
## Summary
- Add `Favn.Manifest.PlanningIndex` built from manifest assets plus the embedded manifest graph, with parity validation and projection support.
- Switch manifest-indexed runtime planning call sites to pass `planning_index` instead of rebuilding `Favn.Assets.GraphIndex`.
- Add `Favn.Plan.NodeIdentity` as a manifest/planning-owned identity seam without changing `RunnerWork`.

## Tests
- `MIX_ENV=test mix do --app favn_core cmd mix test test/manifest/planning_index_test.exs test/manifest/planner_contract_test.exs test/manifest/index_test.exs test/manifest/pipeline_resolver_test.exs test/plan/node_identity_test.exs test/assets/planner_window_test.exs test/boundary_explicit_inputs_test.exs`
- `MIX_ENV=test mix do --app favn_authoring cmd mix test test/assets/graph_planner_parity_test.exs`
- `MIX_ENV=test mix do --app favn_core cmd mix test test/manifest/version_test.exs`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/run_manager_test.exs`

Closes #396