### PR TITLE
Add operator command DTO boundary

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -30,6 +30,10 @@ defmodule FavnOrchestrator do
   alias FavnOrchestrator.LogWriter
   alias FavnOrchestrator.Logs
   alias FavnOrchestrator.ManifestStore
+  alias FavnOrchestrator.OperatorCommands.AssetBackfillRequest
+  alias FavnOrchestrator.OperatorCommands.AssetRunRequest
+  alias FavnOrchestrator.OperatorCommands.PipelineBackfillRequest
+  alias FavnOrchestrator.OperatorCommands.PipelineRunRequest
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.Projector
   alias FavnOrchestrator.RefreshPolicy
@@ -521,11 +525,16 @@ defmodule FavnOrchestrator do
   end
 
   @doc """
-  Submits one asset run for an authenticated operator actor context.
+  Submits one asset run command for an authenticated operator actor context.
 
-  This is the same-BEAM browser boundary for LiveView operator actions. Missing
-  or incomplete actor/session context returns `{:error, :unauthenticated}`;
-  authenticated actors without the operator role return `{:error, :forbidden}`.
+  This is the same-BEAM boundary for browser, API, and CLI operator actions.
+  Callers pass operator intent, such as dependency mode, refresh mode, and
+  selected timeline window. The orchestrator validates that intent and translates
+  it into runtime submit options after resolving the manifest target.
+
+  Missing or incomplete actor/session context returns `{:error,
+  :unauthenticated}`; authenticated actors without the operator role return
+  `{:error, :forbidden}`.
 
   TODO: add a narrow audit event for accepted LiveView operator commands once the
   audit shape for same-BEAM browser actions is finalized.
@@ -539,25 +548,30 @@ defmodule FavnOrchestrator do
           operator_actor_context(),
           String.t(),
           String.t(),
-          keyword() | map()
+          AssetRunRequest.t() | map() | keyword() | nil
         ) :: {:ok, run_id()} | {:error, term()}
   def submit_operator_asset_run(
         actor_context,
         manifest_version_id,
         target_id,
-        opts_or_request \\ []
+        command_input \\ %{}
       ) do
-    with :ok <- require_operator_context(actor_context) do
-      submit_asset_run_for_manifest(manifest_version_id, target_id, opts_or_request)
+    with :ok <- require_operator_context(actor_context),
+         {:ok, request} <- AssetRunRequest.from_input(command_input),
+         {:ok, version} <- get_manifest(manifest_version_id),
+         {:ok, asset} <- resolve_asset_target(version, target_id),
+         {:ok, opts} <- operator_asset_run_opts(asset, request) do
+      submit_asset_run(asset.ref, Keyword.put(opts, :manifest_version_id, manifest_version_id))
     end
   end
 
   @doc """
-  Submits an asset backfill range for an authenticated operator actor context.
+  Submits an asset backfill command for an authenticated operator actor context.
 
-  Thin callers pass the unexpanded operator range request. The orchestrator owns
-  range expansion, parent/child grouping, child refresh defaults, and partial
-  submission compensation.
+  Thin callers pass operator intent for the range, dependency mode, and refresh
+  mode. The orchestrator owns range expansion, parent/child grouping, child
+  refresh defaults, selected-asset refresh translation, and partial submission
+  compensation.
   """
   @spec submit_operator_asset_backfill(
           operator_actor_context(),
@@ -568,15 +582,21 @@ defmodule FavnOrchestrator do
           operator_actor_context(),
           String.t(),
           String.t(),
-          keyword() | map()
+          AssetBackfillRequest.t() | map() | keyword()
         ) :: {:ok, run_id()} | {:error, term()}
-  def submit_operator_asset_backfill(actor_context, manifest_version_id, target_id, opts \\ []) do
+  def submit_operator_asset_backfill(
+        actor_context,
+        manifest_version_id,
+        target_id,
+        command_input \\ %{}
+      ) do
     with :ok <- require_operator_context(actor_context),
+         {:ok, request} <- AssetBackfillRequest.from_input(command_input),
          {:ok, version} <- get_manifest(manifest_version_id),
-         {:ok, asset_ref} <- resolve_asset_target_ref(version, target_id),
-         {:ok, opts} <- normalize_asset_backfill_submit_opts(opts) do
+         {:ok, asset} <- resolve_asset_target(version, target_id),
+         {:ok, opts} <- operator_asset_backfill_opts(asset, request) do
       BackfillManager.submit_asset_backfill(
-        asset_ref,
+        asset.ref,
         Keyword.put(opts, :manifest_version_id, manifest_version_id)
       )
     end
@@ -745,6 +765,92 @@ defmodule FavnOrchestrator do
   defp request_refresh_option(value, _asset_ref, _dependencies),
     do: {:error, {:invalid_refresh_policy, value}}
 
+  defp operator_asset_run_opts(asset, %AssetRunRequest{} = request) do
+    with {:ok, refresh} <-
+           operator_asset_refresh_option(request.refresh_mode, asset.ref, request.dependency_mode) do
+      opts =
+        []
+        |> Keyword.put(:dependencies, request.dependency_mode)
+        |> Keyword.put(:refresh, refresh)
+        |> maybe_put_opt(:metadata, request.metadata)
+        |> maybe_put_opt(:timeout_ms, request.timeout_ms)
+
+      put_asset_run_selection_opts(opts, asset, request.selection)
+    end
+  end
+
+  defp operator_asset_backfill_opts(asset, %AssetBackfillRequest{} = request) do
+    with {:ok, refresh} <-
+           operator_asset_backfill_refresh_option(
+             request.refresh_mode,
+             asset.ref,
+             request.dependency_mode
+           ) do
+      opts =
+        []
+        |> Keyword.put(:range_request, request.range)
+        |> Keyword.put(:dependencies, request.dependency_mode)
+        |> maybe_put_opt(:refresh, refresh)
+        |> maybe_put_opt(:metadata, request.metadata)
+        |> maybe_put_opt(:max_attempts, request.max_attempts)
+        |> maybe_put_opt(:retry_backoff_ms, request.retry_backoff_ms)
+        |> maybe_put_opt(:timeout_ms, request.timeout_ms)
+
+      {:ok, opts}
+    end
+  end
+
+  defp operator_pipeline_run_opts(%PipelineRunRequest{} = request) do
+    opts =
+      []
+      |> maybe_put_opt(:window_request, request.window)
+      |> maybe_put_opt(:refresh, operator_pipeline_refresh_option(request.refresh_mode))
+      |> maybe_put_opt(:metadata, request.metadata)
+      |> maybe_put_opt(:timeout_ms, request.timeout_ms)
+
+    {:ok, opts}
+  end
+
+  defp operator_pipeline_backfill_opts(%PipelineBackfillRequest{} = request) do
+    opts =
+      []
+      |> Keyword.put(:range_request, request.range)
+      |> maybe_put_opt(:coverage_baseline_id, request.coverage_baseline_id)
+      |> maybe_put_opt(:refresh, operator_pipeline_backfill_refresh_option(request.refresh_mode))
+      |> maybe_put_opt(:metadata, request.metadata)
+      |> maybe_put_opt(:max_attempts, request.max_attempts)
+      |> maybe_put_opt(:retry_backoff_ms, request.retry_backoff_ms)
+      |> maybe_put_opt(:timeout_ms, request.timeout_ms)
+
+    {:ok, opts}
+  end
+
+  defp operator_asset_refresh_option(:auto, _asset_ref, _dependencies), do: {:ok, :auto}
+  defp operator_asset_refresh_option(:missing, _asset_ref, _dependencies), do: {:ok, :missing}
+  defp operator_asset_refresh_option(:force_all, _asset_ref, _dependencies), do: {:ok, :force}
+
+  defp operator_asset_refresh_option(:force_selected, asset_ref, _dependencies),
+    do: {:ok, {:force_assets, [asset_ref]}}
+
+  defp operator_asset_refresh_option(:force_selected_upstream, _asset_ref, :none),
+    do: {:error, {:refresh_include_upstream_requires_dependencies, :all}}
+
+  defp operator_asset_refresh_option(:force_selected_upstream, asset_ref, :all),
+    do: {:ok, {:force_assets, [asset_ref], include_upstream: true}}
+
+  defp operator_asset_backfill_refresh_option(:auto, _asset_ref, _dependencies), do: {:ok, nil}
+
+  defp operator_asset_backfill_refresh_option(refresh_mode, asset_ref, dependencies),
+    do: operator_asset_refresh_option(refresh_mode, asset_ref, dependencies)
+
+  defp operator_pipeline_refresh_option(:auto), do: nil
+  defp operator_pipeline_refresh_option(:missing), do: :missing
+  defp operator_pipeline_refresh_option(:force_all), do: :force
+
+  defp operator_pipeline_backfill_refresh_option(:auto), do: nil
+  defp operator_pipeline_backfill_refresh_option(:missing), do: :missing
+  defp operator_pipeline_backfill_refresh_option(:force_all), do: :force
+
   defp put_window_run_metadata(opts, window_id, %Anchor{} = anchor_window) do
     selected_window_metadata = window_run_metadata(window_id, anchor_window)
 
@@ -818,11 +924,15 @@ defmodule FavnOrchestrator do
   end
 
   @doc """
-  Submits one pipeline run for an authenticated operator actor context.
+  Submits one pipeline run command for an authenticated operator actor context.
 
-  This is the same-BEAM browser boundary for LiveView operator actions. Missing
-  or incomplete actor/session context returns `{:error, :unauthenticated}`;
-  authenticated actors without the operator role return `{:error, :forbidden}`.
+  This is the same-BEAM boundary for browser, API, and CLI operator actions.
+  Callers pass operator intent and the orchestrator translates it into runtime
+  submit options after resolving the manifest pipeline target.
+
+  Missing or incomplete actor/session context returns `{:error,
+  :unauthenticated}`; authenticated actors without the operator role return
+  `{:error, :forbidden}`.
 
   TODO: add a narrow audit event for accepted LiveView operator commands once the
   audit shape for same-BEAM browser actions is finalized.
@@ -836,11 +946,23 @@ defmodule FavnOrchestrator do
           operator_actor_context(),
           String.t(),
           String.t(),
-          keyword() | map()
+          PipelineRunRequest.t() | map() | keyword() | nil
         ) :: {:ok, run_id()} | {:error, term()}
-  def submit_operator_pipeline_run(actor_context, manifest_version_id, target_id, opts \\ []) do
-    with :ok <- require_operator_context(actor_context) do
-      submit_pipeline_run_for_manifest(manifest_version_id, target_id, opts)
+  def submit_operator_pipeline_run(
+        actor_context,
+        manifest_version_id,
+        target_id,
+        command_input \\ %{}
+      ) do
+    with :ok <- require_operator_context(actor_context),
+         {:ok, request} <- PipelineRunRequest.from_input(command_input),
+         {:ok, version} <- get_manifest(manifest_version_id),
+         {:ok, pipeline_module} <- resolve_pipeline_target_module(version, target_id),
+         {:ok, opts} <- operator_pipeline_run_opts(request) do
+      submit_pipeline_run(
+        pipeline_module,
+        Keyword.put(opts, :manifest_version_id, manifest_version_id)
+      )
     end
   end
 
@@ -1018,11 +1140,15 @@ defmodule FavnOrchestrator do
   end
 
   @doc """
-  Submits one pipeline backfill for an authenticated operator actor context.
+  Submits one pipeline backfill command for an authenticated operator actor context.
 
-  This is the same-BEAM browser boundary for LiveView operator actions. Missing
-  or incomplete actor/session context returns `{:error, :unauthenticated}`;
-  authenticated actors without the operator role return `{:error, :forbidden}`.
+  This is the same-BEAM boundary for browser, API, and CLI operator actions.
+  Callers pass operator intent for the range and refresh mode. The orchestrator
+  validates and translates that intent before submitting the runtime backfill.
+
+  Missing or incomplete actor/session context returns `{:error,
+  :unauthenticated}`; authenticated actors without the operator role return
+  `{:error, :forbidden}`.
 
   TODO: add a narrow audit event for accepted LiveView operator commands once the
   audit shape for same-BEAM browser actions is finalized.
@@ -1036,11 +1162,23 @@ defmodule FavnOrchestrator do
           operator_actor_context(),
           String.t(),
           String.t(),
-          keyword() | map()
+          PipelineBackfillRequest.t() | map() | keyword()
         ) :: {:ok, run_id()} | {:error, term()}
-  def submit_operator_pipeline_backfill(actor_context, manifest_version_id, target_id, opts \\ []) do
-    with :ok <- require_operator_context(actor_context) do
-      submit_pipeline_backfill_for_manifest(manifest_version_id, target_id, opts)
+  def submit_operator_pipeline_backfill(
+        actor_context,
+        manifest_version_id,
+        target_id,
+        command_input \\ %{}
+      ) do
+    with :ok <- require_operator_context(actor_context),
+         {:ok, request} <- PipelineBackfillRequest.from_input(command_input),
+         {:ok, version} <- get_manifest(manifest_version_id),
+         {:ok, pipeline_module} <- resolve_pipeline_target_module(version, target_id),
+         {:ok, opts} <- operator_pipeline_backfill_opts(request) do
+      submit_pipeline_backfill(
+        pipeline_module,
+        Keyword.put(opts, :manifest_version_id, manifest_version_id)
+      )
     end
   end
 
@@ -2904,31 +3042,6 @@ defmodule FavnOrchestrator do
         |> Keyword.put(:range_request, range_request)
         |> maybe_put_opt(:metadata, field_value(opts, :metadata))
         |> maybe_put_opt(:coverage_baseline_id, field_value(opts, :coverage_baseline_id))
-        |> maybe_put_opt(:refresh, field_value(opts, :refresh))
-        |> maybe_put_opt(:refresh_policy, field_value(opts, :refresh_policy))
-        |> maybe_put_opt(:max_attempts, field_value(opts, :max_attempts))
-        |> maybe_put_opt(:retry_backoff_ms, field_value(opts, :retry_backoff_ms))
-        |> maybe_put_opt(:timeout_ms, field_value(opts, :timeout_ms))
-
-      {:ok, submit_opts}
-    end
-  end
-
-  defp normalize_asset_backfill_submit_opts(opts) when is_list(opts) do
-    with {:ok, range_request} <- RangeRequest.from_value(Keyword.get(opts, :range_request)) do
-      {:ok, Keyword.put(opts, :range_request, range_request)}
-    end
-  end
-
-  defp normalize_asset_backfill_submit_opts(opts) when is_map(opts) do
-    range = field_value(opts, :range) || field_value(opts, :range_request)
-
-    with {:ok, range_request} <- RangeRequest.from_value(range) do
-      submit_opts =
-        []
-        |> Keyword.put(:range_request, range_request)
-        |> maybe_put_opt(:metadata, field_value(opts, :metadata))
-        |> maybe_put_opt(:dependencies, field_value(opts, :dependencies))
         |> maybe_put_opt(:refresh, field_value(opts, :refresh))
         |> maybe_put_opt(:refresh_policy, field_value(opts, :refresh_policy))
         |> maybe_put_opt(:max_attempts, field_value(opts, :max_attempts))

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_backfill_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_backfill_request.ex
@@ -31,7 +31,11 @@ defmodule FavnOrchestrator.OperatorCommands.AssetBackfillRequest do
   Normalizes map, keyword, or struct input into an asset backfill request.
   """
   @spec from_input(t() | map() | keyword()) :: {:ok, t()} | {:error, term()}
-  def from_input(%__MODULE__{} = request), do: {:ok, request}
+  def from_input(%__MODULE__{} = request) do
+    request
+    |> Map.from_struct()
+    |> from_input()
+  end
 
   def from_input(input) when is_map(input) or is_list(input) do
     dependency_value =

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_backfill_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_backfill_request.ex
@@ -1,0 +1,60 @@
+defmodule FavnOrchestrator.OperatorCommands.AssetBackfillRequest do
+  @moduledoc """
+  Operator intent for submitting a manifest asset backfill.
+  """
+
+  alias Favn.Backfill.RangeRequest
+  alias FavnOrchestrator.OperatorCommands.Input
+
+  @type dependency_mode :: :all | :none
+  @type refresh_mode :: :auto | :missing | :force_all | :force_selected | :force_selected_upstream
+
+  @type t :: %__MODULE__{
+          dependency_mode: dependency_mode(),
+          refresh_mode: refresh_mode(),
+          range: RangeRequest.t(),
+          metadata: map() | nil,
+          max_attempts: pos_integer() | nil,
+          retry_backoff_ms: non_neg_integer() | nil,
+          timeout_ms: non_neg_integer() | nil
+        }
+
+  defstruct dependency_mode: :all,
+            refresh_mode: :auto,
+            range: nil,
+            metadata: nil,
+            max_attempts: nil,
+            retry_backoff_ms: nil,
+            timeout_ms: nil
+
+  @doc """
+  Normalizes map, keyword, or struct input into an asset backfill request.
+  """
+  @spec from_input(t() | map() | keyword()) :: {:ok, t()} | {:error, term()}
+  def from_input(%__MODULE__{} = request), do: {:ok, request}
+
+  def from_input(input) when is_map(input) or is_list(input) do
+    dependency_value =
+      Input.field(input, :dependency_mode, Input.field(input, :dependencies, :all))
+
+    refresh_value = Input.field(input, :refresh_mode, Input.field(input, :refresh, :auto))
+    range_value = Input.field(input, :range, Input.field(input, :range_request))
+
+    with {:ok, dependency_mode} <- Input.dependency_mode(dependency_value),
+         {:ok, refresh_mode} <- Input.asset_refresh_mode(refresh_value),
+         {:ok, range} <- Input.range(range_value) do
+      {:ok,
+       %__MODULE__{
+         dependency_mode: dependency_mode,
+         refresh_mode: refresh_mode,
+         range: range,
+         metadata: Input.field(input, :metadata),
+         max_attempts: Input.field(input, :max_attempts),
+         retry_backoff_ms: Input.field(input, :retry_backoff_ms),
+         timeout_ms: Input.field(input, :timeout_ms)
+       }}
+    end
+  end
+
+  def from_input(input), do: {:error, {:invalid_operator_asset_backfill_request, input}}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_run_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_run_request.ex
@@ -38,7 +38,11 @@ defmodule FavnOrchestrator.OperatorCommands.AssetRunRequest do
   Normalizes map, keyword, or struct input into an asset run request.
   """
   @spec from_input(t() | map() | keyword() | nil) :: {:ok, t()} | {:error, term()}
-  def from_input(%__MODULE__{} = request), do: {:ok, request}
+  def from_input(%__MODULE__{} = request) do
+    request
+    |> Map.from_struct()
+    |> from_input()
+  end
 
   def from_input(input) when is_map(input) or is_list(input) or is_nil(input) do
     input = input || %{}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_run_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_run_request.ex
@@ -1,0 +1,66 @@
+defmodule FavnOrchestrator.OperatorCommands.AssetRunRequest do
+  @moduledoc """
+  Operator intent for submitting a single manifest asset run.
+
+  This DTO is accepted at the public orchestrator operator facade. It describes
+  what the operator requested, not the runtime options used to execute the run.
+  """
+
+  alias FavnOrchestrator.OperatorCommands.Input
+
+  @type dependency_mode :: :all | :none
+  @type refresh_mode :: :auto | :missing | :force_all | :force_selected | :force_selected_upstream
+
+  @type selection :: %{
+          required(:source) => :refresh_timeline | :data_coverage_timeline,
+          required(:id) => String.t(),
+          optional(:kind) => atom() | String.t() | nil,
+          optional(:value) => String.t() | nil,
+          optional(:timezone) => String.t(),
+          optional(:run_id) => String.t() | nil
+        }
+
+  @type t :: %__MODULE__{
+          dependency_mode: dependency_mode(),
+          refresh_mode: refresh_mode(),
+          selection: selection() | nil,
+          metadata: map() | nil,
+          timeout_ms: non_neg_integer() | nil
+        }
+
+  defstruct dependency_mode: :all,
+            refresh_mode: :auto,
+            selection: nil,
+            metadata: nil,
+            timeout_ms: nil
+
+  @doc """
+  Normalizes map, keyword, or struct input into an asset run request.
+  """
+  @spec from_input(t() | map() | keyword() | nil) :: {:ok, t()} | {:error, term()}
+  def from_input(%__MODULE__{} = request), do: {:ok, request}
+
+  def from_input(input) when is_map(input) or is_list(input) or is_nil(input) do
+    input = input || %{}
+
+    dependency_value =
+      Input.field(input, :dependency_mode, Input.field(input, :dependencies, :all))
+
+    refresh_value = Input.field(input, :refresh_mode, Input.field(input, :refresh, :auto))
+
+    with {:ok, dependency_mode} <- Input.dependency_mode(dependency_value),
+         {:ok, refresh_mode} <- Input.asset_refresh_mode(refresh_value),
+         {:ok, selection} <- Input.selection(Input.field(input, :selection)) do
+      {:ok,
+       %__MODULE__{
+         dependency_mode: dependency_mode,
+         refresh_mode: refresh_mode,
+         selection: selection,
+         metadata: Input.field(input, :metadata),
+         timeout_ms: Input.field(input, :timeout_ms)
+       }}
+    end
+  end
+
+  def from_input(input), do: {:error, {:invalid_operator_asset_run_request, input}}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/input.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/input.ex
@@ -74,23 +74,29 @@ defmodule FavnOrchestrator.OperatorCommands.Input do
   end
 
   def window(nil), do: {:ok, nil}
-  def window(%WindowRequest{} = request), do: WindowRequest.from_value(request)
+
+  def window(%WindowRequest{} = request) do
+    normalize_window_result(request, fn -> WindowRequest.from_value(request) end)
+  end
 
   def window(value) when is_binary(value) do
-    case WindowRequest.parse(value) do
-      {:ok, %WindowRequest{} = request} -> {:ok, request}
-      {:error, _reason} -> {:error, {:invalid_operator_window, value}}
-    end
+    normalize_window_result(value, fn -> WindowRequest.parse(value) end)
   end
 
   def window(value) when is_map(value) do
-    case WindowRequest.from_value(value) do
-      {:ok, %WindowRequest{} = request} -> {:ok, request}
-      {:error, _reason} -> {:error, {:invalid_operator_window, value}}
-    end
+    normalize_window_result(value, fn -> WindowRequest.from_value(value) end)
   end
 
   def window(value), do: {:error, {:invalid_operator_window, value}}
+
+  defp normalize_window_result(original, fun) do
+    case fun.() do
+      {:ok, %WindowRequest{} = request} -> {:ok, request}
+      {:error, _reason} -> {:error, {:invalid_operator_window, original}}
+    end
+  rescue
+    _exception -> {:error, {:invalid_operator_window, original}}
+  end
 
   defp refresh_mode(:force, modes), do: maybe_refresh_mode(:force_all, modes, :force)
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/input.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/input.ex
@@ -1,0 +1,151 @@
+defmodule FavnOrchestrator.OperatorCommands.Input do
+  @moduledoc false
+
+  alias Favn.Backfill.RangeRequest
+  alias Favn.Window.Request, as: WindowRequest
+
+  @dependency_modes [:all, :none]
+  @asset_refresh_modes [:auto, :missing, :force_all, :force_selected, :force_selected_upstream]
+  @pipeline_refresh_modes [:auto, :missing, :force_all]
+  @selection_sources [:refresh_timeline, :data_coverage_timeline]
+
+  def empty?(nil), do: true
+  def empty?(value) when value in [%{}, []], do: true
+  def empty?(_value), do: false
+
+  def field(value, field, default \\ nil)
+
+  def field(value, field, default) when is_map(value) do
+    Map.get(value, field, Map.get(value, Atom.to_string(field), default))
+  end
+
+  def field(value, field, default) when is_list(value) do
+    Keyword.get(value, field, default)
+  end
+
+  def field(_value, _field, default), do: default
+
+  def dependency_mode(value) when value in @dependency_modes, do: {:ok, value}
+
+  def dependency_mode(value) when is_binary(value) do
+    case value do
+      "all" -> {:ok, :all}
+      "none" -> {:ok, :none}
+      _other -> {:error, {:invalid_operator_dependency_mode, value}}
+    end
+  end
+
+  def dependency_mode(value), do: {:error, {:invalid_operator_dependency_mode, value}}
+
+  def asset_refresh_mode(value), do: refresh_mode(value, @asset_refresh_modes)
+  def pipeline_refresh_mode(value), do: refresh_mode(value, @pipeline_refresh_modes)
+
+  def selection(nil), do: {:ok, nil}
+
+  def selection(value) when is_map(value) do
+    source = field(value, :source)
+    id = field(value, :id)
+    kind = field(value, :kind)
+    timeline_value = field(value, :value)
+    timezone = field(value, :timezone, "Etc/UTC")
+    run_id = field(value, :run_id)
+
+    with {:ok, source} <- selection_source(source),
+         {:ok, id} <- selection_id(source, id, kind, timeline_value) do
+      {:ok,
+       %{
+         source: source,
+         id: id,
+         kind: kind,
+         value: timeline_value,
+         timezone: timezone,
+         run_id: run_id
+       }}
+    end
+  end
+
+  def selection(value), do: {:error, {:invalid_operator_selection, value}}
+
+  def range(value) do
+    case RangeRequest.from_value(value) do
+      {:ok, %RangeRequest{} = request} -> {:ok, request}
+      {:error, _reason} -> {:error, {:invalid_operator_range, value}}
+    end
+  end
+
+  def window(nil), do: {:ok, nil}
+  def window(%WindowRequest{} = request), do: WindowRequest.from_value(request)
+
+  def window(value) when is_binary(value) do
+    case WindowRequest.parse(value) do
+      {:ok, %WindowRequest{} = request} -> {:ok, request}
+      {:error, _reason} -> {:error, {:invalid_operator_window, value}}
+    end
+  end
+
+  def window(value) when is_map(value) do
+    case WindowRequest.from_value(value) do
+      {:ok, %WindowRequest{} = request} -> {:ok, request}
+      {:error, _reason} -> {:error, {:invalid_operator_window, value}}
+    end
+  end
+
+  def window(value), do: {:error, {:invalid_operator_window, value}}
+
+  defp refresh_mode(:force, modes), do: maybe_refresh_mode(:force_all, modes, :force)
+
+  defp refresh_mode(value, modes) when is_atom(value) do
+    if value in modes do
+      {:ok, value}
+    else
+      {:error, {:invalid_operator_refresh_mode, value}}
+    end
+  end
+
+  defp refresh_mode(value, modes) when is_binary(value) do
+    case value do
+      "auto" -> {:ok, :auto}
+      "missing" -> {:ok, :missing}
+      "force" -> {:ok, :force_all}
+      "force_all" -> {:ok, :force_all}
+      "force_selected" -> maybe_refresh_mode(:force_selected, modes, value)
+      "force_selected_upstream" -> maybe_refresh_mode(:force_selected_upstream, modes, value)
+      _other -> {:error, {:invalid_operator_refresh_mode, value}}
+    end
+  end
+
+  defp refresh_mode(value, _modes), do: {:error, {:invalid_operator_refresh_mode, value}}
+
+  defp maybe_refresh_mode(mode, modes, original) do
+    if mode in modes do
+      {:ok, mode}
+    else
+      {:error, {:invalid_operator_refresh_mode, original}}
+    end
+  end
+
+  defp selection_source(source) when source in @selection_sources, do: {:ok, source}
+
+  defp selection_source(source) when is_binary(source) do
+    case source do
+      "refresh_timeline" -> {:ok, :refresh_timeline}
+      "data_coverage_timeline" -> {:ok, :data_coverage_timeline}
+      _other -> {:error, {:invalid_operator_selection_source, source}}
+    end
+  end
+
+  defp selection_source(source), do: {:error, {:invalid_operator_selection_source, source}}
+
+  defp selection_id(_source, id, _kind, _value) when is_binary(id) and id != "", do: {:ok, id}
+
+  defp selection_id(source, _id, kind, value)
+       when is_binary(kind) and kind != "" and is_binary(value) and value != "" do
+    {:ok, derived_selection_id(source, kind, value)}
+  end
+
+  defp selection_id(_source, id, _kind, _value),
+    do: {:error, {:invalid_operator_selection_id, id}}
+
+  defp derived_selection_id(:refresh_timeline, kind, value), do: "refresh:#{kind}:#{value}"
+  defp derived_selection_id(:data_coverage_timeline, kind, value), do: "window:#{kind}:#{value}"
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_backfill_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_backfill_request.ex
@@ -1,0 +1,55 @@
+defmodule FavnOrchestrator.OperatorCommands.PipelineBackfillRequest do
+  @moduledoc """
+  Operator intent for submitting a manifest pipeline backfill.
+  """
+
+  alias Favn.Backfill.RangeRequest
+  alias FavnOrchestrator.OperatorCommands.Input
+
+  @type refresh_mode :: :auto | :missing | :force_all
+
+  @type t :: %__MODULE__{
+          refresh_mode: refresh_mode(),
+          range: RangeRequest.t(),
+          metadata: map() | nil,
+          coverage_baseline_id: String.t() | nil,
+          max_attempts: pos_integer() | nil,
+          retry_backoff_ms: non_neg_integer() | nil,
+          timeout_ms: non_neg_integer() | nil
+        }
+
+  defstruct refresh_mode: :auto,
+            range: nil,
+            metadata: nil,
+            coverage_baseline_id: nil,
+            max_attempts: nil,
+            retry_backoff_ms: nil,
+            timeout_ms: nil
+
+  @doc """
+  Normalizes map, keyword, or struct input into a pipeline backfill request.
+  """
+  @spec from_input(t() | map() | keyword()) :: {:ok, t()} | {:error, term()}
+  def from_input(%__MODULE__{} = request), do: {:ok, request}
+
+  def from_input(input) when is_map(input) or is_list(input) do
+    refresh_value = Input.field(input, :refresh_mode, Input.field(input, :refresh, :auto))
+    range_value = Input.field(input, :range, Input.field(input, :range_request))
+
+    with {:ok, refresh_mode} <- Input.pipeline_refresh_mode(refresh_value),
+         {:ok, range} <- Input.range(range_value) do
+      {:ok,
+       %__MODULE__{
+         refresh_mode: refresh_mode,
+         range: range,
+         metadata: Input.field(input, :metadata),
+         coverage_baseline_id: Input.field(input, :coverage_baseline_id),
+         max_attempts: Input.field(input, :max_attempts),
+         retry_backoff_ms: Input.field(input, :retry_backoff_ms),
+         timeout_ms: Input.field(input, :timeout_ms)
+       }}
+    end
+  end
+
+  def from_input(input), do: {:error, {:invalid_operator_pipeline_backfill_request, input}}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_backfill_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_backfill_request.ex
@@ -30,7 +30,11 @@ defmodule FavnOrchestrator.OperatorCommands.PipelineBackfillRequest do
   Normalizes map, keyword, or struct input into a pipeline backfill request.
   """
   @spec from_input(t() | map() | keyword()) :: {:ok, t()} | {:error, term()}
-  def from_input(%__MODULE__{} = request), do: {:ok, request}
+  def from_input(%__MODULE__{} = request) do
+    request
+    |> Map.from_struct()
+    |> from_input()
+  end
 
   def from_input(input) when is_map(input) or is_list(input) do
     refresh_value = Input.field(input, :refresh_mode, Input.field(input, :refresh, :auto))

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_run_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_run_request.ex
@@ -24,7 +24,11 @@ defmodule FavnOrchestrator.OperatorCommands.PipelineRunRequest do
   Normalizes map, keyword, or struct input into a pipeline run request.
   """
   @spec from_input(t() | map() | keyword() | nil) :: {:ok, t()} | {:error, term()}
-  def from_input(%__MODULE__{} = request), do: {:ok, request}
+  def from_input(%__MODULE__{} = request) do
+    request
+    |> Map.from_struct()
+    |> from_input()
+  end
 
   def from_input(input) when is_map(input) or is_list(input) or is_nil(input) do
     input = input || %{}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_run_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_run_request.ex
@@ -1,0 +1,46 @@
+defmodule FavnOrchestrator.OperatorCommands.PipelineRunRequest do
+  @moduledoc """
+  Operator intent for submitting a single manifest pipeline run.
+  """
+
+  alias Favn.Window.Request, as: WindowRequest
+  alias FavnOrchestrator.OperatorCommands.Input
+
+  @type refresh_mode :: :auto | :missing | :force_all
+
+  @type t :: %__MODULE__{
+          refresh_mode: refresh_mode(),
+          window: WindowRequest.t() | nil,
+          metadata: map() | nil,
+          timeout_ms: non_neg_integer() | nil
+        }
+
+  defstruct refresh_mode: :auto,
+            window: nil,
+            metadata: nil,
+            timeout_ms: nil
+
+  @doc """
+  Normalizes map, keyword, or struct input into a pipeline run request.
+  """
+  @spec from_input(t() | map() | keyword() | nil) :: {:ok, t()} | {:error, term()}
+  def from_input(%__MODULE__{} = request), do: {:ok, request}
+
+  def from_input(input) when is_map(input) or is_list(input) or is_nil(input) do
+    input = input || %{}
+    refresh_value = Input.field(input, :refresh_mode, Input.field(input, :refresh, :auto))
+
+    with {:ok, refresh_mode} <- Input.pipeline_refresh_mode(refresh_value),
+         {:ok, window} <- Input.window(Input.field(input, :window)) do
+      {:ok,
+       %__MODULE__{
+         refresh_mode: refresh_mode,
+         window: window,
+         metadata: Input.field(input, :metadata),
+         timeout_ms: Input.field(input, :timeout_ms)
+       }}
+    end
+  end
+
+  def from_input(input), do: {:error, {:invalid_operator_pipeline_run_request, input}}
+end

--- a/apps/favn_orchestrator/test/auth/operator_facade_test.exs
+++ b/apps/favn_orchestrator/test/auth/operator_facade_test.exs
@@ -143,7 +143,7 @@ defmodule FavnOrchestrator.Auth.OperatorFacadeTest do
                operator_context,
                "missing_manifest",
                "pipeline:missing",
-               []
+               valid_range_request()
              )
   end
 
@@ -211,4 +211,8 @@ defmodule FavnOrchestrator.Auth.OperatorFacadeTest do
 
   defp restore_env(key, nil), do: Application.delete_env(:favn_orchestrator, key)
   defp restore_env(key, value), do: Application.put_env(:favn_orchestrator, key, value)
+
+  defp valid_range_request do
+    %{range: %{kind: "day", from: "2026-05-01", to: "2026-05-03", timezone: "Etc/UTC"}}
+  end
 end

--- a/apps/favn_orchestrator/test/auth/operator_facade_test.exs
+++ b/apps/favn_orchestrator/test/auth/operator_facade_test.exs
@@ -4,6 +4,10 @@ defmodule FavnOrchestrator.Auth.OperatorFacadeTest do
   alias FavnOrchestrator
   alias FavnOrchestrator.Auth
   alias FavnOrchestrator.Auth.Store, as: AuthStore
+  alias FavnOrchestrator.OperatorCommands.AssetBackfillRequest
+  alias FavnOrchestrator.OperatorCommands.AssetRunRequest
+  alias FavnOrchestrator.OperatorCommands.PipelineBackfillRequest
+  alias FavnOrchestrator.OperatorCommands.PipelineRunRequest
 
   setup do
     previous_failure_limit = Application.get_env(:favn_orchestrator, :auth_login_failure_limit)
@@ -189,6 +193,54 @@ defmodule FavnOrchestrator.Auth.OperatorFacadeTest do
              )
   end
 
+  test "operator command wrappers validate malformed DTO structs before manifest lookup" do
+    operator_context = operator_context("operator-malformed-dto")
+
+    assert {:error, {:invalid_operator_refresh_mode, :bogus}} =
+             FavnOrchestrator.submit_operator_asset_run(
+               operator_context,
+               "missing_manifest",
+               "asset:missing",
+               %AssetRunRequest{refresh_mode: :bogus}
+             )
+
+    assert {:error, {:invalid_operator_refresh_mode, :bogus}} =
+             FavnOrchestrator.submit_operator_asset_backfill(
+               operator_context,
+               "missing_manifest",
+               "asset:missing",
+               %AssetBackfillRequest{refresh_mode: :bogus}
+             )
+
+    assert {:error, {:invalid_operator_refresh_mode, :force_selected}} =
+             FavnOrchestrator.submit_operator_pipeline_run(
+               operator_context,
+               "missing_manifest",
+               "pipeline:missing",
+               %PipelineRunRequest{refresh_mode: :force_selected}
+             )
+
+    assert {:error, {:invalid_operator_refresh_mode, :force_selected}} =
+             FavnOrchestrator.submit_operator_pipeline_backfill(
+               operator_context,
+               "missing_manifest",
+               "pipeline:missing",
+               %PipelineBackfillRequest{refresh_mode: :force_selected}
+             )
+  end
+
+  test "operator pipeline run normalizes malformed window input before manifest lookup" do
+    operator_context = operator_context("operator-bad-window")
+
+    assert {:error, {:invalid_operator_window, %{mode: "bad"}}} =
+             FavnOrchestrator.submit_operator_pipeline_run(
+               operator_context,
+               "missing_manifest",
+               "pipeline:missing",
+               %{window: %{mode: "bad"}}
+             )
+  end
+
   defp ensure_auth_store_started do
     case Process.whereis(AuthStore) do
       nil ->
@@ -211,6 +263,16 @@ defmodule FavnOrchestrator.Auth.OperatorFacadeTest do
 
   defp restore_env(key, nil), do: Application.delete_env(:favn_orchestrator, key)
   defp restore_env(key, value), do: Application.put_env(:favn_orchestrator, key, value)
+
+  defp operator_context(username) do
+    assert {:ok, actor} =
+             Auth.create_actor(username, "operator-password-long", "Operator", [:operator])
+
+    assert {:ok, session, ^actor} =
+             FavnOrchestrator.operator_password_login(username, "operator-password-long")
+
+    %{actor: actor, session: session}
+  end
 
   defp valid_range_request do
     %{range: %{kind: "day", from: "2026-05-01", to: "2026-05-03", timezone: "Etc/UTC"}}

--- a/apps/favn_orchestrator/test/operator_commands/request_test.exs
+++ b/apps/favn_orchestrator/test/operator_commands/request_test.exs
@@ -1,0 +1,73 @@
+defmodule FavnOrchestrator.OperatorCommands.RequestTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Backfill.RangeRequest
+  alias FavnOrchestrator.OperatorCommands.AssetBackfillRequest
+  alias FavnOrchestrator.OperatorCommands.AssetRunRequest
+  alias FavnOrchestrator.OperatorCommands.PipelineBackfillRequest
+  alias FavnOrchestrator.OperatorCommands.PipelineRunRequest
+
+  test "asset run requests normalize browser-shaped operator intent" do
+    assert {:ok, request} =
+             AssetRunRequest.from_input(%{
+               "dependencies" => "none",
+               "refresh" => "force_selected_upstream",
+               "selection" => %{
+                 "source" => "refresh_timeline",
+                 "kind" => "day",
+                 "value" => "2026-05-10",
+                 "timezone" => "Etc/UTC"
+               }
+             })
+
+    assert request.dependency_mode == :none
+    assert request.refresh_mode == :force_selected_upstream
+    assert request.selection.source == :refresh_timeline
+    assert request.selection.id == "refresh:day:2026-05-10"
+  end
+
+  test "asset run requests reject unknown dependency refresh and selection values" do
+    assert {:error, {:invalid_operator_dependency_mode, "some"}} =
+             AssetRunRequest.from_input(%{"dependency_mode" => "some"})
+
+    assert {:error, {:invalid_operator_refresh_mode, "sometimes"}} =
+             AssetRunRequest.from_input(%{"refresh_mode" => "sometimes"})
+
+    assert {:error, {:invalid_operator_selection_source, "audit_log"}} =
+             AssetRunRequest.from_input(%{
+               selection: %{source: "audit_log", id: "window:day:2026-05-10"}
+             })
+  end
+
+  test "asset backfill requests normalize ranges and selected refresh modes" do
+    assert {:ok, request} =
+             AssetBackfillRequest.from_input(%{
+               dependency_mode: :all,
+               refresh_mode: :force_selected,
+               range: %{kind: "day", from: "2026-05-01", to: "2026-05-03", timezone: "Etc/UTC"}
+             })
+
+    assert request.dependency_mode == :all
+    assert request.refresh_mode == :force_selected
+    assert %RangeRequest{kind: :day, from: "2026-05-01", to: "2026-05-03"} = request.range
+  end
+
+  test "pipeline requests reject selected-asset refresh modes" do
+    assert {:ok, request} = PipelineRunRequest.from_input(%{refresh_mode: :force})
+    assert request.refresh_mode == :force_all
+
+    assert {:error, {:invalid_operator_refresh_mode, "force_selected"}} =
+             PipelineRunRequest.from_input(%{refresh_mode: "force_selected"})
+
+    assert {:error, {:invalid_operator_refresh_mode, "force_selected_upstream"}} =
+             PipelineBackfillRequest.from_input(%{
+               refresh_mode: "force_selected_upstream",
+               range: %{kind: "day", from: "2026-05-01", to: "2026-05-03"}
+             })
+  end
+
+  test "pipeline backfill requests return stable range errors" do
+    assert {:error, {:invalid_operator_range, %{kind: "day"}}} =
+             PipelineBackfillRequest.from_input(%{range: %{kind: "day"}})
+  end
+end

--- a/apps/favn_orchestrator/test/operator_commands/request_test.exs
+++ b/apps/favn_orchestrator/test/operator_commands/request_test.exs
@@ -66,6 +66,27 @@ defmodule FavnOrchestrator.OperatorCommands.RequestTest do
              })
   end
 
+  test "prebuilt request structs are validated like map input" do
+    assert {:error, {:invalid_operator_refresh_mode, :bogus}} =
+             AssetRunRequest.from_input(%AssetRunRequest{refresh_mode: :bogus})
+
+    assert {:error, {:invalid_operator_refresh_mode, :bogus}} =
+             AssetBackfillRequest.from_input(%AssetBackfillRequest{refresh_mode: :bogus})
+
+    assert {:error, {:invalid_operator_refresh_mode, :force_selected}} =
+             PipelineRunRequest.from_input(%PipelineRunRequest{refresh_mode: :force_selected})
+
+    assert {:error, {:invalid_operator_refresh_mode, :force_selected}} =
+             PipelineBackfillRequest.from_input(%PipelineBackfillRequest{
+               refresh_mode: :force_selected
+             })
+  end
+
+  test "pipeline window maps normalize lower-level request errors" do
+    assert {:error, {:invalid_operator_window, %{mode: "bad"}}} =
+             PipelineRunRequest.from_input(%{window: %{mode: "bad"}})
+  end
+
   test "pipeline backfill requests return stable range errors" do
     assert {:error, {:invalid_operator_range, %{kind: "day"}}} =
              PipelineBackfillRequest.from_input(%{range: %{kind: "day"}})

--- a/apps/favn_view/lib/favn_view/asset_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_detail_live.ex
@@ -128,10 +128,7 @@ defmodule FavnView.AssetDetailLive do
   end
 
   def handle_event("change_run_config", params, socket) do
-    run_config =
-      params
-      |> run_config_from_params(socket.assigns.run_config)
-      |> apply_asset_range_defaults(socket.assigns.selected_window)
+    run_config = run_config_from_params(params, socket.assigns.run_config)
 
     {:noreply, assign(socket, :run_config, run_config)}
   end
@@ -139,10 +136,7 @@ defmodule FavnView.AssetDetailLive do
   def handle_event("run_selected_window", params, socket) do
     %{asset: asset, selected_window: selected_window} = socket.assigns
 
-    run_config =
-      params
-      |> run_config_from_params(socket.assigns.run_config)
-      |> apply_asset_range_defaults(selected_window)
+    run_config = run_config_from_params(params, socket.assigns.run_config)
 
     cond do
       !socket.assigns.can_submit_runs? ->
@@ -164,21 +158,11 @@ defmodule FavnView.AssetDetailLive do
          )}
 
       true ->
-        case run_submit_opts(asset, run_config) do
-          {:ok, opts} ->
-            submit_asset_run(socket, asset, selected_window, run_config, opts)
-
-          {:error, reason} ->
-            {:noreply,
-             assign(socket,
-               run_config: run_config,
-               selected_window_error: submit_error_label(reason)
-             )}
-        end
+        submit_asset_run(socket, asset, selected_window, run_config)
     end
   end
 
-  defp submit_asset_run(socket, asset, selected_window, run_config, opts) do
+  defp submit_asset_run(socket, asset, selected_window, run_config) do
     socket =
       assign(socket,
         run_config: run_config,
@@ -187,7 +171,7 @@ defmodule FavnView.AssetDetailLive do
         submitted_run_id: nil
       )
 
-    case submit_asset_window_run(socket, asset, selected_window, run_config, opts) do
+    case submit_asset_window_run(socket, asset, selected_window, run_config) do
       {:ok, run_id, :single} ->
         {:noreply,
          socket
@@ -209,12 +193,12 @@ defmodule FavnView.AssetDetailLive do
     end
   end
 
-  defp submit_asset_window_run(socket, asset, nil, %{to: to} = run_config, opts)
+  defp submit_asset_window_run(socket, asset, nil, %{to: to} = run_config)
        when is_binary(to) and to != "" do
     request = %{
       range: range_request(run_config),
-      dependencies: Keyword.get(opts, :dependencies),
-      refresh: backfill_refresh_option(opts)
+      dependency_mode: run_config.dependencies,
+      refresh_mode: run_config.refresh
     }
 
     case FavnOrchestrator.submit_operator_asset_backfill(
@@ -228,10 +212,11 @@ defmodule FavnView.AssetDetailLive do
     end
   end
 
-  defp submit_asset_window_run(socket, asset, selected_window, run_config, opts) do
+  defp submit_asset_window_run(socket, asset, selected_window, run_config) do
     request = %{
       selection: timeline_selection(selected_window, run_config),
-      config: Map.new(opts)
+      dependency_mode: run_config.dependencies,
+      refresh_mode: run_config.refresh
     }
 
     case FavnOrchestrator.submit_operator_asset_run(
@@ -495,7 +480,6 @@ defmodule FavnView.AssetDetailLive do
               is_binary(value) and value != "" do
     %{
       source: source,
-      id: selection_id(source, kind, value),
       kind: kind,
       value: value,
       timezone: timezone,
@@ -516,19 +500,8 @@ defmodule FavnView.AssetDetailLive do
     }
   end
 
-  defp selection_id("refresh_timeline", kind, value), do: "refresh:#{kind}:#{value}"
-  defp selection_id("data_coverage_timeline", kind, value), do: "window:#{kind}:#{value}"
-  defp selection_id(_source, kind, value), do: "window:#{kind}:#{value}"
-
   defp range_request(%{kind: kind, value: from, to: to, timezone: timezone}) do
     %{kind: kind, from: from, to: to, timezone: timezone}
-  end
-
-  defp backfill_refresh_option(opts) do
-    case Keyword.get(opts, :refresh) do
-      refresh when refresh in [:auto, :missing] -> nil
-      refresh -> refresh
-    end
   end
 
   defp missing_freshness_detail do
@@ -571,44 +544,6 @@ defmodule FavnView.AssetDetailLive do
 
   defp run_config_from_params(_params, current_config), do: current_config || default_run_config()
 
-  defp apply_asset_range_defaults(%{to: to, refresh: refresh} = run_config, nil)
-       when is_binary(to) and to != "" and refresh == "auto" do
-    %{run_config | refresh: "missing"}
-  end
-
-  defp apply_asset_range_defaults(run_config, _selected_window), do: run_config
-
-  defp run_submit_opts(asset, %{dependencies: dependencies, refresh: refresh}) do
-    with {:ok, dependencies} <- dependency_option(dependencies),
-         {:ok, refresh} <-
-           refresh_option(refresh, Map.get(asset, :canonical_asset_ref), dependencies) do
-      {:ok, [dependencies: dependencies, refresh: refresh]}
-    end
-  end
-
-  defp dependency_option("all"), do: {:ok, :all}
-  defp dependency_option("none"), do: {:ok, :none}
-  defp dependency_option(value), do: {:error, {:invalid_dependencies_mode, value}}
-
-  defp refresh_option("auto", _asset_ref, _dependencies), do: {:ok, :auto}
-  defp refresh_option("missing", _asset_ref, _dependencies), do: {:ok, :missing}
-  defp refresh_option("force_all", _asset_ref, _dependencies), do: {:ok, :force}
-
-  defp refresh_option("force_selected", asset_ref, _dependencies) when is_tuple(asset_ref) do
-    {:ok, {:force_assets, [asset_ref]}}
-  end
-
-  defp refresh_option("force_selected_upstream", _asset_ref, :none) do
-    {:error, {:refresh_include_upstream_requires_dependencies, :all}}
-  end
-
-  defp refresh_option("force_selected_upstream", asset_ref, :all) when is_tuple(asset_ref) do
-    {:ok, {:force_assets, [asset_ref], include_upstream: true}}
-  end
-
-  defp refresh_option(value, _asset_ref, _dependencies),
-    do: {:error, {:invalid_refresh_policy, value}}
-
   defp disabled_reason_label(:asset_has_no_window_policy), do: "This asset has no window policy."
   defp disabled_reason_label(:invalid_window), do: "This window cannot be run."
   defp disabled_reason_label(_reason), do: "This window is not runnable."
@@ -622,9 +557,22 @@ defmodule FavnView.AssetDetailLive do
   defp submit_error_label({:refresh_include_upstream_requires_dependencies, :all}),
     do: "Force selected + upstream requires including upstream dependencies."
 
-  defp submit_error_label({:invalid_dependencies_mode, _value}), do: "Dependency mode is invalid."
+  defp submit_error_label({:invalid_operator_dependency_mode, _value}),
+    do: "Dependency mode is invalid."
 
-  defp submit_error_label({:invalid_refresh_policy, _value}), do: "Refresh behavior is invalid."
+  defp submit_error_label({:invalid_operator_refresh_mode, _value}),
+    do: "Refresh behavior is invalid."
+
+  defp submit_error_label({:invalid_operator_selection_source, _value}),
+    do: "Selected timeline is invalid."
+
+  defp submit_error_label({:invalid_operator_selection, _value}),
+    do: "Selected window is invalid."
+
+  defp submit_error_label({:invalid_operator_selection_id, _value}),
+    do: "Selected window is invalid."
+
+  defp submit_error_label({:invalid_operator_range, _value}), do: "Window range is invalid."
 
   defp submit_error_label(:invalid_window_range), do: "Window range is invalid."
 

--- a/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
@@ -88,7 +88,7 @@ defmodule FavnView.PipelineDetailLive do
              actor_context(socket),
              pipeline.manifest_version_id,
              pipeline.id,
-             %{range: Map.drop(config, [:refresh]), refresh: refresh_option(config.refresh)}
+             %{range: Map.drop(config, [:refresh]), refresh_mode: config.refresh}
            ) do
       {:noreply,
        socket
@@ -240,10 +240,6 @@ defmodule FavnView.PipelineDetailLive do
     }
   end
 
-  defp refresh_option("force"), do: :force
-  defp refresh_option("auto"), do: :auto
-  defp refresh_option(_refresh), do: :missing
-
   defp window_kind(nil), do: :month
 
   defp window_kind(window) do
@@ -394,6 +390,12 @@ defmodule FavnView.PipelineDetailLive do
 
   defp submit_error_label({:invalid_backfill_range_request, _value}),
     do: "Invalid backfill range."
+
+  defp submit_error_label({:invalid_operator_range, _value}),
+    do: "Invalid backfill range."
+
+  defp submit_error_label({:invalid_operator_refresh_mode, _value}),
+    do: "Refresh behavior is invalid."
 
   defp submit_error_label({:missing_window_request, kind}),
     do: "This #{kind} pipeline requires an explicit window request."

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -708,7 +708,9 @@ defmodule FavnView.PageLiveTest do
     })
   end
 
-  test "run asset range defaults visible refresh and child runs to missing", %{conn: conn} do
+  test "run asset range keeps operator refresh intent and child runs default to missing", %{
+    conn: conn
+  } do
     {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
 
     open_run_config(view)
@@ -735,7 +737,7 @@ defmodule FavnView.PageLiveTest do
       }
     })
 
-    assert has_element?(view, ~s(input[name="run_config[refresh]"][value="missing"][checked]))
+    assert has_element?(view, ~s(input[name="run_config[refresh]"][value="auto"][checked]))
 
     view
     |> element(~s([data-testid="run-config-form"]))

--- a/docs/ISSUE_397_OPERATOR_COMMAND_DTO_PLAN.md
+++ b/docs/ISSUE_397_OPERATOR_COMMAND_DTO_PLAN.md
@@ -1,0 +1,182 @@
+# Issue 397 Operator Command DTO Plan
+
+## Goal
+
+Make operator run/backfill commands explicit at the orchestrator facade so
+browser, API, and future CLI submit paths can pass operator intent without
+reconstructing runtime execution options in `favn_view`.
+
+## Current State
+
+- `FavnView.AssetDetailLive` keeps browser form state, but also translates
+  dependency and refresh choices into runtime submit options such as `:force`,
+  `{:force_assets, refs}`, and `include_upstream: true`.
+- `FavnView.AssetDetailLive` derives timeline selection ids and range requests
+  before calling the orchestrator facade.
+- `FavnView.PipelineDetailLive` submits pipeline backfills as plain range and
+  refresh maps, with view-owned defaults.
+- `FavnOrchestrator` already accepts some map-shaped submit input for manifest
+  asset and pipeline commands, but the shape is still runtime-option oriented:
+  `:config`, `:refresh`, `:refresh_policy`, `:dependencies`, `:window_request`,
+  and `:range_request`.
+- Operator auth and role checks already belong at the public orchestrator facade;
+  #397 should preserve that ownership and clarify the command input immediately
+  after auth succeeds.
+
+## Design
+
+- Add orchestrator-owned operator command DTO modules under
+  `FavnOrchestrator.OperatorCommands`.
+- Keep the DTOs in `favn_orchestrator`, not `favn_core`; these are control-plane
+  operator command contracts, not manifest/compiler domain contracts.
+- Use four small structs with moduledocs, docs, types, and `from_input/1` style
+  normalization functions:
+  - `AssetRunRequest`
+  - `AssetBackfillRequest`
+  - `PipelineRunRequest`
+  - `PipelineBackfillRequest`
+- Model operator intent with boring enums and maps:
+  - `dependency_mode`: `:all | :none`
+  - `refresh_mode`: `:auto | :missing | :force_all | :force_selected |
+    :force_selected_upstream`
+  - `selection`: `nil` or a struct/map containing `source`, optional stable `id`,
+    and optional `kind`, `value`, `timezone`, and `run_id`
+  - `range`: `kind`, `from`, `to`, and `timezone`
+  - `window`: optional future pipeline window request intent for single pipeline
+    runs
+- Let DTO normalization accept string-keyed and atom-keyed maps because browser,
+  API, and CLI callers naturally produce different input shapes.
+- Return stable orchestrator-owned error atoms/tuples for invalid command input,
+  such as `{:invalid_operator_dependency_mode, value}`,
+  `{:invalid_operator_refresh_mode, value}`,
+  `{:invalid_operator_selection_source, value}`,
+  `{:invalid_operator_selection, value}`, and
+  `{:invalid_operator_range, value}`.
+- Translate DTOs into existing runtime submit options only inside
+  `FavnOrchestrator` after manifest target resolution provides the asset ref,
+  pipeline module, window policy, and selected target context.
+- Keep `FavnOrchestrator.RefreshPolicy`, `RangeRequest`, and `WindowRequest` as
+  runtime/control-plane internals behind the operator command boundary.
+- Do not return UI labels, component state, CSS concerns, or LiveView-specific
+  field names from orchestrator DTO modules.
+
+## Public Facade Shape
+
+- Keep the four existing operator facade functions as the public entry points:
+  - `submit_operator_asset_run/4`
+  - `submit_operator_asset_backfill/4`
+  - `submit_operator_pipeline_run/4`
+  - `submit_operator_pipeline_backfill/4`
+- Change their docs and specs so the fourth argument is an explicit operator
+  command input or DTO struct, not `keyword() | map()` runtime opts.
+- Preserve `submit_asset_run_for_manifest/3`, `submit_pipeline_run_for_manifest/3`,
+  and backfill equivalents as lower-level manifest/runtime entry points while
+  moving operator-only normalization out of the LiveViews and into the operator
+  facade path.
+- Do not introduce backwards-compatibility aliases for old operator request shapes
+  unless a concrete shipped caller needs them; this repo is private pre-v1.
+
+## Translation Rules
+
+- Asset run:
+  - Normalize dependency and refresh modes from command input.
+  - Resolve the manifest asset target before translating selected-asset refresh
+    modes, because selected-asset refresh needs the canonical asset ref.
+  - Translate `:force_selected_upstream` to `{:force_assets, [asset_ref],
+    include_upstream: true}` only when dependency mode is `:all`; otherwise return
+    the stable dependency/refresh conflict error.
+  - Resolve `selection` against the asset's refresh or data-coverage timeline in
+    the orchestrator, including stable id validation and window/runtime request
+    translation.
+- Asset backfill:
+  - Normalize the operator range request into `Favn.Backfill.RangeRequest` inside
+    the orchestrator.
+  - Apply the same dependency and refresh intent translation as asset runs.
+  - Keep backfill child refresh defaults in the orchestrator/backfill manager, not
+    in the LiveView.
+- Pipeline run:
+  - Normalize optional window and refresh intent at the orchestrator boundary.
+  - Keep pipeline module/target resolution and window-request validation inside
+    the manifest-pinned facade path.
+- Pipeline backfill:
+  - Normalize operator range and refresh intent at the orchestrator boundary.
+  - Preserve existing parent/child backfill behavior and only change the input
+    contract used to reach it.
+
+## LiveView Changes
+
+- Keep `AssetDetailLive` responsible for browser state, selected timeline UI
+  state, and local form value normalization only.
+- Remove asset LiveView translation helpers that produce runtime submit options:
+  `run_submit_opts/2`, `dependency_option/1`, `refresh_option/3`, and
+  `backfill_refresh_option/1`.
+- Stop deriving runtime force policies in the LiveView. Submit refresh mode strings
+  such as `"force_selected"` and `"force_selected_upstream"` as operator intent.
+- Move typed timeline-id derivation for manually entered selections from the
+  LiveView into the orchestrator command translator where practical. The LiveView
+  may pass backend-provided stable ids for clicked windows because those ids are
+  part of the orchestrator-owned asset detail DTO.
+- Keep `PipelineDetailLive` responsible for collecting `from`, `to`, `kind`,
+  `timezone`, and refresh string values only.
+- Keep LiveView error rendering as a mapping from stable orchestrator error atoms
+  to user-facing text. Do not expose orchestrator DTO structs or runtime option
+  tuples in rendered output.
+
+## Landing Slices
+
+1. Add orchestrator command DTO modules and unit tests for pure input
+   normalization, including atom-keyed and string-keyed maps.
+2. Add orchestrator facade tests that assert valid/invalid dependency modes,
+   refresh modes, selected/upstream force behavior, selected timeline ids, range
+   backfills, and permission failures return stable results.
+3. Wire `submit_operator_asset_run/4` and `submit_operator_asset_backfill/4`
+   through the new DTOs and translation functions while preserving existing
+   lower-level runtime submit behavior.
+4. Wire `submit_operator_pipeline_run/4` and
+   `submit_operator_pipeline_backfill/4` through the new DTOs and translation
+   functions.
+5. Thin `AssetDetailLive` submit handlers so they pass operator command intent
+   and render returned error atoms.
+6. Thin `PipelineDetailLive` submit handlers the same way.
+7. Update facade docs, structure docs, and feature docs to describe the operator
+   command boundary.
+
+## Tests
+
+- DTO normalization accepts expected browser/API/CLI map shapes and rejects
+  unknown dependency, refresh, selection-source, range, and window values with
+  stable errors.
+- Operator facade authorization remains first: unauthenticated and forbidden
+  contexts fail before manifest lookup or command translation leaks target state.
+- Asset run facade tests cover `:all`, `:none`, `:auto`, `:missing`,
+  `:force_all`, `:force_selected`, `:force_selected_upstream`, and the
+  `force_selected_upstream` plus `:none` conflict.
+- Asset run facade tests cover refresh timeline and data-coverage timeline
+  selection ids, including invalid ids.
+- Asset and pipeline backfill facade tests cover valid ranges, invalid ranges,
+  range bounds, and default refresh behavior.
+- LiveView submit tests assert the view sends intent-shaped requests and renders
+  returned stable errors. They should not assert runtime option tuples.
+
+## Risks And Tradeoffs
+
+- The operator facade currently also acts as a convenient pass-through to lower
+  level manifest submit functions. Tightening the fourth argument is a breaking
+  pre-v1 change, but it makes the boundary clearer and avoids duplicating refresh
+  semantics in the UI.
+- Some validation depends on resolved manifest targets, so DTO normalization must
+  stay split between pure input parsing and context-aware translation.
+- Error atoms need to be stable enough for UI/API rendering, but should remain
+  domain-oriented and not mirror current component labels.
+- This should not become a generic command framework. Four small DTO modules are
+  enough for the current repeated contract.
+
+## Non-Goals
+
+- Do not change runner contracts or `Favn.Contracts.RunnerWork`.
+- Do not move operator command DTOs into `favn_core`.
+- Do not redesign asset or pipeline detail UI.
+- Do not return UI labels, CSS classes, or component-specific state from the
+  orchestrator.
+- Do not change scheduler, freshness decider, or backfill manager runtime
+  semantics except where required to consume the translated command options.

--- a/docs/structure/favn_orchestrator.md
+++ b/docs/structure/favn_orchestrator.md
@@ -17,6 +17,9 @@ Code:
 - Reusable runtime-state repair passes under `apps/favn_orchestrator/lib/favn_orchestrator/repair/`
 - Refresh policy normalization and forced-run selection in
   `apps/favn_orchestrator/lib/favn_orchestrator/refresh_policy.ex`
+- Operator run/backfill command DTOs under
+  `apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/`, used by the
+  public facade to translate browser/API/CLI intent into runtime submit options.
 - Operational pipeline and asset backfill range expansion, parent/child run
   grouping, ledger rows, and partial-submission compensation in
   `apps/favn_orchestrator/lib/favn_orchestrator/backfill_manager.ex`
@@ -34,6 +37,7 @@ Tests:
 - API contract tests under `apps/favn_orchestrator/test/api/`
 - HTTP schema shape tests under `apps/favn_orchestrator/test/http_contract/`
 - Auth storage/facade tests under `apps/favn_orchestrator/test/auth/`
+- Operator command DTO tests under `apps/favn_orchestrator/test/operator_commands/`
 - Production runtime config/runtime dependency config/readiness/diagnostics tests under `apps/favn_orchestrator/test/production_runtime_config_test.exs`, `apps/favn_orchestrator/test/runtime_config_test.exs`, `apps/favn_orchestrator/test/readiness_test.exs`, and `apps/favn_orchestrator/test/diagnostics_test.exs`
 - storage contract/codec tests under `apps/favn_orchestrator/test/storage/`
 - Freshness decision/query tests under `apps/favn_orchestrator/test/freshness/`


### PR DESCRIPTION
## Summary
- Add orchestrator-owned operator command DTOs for asset/pipeline run and backfill requests.
- Move operator intent validation and runtime option translation into the `FavnOrchestrator` facade.
- Thin asset/pipeline LiveViews so they submit intent-shaped requests and render stable orchestrator errors.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/operator_commands/request_test.exs test/auth/operator_facade_test.exs`
- `MIX_ENV=test mix do --app favn_view cmd mix test`
- `MIX_ENV=test mix do --app favn_local cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser`

Closes #397