### PR TITLE
Unify operator run submission

### DIFF
--- a/apps/favn/lib/mix/tasks/favn.run.ex
+++ b/apps/favn/lib/mix/tasks/favn.run.ex
@@ -1,12 +1,13 @@
 defmodule Mix.Tasks.Favn.Run do
   use Mix.Task
 
-  @shortdoc "Submits a pipeline run to the local Favn dev stack"
+  @shortdoc "Submits an asset or pipeline run to the local Favn dev stack"
 
   @moduledoc """
-  Submits a pipeline run to the running local Favn dev stack.
+  Submits an asset or pipeline run to the running local Favn dev stack.
 
       mix favn.run MyApp.Pipelines.Daily
+      mix favn.run MyApp.Assets.RawEvents:events --window month:2026-01
 
   By default the task waits for the run to finish. Use `--no-wait` to return
   after submission. Use `--wait-timeout-ms` for local polling and
@@ -37,23 +38,23 @@ defmodule Mix.Tasks.Favn.Run do
         run_pipeline(pipeline_module, opts)
 
       {[], []} ->
-        Mix.raise("missing pipeline module; usage: mix favn.run MyApp.Pipelines.Daily")
+        Mix.raise("missing target; usage: mix favn.run MyApp.Pipelines.Daily")
 
       {[], _many} ->
-        Mix.raise("expected one pipeline module; usage: mix favn.run MyApp.Pipelines.Daily")
+        Mix.raise("expected one target; usage: mix favn.run MyApp.Pipelines.Daily")
 
       {_invalid, _rest} ->
         Mix.raise("invalid option for mix favn.run")
     end
   end
 
-  defp run_pipeline(pipeline_module, opts) do
-    case Dev.run_pipeline(pipeline_module, opts) do
+  defp run_pipeline(target, opts) do
+    case Dev.run(target, opts) do
       {:ok, run} ->
-        print_run(run, pipeline_module)
+        print_run(run, target)
 
       {:error, {:run_failed, run}} ->
-        print_run(run, pipeline_module)
+        print_run(run, target)
         Mix.raise(terminal_run_error_message(run))
 
       {:error, reason} ->
@@ -61,8 +62,11 @@ defmodule Mix.Tasks.Favn.Run do
     end
   end
 
+  defp error_message({:target_not_found, requested, available}),
+    do: target_not_found_message(requested, available)
+
   defp error_message({:pipeline_not_found, requested, available}),
-    do: pipeline_not_found_message(requested, available)
+    do: target_not_found_message(requested, available)
 
   defp error_message(:stack_not_running), do: "stack not running; use mix favn.dev"
 
@@ -171,9 +175,9 @@ defmodule Mix.Tasks.Favn.Run do
 
   defp format_orchestrator_details(_details), do: ""
 
-  defp print_run(run, pipeline_module) do
-    IO.puts("Submitted pipeline run")
-    IO.puts("pipeline: #{pipeline_module}")
+  defp print_run(run, target) do
+    IO.puts("Submitted run")
+    IO.puts("target: #{target}")
     IO.puts("manifest: #{run["manifest_version_id"] || "unknown"}")
     IO.puts("run: #{run["id"] || "unknown"}")
     IO.puts("status: #{run["status"] || "unknown"}")
@@ -184,15 +188,18 @@ defmodule Mix.Tasks.Favn.Run do
     end
   end
 
-  defp pipeline_not_found_message(requested, available) do
+  defp target_not_found_message(requested, available) do
     lines = [
-      "pipeline is not present in the active manifest: #{requested}",
-      "hint: run mix favn.reload if the pipeline was added or changed after mix favn.dev started"
+      "target is not present in the active manifest: #{requested}",
+      "hint: run mix favn.reload if the target was added or changed after mix favn.dev started"
     ]
 
     case available do
-      [] -> Enum.join(lines, "\n")
-      _ -> Enum.join(lines ++ ["available pipelines:" | Enum.map(available, &"  - #{&1}")], "\n")
+      [] ->
+        Enum.join(lines, "\n")
+
+      _ ->
+        Enum.join(lines ++ ["available targets:" | Enum.map(available, &"  - #{&1}")], "\n")
     end
   end
 end

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -503,8 +503,8 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
     assert output =~ "hint: run mix favn.stop to clear stale runtime state"
   end
 
-  test "mix favn.run requires a pipeline module" do
-    assert_raise Mix.Error, ~r/missing pipeline module/, fn ->
+  test "mix favn.run requires a target" do
+    assert_raise Mix.Error, ~r/missing target/, fn ->
       RunTask.run([])
     end
   end

--- a/apps/favn_local/lib/favn/dev.ex
+++ b/apps/favn_local/lib/favn/dev.ex
@@ -167,11 +167,17 @@ defmodule Favn.Dev do
   def reload(opts \\ []) when is_list(opts), do: Reload.run(opts)
 
   @doc """
+  Submits an asset or pipeline run to the running local stack.
+  """
+  @spec run(module() | String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def run(target, opts \\ []) when is_list(opts), do: Run.submit(target, opts)
+
+  @doc """
   Submits a pipeline run to the running local stack.
   """
   @spec run_pipeline(module() | String.t(), keyword()) :: {:ok, map()} | {:error, term()}
   def run_pipeline(pipeline_module, opts \\ []) when is_list(opts),
-    do: Run.pipeline(pipeline_module, opts)
+    do: Run.submit(pipeline_module, opts)
 
   @doc """
   Lists persisted runs from the running local stack.

--- a/apps/favn_local/lib/favn/dev/run.ex
+++ b/apps/favn_local/lib/favn/dev/run.ex
@@ -26,11 +26,11 @@ defmodule Favn.Dev.Run do
           poll_interval_ms: pos_integer()
         ]
 
-  @spec pipeline(module() | String.t(), run_opts()) :: {:ok, map()} | {:error, term()}
-  def pipeline(pipeline_module, opts \\ [])
+  @spec submit(module() | String.t(), run_opts()) :: {:ok, map()} | {:error, term()}
+  def submit(target, opts \\ [])
 
-  def pipeline(pipeline_module, opts)
-      when is_atom(pipeline_module) or is_binary(pipeline_module) do
+  def submit(target, opts)
+      when is_atom(target) or is_binary(target) do
     with :ok <- validate_opts(opts),
          {:ok, window_request} <- parse_window_request(opts),
          :ok <- ensure_running(opts),
@@ -43,12 +43,12 @@ defmodule Favn.Dev.Run do
              credentials.service_token,
              session_context
            ),
-         {:ok, target} <- resolve_pipeline_target(active_manifest, pipeline_module),
-         {:ok, run} <-
-           submit_pipeline_run(
-             base_url(runtime, opts),
-             credentials.service_token,
-             session_context,
+          {:ok, target} <- resolve_run_target(active_manifest, target),
+          {:ok, run} <-
+            submit_run(
+              base_url(runtime, opts),
+              credentials.service_token,
+              session_context,
              target,
              window_request,
              run_idempotency_key(opts),
@@ -61,7 +61,7 @@ defmodule Favn.Dev.Run do
     end
   end
 
-  def pipeline(_pipeline_module, _opts), do: {:error, :invalid_pipeline}
+  def submit(_target, _opts), do: {:error, :invalid_target}
 
   defp validate_opts(opts) do
     case validate_timezone_without_window(opts) do
@@ -126,6 +126,27 @@ defmodule Favn.Dev.Run do
     end
   end
 
+  @doc false
+  @spec resolve_run_target(map(), module() | String.t()) :: {:ok, map()} | {:error, term()}
+  def resolve_run_target(active_manifest, target)
+      when is_map(active_manifest) and (is_atom(target) or is_binary(target)) do
+    requested = normalize_pipeline_name(target)
+    targets = active_manifest["targets"] || %{}
+    pipelines = Map.get(targets, "pipelines", [])
+    assets = Map.get(targets, "assets", [])
+
+    cond do
+      pipeline = Enum.find(pipelines, &pipeline_target_match?(&1, requested)) ->
+        {:ok, Map.put(pipeline, "target_type", "pipeline")}
+
+      asset = Enum.find(assets, &asset_target_match?(&1, requested)) ->
+        {:ok, Map.put(asset, "target_type", "asset")}
+
+      true ->
+        {:error, {:target_not_found, requested, available_target_labels(pipelines, assets)}}
+    end
+  end
+
   defp ensure_running(opts) do
     case Status.inspect_stack(opts).stack_status do
       :running -> :ok
@@ -163,7 +184,7 @@ defmodule Favn.Dev.Run do
     end
   end
 
-  defp submit_pipeline_run(
+  defp submit_run(
          base_url,
          service_token,
          session_context,
@@ -173,10 +194,11 @@ defmodule Favn.Dev.Run do
          timeout_ms
        ) do
     case target do
-      %{"target_id" => target_id} when is_binary(target_id) and target_id != "" ->
+      %{"target_id" => target_id, "target_type" => target_type}
+      when target_type in ["asset", "pipeline"] and is_binary(target_id) and target_id != "" ->
         payload =
           %{
-            target: %{type: "pipeline", id: target_id},
+            target: %{type: target_type, id: target_id},
             manifest_selection: %{mode: "active"}
           }
           |> maybe_put_window(window_request)
@@ -190,7 +212,7 @@ defmodule Favn.Dev.Run do
         end
 
       _other ->
-        {:error, :invalid_pipeline_target}
+        {:error, :invalid_target}
     end
   end
 
@@ -345,4 +367,24 @@ defmodule Favn.Dev.Run do
     end)
     |> Enum.reject(&is_nil/1)
   end
+
+  defp available_target_labels(pipelines, assets) do
+    asset_labels =
+      Enum.flat_map(assets, fn asset ->
+        [asset["asset_ref"], asset["target_id"], asset["label"]]
+        |> Enum.filter(&(is_binary(&1) and &1 != ""))
+      end)
+
+    pipelines
+    |> available_pipeline_labels()
+    |> Kernel.++(asset_labels)
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  defp asset_target_match?(asset, requested) when is_map(asset) do
+    requested in [asset["asset_ref"], asset["target_id"], asset["label"]]
+  end
+
+  defp asset_target_match?(_asset, _requested), do: false
 end

--- a/apps/favn_local/test/dev_run_test.exs
+++ b/apps/favn_local/test/dev_run_test.exs
@@ -44,7 +44,28 @@ defmodule Favn.Dev.RunTest do
     }
 
     assert {:error, {:pipeline_not_found, "Missing.Pipeline", ["Other"]}} =
-             Run.resolve_pipeline_target(active_manifest, "Missing.Pipeline")
+              Run.resolve_pipeline_target(active_manifest, "Missing.Pipeline")
+  end
+
+  test "resolve_run_target/2 finds active manifest asset by ref" do
+    active_manifest = %{
+      "targets" => %{
+        "assets" => [
+          %{
+            "target_id" => "asset:Elixir.MyApp.Asset:asset",
+            "asset_ref" => "Elixir.MyApp.Asset:asset",
+            "label" => "Elixir.MyApp.Asset:asset"
+          }
+        ],
+        "pipelines" => []
+      }
+    }
+
+    assert {:ok,
+            %{
+              "target_id" => "asset:Elixir.MyApp.Asset:asset",
+              "target_type" => "asset"
+            }} = Run.resolve_run_target(active_manifest, "Elixir.MyApp.Asset:asset")
   end
 
   test "run_pipeline/2 submits with local-dev context and no password login", %{

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -1426,16 +1426,6 @@ defmodule FavnOrchestrator do
   defp ensure_window_rerunnable(_window), do: {:error, :backfill_window_not_rerunnable}
 
   defp require_operator_context(actor_context) when is_map(actor_context) do
-    if Map.get(actor_context, :__trusted_operator_context__) == true do
-      trusted_operator_context(actor_context)
-    else
-      persisted_operator_context(actor_context)
-    end
-  end
-
-  defp require_operator_context(_actor_context), do: {:error, :unauthenticated}
-
-  defp persisted_operator_context(actor_context) do
     with {:ok, actor} <- actor_context_object(actor_context, :actor),
          {:ok, session} <- actor_context_object(actor_context, :session),
          {:ok, persisted_actor, persisted_session} <- load_operator_context(actor, session),
@@ -1447,14 +1437,7 @@ defmodule FavnOrchestrator do
     end
   end
 
-  defp trusted_operator_context(actor_context) do
-    with {:ok, actor} <- actor_context_object(actor_context, :actor),
-         {:ok, _session} <- actor_context_object(actor_context, :session) do
-      if Auth.has_role?(actor, :operator), do: :ok, else: {:error, :forbidden}
-    else
-      {:error, :missing_context} -> {:error, :unauthenticated}
-    end
-  end
+  defp require_operator_context(_actor_context), do: {:error, :unauthenticated}
 
   defp actor_context_object(actor_context, key) do
     case Map.get(actor_context, key) || Map.get(actor_context, Atom.to_string(key)) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -21,6 +21,7 @@ defmodule FavnOrchestrator do
   alias Favn.Window.Spec, as: WindowSpec
   alias FavnOrchestrator.AssetFreshnessState
   alias FavnOrchestrator.Auth
+  alias FavnOrchestrator.Backfill.AssetWindowState
   alias FavnOrchestrator.Backfill.Repair, as: BackfillRepair
   alias FavnOrchestrator.BackfillManager
   alias FavnOrchestrator.Diagnostics
@@ -443,8 +444,16 @@ defmodule FavnOrchestrator do
     with {:ok, manifest_version_id} <- active_manifest(),
          {:ok, version} <- get_manifest(manifest_version_id),
          {:ok, freshness_states} <- detail_freshness_states(manifest_version_id),
+         {:ok, asset_window_states} <- detail_asset_window_states(manifest_version_id),
          {:ok, runs} <- catalogue_runs(manifest_version_id) do
-      case asset_detail_entry(version, target_id, freshness_states, runs, opts) do
+      case asset_detail_entry(
+             version,
+             target_id,
+             freshness_states,
+             asset_window_states,
+             runs,
+             opts
+           ) do
         nil -> {:error, :not_found}
         detail -> {:ok, detail}
       end
@@ -562,6 +571,27 @@ defmodule FavnOrchestrator do
          {:ok, asset} <- resolve_asset_target(version, target_id),
          {:ok, opts} <- operator_asset_run_opts(asset, request) do
       submit_asset_run(asset.ref, Keyword.put(opts, :manifest_version_id, manifest_version_id))
+    end
+  end
+
+  @doc """
+  Submits one manifest target run for an authenticated operator actor context.
+
+  This is the shared command boundary for browser, API, and CLI callers. The
+  target decides whether the request is normalized as an asset run or a pipeline
+  run; callers should not dispatch to asset/pipeline-specific submit functions.
+  """
+  @spec submit_operator_run(
+          operator_actor_context(),
+          String.t(),
+          map(),
+          AssetRunRequest.t() | PipelineRunRequest.t() | map() | keyword() | nil
+        ) :: {:ok, run_id()} | {:error, term()}
+  def submit_operator_run(actor_context, manifest_version_id, target, command_input \\ %{}) do
+    with :ok <- require_operator_context(actor_context),
+         {:ok, version} <- get_manifest(manifest_version_id),
+         {:ok, normalized_target} <- normalize_operator_run_target(version, target) do
+      submit_operator_run_target(version, normalized_target, command_input)
     end
   end
 
@@ -809,6 +839,55 @@ defmodule FavnOrchestrator do
       |> maybe_put_opt(:timeout_ms, request.timeout_ms)
 
     {:ok, opts}
+  end
+
+  defp normalize_operator_run_target(%Version{} = version, %{type: type, id: target_id})
+       when type in [:asset, "asset"] and is_binary(target_id) do
+    with {:ok, asset} <- resolve_asset_target(version, target_id) do
+      {:ok, %{type: :asset, asset: asset}}
+    end
+  end
+
+  defp normalize_operator_run_target(%Version{} = version, %{type: type, id: target_id})
+       when type in [:pipeline, "pipeline"] and is_binary(target_id) do
+    with {:ok, pipeline_module} <- resolve_pipeline_target_module(version, target_id) do
+      {:ok, %{type: :pipeline, pipeline_module: pipeline_module}}
+    end
+  end
+
+  defp normalize_operator_run_target(%Version{} = version, %{type: type, module: pipeline_module})
+       when type in [:pipeline, "pipeline"] and is_atom(pipeline_module) do
+    if Enum.any?(List.wrap(version.manifest.pipelines), &(&1.module == pipeline_module)) do
+      {:ok, %{type: :pipeline, pipeline_module: pipeline_module}}
+    else
+      {:error, :invalid_pipeline_target}
+    end
+  end
+
+  defp normalize_operator_run_target(_version, _target), do: {:error, :invalid_target}
+
+  defp submit_operator_run_target(%Version{} = version, %{type: :asset, asset: asset}, input) do
+    with {:ok, request} <- AssetRunRequest.from_input(input),
+         {:ok, opts} <- operator_asset_run_opts(asset, request) do
+      submit_asset_run(
+        asset.ref,
+        Keyword.put(opts, :manifest_version_id, version.manifest_version_id)
+      )
+    end
+  end
+
+  defp submit_operator_run_target(
+         %Version{} = version,
+         %{type: :pipeline, pipeline_module: pipeline_module},
+         input
+       ) do
+    with {:ok, request} <- PipelineRunRequest.from_input(input),
+         {:ok, opts} <- operator_pipeline_run_opts(request) do
+      submit_pipeline_run(
+        pipeline_module,
+        Keyword.put(opts, :manifest_version_id, version.manifest_version_id)
+      )
+    end
   end
 
   defp operator_pipeline_backfill_opts(%PipelineBackfillRequest{} = request) do
@@ -1347,6 +1426,16 @@ defmodule FavnOrchestrator do
   defp ensure_window_rerunnable(_window), do: {:error, :backfill_window_not_rerunnable}
 
   defp require_operator_context(actor_context) when is_map(actor_context) do
+    if Map.get(actor_context, :__trusted_operator_context__) == true do
+      trusted_operator_context(actor_context)
+    else
+      persisted_operator_context(actor_context)
+    end
+  end
+
+  defp require_operator_context(_actor_context), do: {:error, :unauthenticated}
+
+  defp persisted_operator_context(actor_context) do
     with {:ok, actor} <- actor_context_object(actor_context, :actor),
          {:ok, session} <- actor_context_object(actor_context, :session),
          {:ok, persisted_actor, persisted_session} <- load_operator_context(actor, session),
@@ -1358,7 +1447,14 @@ defmodule FavnOrchestrator do
     end
   end
 
-  defp require_operator_context(_actor_context), do: {:error, :unauthenticated}
+  defp trusted_operator_context(actor_context) do
+    with {:ok, actor} <- actor_context_object(actor_context, :actor),
+         {:ok, _session} <- actor_context_object(actor_context, :session) do
+      if Auth.has_role?(actor, :operator), do: :ok, else: {:error, :forbidden}
+    else
+      {:error, :missing_context} -> {:error, :unauthenticated}
+    end
+  end
 
   defp actor_context_object(actor_context, key) do
     case Map.get(actor_context, key) || Map.get(actor_context, Atom.to_string(key)) do
@@ -1799,6 +1895,16 @@ defmodule FavnOrchestrator do
     end
   end
 
+  defp detail_asset_window_states(manifest_version_id) do
+    case list_asset_window_states(
+           manifest_version_id: manifest_version_id,
+           limit: Page.max_limit()
+         ) do
+      {:ok, page} -> {:ok, page.items}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp asset_catalogue_entries(%Version{} = version, freshness_states, runs) do
     freshness_by_ref = Map.new(freshness_states, &{freshness_ref_string(&1), &1})
 
@@ -1866,7 +1972,14 @@ defmodule FavnOrchestrator do
     end
   end
 
-  defp asset_detail_entry(%Version{} = version, target_id, freshness_states, runs, opts) do
+  defp asset_detail_entry(
+         %Version{} = version,
+         target_id,
+         freshness_states,
+         asset_window_states,
+         runs,
+         opts
+       ) do
     version.manifest.assets
     |> List.wrap()
     |> Enum.find(&(manifest_asset_target(&1).target_id == target_id))
@@ -1900,6 +2013,7 @@ defmodule FavnOrchestrator do
             latest_freshness,
             latest_run,
             freshness_states,
+            asset_window_states,
             runs_by_id,
             opts
           )
@@ -2234,6 +2348,7 @@ defmodule FavnOrchestrator do
          _latest_freshness,
          _latest_run,
          _freshness_states,
+         _asset_window_states,
          _runs_by_id,
          _opts
        ),
@@ -2244,6 +2359,7 @@ defmodule FavnOrchestrator do
          latest_freshness,
          latest_run,
          freshness_states,
+         asset_window_states,
          runs_by_id,
          opts
        ) do
@@ -2252,7 +2368,8 @@ defmodule FavnOrchestrator do
     selected_value =
       detail_timeline_selected_value(kind, timezone, latest_freshness, latest_run, opts)
 
-    window_states = asset_window_freshness_by_date(asset, freshness_states, kind)
+    window_states = asset_window_state_by_date(asset, asset_window_states, kind, timezone)
+    freshness_states = asset_window_freshness_by_date(asset, freshness_states, kind)
 
     latest_run_value =
       latest_run_at(latest_freshness, latest_run)
@@ -2261,7 +2378,8 @@ defmodule FavnOrchestrator do
     for offset <- 0..29 do
       value = shift_timeline_value(kind, timezone, selected_value, offset - 29)
       date = timeline_value_date(kind, value)
-      window_freshness = Map.get(window_states, value)
+      window_state = Map.get(window_states, value)
+      window_freshness = Map.get(freshness_states, value)
 
       %{
         id: timeline_window_id(kind, value),
@@ -2272,10 +2390,20 @@ defmodule FavnOrchestrator do
         date: date,
         range: timeline_window_range(kind, value),
         status:
-          timeline_status(window_freshness, latest_freshness, latest_run, value, latest_run_value),
-        latest_run_id: latest_run_id(window_freshness, nil),
-        latest_run_status: latest_run_status(window_freshness, nil),
-        latest_run_at: latest_run_at(window_freshness, nil),
+          data_coverage_timeline_status(
+            window_state,
+            window_freshness,
+            latest_freshness,
+            latest_run,
+            value,
+            latest_run_value
+          ),
+        latest_run_id:
+          asset_window_latest_run_id(window_state) || latest_run_id(window_freshness, nil),
+        latest_run_status:
+          asset_window_latest_run_status(window_state) || latest_run_status(window_freshness, nil),
+        latest_run_at:
+          asset_window_latest_run_at(window_state) || latest_run_at(window_freshness, nil),
         run_label: "Run this window"
       }
       |> put_window_run_state(asset)
@@ -2528,6 +2656,85 @@ defmodule FavnOrchestrator do
     end)
     |> Map.new(fn {date, state} -> {date, state} end)
   end
+
+  defp asset_window_state_by_date(asset, asset_window_states, timeline_kind, timezone) do
+    {asset_ref_module, asset_ref_name} = asset.ref
+
+    asset_window_states
+    |> Enum.filter(fn
+      %AssetWindowState{
+        asset_ref_module: ^asset_ref_module,
+        asset_ref_name: ^asset_ref_name,
+        window_kind: ^timeline_kind
+      } ->
+        true
+
+      _other ->
+        false
+    end)
+    |> Map.new(fn %AssetWindowState{} = state ->
+      {timeline_value_from_datetime(timeline_kind, timezone, state.window_start_at), state}
+    end)
+  end
+
+  defp data_coverage_timeline_status(
+         %AssetWindowState{status: :ok},
+         _window_freshness,
+         _latest_freshness,
+         _latest_run,
+         _value,
+         _latest_run_value
+       ),
+       do: :covered
+
+  defp data_coverage_timeline_status(
+         %AssetWindowState{status: status},
+         _window_freshness,
+         _latest_freshness,
+         _latest_run,
+         _value,
+         _latest_run_value
+       )
+       when status in [:running, :pending],
+       do: :running
+
+  defp data_coverage_timeline_status(
+         %AssetWindowState{status: status},
+         _window_freshness,
+         _latest_freshness,
+         _latest_run,
+         _value,
+         _latest_run_value
+       )
+       when status in [:partial, :error, :cancelled, :timed_out],
+       do: :failed
+
+  defp data_coverage_timeline_status(
+         _window_state,
+         window_freshness,
+         latest_freshness,
+         latest_run,
+         value,
+         latest_run_value
+       ) do
+    timeline_status(window_freshness, latest_freshness, latest_run, value, latest_run_value)
+  end
+
+  defp asset_window_latest_run_id(%AssetWindowState{latest_run_id: run_id})
+       when is_binary(run_id),
+       do: run_id
+
+  defp asset_window_latest_run_id(_state), do: nil
+
+  defp asset_window_latest_run_status(%AssetWindowState{status: status}) when not is_nil(status),
+    do: status
+
+  defp asset_window_latest_run_status(_state), do: nil
+
+  defp asset_window_latest_run_at(%AssetWindowState{updated_at: %DateTime{} = updated_at}),
+    do: updated_at
+
+  defp asset_window_latest_run_at(_state), do: nil
 
   defp window_date_from_freshness_key("calendar:day:" <> rest) do
     rest

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
@@ -631,9 +631,7 @@ defmodule FavnOrchestrator.API.Router do
          {:ok, session, actor} <- ensure_actor_context(conn, :operator),
          {:ok, params} <- fetch_json_body(conn) do
       run_idempotent_command(conn, "run.submit", actor.id, session.id, params, fn idempotency ->
-        actor_context = %{actor: actor, session: session, __trusted_operator_context__: true}
-
-        with {:ok, run_id} <- submit_run_from_request(params, actor_context) do
+        with {:ok, run_id} <- submit_run_from_request(params, %{actor: actor, session: session}) do
           put_audit_best_effort(
             %{
               action: "run.submit",
@@ -660,6 +658,18 @@ defmodule FavnOrchestrator.API.Router do
 
           {:error, {:invalid_operator_dependency_mode, _value}} ->
             {:error, 422, "validation_failed", "Invalid dependency mode", %{}}
+
+          {:error, {:invalid_operator_timeout_ms, _value}} ->
+            {:error, 422, "validation_failed", "Invalid timeout_ms", %{}}
+
+          {:error, {:invalid_operator_selection_source, _value}} ->
+            {:error, 422, "validation_failed", "Invalid run window request", %{}}
+
+          {:error, {:invalid_operator_selection_id, _value}} ->
+            {:error, 422, "validation_failed", "Invalid run window request", %{}}
+
+          {:error, :invalid_window_request} ->
+            {:error, 422, "validation_failed", "Invalid run window request", %{}}
 
           {:error, :invalid_asset_target} ->
             {:error, 422, "validation_failed", "Invalid asset target id", %{}}
@@ -1380,28 +1390,41 @@ defmodule FavnOrchestrator.API.Router do
   defp loopback_peer?(_remote_ip), do: false
 
   defp local_dev_actor_context(required_role) do
-    now = DateTime.utc_now()
+    password = "local-dev-cli-password-long"
 
-    session = %{
-      id: "local-dev-cli",
-      actor_id: "local-dev-cli",
-      provider: "local_dev_trusted",
-      issued_at: now,
-      expires_at: DateTime.add(now, 86_400, :second),
-      revoked_at: nil
-    }
+    case Auth.create_actor("local-dev-cli", password, "Local Dev CLI", [:admin]) do
+      {:ok, _actor} ->
+        :ok
 
-    actor = %{
-      id: "local-dev-cli",
-      username: "local-dev-cli",
-      display_name: "Local Dev CLI",
-      roles: [:admin],
-      status: :active,
-      inserted_at: now,
-      updated_at: now
-    }
+      {:error, :username_taken} ->
+        reset_local_dev_actor(password)
 
-    if Auth.has_role?(actor, required_role), do: {:ok, session, actor}, else: {:error, :forbidden}
+      {:error, reason} ->
+        {:error, reason}
+    end
+    |> case do
+      :ok ->
+        with {:ok, session, actor} <- Auth.password_login("local-dev-cli", password) do
+          if Auth.has_role?(actor, required_role),
+            do: {:ok, session, actor},
+            else: {:error, :forbidden}
+        end
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp reset_local_dev_actor(password) do
+    case Enum.find(Auth.list_actors(), &(&1.username == "local-dev-cli")) do
+      %{id: actor_id} ->
+        with {:ok, _actor} <- Auth.update_actor_roles(actor_id, [:admin]) do
+          Auth.set_actor_password(actor_id, password)
+        end
+
+      _other ->
+        {:error, :local_dev_actor_not_found}
+    end
   end
 
   defp ensure_activation_context(conn) do
@@ -1802,16 +1825,15 @@ defmodule FavnOrchestrator.API.Router do
   end
 
   defp run_command_input(params, %{type: "asset"}) when is_map(params) do
-    {:ok,
-     []
-     |> maybe_put_opt(
-       :selection,
-       Map.get(params, "selection") || asset_selection_from_window(params)
-     )
-     |> maybe_put_opt(:dependency_mode, Map.get(params, "dependencies"))
-     |> maybe_put_opt(:refresh_mode, Map.get(params, "refresh"))
-     |> maybe_put_opt(:metadata, Map.get(params, "metadata"))
-     |> maybe_put_opt(:timeout_ms, Map.get(params, "timeout_ms"))}
+    with {:ok, selection} <- asset_run_selection(params) do
+      {:ok,
+       []
+       |> maybe_put_opt(:selection, selection)
+       |> maybe_put_opt(:dependency_mode, Map.get(params, "dependencies"))
+       |> maybe_put_opt(:refresh_mode, Map.get(params, "refresh"))
+       |> maybe_put_opt(:metadata, Map.get(params, "metadata"))
+       |> maybe_put_opt(:timeout_ms, Map.get(params, "timeout_ms"))}
+    end
   end
 
   defp run_command_input(params, %{type: "pipeline"}) when is_map(params) do
@@ -1827,17 +1849,25 @@ defmodule FavnOrchestrator.API.Router do
     end
   end
 
+  defp asset_run_selection(%{"window" => _window} = params) do
+    asset_selection_from_window(params)
+  end
+
+  defp asset_run_selection(params), do: {:ok, Map.get(params, "selection")}
+
   defp asset_selection_from_window(%{"window" => %{} = window}) do
     kind = Map.get(window, "kind") || Map.get(window, :kind)
     value = Map.get(window, "value") || Map.get(window, :value)
     timezone = Map.get(window, "timezone") || Map.get(window, :timezone) || "Etc/UTC"
 
     if is_binary(kind) and kind != "" and is_binary(value) and value != "" do
-      %{source: :data_coverage_timeline, kind: kind, value: value, timezone: timezone}
+      {:ok, %{source: :data_coverage_timeline, kind: kind, value: value, timezone: timezone}}
+    else
+      {:error, :invalid_window_request}
     end
   end
 
-  defp asset_selection_from_window(_params), do: nil
+  defp asset_selection_from_window(_params), do: {:error, :invalid_window_request}
 
   defp submit_backfill_from_request(params) do
     with :ok <- reject_backfill_lookback_params(params),

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
@@ -668,6 +668,9 @@ defmodule FavnOrchestrator.API.Router do
           {:error, {:invalid_operator_selection_id, _value}} ->
             {:error, 422, "validation_failed", "Invalid run window request", %{}}
 
+          {:error, {:invalid_operator_window, _value}} ->
+            {:error, 422, "validation_failed", "Invalid run window request", %{}}
+
           {:error, :invalid_window_request} ->
             {:error, 422, "validation_failed", "Invalid run window request", %{}}
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
@@ -8,7 +8,6 @@ defmodule FavnOrchestrator.API.Router do
   require Logger
 
   alias Favn.Manifest.Version
-  alias Favn.Window.Request, as: WindowRequest
   alias FavnOrchestrator
   alias FavnOrchestrator.API.Config
   alias FavnOrchestrator.API.DTO
@@ -632,7 +631,9 @@ defmodule FavnOrchestrator.API.Router do
          {:ok, session, actor} <- ensure_actor_context(conn, :operator),
          {:ok, params} <- fetch_json_body(conn) do
       run_idempotent_command(conn, "run.submit", actor.id, session.id, params, fn idempotency ->
-        with {:ok, run_id} <- submit_run_from_request(params) do
+        actor_context = %{actor: actor, session: session, __trusted_operator_context__: true}
+
+        with {:ok, run_id} <- submit_run_from_request(params, actor_context) do
           put_audit_best_effort(
             %{
               action: "run.submit",
@@ -655,6 +656,9 @@ defmodule FavnOrchestrator.API.Router do
             {:error, 422, "validation_failed", "Invalid manifest selection", %{}}
 
           {:error, :invalid_dependencies} ->
+            {:error, 422, "validation_failed", "Invalid dependency mode", %{}}
+
+          {:error, {:invalid_operator_dependency_mode, _value}} ->
             {:error, 422, "validation_failed", "Invalid dependency mode", %{}}
 
           {:error, :invalid_asset_target} ->
@@ -1784,36 +1788,56 @@ defmodule FavnOrchestrator.API.Router do
     end
   end
 
-  defp submit_run_from_request(params) do
+  defp submit_run_from_request(params, actor_context) do
     with {:ok, target} <- fetch_target(params),
          {:ok, manifest_version_id} <- select_manifest_version(params),
-         {:ok, dependencies} <- fetch_dependencies(params, target),
-         {:ok, window_request} <- fetch_window_request(params, target),
-         {:ok, run_opts} <- run_submit_opts(params) do
-      case target do
-        %{type: "asset", id: target_id} ->
-          FavnOrchestrator.submit_asset_run_for_manifest(
-            manifest_version_id,
-            target_id,
-            Keyword.put(run_opts, :dependencies, dependencies)
-          )
-
-        %{type: "pipeline", id: target_id} ->
-          FavnOrchestrator.submit_pipeline_run_for_manifest(
-            manifest_version_id,
-            target_id,
-            Keyword.put(run_opts, :window_request, window_request)
-          )
-
-        _ ->
-          {:error, :invalid_target}
-      end
+         {:ok, command_input} <- run_command_input(params, target) do
+      FavnOrchestrator.submit_operator_run(
+        actor_context,
+        manifest_version_id,
+        target,
+        command_input
+      )
     end
   end
 
-  defp run_submit_opts(params) when is_map(params) do
-    {:ok, maybe_put_positive_int_opt([], :timeout_ms, Map.get(params, "timeout_ms"))}
+  defp run_command_input(params, %{type: "asset"}) when is_map(params) do
+    {:ok,
+     []
+     |> maybe_put_opt(
+       :selection,
+       Map.get(params, "selection") || asset_selection_from_window(params)
+     )
+     |> maybe_put_opt(:dependency_mode, Map.get(params, "dependencies"))
+     |> maybe_put_opt(:refresh_mode, Map.get(params, "refresh"))
+     |> maybe_put_opt(:metadata, Map.get(params, "metadata"))
+     |> maybe_put_opt(:timeout_ms, Map.get(params, "timeout_ms"))}
   end
+
+  defp run_command_input(params, %{type: "pipeline"}) when is_map(params) do
+    if Map.has_key?(params, "dependencies") do
+      {:error, :invalid_dependencies}
+    else
+      {:ok,
+       []
+       |> maybe_put_opt(:window, Map.get(params, "window"))
+       |> maybe_put_opt(:refresh_mode, Map.get(params, "refresh"))
+       |> maybe_put_opt(:metadata, Map.get(params, "metadata"))
+       |> maybe_put_opt(:timeout_ms, Map.get(params, "timeout_ms"))}
+    end
+  end
+
+  defp asset_selection_from_window(%{"window" => %{} = window}) do
+    kind = Map.get(window, "kind") || Map.get(window, :kind)
+    value = Map.get(window, "value") || Map.get(window, :value)
+    timezone = Map.get(window, "timezone") || Map.get(window, :timezone) || "Etc/UTC"
+
+    if is_binary(kind) and kind != "" and is_binary(value) and value != "" do
+      %{source: :data_coverage_timeline, kind: kind, value: value, timezone: timezone}
+    end
+  end
+
+  defp asset_selection_from_window(_params), do: nil
 
   defp submit_backfill_from_request(params) do
     with :ok <- reject_backfill_lookback_params(params),
@@ -2005,45 +2029,6 @@ defmodule FavnOrchestrator.API.Router do
         [] -> {:error, :not_found}
         [window | _rest] -> {:ok, window}
       end
-    end
-  end
-
-  defp fetch_window_request(params, %{type: "asset"}) when is_map(params) do
-    if Map.has_key?(params, "window") do
-      {:error, :invalid_window_request}
-    else
-      {:ok, nil}
-    end
-  end
-
-  defp fetch_window_request(params, %{type: "pipeline"}) when is_map(params) do
-    case Map.get(params, "window") do
-      nil ->
-        {:ok, nil}
-
-      %{} = window ->
-        WindowRequest.from_value(window)
-
-      _other ->
-        {:error, :invalid_window_request}
-    end
-  end
-
-  defp fetch_dependencies(params, %{type: "pipeline"}) when is_map(params) do
-    if Map.has_key?(params, "dependencies") do
-      {:error, :invalid_dependencies}
-    else
-      {:ok, nil}
-    end
-  end
-
-  defp fetch_dependencies(params, %{type: "asset"}) when is_map(params) do
-    case Map.get(params, "dependencies", "all") do
-      "all" -> {:ok, :all}
-      "none" -> {:ok, :none}
-      :all -> {:ok, :all}
-      :none -> {:ok, :none}
-      _other -> {:error, :invalid_dependencies}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/asset_window_projector.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/asset_window_projector.ex
@@ -1,0 +1,129 @@
+defmodule FavnOrchestrator.AssetWindowProjector do
+  @moduledoc """
+  Projects terminal windowed asset executions into the asset/window read model.
+
+  The read model is keyed by asset reference and concrete window key, independent
+  of whether the run came from an asset command, pipeline command, or backfill
+  child command.
+  """
+
+  alias Favn.Run.NodeResult
+  alias Favn.Window.Key
+  alias Favn.Window.Runtime
+  alias FavnOrchestrator.Backfill.AssetWindowState
+  alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage
+
+  @terminal_events [:run_finished, :run_failed, :run_cancelled, :run_timed_out]
+
+  @spec project_transition(RunState.t(), atom(), map()) :: :ok | {:error, term()}
+  def project_transition(run_state, event_type, data \\ %{})
+
+  def project_transition(%RunState{} = run_state, event_type, _data)
+      when event_type in @terminal_events do
+    run_state
+    |> node_results()
+    |> Enum.reduce_while(:ok, fn result, :ok ->
+      case put_asset_window_state(run_state, result) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  def project_transition(%RunState{}, _event_type, _data), do: :ok
+
+  defp node_results(%RunState{result: %{node_results: results}}) when is_list(results),
+    do: results
+
+  defp node_results(_run_state), do: []
+
+  defp put_asset_window_state(
+         %RunState{} = run_state,
+         %NodeResult{window: %Runtime{} = window} = result
+       ) do
+    put_asset_window_state(run_state, Map.from_struct(result), window)
+  end
+
+  defp put_asset_window_state(%RunState{} = run_state, %{window: %Runtime{} = window} = result) do
+    put_asset_window_state(run_state, result, window)
+  end
+
+  defp put_asset_window_state(_run_state, _result), do: :ok
+
+  defp put_asset_window_state(%RunState{} = run_state, result, %Runtime{} = window) do
+    with {:ok, {module, name}} <- result_ref(result),
+         {:ok, status} <- result_status(result),
+         {:ok, state} <- build_state(run_state, result, window, module, name, status) do
+      Storage.put_asset_window_state(state)
+    end
+  end
+
+  defp build_state(%RunState{} = run_state, result, %Runtime{} = window, module, name, status) do
+    window_key = Key.encode(window.key)
+    existing = existing_state(module, name, window_key)
+    now = run_state.updated_at || DateTime.utc_now()
+
+    AssetWindowState.new(%{
+      asset_ref_module: module,
+      asset_ref_name: name,
+      pipeline_module: Map.get(run_state.metadata, :pipeline_submit_ref),
+      manifest_version_id: run_state.manifest_version_id,
+      window_kind: window.kind,
+      window_start_at: window.start_at,
+      window_end_at: window.end_at,
+      timezone: window.timezone,
+      window_key: window_key,
+      status: status,
+      latest_run_id: run_state.id,
+      latest_parent_run_id: run_state.parent_run_id,
+      latest_success_run_id: latest_success_run_id(existing, status, run_state.id),
+      latest_error: if(status == :ok, do: nil, else: result_error(result)),
+      errors: next_errors(existing, status, result_error(result)),
+      metadata: result_metadata(result),
+      updated_at: now
+    })
+  end
+
+  defp result_ref(%{ref: {module, name}}) when is_atom(module) and is_atom(name),
+    do: {:ok, {module, name}}
+
+  defp result_ref(_result), do: :error
+
+  defp result_status(%{status: status}) when status in [:ok, :error, :cancelled, :timed_out],
+    do: {:ok, status}
+
+  defp result_status(%{status: :blocked}), do: {:ok, :error}
+  defp result_status(%{status: :skipped_fresh}), do: {:ok, :ok}
+  defp result_status(_result), do: {:ok, :error}
+
+  defp existing_state(module, name, window_key) do
+    case Storage.get_asset_window_state(module, name, window_key) do
+      {:ok, %AssetWindowState{} = state} -> state
+      {:error, :not_found} -> nil
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp latest_success_run_id(_existing, :ok, run_id), do: run_id
+
+  defp latest_success_run_id(%AssetWindowState{latest_success_run_id: run_id}, _status, _run_id),
+    do: run_id
+
+  defp latest_success_run_id(_existing, _status, _run_id), do: nil
+
+  defp next_errors(existing, :ok, _error), do: existing_errors(existing)
+  defp next_errors(existing, _status, nil), do: existing_errors(existing)
+  defp next_errors(existing, _status, error), do: existing_errors(existing) ++ [error]
+
+  defp existing_errors(%AssetWindowState{errors: errors}) when is_list(errors), do: errors
+  defp existing_errors(_existing), do: []
+
+  defp result_error(%{error: error}), do: error
+  defp result_error(%{reason: reason}), do: reason
+  defp result_error(_result), do: nil
+
+  defp result_metadata(%{meta: metadata}) when is_map(metadata), do: metadata
+  defp result_metadata(%{metadata: metadata}) when is_map(metadata), do: metadata
+  defp result_metadata(_result), do: %{}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/asset_window_projector.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/asset_window_projector.ex
@@ -54,14 +54,22 @@ defmodule FavnOrchestrator.AssetWindowProjector do
   defp put_asset_window_state(%RunState{} = run_state, result, %Runtime{} = window) do
     with {:ok, {module, name}} <- result_ref(result),
          {:ok, status} <- result_status(result),
-         {:ok, state} <- build_state(run_state, result, window, module, name, status) do
+         {:ok, existing} <- existing_state(module, name, Key.encode(window.key)),
+         {:ok, state} <- build_state(run_state, result, window, module, name, status, existing) do
       Storage.put_asset_window_state(state)
     end
   end
 
-  defp build_state(%RunState{} = run_state, result, %Runtime{} = window, module, name, status) do
+  defp build_state(
+         %RunState{} = run_state,
+         result,
+         %Runtime{} = window,
+         module,
+         name,
+         status,
+         existing
+       ) do
     window_key = Key.encode(window.key)
-    existing = existing_state(module, name, window_key)
     now = run_state.updated_at || DateTime.utc_now()
 
     AssetWindowState.new(%{
@@ -99,9 +107,9 @@ defmodule FavnOrchestrator.AssetWindowProjector do
 
   defp existing_state(module, name, window_key) do
     case Storage.get_asset_window_state(module, name, window_key) do
-      {:ok, %AssetWindowState{} = state} -> state
-      {:error, :not_found} -> nil
-      {:error, _reason} -> nil
+      {:ok, %AssetWindowState{} = state} -> {:ok, state}
+      {:error, :not_found} -> {:ok, nil}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill/asset_window_state.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill/asset_window_state.ex
@@ -11,7 +11,6 @@ defmodule FavnOrchestrator.Backfill.AssetWindowState do
   @enforce_keys [
     :asset_ref_module,
     :asset_ref_name,
-    :pipeline_module,
     :manifest_version_id,
     :window_kind,
     :window_start_at,
@@ -48,7 +47,7 @@ defmodule FavnOrchestrator.Backfill.AssetWindowState do
   @type t :: %__MODULE__{
           asset_ref_module: module(),
           asset_ref_name: atom(),
-          pipeline_module: module(),
+          pipeline_module: module() | nil,
           manifest_version_id: String.t(),
           window_kind: atom(),
           window_start_at: DateTime.t(),

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_run_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/asset_run_request.ex
@@ -54,14 +54,15 @@ defmodule FavnOrchestrator.OperatorCommands.AssetRunRequest do
 
     with {:ok, dependency_mode} <- Input.dependency_mode(dependency_value),
          {:ok, refresh_mode} <- Input.asset_refresh_mode(refresh_value),
-         {:ok, selection} <- Input.selection(Input.field(input, :selection)) do
+         {:ok, selection} <- Input.selection(Input.field(input, :selection)),
+         {:ok, timeout_ms} <- Input.timeout_ms(Input.field(input, :timeout_ms)) do
       {:ok,
        %__MODULE__{
          dependency_mode: dependency_mode,
          refresh_mode: refresh_mode,
          selection: selection,
          metadata: Input.field(input, :metadata),
-         timeout_ms: Input.field(input, :timeout_ms)
+         timeout_ms: timeout_ms
        }}
     end
   end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/input.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/input.ex
@@ -89,6 +89,10 @@ defmodule FavnOrchestrator.OperatorCommands.Input do
 
   def window(value), do: {:error, {:invalid_operator_window, value}}
 
+  def timeout_ms(nil), do: {:ok, nil}
+  def timeout_ms(value) when is_integer(value) and value > 0, do: {:ok, value}
+  def timeout_ms(value), do: {:error, {:invalid_operator_timeout_ms, value}}
+
   defp normalize_window_result(original, fun) do
     case fun.() do
       {:ok, %WindowRequest{} = request} -> {:ok, request}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_run_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_run_request.ex
@@ -35,13 +35,14 @@ defmodule FavnOrchestrator.OperatorCommands.PipelineRunRequest do
     refresh_value = Input.field(input, :refresh_mode, Input.field(input, :refresh, :auto))
 
     with {:ok, refresh_mode} <- Input.pipeline_refresh_mode(refresh_value),
-         {:ok, window} <- Input.window(Input.field(input, :window)) do
+         {:ok, window} <- Input.window(Input.field(input, :window)),
+         {:ok, timeout_ms} <- Input.timeout_ms(Input.field(input, :timeout_ms)) do
       {:ok,
        %__MODULE__{
          refresh_mode: refresh_mode,
          window: window,
          metadata: Input.field(input, :metadata),
-         timeout_ms: Input.field(input, :timeout_ms)
+         timeout_ms: timeout_ms
        }}
     end
   end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/transition_writer.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/transition_writer.ex
@@ -4,6 +4,7 @@ defmodule FavnOrchestrator.TransitionWriter do
   """
 
   alias FavnOrchestrator.Backfill
+  alias FavnOrchestrator.AssetWindowProjector
   alias FavnOrchestrator.Events
   alias FavnOrchestrator.LogWriter
   alias FavnOrchestrator.OperationalEvents
@@ -56,6 +57,7 @@ defmodule FavnOrchestrator.TransitionWriter do
   defp project_derived_state(%RunState{} = run_state, event_type, data) do
     safe_project(Backfill.Projector, run_state, event_type, data)
     safe_project(Backfill.CoverageProjector, run_state, event_type, data)
+    safe_project(AssetWindowProjector, run_state, event_type, data)
   end
 
   defp safe_emit_transition_log(%RunEvent{entity: :step} = event) do

--- a/apps/favn_orchestrator/test/api/router_test.exs
+++ b/apps/favn_orchestrator/test/api/router_test.exs
@@ -1588,6 +1588,34 @@ defmodule FavnOrchestrator.API.RouterTest do
            } = Jason.decode!(response.resp_body)
   end
 
+  test "run submission rejects malformed pipeline window payload" do
+    version = schedule_manifest_version("mv_pipeline_window_malformed")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password-long")
+
+    response =
+      conn(:post, "/api/orchestrator/v1/runs", %{
+        target: %{type: "pipeline", id: "pipeline:Elixir.MyApp.Pipelines.DailyOrders"},
+        manifest_selection: %{mode: "version", manifest_version_id: version.manifest_version_id},
+        window: %{mode: "bad"}
+      })
+      |> put_req_header("authorization", "Bearer test-service-token")
+      |> put_req_header("x-favn-actor-id", actor.id)
+      |> put_req_header("x-favn-session-token", session.token)
+      |> put_idempotency_key("pipeline-window-malformed")
+      |> Router.call(@opts)
+
+    assert response.status == 422
+
+    assert %{
+             "error" => %{
+               "code" => "validation_failed",
+               "message" => "Invalid run window request"
+             }
+           } = Jason.decode!(response.resp_body)
+  end
+
   test "run submission reports pipeline window kind mismatch clearly" do
     version = schedule_manifest_version("mv_pipeline_window_mismatch")
     assert :ok = FavnOrchestrator.register_manifest(version)

--- a/apps/favn_orchestrator/test/api/router_test.exs
+++ b/apps/favn_orchestrator/test/api/router_test.exs
@@ -13,6 +13,7 @@ defmodule FavnOrchestrator.API.RouterTest do
   alias Favn.Window.Anchor
   alias Favn.Window.Key, as: WindowKey
   alias Favn.Window.Policy
+  alias Favn.Window.Spec, as: WindowSpec
   alias FavnOrchestrator
   alias FavnOrchestrator.API.Router
   alias FavnOrchestrator.Auth
@@ -1242,7 +1243,7 @@ defmodule FavnOrchestrator.API.RouterTest do
     assert response.status == 201
     assert %{"data" => %{"run" => %{"id" => run_id}}} = Jason.decode!(response.resp_body)
 
-    assert [%{action: "run.submit", actor_id: "local-dev-cli", session_id: "local-dev-cli"}] =
+    assert [%{action: "run.submit", service_identity: "local-dev-cli"}] =
              Auth.list_audit(limit: 1)
 
     assert {:ok, run} = FavnOrchestrator.get_run(run_id)
@@ -1450,6 +1451,92 @@ defmodule FavnOrchestrator.API.RouterTest do
 
     assert response.status == 422
     assert %{"error" => %{"code" => "validation_failed"}} = Jason.decode!(response.resp_body)
+  end
+
+  test "run submission rejects malformed asset window payload" do
+    version = windowed_asset_manifest_version("mv_bad_asset_window")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password-long")
+
+    response =
+      conn(:post, "/api/orchestrator/v1/runs", %{
+        target: %{type: "asset", id: "asset:Elixir.MyApp.Assets.Monthly:asset"},
+        manifest_selection: %{mode: "version", manifest_version_id: version.manifest_version_id},
+        window: %{kind: "month"}
+      })
+      |> put_req_header("authorization", "Bearer test-service-token")
+      |> put_req_header("x-favn-actor-id", actor.id)
+      |> put_req_header("x-favn-session-token", session.token)
+      |> put_idempotency_key("run-bad-asset-window")
+      |> Router.call(@opts)
+
+    assert response.status == 422
+
+    assert %{"error" => %{"message" => "Invalid run window request"}} =
+             Jason.decode!(response.resp_body)
+  end
+
+  test "run submission maps asset window payload to data coverage selection" do
+    version = windowed_asset_manifest_version("mv_asset_window_payload")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password-long")
+
+    response =
+      conn(:post, "/api/orchestrator/v1/runs", %{
+        target: %{type: "asset", id: "asset:Elixir.MyApp.Assets.Monthly:asset"},
+        manifest_selection: %{mode: "version", manifest_version_id: version.manifest_version_id},
+        dependencies: "none",
+        window: %{kind: "month", value: "2026-01", timezone: "Etc/UTC"}
+      })
+      |> put_req_header("authorization", "Bearer test-service-token")
+      |> put_req_header("x-favn-actor-id", actor.id)
+      |> put_req_header("x-favn-session-token", session.token)
+      |> put_idempotency_key("run-asset-window-payload")
+      |> Router.call(@opts)
+
+    assert response.status == 201
+    assert %{"data" => %{"run" => %{"id" => run_id}}} = Jason.decode!(response.resp_body)
+    assert {:ok, run} = FavnOrchestrator.get_run(run_id)
+    assert run.metadata.timeline_selection.source == :data_coverage_timeline
+    assert run.metadata.selected_window.id == "window:month:2026-01"
+    assert [{{MyApp.Assets.Monthly, :asset}, window_key}] = run.plan.target_node_keys
+    assert window_key.kind == :month
+    assert window_key.start_at_us == DateTime.to_unix(~U[2026-01-01 00:00:00Z], :microsecond)
+  end
+
+  test "run submission rejects invalid timeout before generic run validation" do
+    asset_version = dependency_manifest_version("mv_invalid_asset_timeout")
+    pipeline_version = schedule_manifest_version("mv_invalid_pipeline_timeout")
+    assert :ok = FavnOrchestrator.register_manifest(asset_version)
+    assert :ok = FavnOrchestrator.register_manifest(pipeline_version)
+
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password-long")
+
+    for {target, manifest_version_id, key} <- [
+          {%{type: "asset", id: "asset:Elixir.MyApp.Assets.Gold:asset"},
+           asset_version.manifest_version_id, "asset"},
+          {%{type: "pipeline", id: "pipeline:Elixir.MyApp.Pipelines.DailyOrders"},
+           pipeline_version.manifest_version_id, "pipeline"}
+        ] do
+      response =
+        conn(:post, "/api/orchestrator/v1/runs", %{
+          target: target,
+          manifest_selection: %{mode: "version", manifest_version_id: manifest_version_id},
+          timeout_ms: 0
+        })
+        |> put_req_header("authorization", "Bearer test-service-token")
+        |> put_req_header("x-favn-actor-id", actor.id)
+        |> put_req_header("x-favn-session-token", session.token)
+        |> put_idempotency_key("run-invalid-timeout-#{key}")
+        |> Router.call(@opts)
+
+      assert response.status == 422
+
+      assert %{"error" => %{"message" => "Invalid timeout_ms"}} =
+               Jason.decode!(response.resp_body)
+    end
   end
 
   test "run submission rejects request-level dependency mode for pipeline targets" do
@@ -2667,6 +2754,23 @@ defmodule FavnOrchestrator.API.RouterTest do
           runtime_config: %{source_system: %{segment_id: Ref.env!("SOURCE_SYSTEM_SEGMENT_ID")}},
           materialization: %Favn.Manifest.SQLExecution{sql: "select 1", template: nil},
           metadata: %{owner: "analytics", api_token: "manifest-target-secret"}
+        }
+      ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
+    version
+  end
+
+  defp windowed_asset_manifest_version(manifest_version_id) do
+    manifest = %Manifest{
+      assets: [
+        %Favn.Manifest.Asset{
+          ref: {MyApp.Assets.Monthly, :asset},
+          module: MyApp.Assets.Monthly,
+          name: :asset,
+          type: :elixir,
+          window: WindowSpec.new!(:month, required: true)
         }
       ]
     }

--- a/apps/favn_orchestrator/test/auth/operator_facade_test.exs
+++ b/apps/favn_orchestrator/test/auth/operator_facade_test.exs
@@ -193,6 +193,22 @@ defmodule FavnOrchestrator.Auth.OperatorFacadeTest do
              )
   end
 
+  test "unified operator run cannot be bypassed with forged context maps" do
+    forged_context = %{
+      actor: %{id: "actor_fake", roles: [:admin]},
+      session: %{id: "session_fake"},
+      __trusted_operator_context__: true
+    }
+
+    assert {:error, :unauthenticated} =
+             FavnOrchestrator.submit_operator_run(
+               forged_context,
+               "missing_manifest",
+               %{type: :asset, id: "asset:missing"},
+               []
+             )
+  end
+
   test "operator command wrappers validate malformed DTO structs before manifest lookup" do
     operator_context = operator_context("operator-malformed-dto")
 

--- a/apps/favn_orchestrator/test/auth/operator_facade_test.exs
+++ b/apps/favn_orchestrator/test/auth/operator_facade_test.exs
@@ -87,26 +87,26 @@ defmodule FavnOrchestrator.Auth.OperatorFacadeTest do
     viewer_context = %{actor: viewer, session: viewer_session}
 
     assert {:error, :unauthenticated} =
-             FavnOrchestrator.submit_operator_asset_run(
+             FavnOrchestrator.submit_operator_run(
                %{},
                "missing_manifest",
-               "asset:missing",
+               %{type: :asset, id: "asset:missing"},
                []
              )
 
     assert {:error, :forbidden} =
-             FavnOrchestrator.submit_operator_asset_run(
+             FavnOrchestrator.submit_operator_run(
                viewer_context,
                "missing_manifest",
-               "asset:missing",
+               %{type: :asset, id: "asset:missing"},
                []
              )
 
     assert {:error, :forbidden} =
-             FavnOrchestrator.submit_operator_pipeline_run(
+             FavnOrchestrator.submit_operator_run(
                viewer_context,
                "missing_manifest",
-               "pipeline:missing",
+               %{type: :pipeline, id: "pipeline:missing"},
                []
              )
 
@@ -127,18 +127,18 @@ defmodule FavnOrchestrator.Auth.OperatorFacadeTest do
     operator_context = %{actor: operator, session: operator_session}
 
     assert {:error, :manifest_version_not_found} =
-             FavnOrchestrator.submit_operator_asset_run(
+             FavnOrchestrator.submit_operator_run(
                operator_context,
                "missing_manifest",
-               "asset:missing",
+               %{type: :asset, id: "asset:missing"},
                []
              )
 
     assert {:error, :manifest_version_not_found} =
-             FavnOrchestrator.submit_operator_pipeline_run(
+             FavnOrchestrator.submit_operator_run(
                operator_context,
                "missing_manifest",
-               "pipeline:missing",
+               %{type: :pipeline, id: "pipeline:missing"},
                []
              )
 

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -5,10 +5,14 @@ defmodule FavnOrchestrator.ManifestStoreTest do
   alias Favn.Manifest.Pipeline
   alias Favn.Manifest.Version
   alias Favn.Run.AssetResult
+  alias Favn.Run.NodeResult
   alias Favn.Window.Policy
+  alias Favn.Window.Runtime, as: RuntimeWindow
   alias Favn.Window.Spec, as: WindowSpec
   alias FavnOrchestrator
+  alias FavnOrchestrator.AssetWindowProjector
   alias FavnOrchestrator.AssetFreshnessState
+  alias FavnOrchestrator.Backfill.AssetWindowState
   alias FavnOrchestrator.ManifestStore
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
@@ -443,6 +447,114 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert refresh_window = Enum.find(detail.refresh_timeline, &(&1.value == "2026-05-19"))
     assert refresh_window.status == :fresh
     assert refresh_window.latest_run_id == "run_daily_sales"
+  end
+
+  test "asset detail data coverage timeline uses asset window state" do
+    now = ~U[2026-05-20 12:00:00Z]
+    ref = {MyApp.MonthlyCoverageAsset, :asset}
+    window_spec = WindowSpec.new!(:month, required: true)
+
+    version =
+      manifest_version(
+        "mv_asset_window_state",
+        ref,
+        [
+          %Pipeline{
+            module: MyApp.MonthlyCoveragePipeline,
+            name: :monthly_coverage_pipeline,
+            selectors: [ref],
+            deps: :all,
+            window: Policy.new!(:monthly),
+            source: :dsl,
+            outputs: [],
+            config: %{},
+            metadata: %{}
+          }
+        ],
+        window_spec
+      )
+
+    assert :ok = ManifestStore.register_manifest(version)
+    assert :ok = ManifestStore.set_active_manifest("mv_asset_window_state")
+
+    {:ok, state} =
+      AssetWindowState.new(%{
+        asset_ref_module: elem(ref, 0),
+        asset_ref_name: elem(ref, 1),
+        manifest_version_id: "mv_asset_window_state",
+        window_kind: :month,
+        window_start_at: ~U[2026-01-01 00:00:00Z],
+        window_end_at: ~U[2026-02-01 00:00:00Z],
+        timezone: "Etc/UTC",
+        window_key: "month:2026-01",
+        status: :ok,
+        latest_run_id: "run_monthly_jan",
+        latest_success_run_id: "run_monthly_jan",
+        updated_at: now
+      })
+
+    assert :ok = Storage.put_asset_window_state(state)
+
+    assert {:ok, detail} =
+             FavnOrchestrator.active_asset_detail(
+               "asset:Elixir.MyApp.MonthlyCoverageAsset:asset",
+               now: now
+             )
+
+    assert jan_window = Enum.find(detail.data_coverage_timeline, &(&1.value == "2026-01"))
+    assert jan_window.status == :covered
+    assert jan_window.latest_run_id == "run_monthly_jan"
+  end
+
+  test "terminal windowed asset runs project asset window state" do
+    now = ~U[2026-01-02 00:00:00Z]
+    ref = {MyApp.ProjectedWindowAsset, :asset}
+    key = Favn.Window.Key.new!(:month, ~U[2026-01-01 00:00:00Z], "Etc/UTC")
+
+    runtime_window =
+      RuntimeWindow.new!(
+        :month,
+        ~U[2026-01-01 00:00:00Z],
+        ~U[2026-02-01 00:00:00Z],
+        key,
+        timezone: "Etc/UTC"
+      )
+
+    run_state =
+      RunState.new(
+        id: "run_project_window",
+        manifest_version_id: "mv_project_window",
+        manifest_content_hash: "hash_project_window",
+        asset_ref: ref,
+        target_refs: [ref]
+      )
+      |> RunState.transition(
+        status: :ok,
+        result: %{
+          node_results: [
+            NodeResult.new(%{
+              node_key: {ref, key},
+              ref: ref,
+              window: runtime_window,
+              status: :ok,
+              finished_at: now
+            })
+          ]
+        }
+      )
+      |> Map.put(:updated_at, now)
+
+    assert :ok = AssetWindowProjector.project_transition(run_state, :run_finished, %{})
+
+    assert {:ok, state} =
+             Storage.get_asset_window_state(
+               elem(ref, 0),
+               elem(ref, 1),
+               Favn.Window.Key.encode(key)
+             )
+
+    assert state.status == :ok
+    assert state.latest_success_run_id == "run_project_window"
   end
 
   test "hourly asset detail timeline uses hours without collapsing same-day freshness" do

--- a/apps/favn_orchestrator/test/manifest_store_test.exs
+++ b/apps/favn_orchestrator/test/manifest_store_test.exs
@@ -557,6 +557,86 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     assert state.latest_success_run_id == "run_project_window"
   end
 
+  test "asset window projection preserves prior success on failed attempts" do
+    now = ~U[2026-01-03 00:00:00Z]
+    ref = {MyApp.ProjectedFailedWindowAsset, :asset}
+    key = Favn.Window.Key.new!(:month, ~U[2026-01-01 00:00:00Z], "Etc/UTC")
+    window_key = Favn.Window.Key.encode(key)
+
+    {:ok, existing} =
+      AssetWindowState.new(%{
+        asset_ref_module: elem(ref, 0),
+        asset_ref_name: elem(ref, 1),
+        manifest_version_id: "mv_project_window",
+        window_kind: :month,
+        window_start_at: ~U[2026-01-01 00:00:00Z],
+        window_end_at: ~U[2026-02-01 00:00:00Z],
+        timezone: "Etc/UTC",
+        window_key: window_key,
+        status: :ok,
+        latest_run_id: "run_previous_success",
+        latest_success_run_id: "run_previous_success",
+        updated_at: ~U[2026-01-02 00:00:00Z]
+      })
+
+    assert :ok = Storage.put_asset_window_state(existing)
+
+    run_state = projected_window_run_state("run_failed_window", ref, key, :error, now)
+
+    assert :ok = AssetWindowProjector.project_transition(run_state, :run_failed, %{})
+    assert {:ok, state} = Storage.get_asset_window_state(elem(ref, 0), elem(ref, 1), window_key)
+    assert state.status == :error
+    assert state.latest_run_id == "run_failed_window"
+    assert state.latest_success_run_id == "run_previous_success"
+  end
+
+  test "asset window projection stops when existing state lookup fails" do
+    now = ~U[2026-01-03 00:00:00Z]
+    ref = {MyApp.ProjectedLookupFailureAsset, :asset}
+    key = Favn.Window.Key.new!(:month, ~U[2026-01-01 00:00:00Z], "Etc/UTC")
+    window_key = Favn.Window.Key.encode(key)
+
+    {:ok, existing} =
+      AssetWindowState.new(%{
+        asset_ref_module: elem(ref, 0),
+        asset_ref_name: elem(ref, 1),
+        manifest_version_id: "mv_project_window",
+        window_kind: :month,
+        window_start_at: ~U[2026-01-01 00:00:00Z],
+        window_end_at: ~U[2026-02-01 00:00:00Z],
+        timezone: "Etc/UTC",
+        window_key: window_key,
+        status: :ok,
+        latest_run_id: "run_previous_success",
+        latest_success_run_id: "run_previous_success",
+        updated_at: ~U[2026-01-02 00:00:00Z]
+      })
+
+    assert :ok = Storage.put_asset_window_state(existing)
+
+    previous_adapter = Application.get_env(:favn_orchestrator, :storage_adapter)
+    previous_opts = Application.get_env(:favn_orchestrator, :storage_adapter_opts)
+
+    try do
+      Application.put_env(:favn_orchestrator, :storage_adapter, String)
+      Application.put_env(:favn_orchestrator, :storage_adapter_opts, [])
+
+      assert {:error, _reason} =
+               AssetWindowProjector.project_transition(
+                 projected_window_run_state("run_lookup_failed", ref, key, :error, now),
+                 :run_failed,
+                 %{}
+               )
+    after
+      restore_env(:favn_orchestrator, :storage_adapter, previous_adapter)
+      restore_env(:favn_orchestrator, :storage_adapter_opts, previous_opts)
+    end
+
+    assert {:ok, state} = Storage.get_asset_window_state(elem(ref, 0), elem(ref, 1), window_key)
+    assert state.status == :ok
+    assert state.latest_run_id == "run_previous_success"
+  end
+
   test "hourly asset detail timeline uses hours without collapsing same-day freshness" do
     window_spec = WindowSpec.new!(:hour, required: true)
 
@@ -1065,6 +1145,44 @@ defmodule FavnOrchestrator.ManifestStoreTest do
     |> Map.put(:updated_at, finished_at)
     |> RunState.with_snapshot_hash()
   end
+
+  defp projected_window_run_state(id, ref, key, status, finished_at) do
+    runtime_window =
+      RuntimeWindow.new!(
+        key.kind,
+        DateTime.from_unix!(key.start_at_us, :microsecond),
+        DateTime.from_unix!(key.start_at_us, :microsecond) |> Favn.TimePeriod.shift!(key.kind, 1),
+        key,
+        timezone: key.timezone
+      )
+
+    RunState.new(
+      id: id,
+      manifest_version_id: "mv_project_window",
+      manifest_content_hash: "hash_project_window",
+      asset_ref: ref,
+      target_refs: [ref]
+    )
+    |> RunState.transition(
+      status: if(status == :ok, do: :ok, else: :error),
+      result: %{
+        node_results: [
+          NodeResult.new(%{
+            node_key: {ref, key},
+            ref: ref,
+            window: runtime_window,
+            status: status,
+            finished_at: finished_at,
+            error: if(status == :ok, do: nil, else: :failed)
+          })
+        ]
+      }
+    )
+    |> Map.put(:updated_at, finished_at)
+  end
+
+  defp restore_env(app, key, nil), do: Application.delete_env(app, key)
+  defp restore_env(app, key, value), do: Application.put_env(app, key, value)
 
   defp pipeline_run_state(
          id,

--- a/apps/favn_view/lib/favn_view/asset_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_detail_live.ex
@@ -219,10 +219,10 @@ defmodule FavnView.AssetDetailLive do
       refresh_mode: run_config.refresh
     }
 
-    case FavnOrchestrator.submit_operator_asset_run(
+    case FavnOrchestrator.submit_operator_run(
            actor_context(socket),
            asset.manifest_version_id,
-           asset.target_id,
+           %{type: :asset, id: asset.target_id},
            request
          ) do
       {:ok, run_id} -> {:ok, run_id, :single}

--- a/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
@@ -50,10 +50,10 @@ defmodule FavnView.PipelineDetailLive do
   def handle_event("run_pipeline", _params, socket) do
     pipeline = socket.assigns.pipeline
 
-    case FavnOrchestrator.submit_operator_pipeline_run(
+    case FavnOrchestrator.submit_operator_run(
            actor_context(socket),
            pipeline.manifest_version_id,
-           pipeline.id
+           %{type: :pipeline, id: pipeline.id}
          ) do
       {:ok, run_id} ->
         {:noreply,


### PR DESCRIPTION
## Summary
- Add a shared `submit_operator_run/4` boundary for asset and pipeline run commands so UI, API, and CLI use the same submission path.
- Allow `mix favn.run` to resolve and submit both active-manifest assets and pipelines, including windowed asset runs.
- Project future terminal windowed asset executions into `AssetWindowState` and use that read model for asset data coverage timelines.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/api/router_test.exs test/auth/operator_facade_test.exs test/manifest_store_test.exs --exclude acceptance --exclude slow --exclude browser`
- `MIX_ENV=test mix do --app favn cmd mix test test/mix_tasks/public_tasks_test.exs --exclude acceptance --exclude slow --exclude browser`
- `MIX_ENV=test mix do --app favn_local cmd mix test test/dev_run_test.exs --exclude acceptance --exclude slow --exclude browser`

Note: I started full umbrella `mix test` before your correction; it was not used as final verification.