### PR TITLE
Make freshness and backfill persistence explicit

### DIFF
--- a/apps/favn_orchestrator/lib/favn/storage/adapter.ex
+++ b/apps/favn_orchestrator/lib/favn/storage/adapter.ex
@@ -38,6 +38,7 @@ defmodule Favn.Storage.Adapter do
   alias FavnOrchestrator.Backfill.AssetWindowState
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
+  alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -47,6 +48,7 @@ defmodule Favn.Storage.Adapter do
   @type filter_opts :: keyword()
   @type error :: :not_found | :invalid_opts | term()
   @type scheduler_key :: {module(), atom() | nil}
+  @type freshness_state_key :: {module(), atom(), String.t()}
   @type child_spec_result :: {:ok, Supervisor.child_spec()} | :none | {:error, error()}
   @type readiness_diagnostics :: map()
   @type diagnostics :: map()
@@ -139,6 +141,15 @@ defmodule Favn.Storage.Adapter do
               {:ok, BackfillWindow.t()} | {:error, error()}
   @callback list_backfill_windows(filter_opts(), adapter_opts()) ::
               {:ok, Page.t(BackfillWindow.t())} | {:error, error()}
+  @callback apply_backfill_child_projection(
+              BackfillWindow.t(),
+              [AssetWindowState.t()],
+              adapter_opts()
+            ) :: {:ok, BackfillProgress.t()} | {:error, error()}
+  @callback get_backfill_progress(String.t(), adapter_opts()) ::
+              {:ok, BackfillProgress.t()} | {:error, error()}
+  @callback rebuild_backfill_progress(String.t(), adapter_opts()) ::
+              {:ok, BackfillProgress.t()} | {:error, error()}
 
   @callback put_asset_window_state(AssetWindowState.t(), adapter_opts()) ::
               :ok | {:error, error()}
@@ -151,6 +162,8 @@ defmodule Favn.Storage.Adapter do
               :ok | {:error, error()}
   @callback get_asset_freshness_state(module(), atom(), String.t(), adapter_opts()) ::
               {:ok, AssetFreshnessState.t()} | {:error, error()}
+  @callback get_asset_freshness_states_by_keys([freshness_state_key()], adapter_opts()) ::
+              {:ok, %{freshness_state_key() => AssetFreshnessState.t()}} | {:error, error()}
   @callback list_asset_freshness_states(filter_opts(), adapter_opts()) ::
               {:ok, Page.t(AssetFreshnessState.t())} | {:error, error()}
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill/progress.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill/progress.ex
@@ -1,0 +1,269 @@
+defmodule FavnOrchestrator.Backfill.Progress do
+  @moduledoc """
+  Persisted aggregate progress for one parent backfill run.
+
+  Backfill windows remain the detailed ledger. This struct stores the derived
+  count summary needed to update parent run status without repeatedly loading
+  every window into the orchestrator process.
+  """
+
+  alias FavnOrchestrator.Backfill.BackfillWindow
+
+  @statuses [:pending, :running, :ok, :partial, :error, :cancelled, :timed_out]
+
+  @enforce_keys [
+    :backfill_run_id,
+    :total_count,
+    :pending_count,
+    :running_count,
+    :ok_count,
+    :partial_count,
+    :error_count,
+    :cancelled_count,
+    :timed_out_count,
+    :status,
+    :updated_at
+  ]
+
+  defstruct [
+    :backfill_run_id,
+    :total_count,
+    :pending_count,
+    :running_count,
+    :ok_count,
+    :partial_count,
+    :error_count,
+    :cancelled_count,
+    :timed_out_count,
+    :status,
+    :updated_at,
+    metadata: %{}
+  ]
+
+  @type status :: BackfillWindow.status()
+
+  @type counts :: %{
+          optional(status()) => non_neg_integer()
+        }
+
+  @type t :: %__MODULE__{
+          backfill_run_id: String.t(),
+          total_count: non_neg_integer(),
+          pending_count: non_neg_integer(),
+          running_count: non_neg_integer(),
+          ok_count: non_neg_integer(),
+          partial_count: non_neg_integer(),
+          error_count: non_neg_integer(),
+          cancelled_count: non_neg_integer(),
+          timed_out_count: non_neg_integer(),
+          status: status(),
+          updated_at: DateTime.t(),
+          metadata: map()
+        }
+
+  @doc "Builds a progress struct from explicit count fields."
+  @spec new(map() | keyword()) :: {:ok, t()} | {:error, term()}
+  def new(attrs) when is_map(attrs) or is_list(attrs) do
+    attrs = Map.new(attrs)
+
+    with {:ok, attrs} <- normalize_attrs(attrs),
+         :ok <- require_keys(attrs, @enforce_keys),
+         :ok <- validate_counts(attrs),
+         :ok <- validate_status(Map.fetch!(attrs, :status)),
+         :ok <- validate_metadata(Map.get(attrs, :metadata, %{})) do
+      {:ok, struct(__MODULE__, Map.merge(%{metadata: %{}}, attrs))}
+    end
+  end
+
+  def new(_attrs), do: {:error, :invalid_attrs}
+
+  @doc "Builds progress from a map of window-status counts."
+  @spec from_counts(String.t(), counts(), DateTime.t(), map()) :: {:ok, t()} | {:error, term()}
+  def from_counts(backfill_run_id, counts, %DateTime{} = updated_at, metadata \\ %{})
+      when is_binary(backfill_run_id) and is_map(counts) do
+    normalized_counts = normalize_counts(counts)
+    total_count = Enum.reduce(normalized_counts, 0, fn {_status, count}, acc -> acc + count end)
+
+    new(%{
+      backfill_run_id: backfill_run_id,
+      total_count: total_count,
+      pending_count: Map.fetch!(normalized_counts, :pending),
+      running_count: Map.fetch!(normalized_counts, :running),
+      ok_count: Map.fetch!(normalized_counts, :ok),
+      partial_count: Map.fetch!(normalized_counts, :partial),
+      error_count: Map.fetch!(normalized_counts, :error),
+      cancelled_count: Map.fetch!(normalized_counts, :cancelled),
+      timed_out_count: Map.fetch!(normalized_counts, :timed_out),
+      status: status_from_counts(total_count, normalized_counts),
+      updated_at: updated_at,
+      metadata: metadata
+    })
+  end
+
+  @doc "Builds progress by counting a backfill's window rows."
+  @spec from_windows(String.t(), [BackfillWindow.t()], DateTime.t()) ::
+          {:ok, t()} | {:error, term()}
+  def from_windows(backfill_run_id, windows, %DateTime{} = updated_at)
+      when is_binary(backfill_run_id) and is_list(windows) do
+    counts =
+      Enum.reduce(windows, %{}, fn %BackfillWindow{status: status}, acc ->
+        Map.update(acc, status, 1, &(&1 + 1))
+      end)
+
+    from_counts(backfill_run_id, counts, updated_at)
+  end
+
+  @doc "Returns the count map used in run transition metadata."
+  @spec window_counts(t()) :: %{status() => non_neg_integer()}
+  def window_counts(%__MODULE__{} = progress) do
+    progress
+    |> counts()
+    |> Enum.reject(fn {_status, count} -> count == 0 end)
+    |> Map.new()
+  end
+
+  @doc "Returns all status counts, including zero values."
+  @spec counts(t()) :: counts()
+  def counts(%__MODULE__{} = progress) do
+    %{
+      pending: progress.pending_count,
+      running: progress.running_count,
+      ok: progress.ok_count,
+      partial: progress.partial_count,
+      error: progress.error_count,
+      cancelled: progress.cancelled_count,
+      timed_out: progress.timed_out_count
+    }
+  end
+
+  @doc false
+  @spec apply_status_change(t(), status() | nil, status(), DateTime.t()) ::
+          {:ok, t()} | {:error, term()}
+  def apply_status_change(%__MODULE__{} = progress, old_status, new_status, %DateTime{} = now) do
+    counts = counts(progress)
+
+    {counts, total_count} =
+      cond do
+        is_nil(old_status) ->
+          {Map.update!(counts, new_status, &(&1 + 1)), progress.total_count + 1}
+
+        old_status == new_status ->
+          {counts, progress.total_count}
+
+        true ->
+          counts =
+            counts
+            |> Map.update!(old_status, &max(&1 - 1, 0))
+            |> Map.update!(new_status, &(&1 + 1))
+
+          {counts, progress.total_count}
+      end
+
+    from_counts(
+      progress.backfill_run_id,
+      Map.put(counts, :__total__, total_count),
+      now,
+      progress.metadata
+    )
+  end
+
+  defp normalize_attrs(attrs) do
+    with {:ok, status} <- normalize_status(Map.get(attrs, :status)),
+         {:ok, updated_at} <- normalize_datetime(Map.get(attrs, :updated_at)) do
+      {:ok,
+       attrs
+       |> Map.put(:status, status)
+       |> Map.put(:updated_at, updated_at)
+       |> normalize_count_fields()}
+    end
+  end
+
+  defp normalize_count_fields(attrs) do
+    Enum.reduce(count_field_keys(), attrs, fn key, acc ->
+      Map.put(acc, key, normalize_count(Map.get(acc, key, 0)))
+    end)
+  end
+
+  defp require_keys(attrs, keys) do
+    missing = Enum.filter(keys, &(Map.get(attrs, &1) in [nil, ""]))
+
+    case missing do
+      [] -> :ok
+      keys -> {:error, {:missing_required_keys, keys}}
+    end
+  end
+
+  defp validate_counts(attrs) do
+    count_field_keys()
+    |> Enum.find_value(:ok, fn key ->
+      count = Map.fetch!(attrs, key)
+      if is_integer(count) and count >= 0, do: false, else: {:error, {:invalid_count, key, count}}
+    end)
+  end
+
+  defp validate_status(status) when status in @statuses, do: :ok
+  defp validate_status(status), do: {:error, {:invalid_status, status}}
+
+  defp validate_metadata(metadata) when is_map(metadata), do: :ok
+  defp validate_metadata(metadata), do: {:error, {:invalid_metadata, metadata}}
+
+  defp normalize_counts(counts) do
+    base = Map.new(@statuses, &{&1, 0})
+
+    Enum.reduce(counts, base, fn
+      {:__total__, _total}, acc -> acc
+      {status, count}, acc -> Map.put(acc, normalize_status_key(status), normalize_count(count))
+    end)
+  end
+
+  defp status_from_counts(0, _counts), do: :running
+
+  defp status_from_counts(total, counts) do
+    cond do
+      Map.fetch!(counts, :pending) > 0 or Map.fetch!(counts, :running) > 0 -> :running
+      Map.fetch!(counts, :ok) == total -> :ok
+      Map.fetch!(counts, :cancelled) == total -> :cancelled
+      Map.fetch!(counts, :timed_out) == total -> :timed_out
+      Map.fetch!(counts, :ok) > 0 or Map.fetch!(counts, :partial) > 0 -> :partial
+      true -> :error
+    end
+  end
+
+  defp normalize_status(value) when value in @statuses, do: {:ok, value}
+
+  defp normalize_status(value) when is_binary(value),
+    do: value |> String.to_atom() |> normalize_status()
+
+  defp normalize_status(value), do: {:error, {:invalid_status, value}}
+
+  defp normalize_status_key(value) when value in @statuses, do: value
+  defp normalize_status_key(value) when is_binary(value), do: String.to_atom(value)
+
+  defp normalize_count(value) when is_integer(value), do: value
+  defp normalize_count(value) when is_binary(value), do: String.to_integer(value)
+  defp normalize_count(_value), do: 0
+
+  defp normalize_datetime(%DateTime{} = value), do: {:ok, value}
+
+  defp normalize_datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> {:ok, datetime}
+      {:error, _reason} -> {:error, {:invalid_datetime, value}}
+    end
+  end
+
+  defp normalize_datetime(value), do: {:error, {:invalid_datetime, value}}
+
+  defp count_field_keys do
+    [
+      :total_count,
+      :pending_count,
+      :running_count,
+      :ok_count,
+      :partial_count,
+      :error_count,
+      :cancelled_count,
+      :timed_out_count
+    ]
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill/progress.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill/progress.ex
@@ -69,6 +69,7 @@ defmodule FavnOrchestrator.Backfill.Progress do
     with {:ok, attrs} <- normalize_attrs(attrs),
          :ok <- require_keys(attrs, @enforce_keys),
          :ok <- validate_counts(attrs),
+         :ok <- validate_total_count(attrs),
          :ok <- validate_status(Map.fetch!(attrs, :status)),
          :ok <- validate_metadata(Map.get(attrs, :metadata, %{})) do
       {:ok, struct(__MODULE__, Map.merge(%{metadata: %{}}, attrs))}
@@ -139,32 +140,50 @@ defmodule FavnOrchestrator.Backfill.Progress do
   @doc false
   @spec apply_status_change(t(), status() | nil, status(), DateTime.t()) ::
           {:ok, t()} | {:error, term()}
+  def apply_status_change(%__MODULE__{} = progress, old_status, new_status, %DateTime{} = now)
+      when not (is_nil(old_status) or old_status in @statuses) do
+    {:error, {:invalid_old_status, progress.backfill_run_id, old_status, new_status, now}}
+  end
+
+  def apply_status_change(%__MODULE__{} = progress, old_status, new_status, %DateTime{} = now)
+      when new_status not in @statuses do
+    {:error, {:invalid_new_status, progress.backfill_run_id, old_status, new_status, now}}
+  end
+
   def apply_status_change(%__MODULE__{} = progress, old_status, new_status, %DateTime{} = now) do
     counts = counts(progress)
 
-    {counts, total_count} =
-      cond do
-        is_nil(old_status) ->
-          {Map.update!(counts, new_status, &(&1 + 1)), progress.total_count + 1}
+    case status_change_counts(counts, progress.total_count, old_status, new_status) do
+      {:ok, counts, total_count} ->
+        from_counts(
+          progress.backfill_run_id,
+          Map.put(counts, :__total__, total_count),
+          now,
+          progress.metadata
+        )
 
-        old_status == new_status ->
-          {counts, progress.total_count}
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
 
-        true ->
-          counts =
-            counts
-            |> Map.update!(old_status, &max(&1 - 1, 0))
-            |> Map.update!(new_status, &(&1 + 1))
+  defp status_change_counts(counts, total_count, nil, new_status),
+    do: {:ok, Map.update!(counts, new_status, &(&1 + 1)), total_count + 1}
 
-          {counts, progress.total_count}
-      end
+  defp status_change_counts(counts, total_count, old_status, old_status),
+    do: {:ok, counts, total_count}
 
-    from_counts(
-      progress.backfill_run_id,
-      Map.put(counts, :__total__, total_count),
-      now,
-      progress.metadata
-    )
+  defp status_change_counts(counts, total_count, old_status, new_status) do
+    if Map.fetch!(counts, old_status) > 0 do
+      counts =
+        counts
+        |> Map.update!(old_status, &(&1 - 1))
+        |> Map.update!(new_status, &(&1 + 1))
+
+      {:ok, counts, total_count}
+    else
+      {:error, {:stale_backfill_progress, old_status, new_status, counts}}
+    end
   end
 
   defp normalize_attrs(attrs) do
@@ -199,6 +218,26 @@ defmodule FavnOrchestrator.Backfill.Progress do
       count = Map.fetch!(attrs, key)
       if is_integer(count) and count >= 0, do: false, else: {:error, {:invalid_count, key, count}}
     end)
+  end
+
+  defp validate_total_count(attrs) do
+    total = Map.fetch!(attrs, :total_count)
+
+    sum =
+      attrs
+      |> Map.take([
+        :pending_count,
+        :running_count,
+        :ok_count,
+        :partial_count,
+        :error_count,
+        :cancelled_count,
+        :timed_out_count
+      ])
+      |> Map.values()
+      |> Enum.sum()
+
+    if total == sum, do: :ok, else: {:error, {:invalid_total_count, total, sum}}
   end
 
   defp validate_status(status) when status in @statuses, do: :ok

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill/projector.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill/projector.ex
@@ -10,6 +10,7 @@ defmodule FavnOrchestrator.Backfill.Projector do
   alias Favn.Run.AssetResult
   alias FavnOrchestrator.Backfill.AssetWindowState
   alias FavnOrchestrator.Backfill.BackfillWindow
+  alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
   alias FavnOrchestrator.TransitionWriter
@@ -74,8 +75,8 @@ defmodule FavnOrchestrator.Backfill.Projector do
              started_at: window.started_at || now,
              updated_at: now
          },
-         :ok <- Storage.put_backfill_window(updated) do
-      maybe_project_parent(context.backfill_run_id)
+         {:ok, progress} <- Storage.apply_backfill_child_projection(updated, []) do
+      maybe_project_parent(progress)
     end
   end
 
@@ -98,9 +99,10 @@ defmodule FavnOrchestrator.Backfill.Projector do
              finished_at: now,
              updated_at: now
          },
-         :ok <- Storage.put_backfill_window(updated),
-         :ok <- project_asset_window_states(updated, run_state) do
-      maybe_project_parent(context.backfill_run_id)
+         {:ok, asset_window_states} <- build_asset_window_states(updated, run_state),
+         {:ok, progress} <-
+           Storage.apply_backfill_child_projection(updated, asset_window_states) do
+      maybe_project_parent(progress)
     end
   end
 
@@ -112,8 +114,8 @@ defmodule FavnOrchestrator.Backfill.Projector do
     Storage.get_backfill_window(backfill_run_id, pipeline_module, window_key)
   end
 
-  defp maybe_project_parent(backfill_run_id) do
-    reproject_parent(backfill_run_id)
+  defp maybe_project_parent(%BackfillProgress{} = progress) do
+    project_parent_from_progress(progress)
   end
 
   @doc "Reprojects a terminal child backfill run into its persisted window."
@@ -137,9 +139,14 @@ defmodule FavnOrchestrator.Backfill.Projector do
   @doc "Reprojects a backfill parent run status from its persisted windows."
   @spec reproject_parent(String.t()) :: :ok | {:error, term()}
   def reproject_parent(backfill_run_id) when is_binary(backfill_run_id) do
-    with {:ok, windows} <- list_all_backfill_windows(backfill_run_id: backfill_run_id),
-         {:ok, parent} <- Storage.get_run(backfill_run_id),
-         status <- parent_status(windows),
+    with {:ok, progress} <- Storage.rebuild_backfill_progress(backfill_run_id) do
+      project_parent_from_progress(progress)
+    end
+  end
+
+  defp project_parent_from_progress(%BackfillProgress{} = progress) do
+    with {:ok, parent} <- Storage.get_run(progress.backfill_run_id),
+         status <- progress.status,
          error <- parent_error(status, parent),
          true <- status != parent.status or error != parent.error do
       event_type = parent_event_type(status)
@@ -148,11 +155,11 @@ defmodule FavnOrchestrator.Backfill.Projector do
       |> RunState.transition(
         status: status,
         error: error,
-        result: %{status: status, backfill_windows: length(windows)}
+        result: %{status: status, backfill_windows: progress.total_count}
       )
       |> TransitionWriter.persist_transition(event_type, %{
         status: status,
-        window_counts: window_counts(windows)
+        window_counts: BackfillProgress.window_counts(progress)
       })
     else
       false -> :ok
@@ -208,27 +215,25 @@ defmodule FavnOrchestrator.Backfill.Projector do
   defp parent_error(:ok, _parent), do: nil
   defp parent_error(_status, %RunState{} = parent), do: parent.error
 
-  defp window_counts(windows) do
-    Enum.reduce(windows, %{}, fn %BackfillWindow{status: status}, acc ->
-      Map.update(acc, status, 1, &(&1 + 1))
-    end)
-  end
-
-  defp project_asset_window_states(%BackfillWindow{} = window, %RunState{} = run_state) do
+  defp build_asset_window_states(%BackfillWindow{} = window, %RunState{} = run_state) do
     run_state
     |> asset_results()
-    |> Enum.reduce_while(:ok, fn result, :ok ->
+    |> Enum.reduce_while({:ok, []}, fn result, {:ok, acc} ->
       case asset_window_state(window, run_state, result) do
         {:ok, state} ->
-          case Storage.put_asset_window_state(state) do
-            :ok -> {:cont, :ok}
-            {:error, _reason} = error -> {:halt, error}
-          end
+          {:cont, {:ok, [state | acc]}}
 
         :ignore ->
-          {:cont, :ok}
+          {:cont, {:ok, acc}}
+
+        {:error, _reason} = error ->
+          {:halt, error}
       end
     end)
+    |> case do
+      {:ok, states} -> {:ok, Enum.reverse(states)}
+      {:error, _reason} = error -> error
+    end
   end
 
   defp asset_window_state(%BackfillWindow{} = window, %RunState{} = run_state, result) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill_manager.ex
@@ -298,29 +298,33 @@ defmodule FavnOrchestrator.BackfillManager do
     now = DateTime.utc_now()
     coverage_baseline_id = Keyword.get(opts, :coverage_baseline_id)
 
-    Enum.reduce_while(range.anchors, :ok, fn anchor, :ok ->
-      with {:ok, window} <-
-             BackfillWindow.new(%{
-               backfill_run_id: backfill_run_id,
-               pipeline_module: pipeline_module,
-               manifest_version_id: manifest_version_id,
-               coverage_baseline_id: coverage_baseline_id,
-               window_kind: anchor.kind,
-               window_start_at: anchor.start_at,
-               window_end_at: anchor.end_at,
-               timezone: anchor.timezone,
-               window_key: WindowKey.encode(anchor.key),
-               status: :pending,
-               attempt_count: 0,
-               created_at: now,
-               updated_at: now
-             }),
-           :ok <- Storage.put_backfill_window(window) do
-        {:cont, :ok}
-      else
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
+    with :ok <-
+           Enum.reduce_while(range.anchors, :ok, fn anchor, :ok ->
+             with {:ok, window} <-
+                    BackfillWindow.new(%{
+                      backfill_run_id: backfill_run_id,
+                      pipeline_module: pipeline_module,
+                      manifest_version_id: manifest_version_id,
+                      coverage_baseline_id: coverage_baseline_id,
+                      window_kind: anchor.kind,
+                      window_start_at: anchor.start_at,
+                      window_end_at: anchor.end_at,
+                      timezone: anchor.timezone,
+                      window_key: WindowKey.encode(anchor.key),
+                      status: :pending,
+                      attempt_count: 0,
+                      created_at: now,
+                      updated_at: now
+                    }),
+                  :ok <- Storage.put_backfill_window(window) do
+               {:cont, :ok}
+             else
+               {:error, _reason} = error -> {:halt, error}
+             end
+           end),
+         {:ok, _progress} <- Storage.rebuild_backfill_progress(backfill_run_id) do
+      :ok
+    end
   end
 
   defp submit_child_runs(%RunState{} = parent, pipeline_module, range, opts) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/freshness/decider.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/freshness/decider.ex
@@ -63,6 +63,24 @@ defmodule FavnOrchestrator.Freshness.Decider do
     Map.new(node_keys, &{&1, decide(plan, &1, opts)})
   end
 
+  @doc """
+  Returns the persisted freshness-state keys a plan may need for decisions.
+
+  The helper shares the same key derivation used by `decide/3`, allowing run
+  startup to fetch only relevant prior freshness rows from storage.
+  """
+  @spec planned_lookup_keys(Plan.t(), opts()) :: [{module(), atom(), String.t()}]
+  def planned_lookup_keys(%Plan{} = plan, opts \\ []) do
+    context = context(plan, opts)
+
+    plan.nodes
+    |> Map.values()
+    |> Enum.map(fn %{ref: {module, name}} = node ->
+      {module, name, freshness_key(node, context)}
+    end)
+    |> Enum.uniq()
+  end
+
   defp dependency_satisfied?(%{upstream: upstream}, context) do
     blocking =
       Enum.filter(upstream, &(Map.get(context.upstream_statuses, &1) in @blocking_statuses))

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -113,9 +113,9 @@ defmodule FavnOrchestrator.RunServer.Execution do
     runner_opts = configured_runner_opts()
 
     with :ok <- validate_runner_client(runner_client),
-         :ok <- runner_client.register_manifest(version, runner_opts) do
+         :ok <- runner_client.register_manifest(version, runner_opts),
+         {:ok, freshness_context} <- initial_freshness_context(run_state, version) do
       stage_groups = pipeline_stage_groups(run_state)
-      freshness_context = initial_freshness_context(run_state, version)
 
       stage_groups
       |> Enum.reduce_while({run_state, [], freshness_context, nil}, fn {stage, node_keys},
@@ -1702,18 +1702,21 @@ defmodule FavnOrchestrator.RunServer.Execution do
     assets_by_ref = assets_by_ref(version)
     refresh_policy = refresh_policy_from_metadata(run_state.metadata)
     now = DateTime.utc_now()
-    prior_states = load_prior_freshness_states(run_state, assets_by_ref, refresh_policy, now)
 
-    %{
-      assets_by_ref: assets_by_ref,
-      refresh_policy: refresh_policy,
-      prior_states: prior_states,
-      current_states: prior_states,
-      completed_node_keys: MapSet.new(),
-      refreshed_node_keys: MapSet.new(),
-      upstream_statuses: %{},
-      now: now
-    }
+    with {:ok, prior_states} <-
+           load_prior_freshness_states(run_state, assets_by_ref, refresh_policy, now) do
+      {:ok,
+       %{
+         assets_by_ref: assets_by_ref,
+         refresh_policy: refresh_policy,
+         prior_states: prior_states,
+         current_states: prior_states,
+         completed_node_keys: MapSet.new(),
+         refreshed_node_keys: MapSet.new(),
+         upstream_statuses: %{},
+         now: now
+       }}
+    end
   end
 
   defp load_prior_freshness_states(
@@ -1731,12 +1734,13 @@ defmodule FavnOrchestrator.RunServer.Execution do
 
     case Storage.get_asset_freshness_states_by_keys(keys) do
       {:ok, states_by_key} ->
-        states_by_key
-        |> Map.values()
-        |> index_freshness_states()
+        {:ok,
+         states_by_key
+         |> Map.values()
+         |> index_freshness_states()}
 
-      _other ->
-        %{}
+      {:error, reason} ->
+        {:error, {:freshness_state_lookup_failed, reason}}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution.ex
@@ -27,7 +27,6 @@ defmodule FavnOrchestrator.RunServer.Execution do
   alias FavnOrchestrator.Freshness.Decider
   alias FavnOrchestrator.Freshness.StateWriter
   alias FavnOrchestrator.MaterializationClaims
-  alias FavnOrchestrator.Page
   alias FavnOrchestrator.Redaction
   alias FavnOrchestrator.RefreshPolicy
   alias FavnOrchestrator.RuntimeConfig
@@ -269,7 +268,7 @@ defmodule FavnOrchestrator.RunServer.Execution do
         completed_node_keys: freshness_context.completed_node_keys,
         refreshed_node_keys: freshness_context.refreshed_node_keys,
         upstream_statuses: freshness_context.upstream_statuses,
-        now: DateTime.utc_now()
+        now: freshness_context.now
       )
 
     Enum.reduce_while(
@@ -1700,51 +1699,45 @@ defmodule FavnOrchestrator.RunServer.Execution do
   end
 
   defp initial_freshness_context(%RunState{} = run_state, %Version{} = version) do
-    prior_states = load_prior_freshness_states(run_state)
+    assets_by_ref = assets_by_ref(version)
+    refresh_policy = refresh_policy_from_metadata(run_state.metadata)
+    now = DateTime.utc_now()
+    prior_states = load_prior_freshness_states(run_state, assets_by_ref, refresh_policy, now)
 
     %{
-      assets_by_ref: assets_by_ref(version),
-      refresh_policy: refresh_policy_from_metadata(run_state.metadata),
+      assets_by_ref: assets_by_ref,
+      refresh_policy: refresh_policy,
       prior_states: prior_states,
       current_states: prior_states,
       completed_node_keys: MapSet.new(),
       refreshed_node_keys: MapSet.new(),
-      upstream_statuses: %{}
+      upstream_statuses: %{},
+      now: now
     }
   end
 
-  defp load_prior_freshness_states(%RunState{plan: %Favn.Plan{} = plan}) do
-    case load_prior_freshness_state_pages(plan, 0, []) do
-      {:ok, states} ->
-        states
+  defp load_prior_freshness_states(
+         %RunState{plan: %Favn.Plan{} = plan},
+         assets_by_ref,
+         refresh_policy,
+         now
+       ) do
+    keys =
+      Decider.planned_lookup_keys(plan,
+        assets_by_ref: assets_by_ref,
+        refresh_policy: refresh_policy,
+        now: now
+      )
+
+    case Storage.get_asset_freshness_states_by_keys(keys) do
+      {:ok, states_by_key} ->
+        states_by_key
+        |> Map.values()
         |> index_freshness_states()
 
       _other ->
         %{}
     end
-  end
-
-  defp load_prior_freshness_state_pages(%Favn.Plan{} = plan, offset, acc) do
-    case Storage.list_asset_freshness_states(limit: Page.max_limit(), offset: offset) do
-      {:ok, %Page{} = page} ->
-        states = Enum.filter(page.items, &planned_freshness_state?(plan, &1))
-        acc = acc ++ states
-
-        if page.has_more? do
-          load_prior_freshness_state_pages(plan, page.next_offset, acc)
-        else
-          {:ok, acc}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp planned_freshness_state?(%Favn.Plan{nodes: nodes}, %AssetFreshnessState{} = state) do
-    Enum.any?(nodes, fn {_node_key, %{ref: {module, name}}} ->
-      state.asset_ref_module == module and state.asset_ref_name == name
-    end)
   end
 
   defp index_freshness_states(states) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -15,10 +15,13 @@ defmodule FavnOrchestrator.Storage do
   alias FavnOrchestrator.Backfill.AssetWindowState
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
+  alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.RunState
+
+  @type freshness_state_key :: StorageAdapter.freshness_state_key()
 
   @spec child_specs() :: {:ok, [Supervisor.child_spec()]} | {:error, term()}
   @spec child_specs(RuntimeConfig.t()) :: {:ok, [Supervisor.child_spec()]} | {:error, term()}
@@ -345,6 +348,25 @@ defmodule FavnOrchestrator.Storage do
     end)
   end
 
+  @spec apply_backfill_child_projection(BackfillWindow.t(), [AssetWindowState.t()]) ::
+          {:ok, BackfillProgress.t()} | {:error, term()}
+  def apply_backfill_child_projection(%BackfillWindow{} = window, asset_window_states)
+      when is_list(asset_window_states) do
+    adapter_call(fn adapter, opts ->
+      adapter.apply_backfill_child_projection(window, asset_window_states, opts)
+    end)
+  end
+
+  @spec get_backfill_progress(String.t()) :: {:ok, BackfillProgress.t()} | {:error, term()}
+  def get_backfill_progress(backfill_run_id) when is_binary(backfill_run_id) do
+    adapter_call(fn adapter, opts -> adapter.get_backfill_progress(backfill_run_id, opts) end)
+  end
+
+  @spec rebuild_backfill_progress(String.t()) :: {:ok, BackfillProgress.t()} | {:error, term()}
+  def rebuild_backfill_progress(backfill_run_id) when is_binary(backfill_run_id) do
+    adapter_call(fn adapter, opts -> adapter.rebuild_backfill_progress(backfill_run_id, opts) end)
+  end
+
   @spec put_asset_window_state(AssetWindowState.t()) :: :ok | {:error, term()}
   def put_asset_window_state(%AssetWindowState{} = state) do
     adapter_call(fn adapter, opts -> adapter.put_asset_window_state(state, opts) end)
@@ -385,6 +407,14 @@ defmodule FavnOrchestrator.Storage do
       [asset_ref_module, asset_ref_name, freshness_key],
       :asset_freshness_state_not_supported
     )
+  end
+
+  @spec get_asset_freshness_states_by_keys([freshness_state_key()]) ::
+          {:ok, %{freshness_state_key() => AssetFreshnessState.t()}} | {:error, term()}
+  def get_asset_freshness_states_by_keys(keys) when is_list(keys) do
+    with {:ok, keys} <- normalize_freshness_state_keys(keys) do
+      adapter_call(fn adapter, opts -> adapter.get_asset_freshness_states_by_keys(keys, opts) end)
+    end
   end
 
   @spec list_asset_freshness_states(keyword()) ::
@@ -589,6 +619,22 @@ defmodule FavnOrchestrator.Storage do
     case Keyword.get(opts, :limit) do
       limit when is_integer(limit) and limit > 0 -> Enum.take(events, limit)
       _other -> events
+    end
+  end
+
+  defp normalize_freshness_state_keys(keys) do
+    keys
+    |> Enum.reduce_while({:ok, MapSet.new()}, fn
+      {module, name, freshness_key} = key, {:ok, acc}
+      when is_atom(module) and is_atom(name) and is_binary(freshness_key) ->
+        {:cont, {:ok, MapSet.put(acc, key)}}
+
+      key, {:ok, _acc} ->
+        {:halt, {:error, {:invalid_freshness_state_key, key}}}
+    end)
+    |> case do
+      {:ok, set} -> {:ok, MapSet.to_list(set)}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -11,6 +11,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   alias FavnOrchestrator.Backfill.AssetWindowState
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
+  alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -51,6 +52,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
           scheduler_states: %{required({module(), atom() | nil}) => map()},
           coverage_baselines: %{required(String.t()) => CoverageBaseline.t()},
           backfill_windows: %{required({String.t(), module(), String.t()}) => BackfillWindow.t()},
+          backfill_progress: %{required(String.t()) => BackfillProgress.t()},
           asset_window_states: %{required({module(), atom(), String.t()}) => AssetWindowState.t()},
           asset_freshness_states: %{
             required({module(), atom(), String.t()}) => AssetFreshnessState.t()
@@ -449,6 +451,27 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   @impl true
+  def apply_backfill_child_projection(%BackfillWindow{} = window, asset_window_states, opts)
+      when is_list(asset_window_states) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:apply_backfill_child_projection, window, asset_window_states})
+  end
+
+  @impl true
+  def get_backfill_progress(backfill_run_id, opts)
+      when is_binary(backfill_run_id) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:get_backfill_progress, backfill_run_id})
+  end
+
+  @impl true
+  def rebuild_backfill_progress(backfill_run_id, opts)
+      when is_binary(backfill_run_id) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:rebuild_backfill_progress, backfill_run_id})
+  end
+
+  @impl true
   def put_asset_window_state(%AssetWindowState{} = state, opts) when is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
     GenServer.call(server, {:put_asset_window_state, state})
@@ -494,6 +517,12 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   def list_asset_freshness_states(filters, opts) when is_list(filters) and is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
     GenServer.call(server, {:list_asset_freshness_states, filters})
+  end
+
+  @impl true
+  def get_asset_freshness_states_by_keys(keys, opts) when is_list(keys) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:get_asset_freshness_states_by_keys, keys})
   end
 
   @impl true
@@ -650,6 +679,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       scheduler_states: %{},
       coverage_baselines: %{},
       backfill_windows: %{},
+      backfill_progress: %{},
       asset_window_states: %{},
       asset_freshness_states: %{},
       auth_actors: %{},
@@ -1178,6 +1208,45 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     {:reply, {:ok, Page.from_fetched(rows, page_opts(filters))}, state}
   end
 
+  def handle_call(
+        {:apply_backfill_child_projection, %BackfillWindow{} = window, asset_window_states},
+        _from,
+        state
+      ) do
+    key = {window.backfill_run_id, window.pipeline_module, window.window_key}
+    old_status = state.backfill_windows[key] && state.backfill_windows[key].status
+
+    next_state = %{
+      state
+      | backfill_windows: Map.put(state.backfill_windows, key, window),
+        asset_window_states:
+          put_asset_window_states(state.asset_window_states, asset_window_states)
+    }
+
+    case next_progress(next_state, window.backfill_run_id, old_status, window.status) do
+      {:ok, progress} ->
+        next_state = put_in(next_state, [:backfill_progress, window.backfill_run_id], progress)
+        {:reply, {:ok, progress}, next_state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  def handle_call({:get_backfill_progress, backfill_run_id}, _from, state) do
+    {:reply, fetch_or_not_found(state.backfill_progress, backfill_run_id), state}
+  end
+
+  def handle_call({:rebuild_backfill_progress, backfill_run_id}, _from, state) do
+    case rebuild_progress_from_windows(state.backfill_windows, backfill_run_id) do
+      {:ok, progress} ->
+        {:reply, {:ok, progress}, put_in(state, [:backfill_progress, backfill_run_id], progress)}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
   def handle_call({:put_asset_window_state, %AssetWindowState{} = window_state}, _from, state) do
     key = {window_state.asset_ref_module, window_state.asset_ref_name, window_state.window_key}
     {:reply, :ok, put_in(state, [:asset_window_states, key], window_state)}
@@ -1238,6 +1307,19 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     end
   end
 
+  def handle_call({:get_asset_freshness_states_by_keys, keys}, _from, state) do
+    rows =
+      keys
+      |> Enum.reduce(%{}, fn key, acc ->
+        case Map.fetch(state.asset_freshness_states, key) do
+          {:ok, %AssetFreshnessState{} = freshness_state} -> Map.put(acc, key, freshness_state)
+          :error -> acc
+        end
+      end)
+
+    {:reply, {:ok, rows}, state}
+  end
+
   def handle_call(
         {:replace_backfill_read_models, scope, coverage_baselines, backfill_windows,
          asset_window_states},
@@ -1254,6 +1336,14 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
           state.backfill_windows
           |> reject_scoped(scope)
           |> put_backfill_windows(backfill_windows),
+        backfill_progress:
+          state.backfill_progress
+          |> reject_scoped_progress(scope)
+          |> rebuild_all_progress(
+            state.backfill_windows
+            |> reject_scoped(scope)
+            |> put_backfill_windows(backfill_windows)
+          ),
         asset_window_states:
           state.asset_window_states
           |> reject_scoped(scope)
@@ -1847,6 +1937,14 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     |> Map.new()
   end
 
+  defp reject_scoped_progress(_values, []), do: %{}
+
+  defp reject_scoped_progress(values, backfill_run_id: backfill_run_id) do
+    Map.delete(values, backfill_run_id)
+  end
+
+  defp reject_scoped_progress(_values, _scope), do: %{}
+
   defp scoped?(value, scope) do
     Enum.all?(scope, fn {key, expected} -> Map.get(value, key) == expected end)
   end
@@ -1870,6 +1968,38 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
         {window_state.asset_ref_module, window_state.asset_ref_name, window_state.window_key},
         window_state
       )
+    end)
+  end
+
+  defp next_progress(state, backfill_run_id, old_status, new_status) do
+    case Map.fetch(state.backfill_progress, backfill_run_id) do
+      {:ok, %BackfillProgress{} = progress} ->
+        BackfillProgress.apply_status_change(progress, old_status, new_status, DateTime.utc_now())
+
+      :error ->
+        rebuild_progress_from_windows(state.backfill_windows, backfill_run_id)
+    end
+  end
+
+  defp rebuild_progress_from_windows(backfill_windows, backfill_run_id) do
+    windows =
+      backfill_windows
+      |> Map.values()
+      |> Enum.filter(&(&1.backfill_run_id == backfill_run_id))
+
+    BackfillProgress.from_windows(backfill_run_id, windows, DateTime.utc_now())
+  end
+
+  defp rebuild_all_progress(progress, backfill_windows) do
+    backfill_windows
+    |> Map.values()
+    |> Enum.map(& &1.backfill_run_id)
+    |> Enum.uniq()
+    |> Enum.reduce(progress, fn backfill_run_id, acc ->
+      case rebuild_progress_from_windows(backfill_windows, backfill_run_id) do
+        {:ok, %BackfillProgress{} = rebuilt} -> Map.put(acc, backfill_run_id, rebuilt)
+        {:error, _reason} -> acc
+      end
     end)
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -1234,7 +1234,20 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   def handle_call({:get_backfill_progress, backfill_run_id}, _from, state) do
-    {:reply, fetch_or_not_found(state.backfill_progress, backfill_run_id), state}
+    case Map.fetch(state.backfill_progress, backfill_run_id) do
+      {:ok, %BackfillProgress{} = progress} ->
+        {:reply, {:ok, progress}, state}
+
+      :error ->
+        case rebuild_progress_from_windows(state.backfill_windows, backfill_run_id) do
+          {:ok, progress} ->
+            {:reply, {:ok, progress},
+             put_in(state, [:backfill_progress, backfill_run_id], progress)}
+
+          {:error, reason} ->
+            {:reply, {:error, reason}, state}
+        end
+    end
   end
 
   def handle_call({:rebuild_backfill_progress, backfill_run_id}, _from, state) do
@@ -1974,7 +1987,21 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   defp next_progress(state, backfill_run_id, old_status, new_status) do
     case Map.fetch(state.backfill_progress, backfill_run_id) do
       {:ok, %BackfillProgress{} = progress} ->
-        BackfillProgress.apply_status_change(progress, old_status, new_status, DateTime.utc_now())
+        case BackfillProgress.apply_status_change(
+               progress,
+               old_status,
+               new_status,
+               DateTime.utc_now()
+             ) do
+          {:ok, %BackfillProgress{} = next_progress} ->
+            {:ok, next_progress}
+
+          {:error, {:stale_backfill_progress, _old_status, _new_status, _counts}} ->
+            rebuild_progress_from_windows(state.backfill_windows, backfill_run_id)
+
+          {:error, reason} ->
+            {:error, reason}
+        end
 
       :error ->
         rebuild_progress_from_windows(state.backfill_windows, backfill_run_id)

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -2014,7 +2014,10 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       |> Map.values()
       |> Enum.filter(&(&1.backfill_run_id == backfill_run_id))
 
-    BackfillProgress.from_windows(backfill_run_id, windows, DateTime.utc_now())
+    case windows do
+      [] -> {:error, :not_found}
+      windows -> BackfillProgress.from_windows(backfill_run_id, windows, DateTime.utc_now())
+    end
   end
 
   defp rebuild_all_progress(progress, backfill_windows) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/backfill/progress_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/backfill/progress_codec.ex
@@ -1,0 +1,78 @@
+defmodule FavnOrchestrator.Storage.Backfill.ProgressCodec do
+  @moduledoc false
+
+  alias FavnOrchestrator.Backfill.Progress
+  alias FavnOrchestrator.Storage.JsonSafe
+
+  @format "favn.backfill.progress.storage.v1"
+
+  @spec encode(Progress.t()) :: {:ok, String.t()} | {:error, term()}
+  def encode(%Progress{} = progress) do
+    {:ok, Jason.encode!(to_dto(progress))}
+  rescue
+    error -> {:error, {:backfill_progress_encode_failed, error}}
+  end
+
+  @spec decode(String.t()) :: {:ok, Progress.t()} | {:error, term()}
+  def decode(payload) when is_binary(payload) do
+    with {:ok, %{"format" => @format, "schema_version" => 1} = dto} <- Jason.decode(payload),
+         {:ok, updated_at} <- datetime(Map.get(dto, "updated_at")),
+         {:ok, metadata} <- map_field(dto, "metadata") do
+      Progress.new(%{
+        backfill_run_id: Map.get(dto, "backfill_run_id"),
+        total_count: Map.get(dto, "total_count"),
+        pending_count: Map.get(dto, "pending_count"),
+        running_count: Map.get(dto, "running_count"),
+        ok_count: Map.get(dto, "ok_count"),
+        partial_count: Map.get(dto, "partial_count"),
+        error_count: Map.get(dto, "error_count"),
+        cancelled_count: Map.get(dto, "cancelled_count"),
+        timed_out_count: Map.get(dto, "timed_out_count"),
+        status: Map.get(dto, "status"),
+        updated_at: updated_at,
+        metadata: metadata
+      })
+    else
+      {:ok, other} -> {:error, {:invalid_backfill_progress_dto, other}}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp to_dto(%Progress{} = progress) do
+    %{
+      "format" => @format,
+      "schema_version" => 1,
+      "backfill_run_id" => progress.backfill_run_id,
+      "total_count" => progress.total_count,
+      "pending_count" => progress.pending_count,
+      "running_count" => progress.running_count,
+      "ok_count" => progress.ok_count,
+      "partial_count" => progress.partial_count,
+      "error_count" => progress.error_count,
+      "cancelled_count" => progress.cancelled_count,
+      "timed_out_count" => progress.timed_out_count,
+      "status" => Atom.to_string(progress.status),
+      "updated_at" => datetime_to_dto(progress.updated_at),
+      "metadata" => JsonSafe.data(progress.metadata || %{})
+    }
+  end
+
+  defp datetime_to_dto(%DateTime{} = datetime), do: DateTime.to_iso8601(datetime)
+
+  defp datetime(value) when is_binary(value) do
+    case DateTime.from_iso8601(value) do
+      {:ok, datetime, _offset} -> {:ok, datetime}
+      {:error, reason} -> {:error, {:invalid_datetime, value, reason}}
+    end
+  end
+
+  defp datetime(value), do: {:error, {:invalid_datetime, value}}
+
+  defp map_field(dto, field) do
+    case Map.fetch(dto, field) do
+      {:ok, value} when is_map(value) -> {:ok, value}
+      {:ok, value} -> {:error, {:invalid_dto_field, field, value}}
+      :error -> {:error, {:missing_dto_field, field}}
+    end
+  end
+end

--- a/apps/favn_orchestrator/test/diagnostics_test.exs
+++ b/apps/favn_orchestrator/test/diagnostics_test.exs
@@ -146,6 +146,15 @@ defmodule FavnOrchestrator.DiagnosticsTest do
     def list_backfill_windows(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
+
+    @impl true
+    def get_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
+    def rebuild_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
     def put_asset_window_state(_state, _opts), do: :ok
 
     @impl true
@@ -164,6 +173,9 @@ defmodule FavnOrchestrator.DiagnosticsTest do
 
     @impl true
     def list_asset_freshness_states(_filters, _opts), do: {:ok, []}
+
+    @impl true
+    def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}
 
     @impl true
     def replace_backfill_read_models(_scope, _baselines, _windows, _states, _opts), do: :ok

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -435,10 +435,17 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert :ok = Storage.put_backfill_window(first)
     assert :ok = Storage.put_backfill_window(second)
 
+    assert {:ok, progress} = Storage.get_backfill_progress(backfill_run_id)
+    assert progress.total_count == 2
+    assert progress.pending_count == 2
+    assert progress.status == :running
+
     assert {:ok, progress} = Storage.rebuild_backfill_progress(backfill_run_id)
     assert progress.total_count == 2
     assert progress.pending_count == 2
     assert progress.status == :running
+
+    assert_concurrent_same_window_projection(label, run)
 
     ok_window = %{
       first
@@ -487,6 +494,48 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert stored_progress.status == :partial
     assert stored_progress.ok_count == 1
     assert stored_progress.error_count == 1
+  end
+
+  defp assert_concurrent_same_window_projection(label, run) do
+    now = DateTime.utc_now()
+    backfill_run_id = "backfill_race_#{label}_#{System.unique_integer([:positive])}"
+
+    assert {:ok, first} = backfill_window(backfill_run_id, run, "race-window", :pending, now)
+    assert {:ok, second} = backfill_window(backfill_run_id, run, "other-window", :pending, now)
+    assert :ok = Storage.put_backfill_window(first)
+    assert :ok = Storage.put_backfill_window(second)
+    assert {:ok, _progress} = Storage.rebuild_backfill_progress(backfill_run_id)
+
+    ok_window = %{
+      first
+      | status: :ok,
+        child_run_id: "#{backfill_run_id}_ok",
+        latest_attempt_run_id: "#{backfill_run_id}_ok",
+        last_success_run_id: "#{backfill_run_id}_ok",
+        finished_at: DateTime.add(now, 1, :second),
+        updated_at: DateTime.add(now, 1, :second)
+    }
+
+    error_window = %{
+      first
+      | status: :error,
+        child_run_id: "#{backfill_run_id}_error",
+        latest_attempt_run_id: "#{backfill_run_id}_error",
+        last_error: %{message: "failed"},
+        errors: [%{message: "failed"}],
+        finished_at: DateTime.add(now, 2, :second),
+        updated_at: DateTime.add(now, 2, :second)
+    }
+
+    [ok_window, error_window]
+    |> Enum.map(&Task.async(fn -> Storage.apply_backfill_child_projection(&1, []) end))
+    |> Enum.each(fn task -> assert {:ok, _progress} = Task.await(task, 5_000) end)
+
+    assert {:ok, progress} = Storage.get_backfill_progress(backfill_run_id)
+    assert progress.total_count == 2
+    assert progress.pending_count == 1
+    assert progress.ok_count + progress.error_count == 1
+    assert progress.status == :running
   end
 
   defp backfill_window(backfill_run_id, run, window_key, status, now) do

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -429,6 +429,8 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     now = DateTime.utc_now()
     backfill_run_id = "backfill_progress_#{label}_#{System.unique_integer([:positive])}"
 
+    assert {:error, :not_found} = Storage.get_backfill_progress("#{backfill_run_id}_missing")
+
     assert {:ok, first} = backfill_window(backfill_run_id, run, "window-1", :pending, now)
     assert {:ok, second} = backfill_window(backfill_run_id, run, "window-2", :pending, now)
 

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -3,6 +3,9 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
 
   alias Favn.Manifest
   alias Favn.Manifest.Version
+  alias FavnOrchestrator.AssetFreshnessState
+  alias FavnOrchestrator.Backfill.AssetWindowState
+  alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.Adapter.Memory
@@ -347,6 +350,9 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
 
     assert :ok = Storage.put_scheduler_state(nil_key, %{version: 1})
     assert {:ok, %Favn.Scheduler.State{schedule_id: nil}} = Storage.get_scheduler_state(nil_key)
+
+    assert_freshness_lookup_contract(label, run)
+    assert_backfill_progress_contract(label, run)
   end
 
   defp manifest_version(manifest_version_id) do
@@ -369,6 +375,154 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
       acquired_at: now,
       expires_at: DateTime.add(now, 5, :second)
     }
+  end
+
+  defp assert_freshness_lookup_contract(label, run) do
+    now = DateTime.utc_now()
+    key = {MyApp.Asset, :asset, "freshness-#{label}"}
+    missing_key = {MyApp.Asset, :asset, "missing-#{label}"}
+    unrelated_key = {MyApp.Asset, :other, "freshness-#{label}"}
+
+    assert {:ok, wanted} =
+             AssetFreshnessState.new(%{
+               asset_ref_module: MyApp.Asset,
+               asset_ref_name: :asset,
+               freshness_key: "freshness-#{label}",
+               status: :ok,
+               freshness_version: "version-#{label}",
+               latest_success_run_id: run.id,
+               latest_success_at: now,
+               updated_at: now
+             })
+
+    assert {:ok, unrelated} =
+             AssetFreshnessState.new(%{
+               asset_ref_module: MyApp.Asset,
+               asset_ref_name: :other,
+               freshness_key: "freshness-#{label}",
+               status: :ok,
+               freshness_version: "other-version-#{label}",
+               latest_success_run_id: run.id,
+               latest_success_at: now,
+               updated_at: now
+             })
+
+    assert :ok = Storage.put_asset_freshness_state(wanted)
+    assert :ok = Storage.put_asset_freshness_state(unrelated)
+
+    assert {:ok, %{^key => fetched}} =
+             Storage.get_asset_freshness_states_by_keys([key, key, missing_key])
+
+    assert fetched.asset_ref_module == wanted.asset_ref_module
+    assert fetched.asset_ref_name == wanted.asset_ref_name
+    assert fetched.freshness_key == wanted.freshness_key
+    assert fetched.freshness_version == wanted.freshness_version
+    assert fetched.latest_success_run_id == wanted.latest_success_run_id
+
+    assert {:ok, states} = Storage.get_asset_freshness_states_by_keys([key, missing_key])
+    assert Map.keys(states) == [key]
+    refute Map.has_key?(states, unrelated_key)
+    assert {:ok, %{}} = Storage.get_asset_freshness_states_by_keys([])
+  end
+
+  defp assert_backfill_progress_contract(label, run) do
+    now = DateTime.utc_now()
+    backfill_run_id = "backfill_progress_#{label}_#{System.unique_integer([:positive])}"
+
+    assert {:ok, first} = backfill_window(backfill_run_id, run, "window-1", :pending, now)
+    assert {:ok, second} = backfill_window(backfill_run_id, run, "window-2", :pending, now)
+
+    assert :ok = Storage.put_backfill_window(first)
+    assert :ok = Storage.put_backfill_window(second)
+
+    assert {:ok, progress} = Storage.rebuild_backfill_progress(backfill_run_id)
+    assert progress.total_count == 2
+    assert progress.pending_count == 2
+    assert progress.status == :running
+
+    ok_window = %{
+      first
+      | status: :ok,
+        child_run_id: "#{backfill_run_id}_child_1",
+        latest_attempt_run_id: "#{backfill_run_id}_child_1",
+        last_success_run_id: "#{backfill_run_id}_child_1",
+        finished_at: DateTime.add(now, 1, :second),
+        updated_at: DateTime.add(now, 1, :second)
+    }
+
+    assert {:ok, asset_state} = asset_window_state(ok_window, run, :ok)
+    assert {:ok, progress} = Storage.apply_backfill_child_projection(ok_window, [asset_state])
+    assert progress.total_count == 2
+    assert progress.pending_count == 1
+    assert progress.ok_count == 1
+    assert progress.status == :running
+
+    assert {:ok, ^asset_state} =
+             Storage.get_asset_window_state(MyApp.Asset, :asset, ok_window.window_key)
+
+    assert {:ok, repeated} = Storage.apply_backfill_child_projection(ok_window, [asset_state])
+    assert repeated.total_count == 2
+    assert repeated.pending_count == 1
+    assert repeated.ok_count == 1
+
+    error_window = %{
+      second
+      | status: :error,
+        child_run_id: "#{backfill_run_id}_child_2",
+        latest_attempt_run_id: "#{backfill_run_id}_child_2",
+        last_error: %{message: "failed"},
+        errors: [%{message: "failed"}],
+        finished_at: DateTime.add(now, 2, :second),
+        updated_at: DateTime.add(now, 2, :second)
+    }
+
+    assert {:ok, progress} = Storage.apply_backfill_child_projection(error_window, [])
+    assert progress.total_count == 2
+    assert progress.pending_count == 0
+    assert progress.ok_count == 1
+    assert progress.error_count == 1
+    assert progress.status == :partial
+
+    assert {:ok, stored_progress} = Storage.get_backfill_progress(backfill_run_id)
+    assert stored_progress.status == :partial
+    assert stored_progress.ok_count == 1
+    assert stored_progress.error_count == 1
+  end
+
+  defp backfill_window(backfill_run_id, run, window_key, status, now) do
+    BackfillWindow.new(%{
+      backfill_run_id: backfill_run_id,
+      pipeline_module: MyApp.Pipeline,
+      manifest_version_id: run.manifest_version_id,
+      window_kind: :day,
+      window_start_at: now,
+      window_end_at: DateTime.add(now, 86_400, :second),
+      timezone: "Etc/UTC",
+      window_key: window_key,
+      status: status,
+      attempt_count: 0,
+      created_at: now,
+      updated_at: now
+    })
+  end
+
+  defp asset_window_state(window, run, status) do
+    AssetWindowState.new(%{
+      asset_ref_module: MyApp.Asset,
+      asset_ref_name: :asset,
+      pipeline_module: window.pipeline_module,
+      manifest_version_id: run.manifest_version_id,
+      window_kind: window.window_kind,
+      window_start_at: window.window_start_at,
+      window_end_at: window.window_end_at,
+      timezone: window.timezone,
+      window_key: window.window_key,
+      status: status,
+      latest_run_id: window.latest_attempt_run_id,
+      latest_parent_run_id: window.backfill_run_id,
+      latest_success_run_id: if(status == :ok, do: window.latest_attempt_run_id),
+      updated_at: window.updated_at
+    })
   end
 
   defp assert_materialization_claim_contract(label, run) do

--- a/apps/favn_orchestrator/test/readiness_test.exs
+++ b/apps/favn_orchestrator/test/readiness_test.exs
@@ -142,6 +142,15 @@ defmodule FavnOrchestrator.ReadinessTest do
     def list_backfill_windows(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
+
+    @impl true
+    def get_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
+    def rebuild_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
     def put_asset_window_state(_state, _opts), do: :ok
 
     @impl true
@@ -160,6 +169,9 @@ defmodule FavnOrchestrator.ReadinessTest do
 
     @impl true
     def list_asset_freshness_states(_filters, _opts), do: {:ok, []}
+
+    @impl true
+    def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}
 
     @impl true
     def replace_backfill_read_models(_scope, _baselines, _windows, _states, _opts), do: :ok

--- a/apps/favn_orchestrator/test/repair_runtime_state_test.exs
+++ b/apps/favn_orchestrator/test/repair_runtime_state_test.exs
@@ -45,9 +45,13 @@ defmodule FavnOrchestrator.Repair.RuntimeStateTest do
     defdelegate put_backfill_window(window, opts), to: Memory
     defdelegate get_backfill_window(backfill_id, module, window_key, opts), to: Memory
     defdelegate list_backfill_windows(filters, opts), to: Memory
+    defdelegate apply_backfill_child_projection(window, states, opts), to: Memory
+    defdelegate get_backfill_progress(backfill_id, opts), to: Memory
+    defdelegate rebuild_backfill_progress(backfill_id, opts), to: Memory
     defdelegate put_asset_window_state(state, opts), to: Memory
     defdelegate get_asset_window_state(module, name, freshness_key, opts), to: Memory
     defdelegate list_asset_window_states(filters, opts), to: Memory
+    defdelegate get_asset_freshness_states_by_keys(keys, opts), to: Memory
 
     defdelegate replace_backfill_read_models(filters, baselines, windows, states, opts),
       to: Memory

--- a/apps/favn_orchestrator/test/run_server_test.exs
+++ b/apps/favn_orchestrator/test/run_server_test.exs
@@ -282,6 +282,53 @@ defmodule FavnOrchestrator.RunServerTest do
     end
   end
 
+  defmodule FreshnessLookupFailingStorageAdapter do
+    @moduledoc false
+    @behaviour Favn.Storage.Adapter
+
+    defdelegate child_spec(opts), to: Memory
+    defdelegate put_manifest_version(version, opts), to: Memory
+    defdelegate get_manifest_version(id, opts), to: Memory
+    defdelegate get_manifest_version_by_content_hash(hash, opts), to: Memory
+    defdelegate list_manifest_versions(opts), to: Memory
+    defdelegate set_active_manifest_version(id, opts), to: Memory
+    defdelegate get_active_manifest_version(opts), to: Memory
+    defdelegate put_run(run, opts), to: Memory
+    defdelegate get_run(id, opts), to: Memory
+    defdelegate list_runs(run_opts, opts), to: Memory
+    defdelegate persist_run_transition(run, event, opts), to: Memory
+    defdelegate append_run_event(run_id, event, opts), to: Memory
+    defdelegate list_run_events(run_id, opts), to: Memory
+    defdelegate list_global_run_events(filters, opts), to: Memory
+    defdelegate try_acquire_execution_lease(lease, opts), to: Memory
+    defdelegate release_execution_lease(lease_id, opts), to: Memory
+    defdelegate expire_execution_leases(now, opts), to: Memory
+    defdelegate list_execution_leases(opts), to: Memory
+    defdelegate persist_log_entries(entries, opts), to: Memory
+    defdelegate list_logs(filter, opts, adapter_opts), to: Memory
+    defdelegate replay_logs_after(cursor, filter, opts, adapter_opts), to: Memory
+    defdelegate put_scheduler_state(key, state, opts), to: Memory
+    defdelegate get_scheduler_state(key, opts), to: Memory
+    defdelegate put_coverage_baseline(baseline, opts), to: Memory
+    defdelegate get_coverage_baseline(id, opts), to: Memory
+    defdelegate list_coverage_baselines(filters, opts), to: Memory
+    defdelegate put_backfill_window(window, opts), to: Memory
+    defdelegate get_backfill_window(backfill_id, module, window_key, opts), to: Memory
+    defdelegate list_backfill_windows(filters, opts), to: Memory
+    defdelegate apply_backfill_child_projection(window, states, opts), to: Memory
+    defdelegate get_backfill_progress(backfill_id, opts), to: Memory
+    defdelegate rebuild_backfill_progress(backfill_id, opts), to: Memory
+    defdelegate put_asset_window_state(state, opts), to: Memory
+    defdelegate get_asset_window_state(module, name, freshness_key, opts), to: Memory
+    defdelegate list_asset_window_states(filters, opts), to: Memory
+
+    def get_asset_freshness_states_by_keys(_keys, _opts),
+      do: {:error, :freshness_lookup_unavailable}
+
+    defdelegate replace_backfill_read_models(filters, baselines, windows, states, opts),
+      to: Memory
+  end
+
   setup do
     previous_client = Application.get_env(:favn_orchestrator, :runner_client)
     previous_opts = Application.get_env(:favn_orchestrator, :runner_client_opts)
@@ -463,6 +510,45 @@ defmodule FavnOrchestrator.RunServerTest do
 
     assert {:ok, events} = Storage.list_run_events(run_state.id)
     assert Enum.map(events, & &1.event_type) == [:run_started, :step_skipped_fresh, :run_finished]
+  end
+
+  test "pipeline marks run as failed when prior freshness lookup fails" do
+    previous_adapter = Application.get_env(:favn_orchestrator, :storage_adapter)
+    previous_opts = Application.get_env(:favn_orchestrator, :storage_adapter_opts)
+
+    on_exit(fn ->
+      restore_env(:favn_orchestrator, :storage_adapter, previous_adapter)
+      restore_env(:favn_orchestrator, :storage_adapter_opts, previous_opts)
+    end)
+
+    Application.put_env(:favn_orchestrator, :runner_client, RunnerClientRecordingStub)
+    Application.put_env(:favn_orchestrator, :runner_client_opts, [])
+
+    Application.put_env(
+      :favn_orchestrator,
+      :storage_adapter,
+      FreshnessLookupFailingStorageAdapter
+    )
+
+    Application.put_env(:favn_orchestrator, :storage_adapter_opts, [])
+
+    version = manifest_version("mv_pipeline_freshness_lookup_failure")
+    plan = single_node_plan({MyApp.Assets.Gold, :asset}, [])
+
+    run_state =
+      pipeline_run_state("run_pipeline_freshness_lookup_failure", version, plan, [
+        {MyApp.Assets.Gold, :asset}
+      ])
+
+    assert :ok = Storage.put_run(run_state)
+    assert {:ok, pid} = RunServer.start_link(%{run_state: run_state, version: version})
+
+    ref = Process.monitor(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+
+    assert {:ok, stored} = Storage.get_run(run_state.id)
+    assert stored.status == :error
+    assert stored.error == {:freshness_state_lookup_failed, :freshness_lookup_unavailable}
   end
 
   test "failed attempt updates latest attempt without replacing prior freshness success" do
@@ -1389,4 +1475,7 @@ defmodule FavnOrchestrator.RunServerTest do
         :ok
     end
   end
+
+  defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_env(app, key, value), do: Application.put_env(app, key, value)
 end

--- a/apps/favn_orchestrator/test/storage_facade_test.exs
+++ b/apps/favn_orchestrator/test/storage_facade_test.exs
@@ -111,6 +111,15 @@ defmodule Favn.StorageFacadeTest do
     def list_backfill_windows(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
+
+    @impl true
+    def get_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
+    def rebuild_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
     def put_asset_window_state(_state, _opts), do: :ok
 
     @impl true
@@ -129,6 +138,9 @@ defmodule Favn.StorageFacadeTest do
 
     @impl true
     def list_asset_freshness_states(_filters, _opts), do: {:ok, []}
+
+    @impl true
+    def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}
 
     @impl true
     def replace_backfill_read_models(
@@ -263,6 +275,15 @@ defmodule Favn.StorageFacadeTest do
     def list_backfill_windows(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
+
+    @impl true
+    def get_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
+    def rebuild_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+    @impl true
     def put_asset_window_state(_state, _opts), do: :ok
 
     @impl true
@@ -281,6 +302,9 @@ defmodule Favn.StorageFacadeTest do
 
     @impl true
     def list_asset_freshness_states(_filters, _opts), do: {:ok, []}
+
+    @impl true
+    def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}
 
     @impl true
     def replace_backfill_read_models(

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -1461,12 +1461,17 @@ defmodule Favn.Storage.Adapter.Postgres do
 
     case SQL.query(repo, sql, [backfill_run_id]) do
       {:ok, %{rows: rows}} ->
-        counts = Map.new(rows, fn [status, count] -> {String.to_existing_atom(status), count} end)
+        if rows == [] do
+          {:error, :not_found}
+        else
+          counts =
+            Map.new(rows, fn [status, count] -> {String.to_existing_atom(status), count} end)
 
-        with {:ok, progress} <-
-               BackfillProgress.from_counts(backfill_run_id, counts, DateTime.utc_now()),
-             :ok <- put_backfill_progress(repo, progress) do
-          {:ok, progress}
+          with {:ok, progress} <-
+                 BackfillProgress.from_counts(backfill_run_id, counts, DateTime.utc_now()),
+               :ok <- put_backfill_progress(repo, progress) do
+            {:ok, progress}
+          end
         end
 
       {:error, reason} ->

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -762,9 +762,8 @@ defmodule Favn.Storage.Adapter.Postgres do
       when is_list(asset_window_states) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts) do
       repo.transact(fn ->
-        old_status = fetch_backfill_window_status(repo, window)
-
-        with :ok <- put_backfill_window(window, opts),
+        with {:ok, old_status} <- lock_and_fetch_backfill_window_status(repo, window),
+             :ok <- put_backfill_window(window, opts),
              :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
              {:ok, progress} <-
                upsert_backfill_progress_after_window_change(repo, window, old_status) do
@@ -1407,15 +1406,16 @@ defmodule Favn.Storage.Adapter.Postgres do
     end
   end
 
-  defp fetch_backfill_window_status(repo, %BackfillWindow{} = window) do
+  defp lock_and_fetch_backfill_window_status(repo, %BackfillWindow{} = window) do
     sql =
-      "SELECT status FROM favn_backfill_windows WHERE backfill_run_id = $1 AND pipeline_module = $2 AND window_key = $3 LIMIT 1"
+      "SELECT status FROM favn_backfill_windows WHERE backfill_run_id = $1 AND pipeline_module = $2 AND window_key = $3 LIMIT 1 FOR UPDATE"
 
     params = [window.backfill_run_id, Atom.to_string(window.pipeline_module), window.window_key]
 
     case SQL.query(repo, sql, params) do
-      {:ok, %{rows: [[status]]}} when is_binary(status) -> String.to_existing_atom(status)
-      _other -> nil
+      {:ok, %{rows: [[status]]}} when is_binary(status) -> {:ok, String.to_existing_atom(status)}
+      {:ok, %{rows: []}} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -1425,7 +1425,7 @@ defmodule Favn.Storage.Adapter.Postgres do
 
     case SQL.query(repo, sql, [backfill_run_id]) do
       {:ok, %{rows: [row]}} -> decode_backfill_progress_row(row)
-      {:ok, %{rows: []}} -> {:error, :not_found}
+      {:ok, %{rows: []}} -> rebuild_backfill_progress_with_repo(repo, backfill_run_id)
       {:error, reason} -> {:error, reason}
     end
   end
@@ -1444,11 +1444,14 @@ defmodule Favn.Storage.Adapter.Postgres do
           {:ok, next_progress}
         end
 
-      {:error, :not_found} ->
-        rebuild_backfill_progress_with_repo(repo, window.backfill_run_id)
-
       {:error, reason} ->
-        {:error, reason}
+        case reason do
+          {:stale_backfill_progress, _old_status, _new_status, _counts} ->
+            rebuild_backfill_progress_with_repo(repo, window.backfill_run_id)
+
+          _other ->
+            {:error, reason}
+        end
     end
   end
 

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -11,12 +11,14 @@ defmodule Favn.Storage.Adapter.Postgres do
   alias FavnOrchestrator.Backfill.AssetWindowState
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
+  alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage.Backfill.AssetWindowStateCodec
   alias FavnOrchestrator.Storage.Backfill.BackfillWindowCodec
   alias FavnOrchestrator.Storage.Backfill.CoverageBaselineCodec
+  alias FavnOrchestrator.Storage.Backfill.ProgressCodec
   alias FavnOrchestrator.Storage.ExecutionLeaseCodec
   alias FavnOrchestrator.Storage.Freshness.AssetFreshnessStateCodec
   alias FavnOrchestrator.Storage.JsonSafe
@@ -756,6 +758,45 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   @impl true
+  def apply_backfill_child_projection(%BackfillWindow{} = window, asset_window_states, opts)
+      when is_list(asset_window_states) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      repo.transact(fn ->
+        old_status = fetch_backfill_window_status(repo, window)
+
+        with :ok <- put_backfill_window(window, opts),
+             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
+             {:ok, progress} <-
+               upsert_backfill_progress_after_window_change(repo, window, old_status) do
+          {:ok, progress}
+        else
+          {:error, reason} -> repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, %BackfillProgress{} = progress} -> {:ok, progress}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def get_backfill_progress(backfill_run_id, opts)
+      when is_binary(backfill_run_id) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      get_backfill_progress_with_repo(repo, backfill_run_id)
+    end
+  end
+
+  @impl true
+  def rebuild_backfill_progress(backfill_run_id, opts)
+      when is_binary(backfill_run_id) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      rebuild_backfill_progress_with_repo(repo, backfill_run_id)
+    end
+  end
+
+  @impl true
   def put_asset_window_state(%AssetWindowState{} = state, opts) when is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts) do
       sql =
@@ -886,6 +927,21 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   @impl true
+  def get_asset_freshness_states_by_keys(keys, opts) when is_list(keys) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      keys
+      |> Enum.uniq()
+      |> Enum.chunk_every(250)
+      |> Enum.reduce_while({:ok, %{}}, fn chunk, {:ok, acc} ->
+        case get_asset_freshness_state_key_chunk(repo, chunk) do
+          {:ok, rows} -> {:cont, {:ok, Map.merge(acc, rows)}}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+      end)
+    end
+  end
+
+  @impl true
   def replace_backfill_read_models(
         scope,
         coverage_baselines,
@@ -913,9 +969,12 @@ defmodule Favn.Storage.Adapter.Postgres do
                  scope,
                  asset_window_state_filter_specs()
                ),
+             :ok <-
+               delete_scoped(repo, "favn_backfill_progress", [], backfill_progress_filter_specs()),
              :ok <- put_all(coverage_baselines, &put_coverage_baseline(&1, opts)),
              :ok <- put_all(backfill_windows, &put_backfill_window(&1, opts)),
-             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)) do
+             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
+             :ok <- rebuild_all_backfill_progress(repo) do
           {:ok, :ok}
         else
           {:error, reason} -> repo.rollback(reason)
@@ -1058,6 +1117,23 @@ defmodule Favn.Storage.Adapter.Postgres do
     ]
   end
 
+  defp backfill_progress_params(%BackfillProgress{} = progress) do
+    [
+      progress.backfill_run_id,
+      progress.total_count,
+      progress.pending_count,
+      progress.running_count,
+      progress.ok_count,
+      progress.partial_count,
+      progress.error_count,
+      progress.cancelled_count,
+      progress.timed_out_count,
+      Atom.to_string(progress.status),
+      encode_backfill_progress(progress),
+      progress.updated_at
+    ]
+  end
+
   defp coverage_baseline_select do
     """
     SELECT record_payload
@@ -1119,6 +1195,13 @@ defmodule Favn.Storage.Adapter.Postgres do
       status: {"status", &Atom.to_string/1},
       coverage_baseline_id: {"coverage_baseline_id", & &1},
       manifest_version_id: {"manifest_version_id", & &1}
+    }
+  end
+
+  defp backfill_progress_filter_specs do
+    %{
+      backfill_run_id: {"backfill_run_id", & &1},
+      status: {"status", &Atom.to_string/1}
     }
   end
 
@@ -1292,6 +1375,145 @@ defmodule Favn.Storage.Adapter.Postgres do
 
   defp decode_asset_freshness_state_row([record_payload]),
     do: AssetFreshnessStateCodec.decode(record_payload)
+
+  defp decode_backfill_progress_row([record_payload]),
+    do: ProgressCodec.decode(record_payload)
+
+  defp get_asset_freshness_state_key_chunk(_repo, []), do: {:ok, %{}}
+
+  defp get_asset_freshness_state_key_chunk(repo, keys) do
+    clauses =
+      keys
+      |> Enum.with_index()
+      |> Enum.map(fn {_key, index} ->
+        base = index * 3
+
+        "(asset_ref_module = $#{base + 1} AND asset_ref_name = $#{base + 2} AND freshness_key = $#{base + 3})"
+      end)
+
+    params =
+      Enum.flat_map(keys, fn {module, name, freshness_key} ->
+        [Atom.to_string(module), Atom.to_string(name), freshness_key]
+      end)
+
+    sql = asset_freshness_state_select() <> "\nWHERE " <> Enum.join(clauses, " OR ")
+
+    with {:ok, states} <-
+           query_and_decode_rows(repo, sql, params, &decode_asset_freshness_state_row/1) do
+      {:ok,
+       Map.new(states, fn %AssetFreshnessState{} = state ->
+         {{state.asset_ref_module, state.asset_ref_name, state.freshness_key}, state}
+       end)}
+    end
+  end
+
+  defp fetch_backfill_window_status(repo, %BackfillWindow{} = window) do
+    sql =
+      "SELECT status FROM favn_backfill_windows WHERE backfill_run_id = $1 AND pipeline_module = $2 AND window_key = $3 LIMIT 1"
+
+    params = [window.backfill_run_id, Atom.to_string(window.pipeline_module), window.window_key]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: [[status]]}} when is_binary(status) -> String.to_existing_atom(status)
+      _other -> nil
+    end
+  end
+
+  defp get_backfill_progress_with_repo(repo, backfill_run_id) do
+    sql =
+      "SELECT record_payload FROM favn_backfill_progress WHERE backfill_run_id = $1 LIMIT 1 FOR UPDATE"
+
+    case SQL.query(repo, sql, [backfill_run_id]) do
+      {:ok, %{rows: [row]}} -> decode_backfill_progress_row(row)
+      {:ok, %{rows: []}} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp upsert_backfill_progress_after_window_change(repo, %BackfillWindow{} = window, old_status) do
+    case get_backfill_progress_with_repo(repo, window.backfill_run_id) do
+      {:ok, %BackfillProgress{} = progress} ->
+        with {:ok, next_progress} <-
+               BackfillProgress.apply_status_change(
+                 progress,
+                 old_status,
+                 window.status,
+                 DateTime.utc_now()
+               ),
+             :ok <- put_backfill_progress(repo, next_progress) do
+          {:ok, next_progress}
+        end
+
+      {:error, :not_found} ->
+        rebuild_backfill_progress_with_repo(repo, window.backfill_run_id)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp rebuild_backfill_progress_with_repo(repo, backfill_run_id) do
+    sql =
+      "SELECT status, COUNT(*) FROM favn_backfill_windows WHERE backfill_run_id = $1 GROUP BY status"
+
+    case SQL.query(repo, sql, [backfill_run_id]) do
+      {:ok, %{rows: rows}} ->
+        counts = Map.new(rows, fn [status, count] -> {String.to_existing_atom(status), count} end)
+
+        with {:ok, progress} <-
+               BackfillProgress.from_counts(backfill_run_id, counts, DateTime.utc_now()),
+             :ok <- put_backfill_progress(repo, progress) do
+          {:ok, progress}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp rebuild_all_backfill_progress(repo) do
+    case SQL.query(repo, "SELECT DISTINCT backfill_run_id FROM favn_backfill_windows", []) do
+      {:ok, %{rows: rows}} ->
+        rows
+        |> Enum.map(fn [backfill_run_id] -> backfill_run_id end)
+        |> Enum.reduce_while(:ok, fn backfill_run_id, :ok ->
+          case rebuild_backfill_progress_with_repo(repo, backfill_run_id) do
+            {:ok, %BackfillProgress{}} -> {:cont, :ok}
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
+        end)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp put_backfill_progress(repo, %BackfillProgress{} = progress) do
+    sql = """
+    INSERT INTO favn_backfill_progress (
+      backfill_run_id, total_count, pending_count, running_count, ok_count,
+      partial_count, error_count, cancelled_count, timed_out_count, status,
+      record_payload, updated_at
+    ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+    ON CONFLICT(backfill_run_id) DO UPDATE SET
+      total_count = EXCLUDED.total_count,
+      pending_count = EXCLUDED.pending_count,
+      running_count = EXCLUDED.running_count,
+      ok_count = EXCLUDED.ok_count,
+      partial_count = EXCLUDED.partial_count,
+      error_count = EXCLUDED.error_count,
+      cancelled_count = EXCLUDED.cancelled_count,
+      timed_out_count = EXCLUDED.timed_out_count,
+      status = EXCLUDED.status,
+      record_payload = EXCLUDED.record_payload,
+      updated_at = EXCLUDED.updated_at
+    """
+
+    case SQL.query(repo, sql, backfill_progress_params(progress)) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   defp decode_materialization_claim_row([record_payload]),
     do: MaterializationClaimCodec.decode(record_payload)
@@ -2488,6 +2710,16 @@ defmodule Favn.Storage.Adapter.Postgres do
 
       {:error, reason} ->
         raise ArgumentError, "invalid asset freshness state payload: #{inspect(reason)}"
+    end
+  end
+
+  defp encode_backfill_progress(%BackfillProgress{} = progress) do
+    case ProgressCodec.encode(progress) do
+      {:ok, payload} ->
+        payload
+
+      {:error, reason} ->
+        raise ArgumentError, "invalid backfill progress payload: #{inspect(reason)}"
     end
   end
 

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
@@ -7,6 +7,7 @@ defmodule FavnStoragePostgres.Migrations do
   alias FavnStoragePostgres.Migrations.AddLogEntries
   alias FavnStoragePostgres.Migrations.AddMaterializationClaims
   alias FavnStoragePostgres.Migrations.AddBackfillState
+  alias FavnStoragePostgres.Migrations.AddBackfillProgress
   alias FavnStoragePostgres.Migrations.AddRunEventGlobalSequence
   alias FavnStoragePostgres.Migrations.AddRunGroupQueryColumns
   alias FavnStoragePostgres.Migrations.CreateFoundation
@@ -21,7 +22,8 @@ defmodule FavnStoragePostgres.Migrations do
     {20_260_510_100_000, AddLogEntries},
     {20_260_520_100_000, AddExecutionLeases},
     {20_260_521_100_000, AddMaterializationClaims},
-    {20_260_521_200_000, AddRunGroupQueryColumns}
+    {20_260_521_200_000, AddRunGroupQueryColumns},
+    {20_260_522_100_000, AddBackfillProgress}
   ]
   @required_tables [
     "public.favn_manifest_versions",
@@ -31,6 +33,7 @@ defmodule FavnStoragePostgres.Migrations do
     "public.favn_scheduler_cursors",
     "public.favn_pipeline_coverage_baselines",
     "public.favn_backfill_windows",
+    "public.favn_backfill_progress",
     "public.favn_asset_window_states",
     "public.favn_asset_freshness_states",
     "public.favn_run_write_seq",

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_backfill_progress.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_backfill_progress.ex
@@ -1,0 +1,29 @@
+defmodule FavnStoragePostgres.Migrations.AddBackfillProgress do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def up do
+    create_if_not_exists table(:favn_backfill_progress, primary_key: false) do
+      add(:backfill_run_id, :string, primary_key: true)
+      add(:total_count, :integer, null: false)
+      add(:pending_count, :integer, null: false)
+      add(:running_count, :integer, null: false)
+      add(:ok_count, :integer, null: false)
+      add(:partial_count, :integer, null: false)
+      add(:error_count, :integer, null: false)
+      add(:cancelled_count, :integer, null: false)
+      add(:timed_out_count, :integer, null: false)
+      add(:status, :string, null: false)
+      add(:record_payload, :text, null: false)
+      add(:updated_at, :utc_datetime_usec, null: false)
+    end
+
+    create_if_not_exists(index(:favn_backfill_progress, [:status, :updated_at]))
+    create_if_not_exists(index(:favn_backfill_windows, [:backfill_run_id, :status]))
+  end
+
+  def down do
+    drop_if_exists(table(:favn_backfill_progress))
+  end
+end

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -1813,12 +1813,17 @@ defmodule Favn.Storage.Adapter.SQLite do
 
     case SQL.query(repo, sql, [backfill_run_id]) do
       {:ok, %{rows: rows}} ->
-        counts = Map.new(rows, fn [status, count] -> {String.to_existing_atom(status), count} end)
+        if rows == [] do
+          {:error, :not_found}
+        else
+          counts =
+            Map.new(rows, fn [status, count] -> {String.to_existing_atom(status), count} end)
 
-        with {:ok, progress} <-
-               BackfillProgress.from_counts(backfill_run_id, counts, DateTime.utc_now()),
-             :ok <- put_backfill_progress(repo, progress) do
-          {:ok, progress}
+          with {:ok, progress} <-
+                 BackfillProgress.from_counts(backfill_run_id, counts, DateTime.utc_now()),
+               :ok <- put_backfill_progress(repo, progress) do
+            {:ok, progress}
+          end
         end
 
       {:error, reason} ->

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -11,6 +11,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   alias FavnOrchestrator.Backfill.AssetWindowState
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
+  alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -18,6 +19,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   alias FavnOrchestrator.Storage.Backfill.AssetWindowStateCodec
   alias FavnOrchestrator.Storage.Backfill.BackfillWindowCodec
   alias FavnOrchestrator.Storage.Backfill.CoverageBaselineCodec
+  alias FavnOrchestrator.Storage.Backfill.ProgressCodec
   alias FavnOrchestrator.Storage.ExecutionLeaseCodec
   alias FavnOrchestrator.Storage.Freshness.AssetFreshnessStateCodec
   alias FavnOrchestrator.Storage.IdempotencyResponseCodec
@@ -804,6 +806,45 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   @impl true
+  def apply_backfill_child_projection(%BackfillWindow{} = window, asset_window_states, opts)
+      when is_list(asset_window_states) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      repo.transact(fn ->
+        old_status = fetch_backfill_window_status(repo, window)
+
+        with :ok <- put_backfill_window(window, opts),
+             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
+             {:ok, progress} <-
+               upsert_backfill_progress_after_window_change(repo, window, old_status) do
+          {:ok, progress}
+        else
+          {:error, reason} -> repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, %BackfillProgress{} = progress} -> {:ok, progress}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def get_backfill_progress(backfill_run_id, opts)
+      when is_binary(backfill_run_id) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      get_backfill_progress_with_repo(repo, backfill_run_id)
+    end
+  end
+
+  @impl true
+  def rebuild_backfill_progress(backfill_run_id, opts)
+      when is_binary(backfill_run_id) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      rebuild_backfill_progress_with_repo(repo, backfill_run_id)
+    end
+  end
+
+  @impl true
   def put_asset_window_state(%AssetWindowState{} = state, opts) when is_list(opts) do
     with {:ok, repo} <- repo_name(opts) do
       sql =
@@ -963,6 +1004,21 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   @impl true
+  def get_asset_freshness_states_by_keys(keys, opts) when is_list(keys) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      keys
+      |> Enum.uniq()
+      |> Enum.chunk_every(250)
+      |> Enum.reduce_while({:ok, %{}}, fn chunk, {:ok, acc} ->
+        case get_asset_freshness_state_key_chunk(repo, chunk) do
+          {:ok, rows} -> {:cont, {:ok, Map.merge(acc, rows)}}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+      end)
+    end
+  end
+
+  @impl true
   def replace_backfill_read_models(
         scope,
         coverage_baselines,
@@ -995,9 +1051,17 @@ defmodule Favn.Storage.Adapter.SQLite do
                  scope,
                  asset_window_state_filter_columns()
                ),
+             :ok <-
+               delete_scoped(
+                 repo,
+                 "favn_backfill_progress",
+                 [],
+                 backfill_progress_filter_columns()
+               ),
              :ok <- put_all(coverage_baselines, &put_coverage_baseline(&1, opts)),
              :ok <- put_all(backfill_windows, &put_backfill_window(&1, opts)),
-             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)) do
+             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
+             :ok <- rebuild_all_backfill_progress(repo) do
           {:ok, :ok}
         else
           {:error, reason} -> repo.rollback(reason)
@@ -1584,6 +1648,13 @@ defmodule Favn.Storage.Adapter.SQLite do
     }
   end
 
+  defp backfill_progress_filter_columns do
+    %{
+      backfill_run_id: {:text, "backfill_run_id"},
+      status: {:atom, "status"}
+    }
+  end
+
   defp asset_window_state_filter_columns do
     %{
       asset_ref_module: {:atom, "asset_ref_module"},
@@ -1644,6 +1715,147 @@ defmodule Favn.Storage.Adapter.SQLite do
 
   defp decode_asset_freshness_state_row([record_payload]),
     do: AssetFreshnessStateCodec.decode(record_payload)
+
+  defp decode_backfill_progress_row([record_payload]),
+    do: ProgressCodec.decode(record_payload)
+
+  defp get_asset_freshness_state_key_chunk(_repo, []), do: {:ok, %{}}
+
+  defp get_asset_freshness_state_key_chunk(repo, keys) do
+    clauses =
+      keys
+      |> Enum.with_index()
+      |> Enum.map(fn {_key, index} ->
+        base = index * 3
+
+        "(asset_ref_module = ?#{base + 1} AND asset_ref_name = ?#{base + 2} AND freshness_key = ?#{base + 3})"
+      end)
+
+    params =
+      Enum.flat_map(keys, fn {module, name, freshness_key} ->
+        [encode_atom(module), encode_atom(name), freshness_key]
+      end)
+
+    sql =
+      "SELECT #{asset_freshness_state_columns()} FROM favn_asset_freshness_states WHERE " <>
+        Enum.join(clauses, " OR ")
+
+    with {:ok, states} <- decode_rows(repo, sql, params, &decode_asset_freshness_state_row/1) do
+      {:ok,
+       Map.new(states, fn %AssetFreshnessState{} = state ->
+         {{state.asset_ref_module, state.asset_ref_name, state.freshness_key}, state}
+       end)}
+    end
+  end
+
+  defp fetch_backfill_window_status(repo, %BackfillWindow{} = window) do
+    sql =
+      "SELECT status FROM favn_backfill_windows WHERE backfill_run_id = ?1 AND pipeline_module = ?2 AND window_key = ?3 LIMIT 1"
+
+    params = [window.backfill_run_id, encode_atom(window.pipeline_module), window.window_key]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: [[status]]}} when is_binary(status) -> String.to_existing_atom(status)
+      _other -> nil
+    end
+  end
+
+  defp get_backfill_progress_with_repo(repo, backfill_run_id) do
+    sql = "SELECT record_payload FROM favn_backfill_progress WHERE backfill_run_id = ?1 LIMIT 1"
+
+    case SQL.query(repo, sql, [backfill_run_id]) do
+      {:ok, %{rows: [row]}} -> decode_backfill_progress_row(row)
+      {:ok, %{rows: []}} -> {:error, :not_found}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp upsert_backfill_progress_after_window_change(repo, %BackfillWindow{} = window, old_status) do
+    case get_backfill_progress_with_repo(repo, window.backfill_run_id) do
+      {:ok, %BackfillProgress{} = progress} ->
+        with {:ok, next_progress} <-
+               BackfillProgress.apply_status_change(
+                 progress,
+                 old_status,
+                 window.status,
+                 DateTime.utc_now()
+               ),
+             :ok <- put_backfill_progress(repo, next_progress) do
+          {:ok, next_progress}
+        end
+
+      {:error, :not_found} ->
+        rebuild_backfill_progress_with_repo(repo, window.backfill_run_id)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp rebuild_backfill_progress_with_repo(repo, backfill_run_id) do
+    sql =
+      "SELECT status, COUNT(*) FROM favn_backfill_windows WHERE backfill_run_id = ?1 GROUP BY status"
+
+    case SQL.query(repo, sql, [backfill_run_id]) do
+      {:ok, %{rows: rows}} ->
+        counts = Map.new(rows, fn [status, count] -> {String.to_existing_atom(status), count} end)
+
+        with {:ok, progress} <-
+               BackfillProgress.from_counts(backfill_run_id, counts, DateTime.utc_now()),
+             :ok <- put_backfill_progress(repo, progress) do
+          {:ok, progress}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp rebuild_all_backfill_progress(repo) do
+    case SQL.query(repo, "SELECT DISTINCT backfill_run_id FROM favn_backfill_windows", []) do
+      {:ok, %{rows: rows}} ->
+        rows
+        |> Enum.map(fn [backfill_run_id] -> backfill_run_id end)
+        |> Enum.reduce_while(:ok, fn backfill_run_id, :ok ->
+          case rebuild_backfill_progress_with_repo(repo, backfill_run_id) do
+            {:ok, %BackfillProgress{}} -> {:cont, :ok}
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
+        end)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp put_backfill_progress(repo, %BackfillProgress{} = progress) do
+    sql = """
+    INSERT INTO favn_backfill_progress (
+      backfill_run_id, total_count, pending_count, running_count, ok_count,
+      partial_count, error_count, cancelled_count, timed_out_count, status,
+      record_payload, updated_at
+    ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+    ON CONFLICT(backfill_run_id) DO UPDATE SET
+      total_count = excluded.total_count,
+      pending_count = excluded.pending_count,
+      running_count = excluded.running_count,
+      ok_count = excluded.ok_count,
+      partial_count = excluded.partial_count,
+      error_count = excluded.error_count,
+      cancelled_count = excluded.cancelled_count,
+      timed_out_count = excluded.timed_out_count,
+      status = excluded.status,
+      record_payload = excluded.record_payload,
+      updated_at = excluded.updated_at
+    """
+
+    params = backfill_progress_params(progress)
+
+    case SQL.query(repo, sql, params) do
+      {:ok, _} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
   defp decode_materialization_claim_row([record_payload]),
     do: MaterializationClaimCodec.decode(record_payload)
@@ -3051,6 +3263,33 @@ defmodule Favn.Storage.Adapter.SQLite do
       {:error, reason} ->
         raise ArgumentError, "invalid asset freshness state payload: #{inspect(reason)}"
     end
+  end
+
+  defp encode_backfill_progress(%BackfillProgress{} = progress) do
+    case ProgressCodec.encode(progress) do
+      {:ok, payload} ->
+        payload
+
+      {:error, reason} ->
+        raise ArgumentError, "invalid backfill progress payload: #{inspect(reason)}"
+    end
+  end
+
+  defp backfill_progress_params(%BackfillProgress{} = progress) do
+    [
+      progress.backfill_run_id,
+      progress.total_count,
+      progress.pending_count,
+      progress.running_count,
+      progress.ok_count,
+      progress.partial_count,
+      progress.error_count,
+      progress.cancelled_count,
+      progress.timed_out_count,
+      encode_atom(progress.status),
+      encode_backfill_progress(progress),
+      encode_datetime(progress.updated_at)
+    ]
   end
 
   defp encode_materialization_claim(%MaterializationClaim{} = claim) do

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -810,9 +810,9 @@ defmodule Favn.Storage.Adapter.SQLite do
       when is_list(asset_window_states) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts) do
       repo.transact(fn ->
-        old_status = fetch_backfill_window_status(repo, window)
-
-        with :ok <- put_backfill_window(window, opts),
+        with :ok <- lock_backfill_window(repo, window),
+             old_status <- fetch_backfill_window_status(repo, window),
+             :ok <- put_backfill_window(window, opts),
              :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
              {:ok, progress} <-
                upsert_backfill_progress_after_window_change(repo, window, old_status) do
@@ -1760,12 +1760,24 @@ defmodule Favn.Storage.Adapter.SQLite do
     end
   end
 
+  defp lock_backfill_window(repo, %BackfillWindow{} = window) do
+    sql =
+      "UPDATE favn_backfill_windows SET updated_at = updated_at WHERE backfill_run_id = ?1 AND pipeline_module = ?2 AND window_key = ?3"
+
+    params = [window.backfill_run_id, encode_atom(window.pipeline_module), window.window_key]
+
+    case SQL.query(repo, sql, params) do
+      {:ok, _result} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp get_backfill_progress_with_repo(repo, backfill_run_id) do
     sql = "SELECT record_payload FROM favn_backfill_progress WHERE backfill_run_id = ?1 LIMIT 1"
 
     case SQL.query(repo, sql, [backfill_run_id]) do
       {:ok, %{rows: [row]}} -> decode_backfill_progress_row(row)
-      {:ok, %{rows: []}} -> {:error, :not_found}
+      {:ok, %{rows: []}} -> rebuild_backfill_progress_with_repo(repo, backfill_run_id)
       {:error, reason} -> {:error, reason}
     end
   end
@@ -1784,11 +1796,14 @@ defmodule Favn.Storage.Adapter.SQLite do
           {:ok, next_progress}
         end
 
-      {:error, :not_found} ->
-        rebuild_backfill_progress_with_repo(repo, window.backfill_run_id)
-
       {:error, reason} ->
-        {:error, reason}
+        case reason do
+          {:stale_backfill_progress, _old_status, _new_status, _counts} ->
+            rebuild_backfill_progress_with_repo(repo, window.backfill_run_id)
+
+          _other ->
+            {:error, reason}
+        end
     end
   end
 

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
@@ -5,6 +5,7 @@ defmodule FavnStorageSqlite.Migrations do
   alias FavnStorageSqlite.Migrations.AddAuthState
   alias FavnStorageSqlite.Migrations.AddAssetFreshnessState
   alias FavnStorageSqlite.Migrations.AddBackfillState
+  alias FavnStorageSqlite.Migrations.AddBackfillProgress
   alias FavnStorageSqlite.Migrations.AddIdempotencyRecords
   alias FavnStorageSqlite.Migrations.AddExecutionLeases
   alias FavnStorageSqlite.Migrations.AddLogEntries
@@ -25,7 +26,8 @@ defmodule FavnStorageSqlite.Migrations do
     {20_260_510_100_000, AddLogEntries},
     {20_260_520_100_000, AddExecutionLeases},
     {20_260_521_100_000, AddMaterializationClaims},
-    {20_260_521_200_000, AddRunGroupQueryColumns}
+    {20_260_521_200_000, AddRunGroupQueryColumns},
+    {20_260_522_100_000, AddBackfillProgress}
   ]
   @required_tables [
     "favn_manifest_versions",
@@ -35,6 +37,7 @@ defmodule FavnStorageSqlite.Migrations do
     "favn_scheduler_cursors",
     "favn_pipeline_coverage_baselines",
     "favn_backfill_windows",
+    "favn_backfill_progress",
     "favn_asset_window_states",
     "favn_asset_freshness_states",
     "favn_auth_actors",

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_backfill_progress.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_backfill_progress.ex
@@ -1,0 +1,25 @@
+defmodule FavnStorageSqlite.Migrations.AddBackfillProgress do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists table(:favn_backfill_progress, primary_key: false) do
+      add(:backfill_run_id, :string, primary_key: true)
+      add(:total_count, :integer, null: false)
+      add(:pending_count, :integer, null: false)
+      add(:running_count, :integer, null: false)
+      add(:ok_count, :integer, null: false)
+      add(:partial_count, :integer, null: false)
+      add(:error_count, :integer, null: false)
+      add(:cancelled_count, :integer, null: false)
+      add(:timed_out_count, :integer, null: false)
+      add(:status, :string, null: false)
+      add(:record_payload, :text, null: false)
+      add(:updated_at, :text, null: false)
+    end
+
+    create_if_not_exists(index(:favn_backfill_progress, [:status, :updated_at]))
+    create_if_not_exists(index(:favn_backfill_windows, [:backfill_run_id, :status]))
+  end
+end

--- a/apps/favn_storage_sqlite/test/sqlite_readiness_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_readiness_test.exs
@@ -239,7 +239,8 @@ defmodule FavnStorageSqlite.ReadinessTest do
              "20260510100000",
              "20260520100000",
              "20260521100000",
-             "20260521200000"
+             "20260521200000",
+             "20260522100000"
            ]
 
     refute Migrations.schema_ready?(Repo)

--- a/apps/favn_test_support/priv/fixtures/assets/runner_assets.ex
+++ b/apps/favn_test_support/priv/fixtures/assets/runner_assets.ex
@@ -340,6 +340,15 @@ defmodule Favn.Test.Fixtures.Assets.Runner.TerminalFailingStore do
   def list_backfill_windows(filters, _opts), do: {:ok, empty_page(filters)}
 
   @impl true
+  def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
+
+  @impl true
+  def get_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+  @impl true
+  def rebuild_backfill_progress(_backfill_run_id, _opts), do: {:error, :not_found}
+
+  @impl true
   def put_asset_window_state(_state, _opts), do: :ok
 
   @impl true
@@ -348,6 +357,9 @@ defmodule Favn.Test.Fixtures.Assets.Runner.TerminalFailingStore do
 
   @impl true
   def list_asset_window_states(filters, _opts), do: {:ok, empty_page(filters)}
+
+  @impl true
+  def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}
 
   @impl true
   def replace_backfill_read_models(

--- a/docs/ISSUE_394_FRESHNESS_BACKFILL_PERSISTENCE_PLAN.md
+++ b/docs/ISSUE_394_FRESHNESS_BACKFILL_PERSISTENCE_PLAN.md
@@ -152,7 +152,8 @@ Contract rules:
   the same transaction before returning.
 - `get_backfill_progress/2` may lazily rebuild a missing aggregate row from
   existing windows. This is the compatibility path for databases upgraded before
-  aggregate rows existed.
+  aggregate rows existed. Unknown backfill ids with no window rows should return
+  `{:error, :not_found}` rather than creating zero-window progress truth.
 - `rebuild_backfill_progress/2` recomputes aggregate truth from
   `favn_backfill_windows` and is the explicit repair path for migrations,
   manual repair, and consistency checks.

--- a/docs/ISSUE_394_FRESHNESS_BACKFILL_PERSISTENCE_PLAN.md
+++ b/docs/ISSUE_394_FRESHNESS_BACKFILL_PERSISTENCE_PLAN.md
@@ -144,8 +144,15 @@ Contract rules:
   backfill, and returns the new aggregate in one storage operation.
 - The operation computes count deltas from the previously persisted window
   status, so repeated writes with the same status are idempotent for counts.
+- SQL adapters must serialize the old-status read with the window update for the
+  same `{backfill_run_id, pipeline_module, window_key}`. Postgres should use row
+  locking; SQLite should acquire its write lock before reading the previous
+  status.
 - If an aggregate row is missing, the operation repairs it from window rows in
   the same transaction before returning.
+- `get_backfill_progress/2` may lazily rebuild a missing aggregate row from
+  existing windows. This is the compatibility path for databases upgraded before
+  aggregate rows existed.
 - `rebuild_backfill_progress/2` recomputes aggregate truth from
   `favn_backfill_windows` and is the explicit repair path for migrations,
   manual repair, and consistency checks.
@@ -190,6 +197,9 @@ Migration/backfill rules:
 - If migration-time decoding is not practical, adapter startup or first access
   should call the same `rebuild_backfill_progress/2` path and document the lazy
   repair behavior.
+- This issue intentionally makes the new freshness and backfill projection
+  callbacks required adapter contracts. External storage adapters must implement
+  them before they can pass `Storage.validate_adapter/1`.
 - `replace_backfill_read_models/4` should replace aggregate rows consistently
   with windows, either by accepting progress rows or by rebuilding progress after
   replacement inside the same adapter transaction.

--- a/docs/ISSUE_394_FRESHNESS_BACKFILL_PERSISTENCE_PLAN.md
+++ b/docs/ISSUE_394_FRESHNESS_BACKFILL_PERSISTENCE_PLAN.md
@@ -1,0 +1,315 @@
+# Issue 394 Freshness And Backfill Persistence Plan
+
+Issue: #394
+
+Status: planned.
+
+## Goal
+
+Make run startup and backfill projection scale with the explicit runtime inputs
+instead of total persisted freshness or window cardinality.
+
+This follows `docs/refactor_review_standard.md`: expose the storage contracts
+that already exist implicitly, keep persisted truth behind the orchestrator
+storage boundary, and protect the behavior with adapter-level tests.
+
+## Current Baseline
+
+- `FavnOrchestrator.RunServer.Execution.initial_freshness_context/2` calls
+  `Storage.list_asset_freshness_states/1` page by page and filters each page
+  against the current plan in memory.
+- Startup latency therefore scales with all persisted freshness rows, not with
+  the planned run graph.
+- `FavnOrchestrator.Backfill.Projector` updates a child window with
+  `Storage.put_backfill_window/1`, updates asset/window rows separately, then
+  calls `reproject_parent/1`.
+- `reproject_parent/1` pages all windows for the backfill after each child
+  transition to compute parent status and counts.
+- `TransitionWriter.persist_transition/3` intentionally writes the authoritative
+  run snapshot/event first and invokes derived projectors afterward, so the new
+  contract should keep derived backfill truth in storage without leaking adapter
+  details into transition writing.
+
+## Architectural Decision
+
+Add explicit orchestrator storage contracts for bounded freshness lookup and
+backfill child projection. Keep freshness and backfill semantics in
+`favn_orchestrator`; adapters only implement indexed lookup, transactions, and
+durable aggregate maintenance.
+
+Do not make storage return UI-shaped progress. Storage should return persisted
+facts such as freshness rows, backfill-window rows, and aggregate counts.
+`Backfill.Projector` should decide whether the parent run needs a transition.
+`favn_view` should continue to read backend state only through the public
+`FavnOrchestrator` facade.
+
+## Freshness Lookup Contract
+
+Extend `Favn.Storage.Adapter` and `FavnOrchestrator.Storage` with a required
+bounded lookup:
+
+```elixir
+@type freshness_state_key :: {module(), atom(), String.t()}
+
+get_asset_freshness_states_by_keys([freshness_state_key()], adapter_opts()) ::
+  {:ok, %{freshness_state_key() => AssetFreshnessState.t()}} | {:error, term()}
+```
+
+Contract rules:
+
+- Keys are exact `{asset_ref_module, asset_ref_name, freshness_key}` tuples.
+- Duplicate keys are collapsed by the facade before adapter work.
+- An empty key list returns `{:ok, %{}}`.
+- Missing keys are omitted from the returned map, not returned as errors.
+- Returned states must be decoded exactly like `get_asset_freshness_state/4` and
+  `list_asset_freshness_states/2`.
+- Ordering is not part of the contract; callers should use the key map.
+
+Implementation rules:
+
+- Memory lookup reads the existing freshness-state map by key.
+- SQLite and Postgres apply the key predicate in SQL and should chunk internally
+  if needed to avoid parameter limits.
+- Keep `list_asset_freshness_states/1` for operator/repair listing, but remove
+  it from run startup.
+
+## Runtime Freshness Plan
+
+Change `RunServer.Execution` to derive the exact planned freshness keys before
+classification:
+
+- Build `assets_by_ref`, `refresh_policy`, and one `now` timestamp in
+  `initial_freshness_context/2`.
+- Add a pure helper in `FavnOrchestrator.Freshness.Decider`, for example
+  `planned_lookup_keys(plan, opts)`, that uses the same policy/key logic as
+  `decide_many/3`.
+- Include one key per planned node for the freshness policy active at `now`.
+- Load prior states with `Storage.get_asset_freshness_states_by_keys/1`.
+- Index loaded states with the existing `index_freshness_states/1` behavior so
+  decisions can still read by `{ref, freshness_key}` and by
+  `latest_success_node_key`.
+- Pass the context timestamp into every stage decision so calendar-period keys do
+  not drift between startup lookup and classification.
+
+Non-obvious behavior to preserve:
+
+- If bounded lookup fails, keep the current conservative behavior of treating
+  prior states as empty only if that is already intentional. Prefer surfacing a
+  storage error if the current silent fallback is not required for compatibility.
+- Forced refresh modes may still perform the bounded lookup because downstream
+  freshness decisions and result metadata can need prior upstream versions.
+
+## Backfill Aggregate Contract
+
+Add a small orchestrator-owned struct, such as
+`FavnOrchestrator.Backfill.Progress`, to represent persisted aggregate truth:
+
+```elixir
+%FavnOrchestrator.Backfill.Progress{
+  backfill_run_id: String.t(),
+  total_count: non_neg_integer(),
+  pending_count: non_neg_integer(),
+  running_count: non_neg_integer(),
+  ok_count: non_neg_integer(),
+  partial_count: non_neg_integer(),
+  error_count: non_neg_integer(),
+  cancelled_count: non_neg_integer(),
+  timed_out_count: non_neg_integer(),
+  status: BackfillWindow.status(),
+  updated_at: DateTime.t()
+}
+```
+
+Extend `Favn.Storage.Adapter` and `FavnOrchestrator.Storage` with named
+backfill-progress operations:
+
+```elixir
+apply_backfill_child_projection(
+  BackfillWindow.t(),
+  [AssetWindowState.t()],
+  adapter_opts()
+) :: {:ok, Backfill.Progress.t()} | {:error, term()}
+
+get_backfill_progress(String.t(), adapter_opts()) ::
+  {:ok, Backfill.Progress.t()} | {:error, term()}
+
+rebuild_backfill_progress(String.t(), adapter_opts()) ::
+  {:ok, Backfill.Progress.t()} | {:error, term()}
+```
+
+Contract rules:
+
+- `apply_backfill_child_projection/3` upserts the child window, upserts all
+  derived asset/window states, updates the aggregate counts for the parent
+  backfill, and returns the new aggregate in one storage operation.
+- The operation computes count deltas from the previously persisted window
+  status, so repeated writes with the same status are idempotent for counts.
+- If an aggregate row is missing, the operation repairs it from window rows in
+  the same transaction before returning.
+- `rebuild_backfill_progress/2` recomputes aggregate truth from
+  `favn_backfill_windows` and is the explicit repair path for migrations,
+  manual repair, and consistency checks.
+- Parent status is derived from counts with the current `parent_status/1` rules:
+  any pending/running window means `:running`; all `:ok` means `:ok`; all
+  `:cancelled` means `:cancelled`; all `:timed_out` means `:timed_out`; any
+  success among terminal mixed results means `:partial`; otherwise `:error`.
+
+## Persistence Shape
+
+Add a derived aggregate table for SQLite and Postgres:
+
+```text
+favn_backfill_progress
+  backfill_run_id text primary key
+  total_count integer not null
+  pending_count integer not null
+  running_count integer not null
+  ok_count integer not null
+  partial_count integer not null
+  error_count integer not null
+  cancelled_count integer not null
+  timed_out_count integer not null
+  status text not null
+  record_payload text not null
+  updated_at timestamp/text not null
+```
+
+Recommended indexes:
+
+- Keep the existing unique window index on
+  `(backfill_run_id, pipeline_module, window_key)` for child projection.
+- Add or verify an index on `favn_backfill_windows(backfill_run_id, status)` for
+  aggregate rebuild.
+- Keep freshness lookup backed by the existing unique freshness index on
+  `(asset_ref_module, asset_ref_name, freshness_key)`.
+
+Migration/backfill rules:
+
+- Existing deployments should rebuild `favn_backfill_progress` from
+  `favn_backfill_windows` during migration where practical.
+- If migration-time decoding is not practical, adapter startup or first access
+  should call the same `rebuild_backfill_progress/2` path and document the lazy
+  repair behavior.
+- `replace_backfill_read_models/4` should replace aggregate rows consistently
+  with windows, either by accepting progress rows or by rebuilding progress after
+  replacement inside the same adapter transaction.
+
+## Projector Flow
+
+Change `FavnOrchestrator.Backfill.Projector` as follows:
+
+- Keep child context extraction and window/asset-state domain construction in
+  the projector.
+- Replace separate `Storage.put_backfill_window/1`,
+  `Storage.put_asset_window_state/1`, and `list_all_backfill_windows/1` calls
+  with `Storage.apply_backfill_child_projection/2` for terminal child
+  transitions.
+- Use the returned `Backfill.Progress` to decide whether the parent run needs a
+  status transition and to populate parent event data/result counts.
+- For running child transitions, either use the same operation with an empty
+  asset-state list or add a separate `apply_backfill_window_progress/1` only if
+  the distinction keeps the contract clearer.
+- Keep parent `TransitionWriter.persist_transition/3` outside the adapter
+  transaction. The aggregate row becomes the immediately consistent persisted
+  progress truth; the parent run event remains the authoritative lifecycle event
+  and can be retried idempotently.
+- Change `reproject_parent/1` to read `Storage.get_backfill_progress/1` or call
+  `Storage.rebuild_backfill_progress/1`, not page all windows.
+
+Change `FavnOrchestrator.BackfillManager` where pending windows are created:
+
+- Prefer a small bulk storage operation for initial pending windows and progress
+  initialization if the adapter code stays simpler.
+- Otherwise keep `put_backfill_window/1` for setup and call
+  `Storage.rebuild_backfill_progress/1` once after all pending rows are written.
+- Do not make every setup `put_backfill_window/1` silently mutate progress unless
+  that behavior is documented as part of the storage contract.
+
+## Adapter Implementation Notes
+
+Memory adapter:
+
+- Store `backfill_progress` next to `backfill_windows`.
+- Update the window map, asset-window map, and progress map in one GenServer call.
+- Rebuild by grouping current in-memory windows by `backfill_run_id`.
+
+SQLite adapter:
+
+- Use the existing repo transaction helper around child projection.
+- SQLite write transactions serialize concurrent writers, so recomputing or
+  delta-updating the single aggregate row inside the transaction is sufficient.
+- Use dynamic `OR` groups or chunked `IN` predicates for freshness-key lookup.
+
+Postgres adapter:
+
+- Use one transaction for child projection.
+- Lock the affected aggregate row or perform atomic count updates from the old
+  window status to avoid lost updates under concurrent child completions.
+- Use a multi-key predicate or an `unnest`/`VALUES` join for freshness lookup,
+  with chunking if adapter parameter handling requires it.
+
+## Landing Slices
+
+1. Add adapter contract tests for bounded freshness lookup and missing-key
+   behavior.
+2. Add `get_asset_freshness_states_by_keys/1` to the storage facade, behavior,
+   memory adapter, SQLite adapter, and Postgres adapter.
+3. Change `RunServer.Execution` to derive planned lookup keys and remove startup
+   use of `list_asset_freshness_states/1`.
+4. Add `Backfill.Progress` and storage contract tests for progress rebuild from
+   window rows.
+5. Add SQLite/Postgres migrations and memory state for `favn_backfill_progress`.
+6. Implement `get_backfill_progress/1` and `rebuild_backfill_progress/1` across
+   adapters.
+7. Implement `apply_backfill_child_projection/2` across adapters with atomic
+   child-window, asset-window, and aggregate updates.
+8. Change `Backfill.Projector` to consume returned progress instead of scanning
+   all windows after each child transition.
+9. Initialize progress during backfill window creation or immediately after the
+   pending windows are written.
+10. Wire `Backfill.Repair` and `replace_backfill_read_models/4` through the same
+    progress rebuild path.
+11. Update docs and module docs for the new freshness and backfill storage
+    contracts.
+
+## Tests
+
+- Adapter contract: multi-key freshness lookup returns only requested rows.
+- Adapter contract: duplicate and empty freshness-key requests are deterministic.
+- Adapter contract: missing freshness keys are omitted without failing the whole
+  lookup.
+- Run startup: a run with unrelated persisted freshness states only queries the
+  planned keys and still makes the same skip/run decisions.
+- Backfill projector: ordered child transitions update parent counts/status
+  without listing all windows.
+- Backfill projector: concurrent child completions preserve correct counts and
+  terminal parent status for memory and SQL adapters where feasible.
+- Backfill projector: repeated/idempotent child projection does not double-count.
+- Backfill repair: aggregate rebuild from window rows produces the same status
+  and counts as the current full-window scan logic.
+- Migration/adapter: existing windows can be repaired into aggregate rows.
+
+## Risks And Tradeoffs
+
+- SQLite and Postgres need different SQL mechanics for multi-key lookup and
+  concurrent aggregate updates; keep the behavior contract identical and hide the
+  mechanics inside adapters.
+- Aggregate rows are derived truth and can drift if future code writes windows
+  outside the named operations. Keep setup/repair paths explicit and tests around
+  every storage write that affects windows.
+- Parent run status still lives in the authoritative run snapshot/event stream,
+  so there is a short window where progress is updated and the parent transition
+  publish fails. The aggregate repair path and idempotent parent transition
+  should make this recoverable without making storage append run events.
+- Calendar-period freshness keys depend on `now`; using one context timestamp
+  avoids intra-run drift but means long-running pipeline stages use the run-start
+  period for initial prior-state lookup.
+
+## Non-Goals
+
+- Do not move freshness policy, staleness, or backfill status rules into storage
+  adapters.
+- Do not expose storage adapters or repos through `favn_view`.
+- Do not remove generic list APIs needed for operator pages and repair workflows.
+- Do not solve distributed backfill coordination beyond preserving correct
+  single-database transactional behavior.


### PR DESCRIPTION
## Summary
- Add bounded freshness-state lookup by explicit planned keys so run startup avoids scanning global freshness state.
- Add persisted backfill progress aggregates plus storage operations that update child windows, asset window states, and parent progress together.
- Implement the contracts across memory, SQLite, and Postgres adapters with migrations, codecs, repair/rebuild paths, and focused contract coverage.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/integration/storage_adapter_contract_test.exs --exclude acceptance --exclude slow --exclude browser`
- `MIX_ENV=test mix do --app favn_storage_sqlite cmd mix test test/sqlite_readiness_test.exs --exclude acceptance --exclude slow --exclude browser`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test --exclude acceptance --exclude slow --exclude browser`

Closes #394