### PR TITLE
Bound operator run read models

### DIFF
--- a/apps/favn_orchestrator/lib/favn/storage/adapter.ex
+++ b/apps/favn_orchestrator/lib/favn/storage/adapter.ex
@@ -68,11 +68,21 @@ defmodule Favn.Storage.Adapter do
   @callback put_run(RunState.t(), adapter_opts()) :: :ok | {:error, error()}
   @callback get_run(String.t(), adapter_opts()) :: {:ok, RunState.t()} | {:error, error()}
   @callback list_runs(list_opts(), adapter_opts()) :: {:ok, [RunState.t()]} | {:error, error()}
+  @callback list_execution_group_runs(String.t(), adapter_opts()) ::
+              {:ok, [RunState.t()]} | {:error, error()}
+  @callback list_execution_group_run_ids(String.t(), adapter_opts()) ::
+              {:ok, [String.t()]} | {:error, error()}
+  @callback list_execution_groups(filter_opts(), adapter_opts()) ::
+              {:ok, Page.t(String.t())} | {:error, error()}
   @callback persist_run_transition(RunState.t(), map(), adapter_opts()) ::
               :ok | :idempotent | {:error, error()}
 
   @callback append_run_event(String.t(), map(), adapter_opts()) :: :ok | {:error, error()}
   @callback list_run_events(String.t(), adapter_opts()) :: {:ok, [map()]} | {:error, error()}
+  @callback list_run_events(String.t(), filter_opts(), adapter_opts()) ::
+              {:ok, [map()]} | {:error, error()}
+  @callback list_execution_group_events(String.t(), filter_opts(), adapter_opts()) ::
+              {:ok, [map()]} | {:error, error()}
   @callback list_global_run_events(filter_opts(), adapter_opts()) ::
               {:ok, [map()]} | {:error, error()}
 
@@ -202,6 +212,11 @@ defmodule Favn.Storage.Adapter do
                       reserve_idempotency_record: 2,
                       complete_idempotency_record: 3,
                       get_idempotency_record: 2,
+                      list_execution_group_runs: 2,
+                      list_execution_group_run_ids: 2,
+                      list_execution_groups: 2,
+                      list_run_events: 3,
+                      list_execution_group_events: 3,
                       put_asset_freshness_state: 2,
                       get_asset_freshness_state: 4,
                       list_asset_freshness_states: 2,

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -1327,6 +1327,15 @@ defmodule FavnOrchestrator do
   end
 
   @doc """
+  Returns a bounded page of execution groups with orchestrator-owned semantics.
+  """
+  @spec page_execution_groups(keyword()) ::
+          {:ok, FavnOrchestrator.Page.t(execution_group_summary())} | {:error, term()}
+  def page_execution_groups(filters \\ []) when is_list(filters) do
+    RunReadModel.page_execution_groups(filters)
+  end
+
+  @doc """
   Returns one execution group detail for redesigned run views.
   """
   @spec get_execution_group_detail(run_id(), keyword()) ::
@@ -1334,6 +1343,16 @@ defmodule FavnOrchestrator do
   def get_execution_group_detail(group_id, filters \\ [])
       when is_binary(group_id) and is_list(filters) do
     RunReadModel.get_execution_group_detail(group_id, filters)
+  end
+
+  @doc """
+  Returns execution group detail for any run id in that group.
+  """
+  @spec get_execution_group_detail_for_run(run_id(), keyword()) ::
+          {:ok, execution_group_detail()} | {:error, term()}
+  def get_execution_group_detail_for_run(run_id, filters \\ [])
+      when is_binary(run_id) and is_list(filters) do
+    RunReadModel.get_execution_group_detail_for_run(run_id, filters)
   end
 
   @doc """
@@ -1401,13 +1420,9 @@ defmodule FavnOrchestrator do
   """
   @spec list_run_events(run_id(), keyword()) :: {:ok, [RunEvent.t()]} | {:error, term()}
   def list_run_events(run_id, opts \\ []) when is_binary(run_id) and is_list(opts) do
-    with {:ok, events} <- Storage.list_run_events(run_id),
-         :ok <- validate_run_event_opts(opts) do
-      {:ok,
-       events
-       |> Enum.map(&RunEvent.from_map/1)
-       |> filter_run_events(opts)
-       |> maybe_limit_run_events(opts)}
+    with :ok <- validate_run_event_opts(opts),
+         {:ok, events} <- Storage.list_run_events(run_id, opts) do
+      {:ok, Enum.map(events, &RunEvent.from_map/1)}
     end
   end
 
@@ -1420,13 +1435,16 @@ defmodule FavnOrchestrator do
     limit = Keyword.get(opts, :limit, 200)
 
     with true <- is_integer(limit) and limit > 0,
-         {:ok, events} <- list_run_events(run_id) do
+         {:ok, cursor_valid?} <- run_event_cursor_valid?(run_id, after_sequence),
+         true <- cursor_valid?,
+         {:ok, events} <-
+           list_run_events(run_id, after_sequence: after_sequence || 0, limit: limit) do
       case after_sequence do
         nil ->
-          {:ok, Enum.take(events, limit)}
+          {:ok, events}
 
         sequence when is_integer(sequence) and sequence >= 0 ->
-          replay_after_sequence(events, sequence, limit)
+          {:ok, events}
 
         _ ->
           {:error, :cursor_invalid}
@@ -1574,37 +1592,16 @@ defmodule FavnOrchestrator do
     end
   end
 
-  defp filter_run_events(events, opts) do
-    case Keyword.get(opts, :after_sequence) do
-      sequence when is_integer(sequence) and sequence >= 0 ->
-        Enum.filter(events, &(&1.sequence > sequence))
+  defp run_event_cursor_valid?(_run_id, nil), do: {:ok, true}
+  defp run_event_cursor_valid?(_run_id, 0), do: {:ok, true}
 
-      _ ->
-        events
+  defp run_event_cursor_valid?(run_id, sequence) when is_integer(sequence) and sequence > 0 do
+    with {:ok, events} <- list_run_events(run_id, after_sequence: sequence - 1, limit: 1) do
+      {:ok, match?([%RunEvent{sequence: ^sequence}], events)}
     end
   end
 
-  defp maybe_limit_run_events(events, opts) do
-    case Keyword.get(opts, :limit) do
-      limit when is_integer(limit) and limit > 0 -> Enum.take(events, limit)
-      _ -> events
-    end
-  end
-
-  defp replay_after_sequence(events, sequence, limit) do
-    if sequence == 0 do
-      {:ok, Enum.take(events, limit)}
-    else
-      if Enum.any?(events, &(&1.sequence == sequence)) do
-        {:ok,
-         events
-         |> Enum.filter(&(&1.sequence > sequence))
-         |> Enum.take(limit)}
-      else
-        {:error, :cursor_invalid}
-      end
-    end
-  end
+  defp run_event_cursor_valid?(_run_id, _sequence), do: {:ok, false}
 
   defp list_schedule_entries_from_active_manifest do
     with {:ok, manifest_version_id} <- active_manifest(),

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -648,7 +648,6 @@ defmodule FavnOrchestrator.RunReadModel do
 
   defp target_assets(%RunState{asset_ref: ref}), do: [public_ref(ref)]
 
-  defp trigger_type(%RunState{submit_kind: :rerun}), do: :retry
   defp trigger_type(%RunState{} = run), do: RunQuery.trigger_type(run)
 
   defp execution_group_asset_attempts(group, mode) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -621,8 +621,8 @@ defmodule FavnOrchestrator.RunReadModel do
 
   defp execution_group_status(root_status, attempt_counts, window_counts, active?) do
     cond do
-      active? -> :running
       attempt_counts.failed > 0 or window_counts.failed > 0 -> :error
+      active? -> :running
       root_status -> root_status
       true -> :pending
     end
@@ -649,16 +649,7 @@ defmodule FavnOrchestrator.RunReadModel do
   defp target_assets(%RunState{asset_ref: ref}), do: [public_ref(ref)]
 
   defp trigger_type(%RunState{submit_kind: :rerun}), do: :retry
-
-  defp trigger_type(%RunState{submit_kind: submit_kind})
-       when submit_kind in [:backfill_asset, :backfill_pipeline],
-       do: :backfill
-
-  defp trigger_type(%RunState{trigger: trigger}) when is_map(trigger) do
-    Map.get(trigger, :kind) || Map.get(trigger, "kind") || :manual
-  end
-
-  defp trigger_type(_run), do: :manual
+  defp trigger_type(%RunState{} = run), do: RunQuery.trigger_type(run)
 
   defp execution_group_asset_attempts(group, mode) do
     windows_by_child_run_id =

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -16,6 +16,7 @@ defmodule FavnOrchestrator.RunReadModel do
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.JsonSafe
+  alias FavnOrchestrator.Storage.RunQuery
 
   @backfill_failure_detail_limit 10
   @execution_group_overview_default_scan_limit 500
@@ -133,6 +134,9 @@ defmodule FavnOrchestrator.RunReadModel do
   @type execution_group_summary :: %{
           required(:id) => String.t(),
           required(:root_execution_group_id) => String.t(),
+          required(:status) => RunState.status(),
+          required(:health) => :ok | :warning | :error | :active,
+          required(:active?) => boolean(),
           required(:trigger_type) => atom() | nil,
           required(:target_assets) => [String.t()],
           required(:root_status) => RunState.status(),
@@ -147,6 +151,10 @@ defmodule FavnOrchestrator.RunReadModel do
           required(:failed_asset_attempts) => non_neg_integer(),
           required(:running_asset_attempts) => non_neg_integer(),
           required(:queued_asset_attempts) => non_neg_integer(),
+          required(:failure_count) => non_neg_integer(),
+          required(:progress) => progress_summary() | nil,
+          required(:summary_totals) => map(),
+          required(:last_activity_at) => DateTime.t() | nil,
           required(:currently_running_asset_attempts) => [asset_attempt_summary()],
           required(:child_run_ids) => [String.t()]
         }
@@ -239,15 +247,26 @@ defmodule FavnOrchestrator.RunReadModel do
   """
   @spec list_execution_groups(keyword()) :: {:ok, [execution_group_summary()]} | {:error, term()}
   def list_execution_groups(filters \\ []) when is_list(filters) do
-    with {:ok, runs} <- Storage.list_runs(limit: execution_group_scan_limit(filters)) do
-      runs = include_missing_execution_group_roots(runs)
-      groups = execution_groups(runs)
+    with {:ok, page} <- page_execution_groups(filters) do
+      {:ok, page.items}
+    end
+  end
 
-      {:ok,
-       groups
-       |> Enum.map(&execution_group_summary(&1, :overview))
-       |> filter_execution_group_summaries(filters)
-       |> maybe_limit_execution_groups(filters)}
+  @doc """
+  Returns a bounded page of execution groups for operator list screens.
+  """
+  @spec page_execution_groups(keyword()) ::
+          {:ok, Page.t(execution_group_summary())} | {:error, term()}
+  def page_execution_groups(filters \\ []) when is_list(filters) do
+    case Storage.list_execution_groups(normalize_execution_group_filters(filters)) do
+      {:ok, %Page{} = page} ->
+        hydrate_execution_group_page(page)
+
+      {:error, :execution_group_reads_not_supported} ->
+        page_execution_groups_from_run_scan(filters)
+
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -258,8 +277,7 @@ defmodule FavnOrchestrator.RunReadModel do
           {:ok, execution_group_detail()} | {:error, term()}
   def get_execution_group_detail(group_id, filters \\ [])
       when is_binary(group_id) and is_list(filters) do
-    with {:ok, runs} <- Storage.list_runs(),
-         {:ok, group} <- find_execution_group(runs, group_id) do
+    with {:ok, group} <- load_execution_group(group_id) do
       attempts =
         group |> execution_group_asset_attempts(:detail) |> filter_asset_attempts(filters)
 
@@ -283,14 +301,36 @@ defmodule FavnOrchestrator.RunReadModel do
   end
 
   @doc """
+  Returns execution group detail for any run id in the group.
+  """
+  @spec get_execution_group_detail_for_run(String.t(), keyword()) ::
+          {:ok, execution_group_detail()} | {:error, term()}
+  def get_execution_group_detail_for_run(run_id, filters \\ [])
+      when is_binary(run_id) and is_list(filters) do
+    with {:ok, %RunState{} = run} <- Storage.get_run(run_id) do
+      run
+      |> RunQuery.root_execution_group_id()
+      |> get_execution_group_detail(filters)
+    end
+  end
+
+  @doc """
   Lists persisted events for an execution group, including child/window runs.
   """
   @spec list_execution_group_events(String.t(), keyword()) ::
           {:ok, [RunEvent.t()]} | {:error, term()}
-  def list_execution_group_events(group_id, _filters \\ []) when is_binary(group_id) do
-    with {:ok, runs} <- Storage.list_runs(),
-         {:ok, group} <- find_execution_group(runs, group_id) do
-      {:ok, execution_group_events(group)}
+  def list_execution_group_events(group_id, filters \\ []) when is_binary(group_id) do
+    case Storage.list_execution_group_events(group_id, filters) do
+      {:ok, events} ->
+        {:ok, Enum.map(events, &RunEvent.from_map/1)}
+
+      {:error, :execution_group_reads_not_supported} ->
+        with {:ok, group} <- load_execution_group(group_id) do
+          {:ok, execution_group_events(group)}
+        end
+
+      {:error, _reason} = error ->
+        error
     end
   end
 
@@ -397,6 +437,98 @@ defmodule FavnOrchestrator.RunReadModel do
     |> Enum.sort_by(&group_run_activity_sort_key/1, :desc)
   end
 
+  defp hydrate_execution_group_page(%Page{} = page) do
+    page.items
+    |> Enum.reduce_while({:ok, []}, fn group_id, {:ok, acc} ->
+      case get_execution_group_summary(group_id) do
+        {:ok, summary} -> {:cont, {:ok, [summary | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, summaries} -> {:ok, %{page | items: Enum.reverse(summaries)}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp page_execution_groups_from_run_scan(filters) do
+    with {:ok, runs} <- Storage.list_runs(limit: execution_group_scan_limit(filters)),
+         {:ok, page_opts} <- Page.normalize_opts(filters) do
+      runs = include_missing_execution_group_roots(runs)
+
+      page =
+        runs
+        |> execution_groups()
+        |> Enum.map(&execution_group_summary(&1, :overview))
+        |> filter_execution_group_summaries(filters)
+        |> Enum.drop(Keyword.fetch!(page_opts, :offset))
+        |> Enum.take(Keyword.fetch!(page_opts, :limit) + 1)
+        |> Page.from_fetched(page_opts)
+
+      {:ok, page}
+    end
+  end
+
+  defp get_execution_group_summary(group_id) do
+    with {:ok, group} <- load_execution_group(group_id) do
+      {:ok, execution_group_summary(group, :overview)}
+    end
+  end
+
+  defp load_execution_group(group_id) do
+    case Storage.list_execution_group_runs(group_id) do
+      {:ok, [_ | _] = runs} ->
+        find_execution_group(runs, group_id)
+
+      {:ok, []} ->
+        {:error, :not_found}
+
+      {:error, :execution_group_reads_not_supported} ->
+        with {:ok, runs} <- Storage.list_runs() do
+          find_execution_group(runs, group_id)
+        end
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp normalize_execution_group_filters(filters) do
+    filters
+    |> Keyword.update(:sort, :started_desc, &normalize_execution_group_sort/1)
+    |> normalize_execution_group_filter(:status, &normalize_existing_atom/1)
+    |> normalize_execution_group_filter(:trigger_type, &normalize_existing_atom/1)
+    |> normalize_execution_group_filter(:window, &normalize_existing_atom/1)
+  end
+
+  defp normalize_execution_group_filter(filters, key, fun) do
+    case Keyword.fetch(filters, key) do
+      {:ok, value} -> Keyword.put(filters, key, fun.(value))
+      :error -> filters
+    end
+  end
+
+  defp normalize_execution_group_sort(value)
+       when value in [:started_desc, :failed_first, :running_first, :status_priority], do: value
+
+  defp normalize_execution_group_sort(value)
+       when value in ["started_desc", "failed_first", "running_first", "status_priority"],
+       do: String.to_existing_atom(value)
+
+  defp normalize_execution_group_sort(_value), do: :started_desc
+
+  defp normalize_existing_atom(value) when is_atom(value), do: value
+
+  defp normalize_existing_atom(value) when is_binary(value) do
+    try do
+      String.to_existing_atom(value)
+    rescue
+      ArgumentError -> value
+    end
+  end
+
+  defp normalize_existing_atom(value), do: value
+
   defp include_missing_execution_group_roots(runs) do
     runs_by_id = Map.new(runs, &{&1.id, &1})
 
@@ -444,10 +576,16 @@ defmodule FavnOrchestrator.RunReadModel do
     window_counts = window_counts(windows)
     root = with_public_status(group.root)
     timing = execution_group_timing(group, attempts, windows, attempt_counts)
+    active? = execution_group_active?(group, windows, attempt_counts)
+    status = execution_group_status(root.status, attempt_counts, window_counts, active?)
+    failure_count = attempt_counts.failed + window_counts.failed
 
     %{
       id: root.id,
       root_execution_group_id: root.id,
+      status: status,
+      health: execution_group_health(status, failure_count, active?),
+      active?: active?,
       trigger_type: trigger_type(root),
       target_assets: target_assets(root),
       root_status: root.status,
@@ -462,8 +600,46 @@ defmodule FavnOrchestrator.RunReadModel do
       failed_asset_attempts: attempt_counts.failed,
       running_asset_attempts: attempt_counts.running,
       queued_asset_attempts: attempt_counts.queued,
+      failure_count: failure_count,
+      progress: execution_group_progress(attempt_counts),
+      summary_totals: %{
+        windows: window_counts,
+        asset_attempts: attempt_counts
+      },
+      last_activity_at:
+        latest_datetime(Enum.flat_map(group.runs, &[&1.updated_at, &1.inserted_at])),
       currently_running_asset_attempts: Enum.filter(attempts, &running_status?(&1.status)),
       child_run_ids: Enum.map(group.children, & &1.id)
+    }
+  end
+
+  defp execution_group_active?(group, windows, attempt_counts) do
+    attempt_counts.running > 0 or attempt_counts.queued > 0 or
+      Enum.any?(group.runs, &(with_public_status(&1).status in [:pending, :running])) or
+      Enum.any?(windows, &(Map.get(&1, :status) in [:pending, :queued, :running]))
+  end
+
+  defp execution_group_status(root_status, attempt_counts, window_counts, active?) do
+    cond do
+      active? -> :running
+      attempt_counts.failed > 0 or window_counts.failed > 0 -> :error
+      root_status -> root_status
+      true -> :pending
+    end
+  end
+
+  defp execution_group_health(_status, failure_count, _active?) when failure_count > 0, do: :error
+  defp execution_group_health(_status, _failure_count, true), do: :active
+  defp execution_group_health(:partial, _failure_count, _active?), do: :warning
+  defp execution_group_health(_status, _failure_count, _active?), do: :ok
+
+  defp execution_group_progress(%{total: 0}), do: nil
+
+  defp execution_group_progress(attempt_counts) do
+    %{
+      unit: :assets,
+      label: "#{attempt_counts.completed} / #{attempt_counts.total} asset attempts",
+      counts: attempt_counts
     }
   end
 
@@ -676,13 +852,6 @@ defmodule FavnOrchestrator.RunReadModel do
         matches_target_asset?(group, Keyword.get(filters, :target_asset)) and
         matches_group_only_filters?(group, filters)
     end)
-  end
-
-  defp maybe_limit_execution_groups(groups, filters) do
-    case Keyword.get(filters, :limit) do
-      limit when is_integer(limit) and limit > 0 -> Enum.take(groups, limit)
-      _other -> groups
-    end
   end
 
   defp execution_group_scan_limit(filters) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -115,14 +115,62 @@ defmodule FavnOrchestrator.Storage do
     adapter_call(fn adapter, opts -> adapter.list_runs(run_opts, opts) end)
   end
 
+  @spec list_execution_group_runs(String.t()) :: {:ok, [RunState.t()]} | {:error, term()}
+  def list_execution_group_runs(group_id) when is_binary(group_id) do
+    optional_adapter_call(
+      :list_execution_group_runs,
+      [group_id],
+      :execution_group_reads_not_supported
+    )
+  end
+
+  @spec list_execution_group_run_ids(String.t()) :: {:ok, [String.t()]} | {:error, term()}
+  def list_execution_group_run_ids(group_id) when is_binary(group_id) do
+    optional_adapter_call(
+      :list_execution_group_run_ids,
+      [group_id],
+      :execution_group_reads_not_supported
+    )
+  end
+
+  @spec list_execution_groups(keyword()) :: {:ok, Page.t(String.t())} | {:error, term()}
+  def list_execution_groups(group_opts \\ []) when is_list(group_opts) do
+    paginated_adapter_call(group_opts, fn adapter, filters, opts ->
+      if function_exported?(adapter, :list_execution_groups, 2) do
+        adapter.list_execution_groups(filters, opts)
+      else
+        {:error, :execution_group_reads_not_supported}
+      end
+    end)
+  end
+
   @spec append_run_event(String.t(), map()) :: :ok | {:error, term()}
   def append_run_event(run_id, event) when is_binary(run_id) and is_map(event) do
     adapter_call(fn adapter, opts -> adapter.append_run_event(run_id, event, opts) end)
   end
 
-  @spec list_run_events(String.t()) :: {:ok, [map()]} | {:error, term()}
-  def list_run_events(run_id) when is_binary(run_id) do
-    adapter_call(fn adapter, opts -> adapter.list_run_events(run_id, opts) end)
+  @spec list_run_events(String.t(), keyword()) :: {:ok, [map()]} | {:error, term()}
+  def list_run_events(run_id, run_event_opts \\ [])
+      when is_binary(run_id) and is_list(run_event_opts) do
+    adapter_call(fn adapter, opts ->
+      if function_exported?(adapter, :list_run_events, 3) do
+        adapter.list_run_events(run_id, run_event_opts, opts)
+      else
+        with {:ok, events} <- adapter.list_run_events(run_id, opts) do
+          {:ok, filter_run_events(events, run_event_opts)}
+        end
+      end
+    end)
+  end
+
+  @spec list_execution_group_events(String.t(), keyword()) :: {:ok, [map()]} | {:error, term()}
+  def list_execution_group_events(group_id, run_event_opts \\ [])
+      when is_binary(group_id) and is_list(run_event_opts) do
+    optional_adapter_call(
+      :list_execution_group_events,
+      [group_id, run_event_opts],
+      :execution_group_reads_not_supported
+    )
   end
 
   @spec list_global_run_events(keyword()) :: {:ok, [map()]} | {:error, term()}
@@ -521,6 +569,27 @@ defmodule FavnOrchestrator.Storage do
     error -> {:error, {:invalid_log_entry, error}}
   catch
     kind, reason -> {:error, {:invalid_log_entry, {kind, reason}}}
+  end
+
+  defp filter_run_events(events, opts) do
+    events
+    |> Enum.filter(fn event ->
+      case Keyword.get(opts, :after_sequence) do
+        sequence when is_integer(sequence) and sequence >= 0 ->
+          Map.get(event, :sequence) > sequence
+
+        _other ->
+          true
+      end
+    end)
+    |> maybe_limit_run_events(opts)
+  end
+
+  defp maybe_limit_run_events(events, opts) do
+    case Keyword.get(opts, :limit) do
+      limit when is_integer(limit) and limit > 0 -> Enum.take(events, limit)
+      _other -> events
+    end
   end
 
   @spec validate_adapter(module()) :: :ok | {:error, term()}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -880,7 +880,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       |> List.flatten()
       |> Enum.filter(&(Map.get(&1, :run_id) in run_ids))
       |> Enum.sort_by(&event_sort_key/1)
-      |> filter_run_events(run_event_opts)
+      |> filter_execution_group_events(run_event_opts)
 
     {:reply, {:ok, events}, state}
   end
@@ -1515,7 +1515,9 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   defp matches_execution_group_status?(%{root: root}, status), do: root.status == status
 
   defp matches_execution_group_trigger?(_group, nil), do: true
-  defp matches_execution_group_trigger?(%{root: root}, trigger), do: trigger_type(root) == trigger
+
+  defp matches_execution_group_trigger?(%{root: root}, trigger),
+    do: RunQuery.trigger_type(root) == trigger
 
   defp matches_execution_group_target?(_group, nil), do: true
 
@@ -1534,7 +1536,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
 
     [
       id,
-      metadata.submit_kind,
+      metadata.trigger_type,
       metadata.asset_ref_text,
       metadata.target_refs_text,
       metadata.window_key
@@ -1577,16 +1579,6 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     end
   end
 
-  defp trigger_type(%RunState{submit_kind: :rerun}), do: :retry
-
-  defp trigger_type(%RunState{submit_kind: kind})
-       when kind in [:backfill_asset, :backfill_pipeline], do: :backfill
-
-  defp trigger_type(%RunState{trigger: trigger}) when is_map(trigger),
-    do: Map.get(trigger, :kind) || Map.get(trigger, "kind") || :manual
-
-  defp trigger_type(_run), do: :manual
-
   defp execution_group_has_window?(%{runs: runs}) do
     Enum.any?(runs, fn run -> RunQuery.metadata(run).window_key not in [nil, ""] end)
   end
@@ -1614,6 +1606,20 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       case Keyword.get(opts, :after_sequence) do
         sequence when is_integer(sequence) and sequence >= 0 ->
           Map.get(event, :sequence) > sequence
+
+        _other ->
+          true
+      end
+    end)
+    |> maybe_limit_events(opts)
+  end
+
+  defp filter_execution_group_events(events, opts) do
+    events
+    |> Enum.filter(fn event ->
+      case Keyword.get(opts, :after_global_sequence) do
+        sequence when is_integer(sequence) and sequence >= 0 ->
+          Map.get(event, :global_sequence, 0) > sequence
 
         _other ->
           true

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -17,6 +17,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   alias FavnOrchestrator.Storage.LogEntryCodec
   alias FavnOrchestrator.Storage.MaterializationClaimCodec
   alias FavnOrchestrator.Storage.RunEventCodec
+  alias FavnOrchestrator.Storage.RunQuery
   alias FavnOrchestrator.Storage.RunStateCodec
   alias FavnOrchestrator.Storage.SchedulerStateCodec
   alias FavnOrchestrator.Storage.WriteSemantics
@@ -215,6 +216,26 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   @impl true
+  def list_execution_group_runs(group_id, opts \\ [])
+      when is_binary(group_id) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:list_execution_group_runs, group_id})
+  end
+
+  @impl true
+  def list_execution_group_run_ids(group_id, opts \\ [])
+      when is_binary(group_id) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:list_execution_group_run_ids, group_id})
+  end
+
+  @impl true
+  def list_execution_groups(group_opts, opts) when is_list(group_opts) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:list_execution_groups, group_opts})
+  end
+
+  @impl true
   def append_run_event(run_id, event, opts \\ [])
       when is_binary(run_id) and is_map(event) and is_list(opts) do
     with {:ok, normalized} <- RunEventCodec.normalize(run_id, event) do
@@ -227,6 +248,20 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   def list_run_events(run_id, opts \\ []) when is_binary(run_id) and is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
     GenServer.call(server, {:list_run_events, run_id})
+  end
+
+  @impl true
+  def list_run_events(run_id, run_event_opts, opts)
+      when is_binary(run_id) and is_list(run_event_opts) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:list_run_events, run_id, run_event_opts})
+  end
+
+  @impl true
+  def list_execution_group_events(group_id, run_event_opts, opts)
+      when is_binary(group_id) and is_list(run_event_opts) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:list_execution_group_events, group_id, run_event_opts})
   end
 
   @impl true
@@ -777,6 +812,33 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     {:reply, {:ok, runs}, state}
   end
 
+  def handle_call({:list_execution_group_runs, group_id}, _from, state) do
+    runs = execution_group_runs(state.runs, group_id)
+    {:reply, {:ok, runs}, state}
+  end
+
+  def handle_call({:list_execution_group_run_ids, group_id}, _from, state) do
+    run_ids =
+      state.runs
+      |> execution_group_runs(group_id)
+      |> Enum.map(& &1.id)
+
+    {:reply, {:ok, run_ids}, state}
+  end
+
+  def handle_call({:list_execution_groups, group_opts}, _from, state) do
+    page_opts = page_opts(group_opts)
+
+    page =
+      state.runs
+      |> execution_group_ids(group_opts)
+      |> Enum.drop(Keyword.fetch!(page_opts, :offset))
+      |> Enum.take(Keyword.fetch!(page_opts, :limit) + 1)
+      |> Page.from_fetched(page_opts)
+
+    {:reply, {:ok, page}, state}
+  end
+
   def handle_call({:append_run_event, run_id, event}, _from, state) do
     current = Map.get(state.run_events, run_id, [])
 
@@ -797,6 +859,29 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
 
   def handle_call({:list_run_events, run_id}, _from, state) do
     events = Map.get(state.run_events, run_id, [])
+    {:reply, {:ok, events}, state}
+  end
+
+  def handle_call({:list_run_events, run_id, run_event_opts}, _from, state) do
+    events =
+      state.run_events
+      |> Map.get(run_id, [])
+      |> filter_run_events(run_event_opts)
+
+    {:reply, {:ok, events}, state}
+  end
+
+  def handle_call({:list_execution_group_events, group_id, run_event_opts}, _from, state) do
+    run_ids = MapSet.new(Enum.map(execution_group_runs(state.runs, group_id), & &1.id))
+
+    events =
+      state.run_events
+      |> Map.values()
+      |> List.flatten()
+      |> Enum.filter(&(Map.get(&1, :run_id) in run_ids))
+      |> Enum.sort_by(&event_sort_key/1)
+      |> filter_run_events(run_event_opts)
+
     {:reply, {:ok, events}, state}
   end
 
@@ -1388,6 +1473,165 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
           Keyword.get(run_opts, :manifest_version_id)
         )
     end)
+  end
+
+  defp execution_group_runs(runs, group_id) when is_map(runs) do
+    runs
+    |> Map.values()
+    |> Enum.filter(&(RunQuery.root_execution_group_id(&1) == group_id))
+    |> Enum.sort_by(&execution_group_run_sort_key/1)
+  end
+
+  defp execution_group_ids(runs, group_opts) when is_map(runs) do
+    runs
+    |> Map.values()
+    |> Enum.group_by(&RunQuery.root_execution_group_id/1)
+    |> Enum.map(fn {group_id, group_runs} ->
+      root =
+        Enum.find(group_runs, &(&1.id == group_id)) || Enum.min_by(group_runs, &run_sort_key/1)
+
+      %{
+        id: group_id,
+        root: root,
+        runs: group_runs,
+        activity: Enum.map(group_runs, &run_sort_key/1) |> Enum.max(fn -> 0 end)
+      }
+    end)
+    |> Enum.filter(&matches_execution_group_filters?(&1, group_opts))
+    |> sort_execution_groups(Keyword.get(group_opts, :sort, :started_desc))
+    |> Enum.map(& &1.id)
+  end
+
+  defp matches_execution_group_filters?(group, opts) do
+    matches_execution_group_status?(group, Keyword.get(opts, :status)) and
+      matches_execution_group_trigger?(group, Keyword.get(opts, :trigger_type)) and
+      matches_execution_group_target?(group, Keyword.get(opts, :target_asset)) and
+      matches_execution_group_search?(group, Keyword.get(opts, :search)) and
+      matches_execution_group_window?(group, Keyword.get(opts, :window)) and
+      matches_execution_group_only_filters?(group, opts)
+  end
+
+  defp matches_execution_group_status?(_group, nil), do: true
+  defp matches_execution_group_status?(%{root: root}, status), do: root.status == status
+
+  defp matches_execution_group_trigger?(_group, nil), do: true
+  defp matches_execution_group_trigger?(%{root: root}, trigger), do: trigger_type(root) == trigger
+
+  defp matches_execution_group_target?(_group, nil), do: true
+
+  defp matches_execution_group_target?(%{root: root}, target) do
+    root
+    |> RunQuery.target_refs()
+    |> Enum.map(&RunQuery.public_ref/1)
+    |> Enum.member?(target)
+  end
+
+  defp matches_execution_group_search?(_group, value) when value in [nil, ""], do: true
+
+  defp matches_execution_group_search?(%{id: id, root: root}, search) do
+    search = String.downcase(to_string(search))
+    metadata = RunQuery.metadata(root)
+
+    [
+      id,
+      metadata.submit_kind,
+      metadata.asset_ref_text,
+      metadata.target_refs_text,
+      metadata.window_key
+    ]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
+    |> String.downcase()
+    |> String.contains?(search)
+  end
+
+  defp matches_execution_group_window?(_group, nil), do: true
+  defp matches_execution_group_window?(group, :has_window), do: execution_group_has_window?(group)
+
+  defp matches_execution_group_window?(group, :no_window),
+    do: not execution_group_has_window?(group)
+
+  defp matches_execution_group_window?(_group, _window), do: true
+
+  defp matches_execution_group_only_filters?(group, opts) do
+    (not Keyword.get(opts, :only_failed, false) or failed_execution_group?(group)) and
+      (not Keyword.get(opts, :only_running, false) or running_execution_group?(group)) and
+      (not Keyword.get(opts, :only_incomplete, false) or running_execution_group?(group))
+  end
+
+  defp sort_execution_groups(groups, :failed_first),
+    do: Enum.sort_by(groups, &{if(failed_execution_group?(&1), do: 0, else: 1), -&1.activity})
+
+  defp sort_execution_groups(groups, :running_first),
+    do: Enum.sort_by(groups, &{if(running_execution_group?(&1), do: 0, else: 1), -&1.activity})
+
+  defp sort_execution_groups(groups, :status_priority),
+    do: Enum.sort_by(groups, &{execution_group_status_priority(&1), -&1.activity})
+
+  defp sort_execution_groups(groups, _sort), do: Enum.sort_by(groups, & &1.activity, :desc)
+
+  defp execution_group_run_sort_key(%RunState{id: id} = run) do
+    case RunQuery.root_execution_group_id(run) do
+      ^id -> {0, id}
+      _other -> {1, id}
+    end
+  end
+
+  defp trigger_type(%RunState{submit_kind: :rerun}), do: :retry
+
+  defp trigger_type(%RunState{submit_kind: kind})
+       when kind in [:backfill_asset, :backfill_pipeline], do: :backfill
+
+  defp trigger_type(%RunState{trigger: trigger}) when is_map(trigger),
+    do: Map.get(trigger, :kind) || Map.get(trigger, "kind") || :manual
+
+  defp trigger_type(_run), do: :manual
+
+  defp execution_group_has_window?(%{runs: runs}) do
+    Enum.any?(runs, fn run -> RunQuery.metadata(run).window_key not in [nil, ""] end)
+  end
+
+  defp failed_execution_group?(%{root: root, runs: runs}) do
+    root.status in [:error, :partial, :cancelled, :timed_out] or
+      Enum.any?(runs, &(&1.status in [:error, :partial, :cancelled, :timed_out]))
+  end
+
+  defp running_execution_group?(%{root: root, runs: runs}) do
+    root.status in [:pending, :running] or Enum.any?(runs, &(&1.status in [:pending, :running]))
+  end
+
+  defp execution_group_status_priority(group) do
+    cond do
+      failed_execution_group?(group) -> 0
+      running_execution_group?(group) -> 1
+      true -> 2
+    end
+  end
+
+  defp filter_run_events(events, opts) do
+    events
+    |> Enum.filter(fn event ->
+      case Keyword.get(opts, :after_sequence) do
+        sequence when is_integer(sequence) and sequence >= 0 ->
+          Map.get(event, :sequence) > sequence
+
+        _other ->
+          true
+      end
+    end)
+    |> maybe_limit_events(opts)
+  end
+
+  defp maybe_limit_events(events, opts) do
+    case Keyword.get(opts, :limit) do
+      limit when is_integer(limit) and limit > 0 -> Enum.take(events, limit)
+      _other -> events
+    end
+  end
+
+  defp event_sort_key(event) do
+    {Map.get(event, :global_sequence) || 0, Map.get(event, :run_id) || "",
+     Map.get(event, :sequence) || 0}
   end
 
   defp matches_run_filter?(_run, _field, nil), do: true

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_query.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_query.ex
@@ -1,0 +1,89 @@
+defmodule FavnOrchestrator.Storage.RunQuery do
+  @moduledoc false
+
+  alias FavnOrchestrator.RunState
+
+  @type metadata :: %{
+          required(:root_execution_group_id) => String.t(),
+          required(:parent_run_id) => String.t() | nil,
+          required(:root_run_id) => String.t() | nil,
+          required(:submit_kind) => String.t(),
+          required(:asset_ref_text) => String.t(),
+          required(:target_refs_text) => String.t(),
+          required(:window_key) => String.t() | nil
+        }
+
+  @spec metadata(RunState.t()) :: metadata()
+  def metadata(%RunState{} = run) do
+    targets = target_refs(run)
+
+    %{
+      root_execution_group_id: root_execution_group_id(run),
+      parent_run_id: run.parent_run_id,
+      root_run_id: run.root_run_id,
+      submit_kind: Atom.to_string(run.submit_kind),
+      asset_ref_text: public_ref(run.asset_ref),
+      target_refs_text: Enum.join(Enum.map(targets, &public_ref/1), "\n"),
+      window_key: window_key(run)
+    }
+  end
+
+  @spec root_execution_group_id(RunState.t()) :: String.t()
+  def root_execution_group_id(%RunState{root_run_id: root_run_id}) when is_binary(root_run_id),
+    do: root_run_id
+
+  def root_execution_group_id(%RunState{parent_run_id: parent_run_id})
+      when is_binary(parent_run_id),
+      do: parent_run_id
+
+  def root_execution_group_id(%RunState{id: id}), do: id
+
+  @spec public_ref(term()) :: String.t()
+  def public_ref({module, name}), do: "#{module_label(module)}.#{name}"
+  def public_ref(%{module: module, name: name}), do: "#{module_label(module)}.#{name}"
+  def public_ref(%{"module" => module, "name" => name}), do: "#{module_label(module)}.#{name}"
+  def public_ref(ref) when is_atom(ref), do: ref |> Atom.to_string() |> strip_elixir_prefix()
+  def public_ref(ref) when is_binary(ref), do: strip_elixir_prefix(ref)
+  def public_ref(nil), do: "Unknown asset"
+  def public_ref(ref), do: inspect(ref)
+
+  @spec target_refs(RunState.t()) :: [term()]
+  def target_refs(%RunState{target_refs: [_ | _] = refs}), do: refs
+  def target_refs(%RunState{asset_ref: ref}), do: [ref]
+
+  defp module_label(module) when is_atom(module),
+    do: module |> Atom.to_string() |> strip_elixir_prefix()
+
+  defp module_label(module), do: module |> to_string() |> strip_elixir_prefix()
+
+  defp strip_elixir_prefix("Elixir." <> module), do: module
+  defp strip_elixir_prefix(module), do: module
+
+  defp window_key(%RunState{} = run) do
+    run.trigger
+    |> map_get(:window_key)
+    |> case do
+      value when is_binary(value) -> value
+      value when not is_nil(value) -> to_string(value)
+      nil -> window_key_from_metadata(run.metadata)
+    end
+  end
+
+  defp window_key_from_metadata(metadata) do
+    metadata
+    |> map_get(:pipeline_context)
+    |> case do
+      context when is_map(context) -> context |> map_get(:anchor_window) |> anchor_key()
+      _other -> nil
+    end
+  end
+
+  defp anchor_key(%{key: key}), do: inspect(key)
+  defp anchor_key(%{"key" => key}), do: inspect(key)
+  defp anchor_key(_value), do: nil
+
+  defp map_get(map, key) when is_map(map),
+    do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+
+  defp map_get(_value, _key), do: nil
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_query.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_query.ex
@@ -8,6 +8,7 @@ defmodule FavnOrchestrator.Storage.RunQuery do
           required(:parent_run_id) => String.t() | nil,
           required(:root_run_id) => String.t() | nil,
           required(:submit_kind) => String.t(),
+          required(:trigger_type) => String.t(),
           required(:asset_ref_text) => String.t(),
           required(:target_refs_text) => String.t(),
           required(:window_key) => String.t() | nil
@@ -22,6 +23,7 @@ defmodule FavnOrchestrator.Storage.RunQuery do
       parent_run_id: run.parent_run_id,
       root_run_id: run.root_run_id,
       submit_kind: Atom.to_string(run.submit_kind),
+      trigger_type: Atom.to_string(trigger_type(run)),
       asset_ref_text: public_ref(run.asset_ref),
       target_refs_text: Enum.join(Enum.map(targets, &public_ref/1), "\n"),
       window_key: window_key(run)
@@ -50,6 +52,26 @@ defmodule FavnOrchestrator.Storage.RunQuery do
   @spec target_refs(RunState.t()) :: [term()]
   def target_refs(%RunState{target_refs: [_ | _] = refs}), do: refs
   def target_refs(%RunState{asset_ref: ref}), do: [ref]
+
+  @spec trigger_type(RunState.t()) :: atom()
+  def trigger_type(%RunState{submit_kind: :rerun}), do: :retry
+
+  def trigger_type(%RunState{submit_kind: submit_kind})
+      when submit_kind in [:backfill_asset, :backfill_pipeline],
+      do: :backfill
+
+  def trigger_type(%RunState{trigger: trigger}) when is_map(trigger) do
+    case map_get(trigger, :kind) do
+      kind when is_atom(kind) and not is_nil(kind) -> kind
+      "schedule" -> :schedule
+      "manual" -> :manual
+      "backfill" -> :backfill
+      "retry" -> :retry
+      _other -> :manual
+    end
+  end
+
+  def trigger_type(_run), do: :manual
 
   defp module_label(module) when is_atom(module),
     do: module |> Atom.to_string() |> strip_elixir_prefix()

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -139,6 +139,67 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert {:ok, group_page} = Storage.list_execution_groups(search: run.id, limit: 10, offset: 0)
     assert run.id in group_page.items
 
+    schedule =
+      RunState.new(
+        id: "run_contract_#{label}_schedule_#{System.unique_integer([:positive])}",
+        manifest_version_id: version.manifest_version_id,
+        manifest_content_hash: version.content_hash,
+        asset_ref: {MyApp.Asset, :asset},
+        trigger: %{kind: :schedule}
+      )
+
+    backfill =
+      RunState.new(
+        id: "run_contract_#{label}_backfill_#{System.unique_integer([:positive])}",
+        manifest_version_id: version.manifest_version_id,
+        manifest_content_hash: version.content_hash,
+        asset_ref: {MyApp.Asset, :asset},
+        submit_kind: :backfill_asset
+      )
+
+    retry =
+      RunState.new(
+        id: "run_contract_#{label}_retry_#{System.unique_integer([:positive])}",
+        manifest_version_id: version.manifest_version_id,
+        manifest_content_hash: version.content_hash,
+        asset_ref: {MyApp.Asset, :asset},
+        submit_kind: :rerun
+      )
+
+    target_prefix =
+      RunState.new(
+        id: "run_contract_#{label}_target_prefix_#{System.unique_integer([:positive])}",
+        manifest_version_id: version.manifest_version_id,
+        manifest_content_hash: version.content_hash,
+        asset_ref: {MyApp.Asset, :asset_extra}
+      )
+
+    Enum.each([schedule, backfill, retry, target_prefix], &assert(:ok = Storage.put_run(&1)))
+
+    assert {:ok, manual_page} = Storage.list_execution_groups(trigger_type: :manual, limit: 20)
+    assert run.id in manual_page.items
+    refute schedule.id in manual_page.items
+
+    assert {:ok, schedule_page} =
+             Storage.list_execution_groups(trigger_type: :schedule, limit: 20)
+
+    assert schedule.id in schedule_page.items
+    refute run.id in schedule_page.items
+
+    assert {:ok, backfill_page} =
+             Storage.list_execution_groups(trigger_type: :backfill, limit: 20)
+
+    assert backfill.id in backfill_page.items
+
+    assert {:ok, retry_page} = Storage.list_execution_groups(trigger_type: :retry, limit: 20)
+    assert retry.id in retry_page.items
+
+    assert {:ok, target_page} =
+             Storage.list_execution_groups(target_asset: "MyApp.Asset.asset", limit: 20)
+
+    assert run.id in target_page.items
+    refute target_prefix.id in target_page.items
+
     event = %{
       sequence: 1,
       event_type: :run_started,
@@ -173,6 +234,18 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert :ok = Storage.append_run_event(child.id, next_event)
     assert {:ok, [cursor_event]} = Storage.list_run_events(child.id, after_sequence: 1, limit: 1)
     assert cursor_event.sequence == 2
+
+    assert {:ok, group_events} = Storage.list_execution_group_events(run.id)
+    assert Enum.map(group_events, & &1.run_id) == [run.id, child.id, child.id]
+    [first_group_event | _] = group_events
+
+    assert {:ok, [group_cursor_event]} =
+             Storage.list_execution_group_events(run.id,
+               after_global_sequence: first_group_event.global_sequence,
+               limit: 1
+             )
+
+    assert group_cursor_event.run_id == child.id
 
     now = DateTime.utc_now()
     lease = execution_lease(run.id, "step-1", now, [%{kind: :run, key: run.id, limit: 1}])

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -121,6 +121,24 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert {:ok, listed} = Storage.list_runs(status: :pending, limit: 10)
     assert Enum.any?(listed, &(&1.id == run.id))
 
+    child =
+      RunState.new(
+        id: "run_contract_#{label}_child_#{System.unique_integer([:positive])}",
+        manifest_version_id: version.manifest_version_id,
+        manifest_content_hash: version.content_hash,
+        asset_ref: {MyApp.Asset, :asset},
+        parent_run_id: run.id,
+        root_run_id: run.id,
+        lineage_depth: 1
+      )
+
+    assert :ok = Storage.put_run(child)
+    assert {:ok, group_runs} = Storage.list_execution_group_runs(run.id)
+    assert Enum.map(group_runs, & &1.id) == [run.id, child.id]
+    assert {:ok, [run.id, child.id]} == Storage.list_execution_group_run_ids(run.id)
+    assert {:ok, group_page} = Storage.list_execution_groups(search: run.id, limit: 10, offset: 0)
+    assert run.id in group_page.items
+
     event = %{
       sequence: 1,
       event_type: :run_started,
@@ -136,6 +154,25 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
 
     assert {:ok, [stored_event]} = Storage.list_run_events(run.id)
     assert stored_event.sequence == 1
+
+    assert :ok =
+             Storage.append_run_event(child.id, %{
+               sequence: 1,
+               event_type: :run_started,
+               occurred_at: DateTime.utc_now(),
+               data: %{kind: label}
+             })
+
+    next_event = %{
+      sequence: 2,
+      event_type: :run_updated,
+      occurred_at: DateTime.utc_now(),
+      data: %{kind: label}
+    }
+
+    assert :ok = Storage.append_run_event(child.id, next_event)
+    assert {:ok, [cursor_event]} = Storage.list_run_events(child.id, after_sequence: 1, limit: 1)
+    assert cursor_event.sequence == 2
 
     now = DateTime.utc_now()
     lease = execution_lease(run.id, "step-1", now, [%{kind: :run, key: run.id, limit: 1}])

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -24,6 +24,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   alias FavnOrchestrator.Storage.ManifestCodec
   alias FavnOrchestrator.Storage.MaterializationClaimCodec
   alias FavnOrchestrator.Storage.RunEventCodec
+  alias FavnOrchestrator.Storage.RunQuery
   alias FavnOrchestrator.Storage.RunSnapshotCodec
   alias FavnOrchestrator.Storage.RunStateCodec
   alias FavnOrchestrator.Storage.SchedulerStateCodec
@@ -258,6 +259,53 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   @impl true
+  def list_execution_group_runs(group_id, opts) when is_binary(group_id) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         :ok <- repair_missing_run_query_metadata(repo) do
+      sql =
+        run_snapshot_select() <>
+          " WHERE r.root_execution_group_id = $1 ORDER BY CASE WHEN r.run_id = r.root_execution_group_id THEN 0 ELSE 1 END, r.inserted_at ASC, r.run_id ASC"
+
+      case SQL.query(repo, sql, [group_id]) do
+        {:ok, %{rows: rows}} -> decode_run_rows(rows)
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_execution_group_run_ids(group_id, opts) when is_binary(group_id) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         :ok <- repair_missing_run_query_metadata(repo) do
+      sql =
+        "SELECT run_id FROM favn_runs WHERE root_execution_group_id = $1 ORDER BY CASE WHEN run_id = root_execution_group_id THEN 0 ELSE 1 END, inserted_at ASC, run_id ASC"
+
+      case SQL.query(repo, sql, [group_id]) do
+        {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [run_id] -> run_id end)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_execution_groups(group_opts, opts) when is_list(group_opts) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         :ok <- repair_missing_run_query_metadata(repo),
+         {:ok, query, params, page_opts} <- execution_groups_query(group_opts) do
+      case SQL.query(repo, query, params) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> Enum.map(fn [group_id] -> group_id end)
+          |> Page.from_fetched(page_opts)
+          |> then(&{:ok, &1})
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
   def append_run_event(run_id, event, opts)
       when is_binary(run_id) and is_map(event) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts),
@@ -277,6 +325,46 @@ defmodule Favn.Storage.Adapter.Postgres do
         "SELECT global_sequence, event_blob FROM favn_run_events WHERE run_id = $1 ORDER BY sequence ASC"
 
       case SQL.query(repo, sql, [run_id]) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> decode_event_rows()
+          |> case do
+            {:ok, events} -> {:ok, Enum.reverse(events)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_run_events(run_id, run_event_opts, opts)
+      when is_binary(run_id) and is_list(run_event_opts) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, query, params} <- run_events_query(run_id, run_event_opts) do
+      case SQL.query(repo, query, params) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> decode_event_rows()
+          |> case do
+            {:ok, events} -> {:ok, Enum.reverse(events)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_execution_group_events(group_id, run_event_opts, opts)
+      when is_binary(group_id) and is_list(run_event_opts) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, query, params} <- execution_group_events_query(group_id, run_event_opts) do
+      case SQL.query(repo, query, params) do
         {:ok, %{rows: rows}} ->
           rows
           |> decode_event_rows()
@@ -1225,6 +1313,8 @@ defmodule Favn.Storage.Adapter.Postgres do
 
   defp guarded_put_run(repo, run) do
     with {:ok, updated_seq} <- next_updated_seq(repo) do
+      query_metadata = RunQuery.metadata(run)
+
       sql =
         """
         INSERT INTO favn_runs (
@@ -1237,8 +1327,15 @@ defmodule Favn.Storage.Adapter.Postgres do
           updated_seq,
           inserted_at,
           updated_at,
-          run_blob
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+          run_blob,
+          root_execution_group_id,
+          parent_run_id,
+          root_run_id,
+          submit_kind,
+          asset_ref_text,
+          target_refs_text,
+          window_key
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
         ON CONFLICT(run_id) DO UPDATE SET
           manifest_version_id = EXCLUDED.manifest_version_id,
           manifest_content_hash = EXCLUDED.manifest_content_hash,
@@ -1248,7 +1345,14 @@ defmodule Favn.Storage.Adapter.Postgres do
           updated_seq = EXCLUDED.updated_seq,
           inserted_at = EXCLUDED.inserted_at,
           updated_at = EXCLUDED.updated_at,
-          run_blob = EXCLUDED.run_blob
+          run_blob = EXCLUDED.run_blob,
+          root_execution_group_id = EXCLUDED.root_execution_group_id,
+          parent_run_id = EXCLUDED.parent_run_id,
+          root_run_id = EXCLUDED.root_run_id,
+          submit_kind = EXCLUDED.submit_kind,
+          asset_ref_text = EXCLUDED.asset_ref_text,
+          target_refs_text = EXCLUDED.target_refs_text,
+          window_key = EXCLUDED.window_key
         WHERE EXCLUDED.event_seq > favn_runs.event_seq
         """
 
@@ -1262,7 +1366,14 @@ defmodule Favn.Storage.Adapter.Postgres do
         updated_seq,
         run.inserted_at,
         run.updated_at,
-        encode_run_snapshot(run)
+        encode_run_snapshot(run),
+        query_metadata.root_execution_group_id,
+        query_metadata.parent_run_id,
+        query_metadata.root_run_id,
+        query_metadata.submit_kind,
+        query_metadata.asset_ref_text,
+        query_metadata.target_refs_text,
+        query_metadata.window_key
       ]
 
       case SQL.query(repo, sql, params) do
@@ -1847,6 +1958,224 @@ defmodule Favn.Storage.Adapter.Postgres do
        where_sql <> " ORDER BY r.updated_seq DESC, r.run_id DESC" <> limit_sql, params}
   end
 
+  defp execution_groups_query(group_opts) do
+    with {:ok, page_opts} <- Page.normalize_opts(group_opts) do
+      filters = Keyword.drop(group_opts, [:limit, :offset, :sort])
+      {where_sql, params} = execution_group_filter_sql(filters)
+      sort_sql = execution_group_sort_sql(Keyword.get(group_opts, :sort, :started_desc))
+      limit_placeholder = "$#{length(params) + 1}"
+      offset_placeholder = "$#{length(params) + 2}"
+
+      {:ok,
+       """
+       SELECT group_id
+       FROM (
+         SELECT
+           r.root_execution_group_id AS group_id,
+           MAX(r.updated_seq) AS activity_seq,
+           MAX(CASE WHEN r.status IN ('error', 'partial', 'cancelled', 'timed_out') THEN 1 ELSE 0 END) AS failed,
+           MAX(CASE WHEN r.status IN ('pending', 'running') THEN 1 ELSE 0 END) AS running,
+           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.status ELSE NULL END) AS root_status,
+           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.submit_kind ELSE NULL END) AS root_submit_kind,
+           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.target_refs_text ELSE NULL END) AS root_targets,
+           MAX(CASE WHEN r.window_key IS NOT NULL AND r.window_key != '' THEN 1 ELSE 0 END) AS has_window
+         FROM favn_runs AS r
+         GROUP BY r.root_execution_group_id
+       ) AS groups
+       #{where_sql}
+       ORDER BY #{sort_sql}, group_id DESC
+       LIMIT #{limit_placeholder} OFFSET #{offset_placeholder}
+       """, params ++ [Keyword.fetch!(page_opts, :limit) + 1, Keyword.fetch!(page_opts, :offset)],
+       page_opts}
+    end
+  end
+
+  defp execution_group_filter_sql(filters) do
+    filters
+    |> Enum.reduce({[], []}, fn
+      {:status, status}, {clauses, params} when not is_nil(status) ->
+        {clauses ++ ["root_status = $#{length(params) + 1}"], params ++ [Atom.to_string(status)]}
+
+      {:trigger_type, :backfill}, {clauses, params} ->
+        {clauses ++ ["root_submit_kind IN ('backfill_asset', 'backfill_pipeline')"], params}
+
+      {:trigger_type, :retry}, {clauses, params} ->
+        {clauses ++ ["root_submit_kind = 'rerun'"], params}
+
+      {:trigger_type, trigger}, {clauses, params} when not is_nil(trigger) ->
+        {clauses ++ ["root_submit_kind = $#{length(params) + 1}"],
+         params ++ [Atom.to_string(trigger)]}
+
+      {:target_asset, target}, {clauses, params} when is_binary(target) and target != "" ->
+        {clauses ++ ["root_targets LIKE $#{length(params) + 1}"], params ++ ["%#{target}%"]}
+
+      {:search, search}, {clauses, params} when is_binary(search) and search != "" ->
+        placeholder = "$#{length(params) + 1}"
+
+        {clauses ++
+           [
+             "(group_id LIKE #{placeholder} OR root_targets LIKE #{placeholder} OR root_submit_kind LIKE #{placeholder})"
+           ], params ++ ["%#{search}%"]}
+
+      {:window, :has_window}, {clauses, params} ->
+        {clauses ++ ["has_window = 1"], params}
+
+      {:window, :no_window}, {clauses, params} ->
+        {clauses ++ ["has_window = 0"], params}
+
+      {:only_failed, true}, {clauses, params} ->
+        {clauses ++ ["failed = 1"], params}
+
+      {:only_running, true}, {clauses, params} ->
+        {clauses ++ ["running = 1"], params}
+
+      {:only_incomplete, true}, {clauses, params} ->
+        {clauses ++ ["running = 1"], params}
+
+      _other, acc ->
+        acc
+    end)
+    |> case do
+      {[], params} -> {"", params}
+      {clauses, params} -> {"WHERE " <> Enum.join(clauses, " AND "), params}
+    end
+  end
+
+  defp execution_group_sort_sql(:failed_first), do: "failed DESC, activity_seq DESC"
+  defp execution_group_sort_sql(:running_first), do: "running DESC, activity_seq DESC"
+
+  defp execution_group_sort_sql(:status_priority),
+    do: "failed DESC, running DESC, activity_seq DESC"
+
+  defp execution_group_sort_sql(_sort), do: "activity_seq DESC"
+
+  defp run_events_query(run_id, opts) do
+    after_sequence = Keyword.get(opts, :after_sequence)
+    limit = Keyword.get(opts, :limit)
+
+    cond do
+      not is_nil(after_sequence) and (not is_integer(after_sequence) or after_sequence < 0) ->
+        {:error, :invalid_opts}
+
+      not is_nil(limit) and (not is_integer(limit) or limit <= 0) ->
+        {:error, :invalid_opts}
+
+      true ->
+        clauses = ["run_id = $1"]
+        params = [run_id]
+        {clauses, params} = maybe_after_sequence_clause(clauses, params, after_sequence)
+        {limit_sql, params} = maybe_limit_clause(params, limit)
+
+        {:ok,
+         "SELECT global_sequence, event_blob FROM favn_run_events WHERE #{Enum.join(clauses, " AND ")} ORDER BY sequence ASC#{limit_sql}",
+         params}
+    end
+  end
+
+  defp execution_group_events_query(group_id, opts) do
+    after_global_sequence = Keyword.get(opts, :after_global_sequence)
+    limit = Keyword.get(opts, :limit)
+
+    cond do
+      not is_nil(after_global_sequence) and
+          (not is_integer(after_global_sequence) or after_global_sequence < 0) ->
+        {:error, :invalid_opts}
+
+      not is_nil(limit) and (not is_integer(limit) or limit <= 0) ->
+        {:error, :invalid_opts}
+
+      true ->
+        clauses = ["r.root_execution_group_id = $1"]
+        params = [group_id]
+
+        {clauses, params} =
+          case after_global_sequence do
+            sequence when is_integer(sequence) and sequence >= 0 ->
+              {clauses ++ ["e.global_sequence > $#{length(params) + 1}"], params ++ [sequence]}
+
+            _other ->
+              {clauses, params}
+          end
+
+        {limit_sql, params} = maybe_limit_clause(params, limit)
+
+        {:ok,
+         """
+         SELECT e.global_sequence, e.event_blob
+         FROM favn_run_events AS e
+         INNER JOIN favn_runs AS r ON r.run_id = e.run_id
+         WHERE #{Enum.join(clauses, " AND ")}
+         ORDER BY e.global_sequence ASC, e.run_id ASC, e.sequence ASC#{limit_sql}
+         """, params}
+    end
+  end
+
+  defp maybe_after_sequence_clause(clauses, params, sequence)
+       when is_integer(sequence) and sequence >= 0,
+       do: {clauses ++ ["sequence > $#{length(params) + 1}"], params ++ [sequence]}
+
+  defp maybe_after_sequence_clause(clauses, params, _sequence), do: {clauses, params}
+
+  defp maybe_limit_clause(params, limit) when is_integer(limit) and limit > 0,
+    do: {" LIMIT $#{length(params) + 1}", params ++ [limit]}
+
+  defp maybe_limit_clause(params, _limit), do: {"", params}
+
+  defp repair_missing_run_query_metadata(repo) do
+    sql = run_snapshot_select() <> " WHERE r.root_execution_group_id IS NULL"
+
+    case SQL.query(repo, sql, []) do
+      {:ok, %{rows: []}} ->
+        :ok
+
+      {:ok, %{rows: rows}} ->
+        with {:ok, runs} <- decode_run_rows(rows) do
+          Enum.reduce_while(runs, :ok, fn run, :ok ->
+            case update_run_query_metadata(repo, run) do
+              :ok -> {:cont, :ok}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp update_run_query_metadata(repo, run) do
+    metadata = RunQuery.metadata(run)
+
+    sql =
+      """
+      UPDATE favn_runs
+      SET root_execution_group_id = $1,
+          parent_run_id = $2,
+          root_run_id = $3,
+          submit_kind = $4,
+          asset_ref_text = $5,
+          target_refs_text = $6,
+          window_key = $7
+      WHERE run_id = $8
+      """
+
+    params = [
+      metadata.root_execution_group_id,
+      metadata.parent_run_id,
+      metadata.root_run_id,
+      metadata.submit_kind,
+      metadata.asset_ref_text,
+      metadata.target_refs_text,
+      metadata.window_key,
+      run.id
+    ]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, _result} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp run_filter_sql(filters) do
     filters
     |> Enum.reduce({[], []}, fn
@@ -2038,6 +2367,20 @@ defmodule Favn.Storage.Adapter.Postgres do
     FROM favn_runs AS r
     LEFT JOIN favn_manifest_versions AS m ON m.manifest_version_id = r.manifest_version_id
     """
+  end
+
+  defp decode_run_rows(rows) do
+    rows
+    |> Enum.reduce_while({:ok, []}, fn row, {:ok, acc} ->
+      case decode_run_row(row) do
+        {:ok, run} -> {:cont, {:ok, [run | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, runs} -> {:ok, Enum.reverse(runs)}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   defp decode_run_row([

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -1332,10 +1332,11 @@ defmodule Favn.Storage.Adapter.Postgres do
           parent_run_id,
           root_run_id,
           submit_kind,
+          trigger_type,
           asset_ref_text,
           target_refs_text,
           window_key
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17)
+        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)
         ON CONFLICT(run_id) DO UPDATE SET
           manifest_version_id = EXCLUDED.manifest_version_id,
           manifest_content_hash = EXCLUDED.manifest_content_hash,
@@ -1350,6 +1351,7 @@ defmodule Favn.Storage.Adapter.Postgres do
           parent_run_id = EXCLUDED.parent_run_id,
           root_run_id = EXCLUDED.root_run_id,
           submit_kind = EXCLUDED.submit_kind,
+          trigger_type = EXCLUDED.trigger_type,
           asset_ref_text = EXCLUDED.asset_ref_text,
           target_refs_text = EXCLUDED.target_refs_text,
           window_key = EXCLUDED.window_key
@@ -1371,6 +1373,7 @@ defmodule Favn.Storage.Adapter.Postgres do
         query_metadata.parent_run_id,
         query_metadata.root_run_id,
         query_metadata.submit_kind,
+        query_metadata.trigger_type,
         query_metadata.asset_ref_text,
         query_metadata.target_refs_text,
         query_metadata.window_key
@@ -1976,7 +1979,7 @@ defmodule Favn.Storage.Adapter.Postgres do
            MAX(CASE WHEN r.status IN ('error', 'partial', 'cancelled', 'timed_out') THEN 1 ELSE 0 END) AS failed,
            MAX(CASE WHEN r.status IN ('pending', 'running') THEN 1 ELSE 0 END) AS running,
            MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.status ELSE NULL END) AS root_status,
-           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.submit_kind ELSE NULL END) AS root_submit_kind,
+           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.trigger_type ELSE NULL END) AS root_trigger_type,
            MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.target_refs_text ELSE NULL END) AS root_targets,
            MAX(CASE WHEN r.window_key IS NOT NULL AND r.window_key != '' THEN 1 ELSE 0 END) AS has_window
          FROM favn_runs AS r
@@ -1996,25 +1999,22 @@ defmodule Favn.Storage.Adapter.Postgres do
       {:status, status}, {clauses, params} when not is_nil(status) ->
         {clauses ++ ["root_status = $#{length(params) + 1}"], params ++ [Atom.to_string(status)]}
 
-      {:trigger_type, :backfill}, {clauses, params} ->
-        {clauses ++ ["root_submit_kind IN ('backfill_asset', 'backfill_pipeline')"], params}
-
-      {:trigger_type, :retry}, {clauses, params} ->
-        {clauses ++ ["root_submit_kind = 'rerun'"], params}
-
       {:trigger_type, trigger}, {clauses, params} when not is_nil(trigger) ->
-        {clauses ++ ["root_submit_kind = $#{length(params) + 1}"],
+        {clauses ++ ["root_trigger_type = $#{length(params) + 1}"],
          params ++ [Atom.to_string(trigger)]}
 
       {:target_asset, target}, {clauses, params} when is_binary(target) and target != "" ->
-        {clauses ++ ["root_targets LIKE $#{length(params) + 1}"], params ++ ["%#{target}%"]}
+        {clauses ++
+           [
+             "POSITION(E'\\n' || $#{length(params) + 1} || E'\\n' IN E'\\n' || root_targets || E'\\n') > 0"
+           ], params ++ [target]}
 
       {:search, search}, {clauses, params} when is_binary(search) and search != "" ->
         placeholder = "$#{length(params) + 1}"
 
         {clauses ++
            [
-             "(group_id LIKE #{placeholder} OR root_targets LIKE #{placeholder} OR root_submit_kind LIKE #{placeholder})"
+             "(group_id LIKE #{placeholder} OR root_targets LIKE #{placeholder} OR root_trigger_type LIKE #{placeholder})"
            ], params ++ ["%#{search}%"]}
 
       {:window, :has_window}, {clauses, params} ->
@@ -2153,10 +2153,11 @@ defmodule Favn.Storage.Adapter.Postgres do
           parent_run_id = $2,
           root_run_id = $3,
           submit_kind = $4,
-          asset_ref_text = $5,
-          target_refs_text = $6,
-          window_key = $7
-      WHERE run_id = $8
+          trigger_type = $5,
+          asset_ref_text = $6,
+          target_refs_text = $7,
+          window_key = $8
+      WHERE run_id = $9
       """
 
     params = [
@@ -2164,6 +2165,7 @@ defmodule Favn.Storage.Adapter.Postgres do
       metadata.parent_run_id,
       metadata.root_run_id,
       metadata.submit_kind,
+      metadata.trigger_type,
       metadata.asset_ref_text,
       metadata.target_refs_text,
       metadata.window_key,

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
@@ -8,6 +8,7 @@ defmodule FavnStoragePostgres.Migrations do
   alias FavnStoragePostgres.Migrations.AddMaterializationClaims
   alias FavnStoragePostgres.Migrations.AddBackfillState
   alias FavnStoragePostgres.Migrations.AddRunEventGlobalSequence
+  alias FavnStoragePostgres.Migrations.AddRunGroupQueryColumns
   alias FavnStoragePostgres.Migrations.CreateFoundation
   alias FavnStoragePostgres.Migrations.RebuildBackfillReadModelsForDtos
 
@@ -19,7 +20,8 @@ defmodule FavnStoragePostgres.Migrations do
     {20_260_509_100_000, AddAssetFreshnessState},
     {20_260_510_100_000, AddLogEntries},
     {20_260_520_100_000, AddExecutionLeases},
-    {20_260_521_100_000, AddMaterializationClaims}
+    {20_260_521_100_000, AddMaterializationClaims},
+    {20_260_521_200_000, AddRunGroupQueryColumns}
   ]
   @required_tables [
     "public.favn_manifest_versions",

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_run_group_query_columns.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_run_group_query_columns.ex
@@ -1,0 +1,20 @@
+defmodule FavnStoragePostgres.Migrations.AddRunGroupQueryColumns do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:favn_runs) do
+      add(:root_execution_group_id, :string)
+      add(:parent_run_id, :string)
+      add(:root_run_id, :string)
+      add(:submit_kind, :string)
+      add(:asset_ref_text, :text)
+      add(:target_refs_text, :text)
+      add(:window_key, :text)
+    end
+
+    create(index(:favn_runs, [:root_execution_group_id, :updated_seq]))
+    create(index(:favn_runs, [:root_execution_group_id, :run_id]))
+  end
+end

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_run_group_query_columns.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_run_group_query_columns.ex
@@ -9,6 +9,7 @@ defmodule FavnStoragePostgres.Migrations.AddRunGroupQueryColumns do
       add(:parent_run_id, :string)
       add(:root_run_id, :string)
       add(:submit_kind, :string)
+      add(:trigger_type, :string)
       add(:asset_ref_text, :text)
       add(:target_refs_text, :text)
       add(:window_key, :text)

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -26,6 +26,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   alias FavnOrchestrator.Storage.MaterializationClaimCodec
   alias FavnOrchestrator.Storage.JsonSafe
   alias FavnOrchestrator.Storage.RunEventCodec
+  alias FavnOrchestrator.Storage.RunQuery
   alias FavnOrchestrator.Storage.RunSnapshotCodec
   alias FavnOrchestrator.Storage.RunStateCodec
   alias FavnOrchestrator.Storage.SchedulerStateCodec
@@ -263,6 +264,53 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   @impl true
+  def list_execution_group_runs(group_id, opts) when is_binary(group_id) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         :ok <- repair_missing_run_query_metadata(repo) do
+      sql =
+        run_snapshot_select() <>
+          " WHERE r.root_execution_group_id = ?1 ORDER BY CASE WHEN r.run_id = r.root_execution_group_id THEN 0 ELSE 1 END, r.inserted_at ASC, r.run_id ASC"
+
+      case SQL.query(repo, sql, [group_id]) do
+        {:ok, %{rows: rows}} -> decode_run_rows(rows)
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_execution_group_run_ids(group_id, opts) when is_binary(group_id) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         :ok <- repair_missing_run_query_metadata(repo) do
+      sql =
+        "SELECT run_id FROM favn_runs WHERE root_execution_group_id = ?1 ORDER BY CASE WHEN run_id = root_execution_group_id THEN 0 ELSE 1 END, inserted_at ASC, run_id ASC"
+
+      case SQL.query(repo, sql, [group_id]) do
+        {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [run_id] -> run_id end)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_execution_groups(group_opts, opts) when is_list(group_opts) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         :ok <- repair_missing_run_query_metadata(repo),
+         {:ok, query, params, page_opts} <- execution_groups_query(group_opts) do
+      case SQL.query(repo, query, params) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> Enum.map(fn [group_id] -> group_id end)
+          |> Page.from_fetched(page_opts)
+          |> then(&{:ok, &1})
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
   def append_run_event(run_id, event, opts)
       when is_binary(run_id) and is_map(event) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts),
@@ -282,6 +330,46 @@ defmodule Favn.Storage.Adapter.SQLite do
         "SELECT global_sequence, event_blob FROM favn_run_events WHERE run_id = ?1 ORDER BY sequence ASC"
 
       case SQL.query(repo, sql, [run_id]) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> decode_event_rows()
+          |> case do
+            {:ok, events} -> {:ok, Enum.reverse(events)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_run_events(run_id, run_event_opts, opts)
+      when is_binary(run_id) and is_list(run_event_opts) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, query, params} <- run_events_query(run_id, run_event_opts) do
+      case SQL.query(repo, query, params) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> decode_event_rows()
+          |> case do
+            {:ok, events} -> {:ok, Enum.reverse(events)}
+            {:error, reason} -> {:error, reason}
+          end
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_execution_group_events(group_id, run_event_opts, opts)
+      when is_binary(group_id) and is_list(run_event_opts) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, query, params} <- execution_group_events_query(group_id, run_event_opts) do
+      case SQL.query(repo, query, params) do
         {:ok, %{rows: rows}} ->
           rows
           |> decode_event_rows()
@@ -1728,6 +1816,8 @@ defmodule Favn.Storage.Adapter.SQLite do
 
   defp guarded_put_run(repo, run) do
     with {:ok, updated_seq} <- next_updated_seq(repo) do
+      query_metadata = RunQuery.metadata(run)
+
       sql =
         """
         INSERT INTO favn_runs (
@@ -1740,8 +1830,15 @@ defmodule Favn.Storage.Adapter.SQLite do
           updated_seq,
           inserted_at,
           updated_at,
-          run_blob
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)
+          run_blob,
+          root_execution_group_id,
+          parent_run_id,
+          root_run_id,
+          submit_kind,
+          asset_ref_text,
+          target_refs_text,
+          window_key
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
         ON CONFLICT(run_id) DO UPDATE SET
           manifest_version_id = excluded.manifest_version_id,
           manifest_content_hash = excluded.manifest_content_hash,
@@ -1751,7 +1848,14 @@ defmodule Favn.Storage.Adapter.SQLite do
           updated_seq = excluded.updated_seq,
           inserted_at = excluded.inserted_at,
           updated_at = excluded.updated_at,
-          run_blob = excluded.run_blob
+          run_blob = excluded.run_blob,
+          root_execution_group_id = excluded.root_execution_group_id,
+          parent_run_id = excluded.parent_run_id,
+          root_run_id = excluded.root_run_id,
+          submit_kind = excluded.submit_kind,
+          asset_ref_text = excluded.asset_ref_text,
+          target_refs_text = excluded.target_refs_text,
+          window_key = excluded.window_key
         WHERE excluded.event_seq > favn_runs.event_seq
         """
 
@@ -1765,7 +1869,14 @@ defmodule Favn.Storage.Adapter.SQLite do
         updated_seq,
         run.inserted_at,
         run.updated_at,
-        encode_run_snapshot(run)
+        encode_run_snapshot(run),
+        query_metadata.root_execution_group_id,
+        query_metadata.parent_run_id,
+        query_metadata.root_run_id,
+        query_metadata.submit_kind,
+        query_metadata.asset_ref_text,
+        query_metadata.target_refs_text,
+        query_metadata.window_key
       ]
 
       case SQL.query(repo, sql, params) do
@@ -2578,6 +2689,224 @@ defmodule Favn.Storage.Adapter.SQLite do
        where_sql <> " ORDER BY r.updated_seq DESC, r.run_id DESC" <> limit_sql, params}
   end
 
+  defp execution_groups_query(group_opts) do
+    with {:ok, page_opts} <- Page.normalize_opts(group_opts) do
+      filters = Keyword.drop(group_opts, [:limit, :offset, :sort])
+      {where_sql, params} = execution_group_filter_sql(filters)
+      sort_sql = execution_group_sort_sql(Keyword.get(group_opts, :sort, :started_desc))
+      limit_placeholder = "?#{length(params) + 1}"
+      offset_placeholder = "?#{length(params) + 2}"
+
+      {:ok,
+       """
+       SELECT group_id
+       FROM (
+         SELECT
+           r.root_execution_group_id AS group_id,
+           MAX(r.updated_seq) AS activity_seq,
+           MAX(CASE WHEN r.status IN ('error', 'partial', 'cancelled', 'timed_out') THEN 1 ELSE 0 END) AS failed,
+           MAX(CASE WHEN r.status IN ('pending', 'running') THEN 1 ELSE 0 END) AS running,
+           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.status ELSE NULL END) AS root_status,
+           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.submit_kind ELSE NULL END) AS root_submit_kind,
+           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.target_refs_text ELSE NULL END) AS root_targets,
+           MAX(CASE WHEN r.window_key IS NOT NULL AND r.window_key != '' THEN 1 ELSE 0 END) AS has_window
+         FROM favn_runs AS r
+         GROUP BY r.root_execution_group_id
+       ) AS groups
+       #{where_sql}
+       ORDER BY #{sort_sql}, group_id DESC
+       LIMIT #{limit_placeholder} OFFSET #{offset_placeholder}
+       """, params ++ [Keyword.fetch!(page_opts, :limit) + 1, Keyword.fetch!(page_opts, :offset)],
+       page_opts}
+    end
+  end
+
+  defp execution_group_filter_sql(filters) do
+    filters
+    |> Enum.reduce({[], []}, fn
+      {:status, status}, {clauses, params} when not is_nil(status) ->
+        {clauses ++ ["root_status = ?#{length(params) + 1}"], params ++ [Atom.to_string(status)]}
+
+      {:trigger_type, :backfill}, {clauses, params} ->
+        {clauses ++ ["root_submit_kind IN ('backfill_asset', 'backfill_pipeline')"], params}
+
+      {:trigger_type, :retry}, {clauses, params} ->
+        {clauses ++ ["root_submit_kind = 'rerun'"], params}
+
+      {:trigger_type, trigger}, {clauses, params} when not is_nil(trigger) ->
+        {clauses ++ ["root_submit_kind = ?#{length(params) + 1}"],
+         params ++ [Atom.to_string(trigger)]}
+
+      {:target_asset, target}, {clauses, params} when is_binary(target) and target != "" ->
+        {clauses ++ ["root_targets LIKE ?#{length(params) + 1}"], params ++ ["%#{target}%"]}
+
+      {:search, search}, {clauses, params} when is_binary(search) and search != "" ->
+        placeholder = "?#{length(params) + 1}"
+
+        {clauses ++
+           [
+             "(group_id LIKE #{placeholder} OR root_targets LIKE #{placeholder} OR root_submit_kind LIKE #{placeholder})"
+           ], params ++ ["%#{search}%"]}
+
+      {:window, :has_window}, {clauses, params} ->
+        {clauses ++ ["has_window = 1"], params}
+
+      {:window, :no_window}, {clauses, params} ->
+        {clauses ++ ["has_window = 0"], params}
+
+      {:only_failed, true}, {clauses, params} ->
+        {clauses ++ ["failed = 1"], params}
+
+      {:only_running, true}, {clauses, params} ->
+        {clauses ++ ["running = 1"], params}
+
+      {:only_incomplete, true}, {clauses, params} ->
+        {clauses ++ ["running = 1"], params}
+
+      _other, acc ->
+        acc
+    end)
+    |> case do
+      {[], params} -> {"", params}
+      {clauses, params} -> {"WHERE " <> Enum.join(clauses, " AND "), params}
+    end
+  end
+
+  defp execution_group_sort_sql(:failed_first), do: "failed DESC, activity_seq DESC"
+  defp execution_group_sort_sql(:running_first), do: "running DESC, activity_seq DESC"
+
+  defp execution_group_sort_sql(:status_priority),
+    do: "failed DESC, running DESC, activity_seq DESC"
+
+  defp execution_group_sort_sql(_sort), do: "activity_seq DESC"
+
+  defp run_events_query(run_id, opts) do
+    after_sequence = Keyword.get(opts, :after_sequence)
+    limit = Keyword.get(opts, :limit)
+
+    cond do
+      not is_nil(after_sequence) and (not is_integer(after_sequence) or after_sequence < 0) ->
+        {:error, :invalid_opts}
+
+      not is_nil(limit) and (not is_integer(limit) or limit <= 0) ->
+        {:error, :invalid_opts}
+
+      true ->
+        clauses = ["run_id = ?1"]
+        params = [run_id]
+        {clauses, params} = maybe_after_sequence_clause(clauses, params, after_sequence)
+        {limit_sql, params} = maybe_limit_clause(params, limit)
+
+        {:ok,
+         "SELECT global_sequence, event_blob FROM favn_run_events WHERE #{Enum.join(clauses, " AND ")} ORDER BY sequence ASC#{limit_sql}",
+         params}
+    end
+  end
+
+  defp execution_group_events_query(group_id, opts) do
+    after_global_sequence = Keyword.get(opts, :after_global_sequence)
+    limit = Keyword.get(opts, :limit)
+
+    cond do
+      not is_nil(after_global_sequence) and
+          (not is_integer(after_global_sequence) or after_global_sequence < 0) ->
+        {:error, :invalid_opts}
+
+      not is_nil(limit) and (not is_integer(limit) or limit <= 0) ->
+        {:error, :invalid_opts}
+
+      true ->
+        clauses = ["r.root_execution_group_id = ?1"]
+        params = [group_id]
+
+        {clauses, params} =
+          case after_global_sequence do
+            sequence when is_integer(sequence) and sequence >= 0 ->
+              {clauses ++ ["e.global_sequence > ?#{length(params) + 1}"], params ++ [sequence]}
+
+            _other ->
+              {clauses, params}
+          end
+
+        {limit_sql, params} = maybe_limit_clause(params, limit)
+
+        {:ok,
+         """
+         SELECT e.global_sequence, e.event_blob
+         FROM favn_run_events AS e
+         INNER JOIN favn_runs AS r ON r.run_id = e.run_id
+         WHERE #{Enum.join(clauses, " AND ")}
+         ORDER BY e.global_sequence ASC, e.run_id ASC, e.sequence ASC#{limit_sql}
+         """, params}
+    end
+  end
+
+  defp maybe_after_sequence_clause(clauses, params, sequence)
+       when is_integer(sequence) and sequence >= 0,
+       do: {clauses ++ ["sequence > ?#{length(params) + 1}"], params ++ [sequence]}
+
+  defp maybe_after_sequence_clause(clauses, params, _sequence), do: {clauses, params}
+
+  defp maybe_limit_clause(params, limit) when is_integer(limit) and limit > 0,
+    do: {" LIMIT ?#{length(params) + 1}", params ++ [limit]}
+
+  defp maybe_limit_clause(params, _limit), do: {"", params}
+
+  defp repair_missing_run_query_metadata(repo) do
+    sql = run_snapshot_select() <> " WHERE r.root_execution_group_id IS NULL"
+
+    case SQL.query(repo, sql, []) do
+      {:ok, %{rows: []}} ->
+        :ok
+
+      {:ok, %{rows: rows}} ->
+        with {:ok, runs} <- decode_run_rows(rows) do
+          Enum.reduce_while(runs, :ok, fn run, :ok ->
+            case update_run_query_metadata(repo, run) do
+              :ok -> {:cont, :ok}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp update_run_query_metadata(repo, run) do
+    metadata = RunQuery.metadata(run)
+
+    sql =
+      """
+      UPDATE favn_runs
+      SET root_execution_group_id = ?1,
+          parent_run_id = ?2,
+          root_run_id = ?3,
+          submit_kind = ?4,
+          asset_ref_text = ?5,
+          target_refs_text = ?6,
+          window_key = ?7
+      WHERE run_id = ?8
+      """
+
+    params = [
+      metadata.root_execution_group_id,
+      metadata.parent_run_id,
+      metadata.root_run_id,
+      metadata.submit_kind,
+      metadata.asset_ref_text,
+      metadata.target_refs_text,
+      metadata.window_key,
+      run.id
+    ]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, _result} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp run_filter_sql(filters) do
     filters
     |> Enum.reduce({[], []}, fn
@@ -2600,6 +2929,20 @@ defmodule Favn.Storage.Adapter.SQLite do
     FROM favn_runs AS r
     LEFT JOIN favn_manifest_versions AS m ON m.manifest_version_id = r.manifest_version_id
     """
+  end
+
+  defp decode_run_rows(rows) do
+    rows
+    |> Enum.reduce_while({:ok, []}, fn row, {:ok, acc} ->
+      case decode_run_row(row) do
+        {:ok, run} -> {:cont, {:ok, [run | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, runs} -> {:ok, Enum.reverse(runs)}
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   defp decode_run_row([

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -1835,10 +1835,11 @@ defmodule Favn.Storage.Adapter.SQLite do
           parent_run_id,
           root_run_id,
           submit_kind,
+          trigger_type,
           asset_ref_text,
           target_refs_text,
           window_key
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17)
+        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18)
         ON CONFLICT(run_id) DO UPDATE SET
           manifest_version_id = excluded.manifest_version_id,
           manifest_content_hash = excluded.manifest_content_hash,
@@ -1853,6 +1854,7 @@ defmodule Favn.Storage.Adapter.SQLite do
           parent_run_id = excluded.parent_run_id,
           root_run_id = excluded.root_run_id,
           submit_kind = excluded.submit_kind,
+          trigger_type = excluded.trigger_type,
           asset_ref_text = excluded.asset_ref_text,
           target_refs_text = excluded.target_refs_text,
           window_key = excluded.window_key
@@ -1874,6 +1876,7 @@ defmodule Favn.Storage.Adapter.SQLite do
         query_metadata.parent_run_id,
         query_metadata.root_run_id,
         query_metadata.submit_kind,
+        query_metadata.trigger_type,
         query_metadata.asset_ref_text,
         query_metadata.target_refs_text,
         query_metadata.window_key
@@ -2707,7 +2710,7 @@ defmodule Favn.Storage.Adapter.SQLite do
            MAX(CASE WHEN r.status IN ('error', 'partial', 'cancelled', 'timed_out') THEN 1 ELSE 0 END) AS failed,
            MAX(CASE WHEN r.status IN ('pending', 'running') THEN 1 ELSE 0 END) AS running,
            MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.status ELSE NULL END) AS root_status,
-           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.submit_kind ELSE NULL END) AS root_submit_kind,
+           MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.trigger_type ELSE NULL END) AS root_trigger_type,
            MAX(CASE WHEN r.run_id = r.root_execution_group_id THEN r.target_refs_text ELSE NULL END) AS root_targets,
            MAX(CASE WHEN r.window_key IS NOT NULL AND r.window_key != '' THEN 1 ELSE 0 END) AS has_window
          FROM favn_runs AS r
@@ -2727,25 +2730,22 @@ defmodule Favn.Storage.Adapter.SQLite do
       {:status, status}, {clauses, params} when not is_nil(status) ->
         {clauses ++ ["root_status = ?#{length(params) + 1}"], params ++ [Atom.to_string(status)]}
 
-      {:trigger_type, :backfill}, {clauses, params} ->
-        {clauses ++ ["root_submit_kind IN ('backfill_asset', 'backfill_pipeline')"], params}
-
-      {:trigger_type, :retry}, {clauses, params} ->
-        {clauses ++ ["root_submit_kind = 'rerun'"], params}
-
       {:trigger_type, trigger}, {clauses, params} when not is_nil(trigger) ->
-        {clauses ++ ["root_submit_kind = ?#{length(params) + 1}"],
+        {clauses ++ ["root_trigger_type = ?#{length(params) + 1}"],
          params ++ [Atom.to_string(trigger)]}
 
       {:target_asset, target}, {clauses, params} when is_binary(target) and target != "" ->
-        {clauses ++ ["root_targets LIKE ?#{length(params) + 1}"], params ++ ["%#{target}%"]}
+        {clauses ++
+           [
+             "instr(char(10) || root_targets || char(10), char(10) || ?#{length(params) + 1} || char(10)) > 0"
+           ], params ++ [target]}
 
       {:search, search}, {clauses, params} when is_binary(search) and search != "" ->
         placeholder = "?#{length(params) + 1}"
 
         {clauses ++
            [
-             "(group_id LIKE #{placeholder} OR root_targets LIKE #{placeholder} OR root_submit_kind LIKE #{placeholder})"
+             "(group_id LIKE #{placeholder} OR root_targets LIKE #{placeholder} OR root_trigger_type LIKE #{placeholder})"
            ], params ++ ["%#{search}%"]}
 
       {:window, :has_window}, {clauses, params} ->
@@ -2884,10 +2884,11 @@ defmodule Favn.Storage.Adapter.SQLite do
           parent_run_id = ?2,
           root_run_id = ?3,
           submit_kind = ?4,
-          asset_ref_text = ?5,
-          target_refs_text = ?6,
-          window_key = ?7
-      WHERE run_id = ?8
+          trigger_type = ?5,
+          asset_ref_text = ?6,
+          target_refs_text = ?7,
+          window_key = ?8
+      WHERE run_id = ?9
       """
 
     params = [
@@ -2895,6 +2896,7 @@ defmodule Favn.Storage.Adapter.SQLite do
       metadata.parent_run_id,
       metadata.root_run_id,
       metadata.submit_kind,
+      metadata.trigger_type,
       metadata.asset_ref_text,
       metadata.target_refs_text,
       metadata.window_key,

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
@@ -9,6 +9,7 @@ defmodule FavnStorageSqlite.Migrations do
   alias FavnStorageSqlite.Migrations.AddExecutionLeases
   alias FavnStorageSqlite.Migrations.AddLogEntries
   alias FavnStorageSqlite.Migrations.AddMaterializationClaims
+  alias FavnStorageSqlite.Migrations.AddRunGroupQueryColumns
   alias FavnStorageSqlite.Migrations.AddRunEventGlobalSequence
   alias FavnStorageSqlite.Migrations.CreateFoundation
   alias FavnStorageSqlite.Migrations.RebuildBackfillReadModelsForDtos
@@ -23,7 +24,8 @@ defmodule FavnStorageSqlite.Migrations do
     {20_260_509_100_000, AddAssetFreshnessState},
     {20_260_510_100_000, AddLogEntries},
     {20_260_520_100_000, AddExecutionLeases},
-    {20_260_521_100_000, AddMaterializationClaims}
+    {20_260_521_100_000, AddMaterializationClaims},
+    {20_260_521_200_000, AddRunGroupQueryColumns}
   ]
   @required_tables [
     "favn_manifest_versions",

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_run_group_query_columns.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_run_group_query_columns.ex
@@ -1,0 +1,20 @@
+defmodule FavnStorageSqlite.Migrations.AddRunGroupQueryColumns do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    alter table(:favn_runs) do
+      add(:root_execution_group_id, :string)
+      add(:parent_run_id, :string)
+      add(:root_run_id, :string)
+      add(:submit_kind, :string)
+      add(:asset_ref_text, :text)
+      add(:target_refs_text, :text)
+      add(:window_key, :text)
+    end
+
+    create(index(:favn_runs, [:root_execution_group_id, :updated_seq]))
+    create(index(:favn_runs, [:root_execution_group_id, :run_id]))
+  end
+end

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_run_group_query_columns.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_run_group_query_columns.ex
@@ -9,6 +9,7 @@ defmodule FavnStorageSqlite.Migrations.AddRunGroupQueryColumns do
       add(:parent_run_id, :string)
       add(:root_run_id, :string)
       add(:submit_kind, :string)
+      add(:trigger_type, :string)
       add(:asset_ref_text, :text)
       add(:target_refs_text, :text)
       add(:window_key, :text)

--- a/apps/favn_storage_sqlite/test/sqlite_readiness_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_readiness_test.exs
@@ -238,7 +238,8 @@ defmodule FavnStorageSqlite.ReadinessTest do
              "20260509100000",
              "20260510100000",
              "20260520100000",
-             "20260521100000"
+             "20260521100000",
+             "20260521200000"
            ]
 
     refute Migrations.schema_ready?(Repo)

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -193,27 +193,9 @@ defmodule FavnView.RunDetailLive do
   end
 
   defp load_run(run_id, existing_back_asset_href \\ nil) do
-    group_id = execution_group_id(run_id)
-
-    case FavnOrchestrator.get_execution_group_detail(group_id) do
+    case FavnOrchestrator.get_execution_group_detail_for_run(run_id) do
       {:ok, detail} -> detail_from_execution_group(detail, run_id, existing_back_asset_href)
       {:error, reason} -> %{id: run_id, found?: false, error: error_label(reason)}
-    end
-  end
-
-  defp execution_group_id(run_id) do
-    case FavnOrchestrator.get_run_detail(run_id) do
-      {:ok, %{summary: %{root_run_id: root_run_id}}} when is_binary(root_run_id) ->
-        root_run_id
-
-      {:ok, %{summary: %{parent_run_id: parent_run_id}}} when is_binary(parent_run_id) ->
-        parent_run_id
-
-      {:ok, %{summary: %{id: id}}} ->
-        id
-
-      {:error, _reason} ->
-        run_id
     end
   end
 

--- a/apps/favn_view/lib/favn_view/runs_list_live.ex
+++ b/apps/favn_view/lib/favn_view/runs_list_live.ex
@@ -23,13 +23,13 @@ defmodule FavnView.RunsListLive do
 
   @impl true
   def mount(_params, _session, socket) do
-    {groups, error} = load_groups()
     filters = @default_filters
+    {groups, error} = load_groups(filters)
 
     socket =
       assign(socket,
         groups: groups,
-        visible_groups: filtered_groups(groups, filters),
+        visible_groups: groups,
         group_details: %{},
         expanded_group_ids: MapSet.new(),
         filters: filters,
@@ -49,7 +49,7 @@ defmodule FavnView.RunsListLive do
 
   @impl true
   def handle_info(:refresh_runs, socket) do
-    {groups, error} = load_groups()
+    {groups, error} = load_groups(socket.assigns.filters)
 
     {:noreply,
      socket
@@ -59,7 +59,7 @@ defmodule FavnView.RunsListLive do
   end
 
   def handle_info({:favn_run_event, _event}, socket) do
-    {groups, error} = load_groups()
+    {groups, error} = load_groups(socket.assigns.filters)
 
     {:noreply,
      socket
@@ -77,11 +77,14 @@ defmodule FavnView.RunsListLive do
 
   def handle_event("filter_groups", %{"filters" => params}, socket) do
     filters = normalize_filters(socket.assigns.filters, params)
+    {visible_groups, error} = load_groups(filters)
 
     {:noreply,
      assign(socket,
        filters: filters,
-       visible_groups: filtered_groups(socket.assigns.groups, filters)
+       visible_groups: visible_groups,
+       summary: overview_summary(visible_groups),
+       error: error
      )}
   end
 
@@ -101,11 +104,12 @@ defmodule FavnView.RunsListLive do
   end
 
   def handle_event("clear_filters", _params, socket) do
+    {groups, error} = load_groups(@default_filters)
+
     {:noreply,
-     assign(socket,
-       filters: @default_filters,
-       visible_groups: filtered_groups(socket.assigns.groups, @default_filters)
-     )}
+     socket
+     |> assign_groups(groups, error)
+     |> assign(filters: @default_filters)}
   end
 
   @impl true
@@ -136,9 +140,9 @@ defmodule FavnView.RunsListLive do
     :ok
   end
 
-  defp load_groups do
-    case FavnOrchestrator.list_execution_groups(limit: 100) do
-      {:ok, groups} -> {Enum.map(groups, &group_from_public/1), nil}
+  defp load_groups(filters) do
+    case FavnOrchestrator.page_execution_groups(orchestrator_filters(filters)) do
+      {:ok, %{items: groups}} -> {Enum.map(groups, &group_from_public/1), nil}
       {:error, reason} -> {[], inspect(reason)}
     end
   end
@@ -165,16 +169,69 @@ defmodule FavnView.RunsListLive do
   end
 
   defp assign_groups(socket, groups, error) do
-    filters = socket.assigns.filters
-
     assign(socket,
       groups: groups,
-      visible_groups: filtered_groups(groups, filters),
+      visible_groups: groups,
       filter_options: filter_options(groups),
       summary: overview_summary(groups),
       error: error
     )
   end
+
+  defp orchestrator_filters(filters) do
+    []
+    |> Keyword.put(:limit, 100)
+    |> maybe_put_search_filter(Map.get(filters, "search"))
+    |> maybe_put_status_filter(Map.get(filters, "status"))
+    |> maybe_put_atom_filter(:trigger_type, Map.get(filters, "trigger"))
+    |> maybe_put_filter(:target_asset, Map.get(filters, "target"))
+    |> maybe_put_atom_filter(:window, Map.get(filters, "window"))
+    |> maybe_put_boolean_filter(:only_failed, Map.get(filters, "only_failed"))
+    |> maybe_put_boolean_filter(:only_running, Map.get(filters, "only_running"))
+    |> maybe_put_boolean_filter(:only_incomplete, Map.get(filters, "only_incomplete"))
+    |> Keyword.put(:sort, sort_filter(Map.get(filters, "sort")))
+  end
+
+  defp maybe_put_search_filter(opts, value) when is_binary(value) and value != "",
+    do: Keyword.put(opts, :search, value)
+
+  defp maybe_put_search_filter(opts, _value), do: opts
+
+  defp maybe_put_status_filter(opts, "failed"), do: Keyword.put(opts, :only_failed, true)
+  defp maybe_put_status_filter(opts, "running"), do: Keyword.put(opts, :only_running, true)
+  defp maybe_put_status_filter(opts, "incomplete"), do: Keyword.put(opts, :only_incomplete, true)
+  defp maybe_put_status_filter(opts, "succeeded"), do: Keyword.put(opts, :status, :ok)
+  defp maybe_put_status_filter(opts, "partial"), do: Keyword.put(opts, :status, :partial)
+  defp maybe_put_status_filter(opts, "queued"), do: Keyword.put(opts, :status, :pending)
+  defp maybe_put_status_filter(opts, _value), do: opts
+
+  defp maybe_put_atom_filter(opts, _key, value) when value in [nil, "", "all"], do: opts
+
+  defp maybe_put_atom_filter(opts, key, value) do
+    case known_filter_atom(value) do
+      nil -> opts
+      atom -> Keyword.put(opts, key, atom)
+    end
+  end
+
+  defp maybe_put_filter(opts, _key, value) when value in [nil, "", "all"], do: opts
+  defp maybe_put_filter(opts, key, value), do: Keyword.put(opts, key, value)
+
+  defp maybe_put_boolean_filter(opts, key, "true"), do: Keyword.put(opts, key, true)
+  defp maybe_put_boolean_filter(opts, _key, _value), do: opts
+
+  defp sort_filter(value) when value in ["status_priority", "failed_first", "running_first"],
+    do: String.to_existing_atom(value)
+
+  defp sort_filter(_value), do: :started_desc
+
+  defp known_filter_atom("backfill"), do: :backfill
+  defp known_filter_atom("manual"), do: :manual
+  defp known_filter_atom("schedule"), do: :schedule
+  defp known_filter_atom("retry"), do: :retry
+  defp known_filter_atom("has_window"), do: :has_window
+  defp known_filter_atom("no_window"), do: :no_window
+  defp known_filter_atom(_value), do: nil
 
   defp ensure_group_detail(socket, group_id) do
     if Map.has_key?(socket.assigns.group_details, group_id) do
@@ -261,59 +318,6 @@ defmodule FavnView.RunsListLive do
     }
   end
 
-  defp filtered_groups(groups, filters) do
-    groups
-    |> Enum.filter(&matches_filters?(&1, filters))
-    |> sort_groups(Map.get(filters, "sort", "started_desc"))
-  end
-
-  defp matches_filters?(group, filters) do
-    matches_search?(group, Map.get(filters, "search", "")) and
-      matches_select?(to_string(group.status), Map.get(filters, "status", "all")) and
-      matches_select?(
-        to_string(group.trigger_type || "unknown"),
-        Map.get(filters, "trigger", "all")
-      ) and
-      matches_target?(group, Map.get(filters, "target", "all")) and
-      matches_window?(group, Map.get(filters, "window", "all")) and
-      (Map.get(filters, "only_failed") != "true" or failed_group?(group)) and
-      (Map.get(filters, "only_running") != "true" or running_group?(group)) and
-      (Map.get(filters, "only_incomplete") != "true" or incomplete_group?(group))
-  end
-
-  defp matches_search?(_group, ""), do: true
-
-  defp matches_search?(group, search) do
-    haystack =
-      [group.id, group.short_id, group.trigger, group.window | group.targets]
-      |> Enum.join(" ")
-      |> String.downcase()
-
-    String.contains?(haystack, String.downcase(search))
-  end
-
-  defp matches_select?(_value, value) when value in [nil, "", "all"], do: true
-  defp matches_select?(value, expected), do: value == expected
-
-  defp matches_target?(_group, value) when value in [nil, "", "all"], do: true
-  defp matches_target?(group, value), do: value in group.targets
-
-  defp matches_window?(_group, value) when value in [nil, "", "all"], do: true
-  defp matches_window?(group, "has_window"), do: group.total_windows > 0
-  defp matches_window?(group, "no_window"), do: group.total_windows == 0
-  defp matches_window?(_group, _value), do: true
-
-  defp sort_groups(groups, "failed_first"),
-    do: Enum.sort_by(groups, &{if(failed_group?(&1), do: 0, else: 1), -&1.started_at_sort})
-
-  defp sort_groups(groups, "running_first"),
-    do: Enum.sort_by(groups, &{if(running_group?(&1), do: 0, else: 1), -&1.started_at_sort})
-
-  defp sort_groups(groups, "status_priority"),
-    do: Enum.sort_by(groups, &{status_priority(&1.status), -&1.started_at_sort})
-
-  defp sort_groups(groups, _sort), do: Enum.sort_by(groups, & &1.started_at_sort, :desc)
-
   defp normalize_filters(existing, params) do
     @default_filters
     |> Map.merge(existing || %{})
@@ -389,9 +393,6 @@ defmodule FavnView.RunsListLive do
   defp display_run_status(:pending), do: :queued
   defp display_run_status(status), do: status || :unknown
 
-  defp failed_group?(group), do: group.status in [:failed, :partial]
-  defp running_group?(group), do: group.status == :running
-
   defp incomplete_public_group?(group) do
     root_status = Map.get(group, :root_status)
 
@@ -403,21 +404,6 @@ defmodule FavnView.RunsListLive do
       (Map.get(group, :total_asset_attempts, 0) > 0 and
          Map.get(group, :completed_asset_attempts, 0) < Map.get(group, :total_asset_attempts, 0))
   end
-
-  defp incomplete_group?(group) do
-    group.status in [:queued, :running, :incomplete] or
-      (group.total_windows > 0 and group.completed_windows < group.total_windows) or
-      (group.total_asset_attempts > 0 and
-         group.completed_asset_attempts < group.total_asset_attempts)
-  end
-
-  defp status_priority(:failed), do: 0
-  defp status_priority(:partial), do: 1
-  defp status_priority(:running), do: 2
-  defp status_priority(:queued), do: 3
-  defp status_priority(:incomplete), do: 4
-  defp status_priority(:succeeded), do: 5
-  defp status_priority(_status), do: 6
 
   defp current_activity([attempt | _]) do
     window = window_label(Map.get(attempt, :window)) || "current window"

--- a/apps/favn_view/lib/favn_view/runs_list_live.ex
+++ b/apps/favn_view/lib/favn_view/runs_list_live.ex
@@ -260,7 +260,7 @@ defmodule FavnView.RunsListLive do
   defp group_from_public(group) do
     targets = targets(Map.get(group, :target_assets, []), nil)
     target = List.first(targets) || "No target"
-    status = display_status(group)
+    status = display_group_status(Map.get(group, :status))
     current_activity = current_activity(Map.get(group, :currently_running_asset_attempts, []))
     window = window_range_label(group)
     progress = progress(group)
@@ -273,7 +273,7 @@ defmodule FavnView.RunsListLive do
       target_title: target,
       targets: targets,
       status: status,
-      raw_status: Map.get(group, :root_status),
+      raw_status: Map.get(group, :status),
       trigger: label(Map.get(group, :trigger_type)),
       trigger_type: Map.get(group, :trigger_type),
       window: window,
@@ -363,47 +363,15 @@ defmodule FavnView.RunsListLive do
   defp health_bucket(:incomplete), do: :queued
   defp health_bucket(_status), do: :succeeded
 
-  defp display_status(group) do
-    cond do
-      Map.get(group, :failed_asset_attempts, 0) > 0 or Map.get(group, :failed_windows, 0) > 0 ->
-        :failed
-
-      Map.get(group, :running_asset_attempts, 0) > 0 or Map.get(group, :root_status) == :running ->
-        :running
-
-      Map.get(group, :queued_asset_attempts, 0) > 0 or Map.get(group, :root_status) == :pending ->
-        :queued
-
-      incomplete_public_group?(group) ->
-        :incomplete
-
-      Map.get(group, :root_status) == :partial ->
-        :partial
-
-      Map.get(group, :root_status) == :ok ->
-        :succeeded
-
-      true ->
-        display_run_status(Map.get(group, :root_status))
-    end
-  end
+  defp display_group_status(:ok), do: :succeeded
+  defp display_group_status(:error), do: :failed
+  defp display_group_status(:pending), do: :queued
+  defp display_group_status(status), do: status || :unknown
 
   defp display_run_status(:ok), do: :succeeded
   defp display_run_status(:error), do: :failed
   defp display_run_status(:pending), do: :queued
   defp display_run_status(status), do: status || :unknown
-
-  defp incomplete_public_group?(group) do
-    root_status = Map.get(group, :root_status)
-
-    root_status in [:pending, :running] or
-      Map.get(group, :running_asset_attempts, 0) > 0 or
-      Map.get(group, :queued_asset_attempts, 0) > 0 or
-      (Map.get(group, :total_windows, 0) > 0 and
-         Map.get(group, :completed_windows, 0) < Map.get(group, :total_windows, 0)) or
-      (Map.get(group, :total_asset_attempts, 0) > 0 and
-         Map.get(group, :completed_asset_attempts, 0) < Map.get(group, :total_asset_attempts, 0))
-  end
 
   defp current_activity([attempt | _]) do
     window = window_label(Map.get(attempt, :window)) || "current window"
@@ -413,10 +381,20 @@ defmodule FavnView.RunsListLive do
   defp current_activity(_attempts), do: nil
 
   defp progress(group) do
-    window_label = "#{group.completed_windows} / #{group.total_windows} windows"
-    attempt_label = "#{group.completed_asset_attempts} / #{group.total_asset_attempts} attempts"
-    total = max(group.total_asset_attempts, 1)
-    percent = min(100, round(group.completed_asset_attempts * 100 / total))
+    totals = Map.get(group, :summary_totals, %{})
+    window_counts = Map.get(totals, :windows, %{})
+
+    attempt_counts =
+      Map.get(totals, :asset_attempts, Map.get(group, :progress, %{})[:counts] || %{})
+
+    completed_windows = Map.get(window_counts, :completed, group.completed_windows)
+    total_windows = Map.get(window_counts, :total, group.total_windows)
+    completed_attempts = Map.get(attempt_counts, :completed, group.completed_asset_attempts)
+    total_attempts = Map.get(attempt_counts, :total, group.total_asset_attempts)
+    window_label = "#{completed_windows} / #{total_windows} windows"
+    attempt_label = "#{completed_attempts} / #{total_attempts} attempts"
+    total = max(total_attempts, 1)
+    percent = min(100, round(completed_attempts * 100 / total))
 
     %{
       window_label: if(group.total_windows > 0, do: window_label, else: "No windows"),
@@ -430,15 +408,26 @@ defmodule FavnView.RunsListLive do
   defp progress_tone(%{status: :failed}), do: :error
   defp progress_tone(%{status: :partial}), do: :warning
   defp progress_tone(%{status: :running}), do: :info
+  defp progress_tone(%{health: :error}), do: :error
+  defp progress_tone(%{health: :warning}), do: :warning
+  defp progress_tone(%{health: :active}), do: :info
   defp progress_tone(_group), do: :success
 
   defp health(group) do
-    succeeded = max(group.completed_asset_attempts - group.failed_asset_attempts, 0)
-    failed = group.failed_asset_attempts
-    running = group.running_asset_attempts
-    queued = group.queued_asset_attempts
+    counts = group |> Map.get(:summary_totals, %{}) |> Map.get(:asset_attempts, %{})
+    failed = Map.get(counts, :failed, group.failed_asset_attempts)
+    running = Map.get(counts, :running, group.running_asset_attempts)
+    queued = Map.get(counts, :queued, group.queued_asset_attempts)
+    completed = Map.get(counts, :completed, group.completed_asset_attempts)
+    succeeded = max(completed - failed, 0)
 
-    %{succeeded: succeeded, failed: failed, running: running, queued: queued}
+    %{
+      succeeded: succeeded,
+      failed: failed,
+      running: running,
+      queued: queued,
+      status: group.health
+    }
   end
 
   defp window_range_label(%{total_windows: 0}), do: "-"

--- a/docs/ISSUE_393_BOUNDED_RUN_READ_MODELS_PLAN.md
+++ b/docs/ISSUE_393_BOUNDED_RUN_READ_MODELS_PLAN.md
@@ -1,0 +1,299 @@
+# Issue 393 Bounded Run Read Models Plan
+
+Issue: #393
+
+Status: implemented in this branch.
+
+## Goal
+
+Make operator-facing run read paths scale with the requested group, page, and
+cursor instead of total persisted run history. The orchestrator should own run
+group semantics, lifecycle status, health, progress, and summary totals. The
+view should keep only visual labels, component formatting, and interaction
+state.
+
+This follows `docs/refactor_review_standard.md`: expose explicit storage and
+read-model contracts where broad scans currently hide real runtime contracts.
+
+## Current Baseline
+
+The affected paths are already behind the public `FavnOrchestrator` facade, but
+the contracts underneath are too broad:
+
+- `FavnOrchestrator.RunReadModel.list_execution_groups/1` calls
+  `Storage.list_runs(limit: scan_limit)`, groups in memory, then filters and
+  limits after grouping.
+- `FavnOrchestrator.RunReadModel.get_execution_group_detail/2` and
+  `list_execution_group_events/2` call `Storage.list_runs()` and find one group
+  in memory.
+- `FavnOrchestrator.list_run_stream_events/2` calls `list_run_events/2`, loading
+  all events for a run before applying `after_sequence` and `limit`.
+- `FavnView.RunsListLive` fetches `FavnOrchestrator.list_execution_groups(limit:
+  100)` and applies search, status, trigger, target, window, and sort filters in
+  the LiveView after the hard limit.
+- SQLite and Postgres persist `favn_runs` with status, event sequence, update
+  sequence, timestamps, and the encoded run blob. They do not currently expose
+  root/parent/group columns needed for indexed group reads.
+- `favn_run_events` has `{run_id, sequence}` and `global_sequence` indexes, so
+  run-scoped event cursor reads can be made bounded without changing the event
+  model.
+
+## Architectural Decision
+
+Add explicit orchestrator storage contracts for run group membership and
+run-event cursors, then keep orchestration semantics in `RunReadModel`.
+
+Do not make storage return component-shaped data. Storage should return
+persisted facts and bounded pages. `RunReadModel` should turn those facts into
+operator semantic read models. `favn_view` should call only the public
+`FavnOrchestrator` facade and convert semantic fields into labels, tones, and
+page assigns.
+
+Use offset pagination for execution group lists in V1 because it aligns with the
+existing `FavnOrchestrator.Page` contract and current operator list behavior.
+Use sequence cursors for run events because event replay already has stable
+monotonic per-run and global sequences.
+
+## Storage Contract V1
+
+Extend `Favn.Storage.Adapter` and `FavnOrchestrator.Storage` with these bounded
+callbacks:
+
+```elixir
+list_execution_group_runs(group_id, opts) :: {:ok, [RunState.t()]} | {:error, term()}
+list_execution_group_run_ids(group_id, opts) :: {:ok, [String.t()]} | {:error, term()}
+list_execution_group_events(group_id, opts) :: {:ok, [map()]} | {:error, term()}
+list_run_events(run_id, run_event_opts, opts) :: {:ok, [map()]} | {:error, term()}
+list_execution_groups(group_opts, opts) :: {:ok, Page.t(map())} | {:error, term()}
+```
+
+Contract rules:
+
+- `group_id` identifies the root execution group id.
+- Group membership is any run whose persisted group id is `group_id`, including
+  the root run itself.
+- `list_execution_group_runs/2` returns the root plus children in deterministic
+  group order without scanning unrelated runs.
+- `list_execution_group_run_ids/2` exists so grouped event reads can avoid
+  decoding full run snapshots when only run ids are needed.
+- `list_execution_group_events/2` accepts `after_global_sequence`, `limit`, and
+  optionally `after_sequence` only if the cursor is explicitly run-scoped. The
+  default should be chronological ascending and bounded.
+- `list_run_events/3` accepts `after_sequence` and `limit`, validates them before
+  adapter work, and applies both predicates in storage.
+- `list_execution_groups/2` applies filters, sort, limit, and offset before page
+  slicing. It returns persisted grouping facts plus summary columns, not UI
+  strings.
+
+Keep `Storage.list_runs/1` for generic legacy/internal reads, but stop using it
+for group detail, group events, SSE replay, and operator run list pages.
+
+## Persistence Shape
+
+Add denormalized run-group query columns to `favn_runs` for SQLite and Postgres:
+
+```text
+root_execution_group_id text not null
+parent_run_id text null
+root_run_id text null
+submit_kind text null
+asset_ref_text text null
+target_refs_text text null
+window_key text null
+started_at utc_datetime_usec null
+finished_at utc_datetime_usec null
+```
+
+The exact column set should stay minimal, but the adapter must be able to filter
+and sort execution group lists before decoding arbitrary blobs. At minimum, the
+first implementation needs `root_execution_group_id`, `parent_run_id`,
+`root_run_id`, `status`, `updated_seq`, `inserted_at`, and `updated_at`.
+
+Recommended indexes:
+
+- `favn_runs(root_execution_group_id, updated_seq)` for group detail and group
+  run-id lookup.
+- `favn_runs(root_execution_group_id, run_id)` for deterministic membership.
+- `favn_runs(status, updated_seq)` remains for status-filtered generic run reads.
+- `favn_run_events(run_id, sequence)` already exists and should back
+  run-scoped cursor reads.
+- `favn_run_events(global_sequence)` already exists and should back global and
+  grouped chronological replay.
+
+Migration/backfill rules:
+
+- New columns are derived from `RunState` at `put_run/2` and
+  `persist_run_transition/3` time.
+- Existing rows must be backfilled by decoding `run_blob` once during migration
+  where practical. If SQLite migration code cannot safely decode Elixir terms,
+  add adapter startup repair or lazy update on first write/read, but document the
+  temporary fallback explicitly.
+- Memory adapter stores the same derived facts in state or computes them from
+  `RunState` without changing semantics.
+
+## Run Read Model Contract
+
+Update `FavnOrchestrator.RunReadModel` to use bounded storage APIs:
+
+- `list_execution_groups/1` delegates list filters and pagination to storage,
+  then computes semantic fields from returned group facts and any required
+  bounded child/window summaries.
+- `get_execution_group_detail/2` calls `Storage.list_execution_group_runs/1` for
+  the requested group only.
+- `list_execution_group_events/2` calls `Storage.list_execution_group_events/2`
+  or uses `list_execution_group_run_ids/1` plus run-event cursor queries.
+- `list_execution_group_asset_attempts/2`, `list_execution_group_windows/2`, and
+  `list_execution_group_timeline/2` reuse the bounded detail path rather than
+  calling a full run scan.
+- The public summary shape should add orchestrator-owned semantic fields so the
+  LiveViews do not reconstruct them:
+  `status`, `health`, `active?`, `progress`, `failure_count`, `summary_totals`,
+  and `last_activity_at`.
+- Keep visual concerns out of this module. No CSS tones, copy labels, or
+  component-specific flags.
+
+## Public Facade And API Contract
+
+Keep `FavnOrchestrator` as the only backend dependency for `favn_view`:
+
+- Change `FavnOrchestrator.list_execution_groups/1` to return
+  `{:ok, %Page{items: groups}}` or add a new `page_execution_groups/1` facade and
+  remove legacy list usage from the UI in the same issue.
+- Add `FavnOrchestrator.list_execution_group_events/2` cursor options for
+  grouped replay where needed.
+- Change `FavnOrchestrator.list_run_stream_events/2` to call storage with
+  `after_sequence` and `limit` instead of loading all events.
+- Add or update HTTP endpoints only where the browser/operator API needs them.
+  API routes should parse filters and pagination, then delegate to facade
+  functions. They should not query storage directly.
+- For SSE, keep cursor-invalid behavior: when replay needs more than
+  `@sse_replay_limit`, return `410 cursor_expired` rather than falling back to an
+  unbounded scan.
+
+## Operator Filter Contract
+
+Normalize run-list filters at the orchestrator boundary, not in the LiveView:
+
+```elixir
+[
+  search: String.t() | nil,
+  status: atom() | nil,
+  trigger_type: atom() | nil,
+  target_asset: String.t() | nil,
+  window: :has_window | :no_window | nil,
+  only_failed: boolean(),
+  only_running: boolean(),
+  only_incomplete: boolean(),
+  sort: :started_desc | :failed_first | :running_first | :status_priority,
+  limit: pos_integer(),
+  offset: non_neg_integer()
+]
+```
+
+Storage applies cheap persisted filters and stable ordering first. `RunReadModel`
+applies semantic filters that require derived group totals only after it has a
+bounded candidate set, or storage gets additional summary columns if correctness
+requires exact filter-before-limit behavior for that semantic field.
+
+For #393, exact filter-before-limit behavior is required for the operator list.
+If a filter cannot be applied correctly without persisted group summaries, add
+the smallest persisted summary/read-model table rather than over-fetching and
+guessing.
+
+## View Plan
+
+`FavnView.RunsListLive` should become a thin paginated client of the orchestrator
+read model:
+
+- Keep filter form state and mode state in the LiveView.
+- On filter changes, call `FavnOrchestrator.list_execution_groups/1` with
+  normalized filters and reset `offset` to `0`.
+- Render `page.items`; use `page.has_more?` and `page.next_offset` for incremental
+  loading or page controls.
+- Remove client-side filtering and sorting for execution groups.
+- Keep `filter_options/1` either sourced from a bounded orchestrator facet API or
+  limited to options present on the current page. Do not scan all groups in the
+  LiveView to populate dropdowns.
+
+`FavnView.RunDetailLive` should use a single bounded group detail call:
+
+- Add a facade helper if needed to resolve a requested run id to its execution
+  group id without loading all detail first.
+- Stop calling `get_run_detail/1` only to derive the group id when storage can
+  expose the persisted group id.
+- Keep detail transformation, labels, tones, and component assigns in the view.
+
+## Implementation Tasks
+
+- [x] Add run group query metadata derivation helper in `favn_orchestrator` close
+  to `RunState`/storage codec ownership.
+- [x] Add SQLite and Postgres migrations for persisted run group columns and
+  indexes.
+- [x] Update SQLite/Postgres `put_run` and `persist_run_transition` writes to
+  populate group query columns.
+- [x] Add storage behaviour callbacks and `FavnOrchestrator.Storage` facade
+  functions for group runs, group run ids, group events, run-event cursors, and
+  paged execution group lists.
+- [x] Implement the new callbacks in memory, SQLite, and Postgres adapters.
+- [x] Update `FavnOrchestrator.list_run_stream_events/2` to use bounded storage
+  cursor reads.
+- [x] Update `RunReadModel` group detail/event/list functions to stop calling
+  broad `Storage.list_runs/0` paths.
+- [x] Move operator run-list filter and sort normalization into
+  `FavnOrchestrator`/`RunReadModel` and return a page.
+- [x] Update `FavnOrchestrator.API.Router` event/list parsing and response shapes
+  where needed.
+- [x] Update `FavnView.RunsListLive` and `FavnView.RunDetailLive` to consume the
+  new facade contracts only.
+- [x] Capture implementation status and verification notes in this plan document.
+
+## Testing Plan
+
+Add the smallest tests at the owning layers:
+
+- Shared adapter contract tests for `list_execution_group_runs/2`, group run-id
+  lookup, paged execution group filtering/sorting, and `list_run_events/3` with
+  `after_sequence` plus `limit`.
+- SQLite and Postgres migration/backfill coverage for new query columns where
+  practical.
+- `RunReadModel` tests proving group detail, group events, status, health,
+  active state, progress, failures, and totals do not depend on unrelated runs.
+- SSE replay tests proving run-scoped replay is cursor-bounded and still returns
+  `cursor_expired` for unreplayable gaps.
+- LiveView regressions proving filters are sent through the facade and results
+  reflect filter-before-limit behavior.
+
+Focused checks during implementation:
+
+```bash
+MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser test/integration/storage_adapter_contract_test.exs test/run_read_model_test.exs test/events_test.exs test/api/router_test.exs
+MIX_ENV=test mix do --app favn_view cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser test/favn_view/page_live_test.exs
+```
+
+Full gate before finishing code changes:
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+```
+
+Focused verification run for this branch:
+
+```bash
+mix format
+mix compile --warnings-as-errors
+MIX_ENV=test mix do --app favn_orchestrator cmd mix test --exclude acceptance --exclude slow --exclude browser test/integration/storage_adapter_contract_test.exs test/run_read_model_test.exs test/events_test.exs test/api/router_test.exs
+MIX_ENV=test mix do --app favn_view cmd mix test --exclude acceptance --exclude slow --exclude browser test/favn_view/page_live_test.exs
+```
+
+## Risks And Follow-Up Decisions
+
+- Adding persisted run group columns is a schema change, but it is the cleanest
+  way to guarantee filter-before-limit behavior without hidden scans.
+- Persisted group summary tables may be needed if exact `only_failed`,
+  `only_running`, or health filtering cannot be implemented from indexed run
+  columns plus bounded window reads. Prefer adding that explicit read model over
+  scan-limit heuristics.
+- Existing private pre-v1 contracts may be changed directly. Remove deprecated
+  UI/list paths in the implementation rather than keeping compatibility shims.


### PR DESCRIPTION
## Summary
- Add bounded storage contracts for execution group runs, group ids, grouped events, paged execution groups, and run-event cursor reads.
- Persist run group query metadata in SQLite/Postgres with lazy metadata repair for existing rows, and wire RunReadModel/LiveViews through the public orchestrator facade.
- Document the issue #393 architecture and focused verification plan.

## Verification
- mix format
- mix compile --warnings-as-errors
- MIX_ENV=test mix do --app favn_orchestrator cmd mix test --exclude acceptance --exclude slow --exclude browser test/integration/storage_adapter_contract_test.exs test/run_read_model_test.exs test/events_test.exs test/api/router_test.exs
- MIX_ENV=test mix do --app favn_view cmd mix test --exclude acceptance --exclude slow --exclude browser test/favn_view/page_live_test.exs