### PR TITLE
Add stable read-model scan contracts

### DIFF
--- a/apps/favn/lib/mix/tasks/favn.backfill.ex
+++ b/apps/favn/lib/mix/tasks/favn.backfill.ex
@@ -13,6 +13,7 @@ defmodule Mix.Tasks.Favn.Backfill do
       mix favn.backfill asset-window-states
       mix favn.backfill rerun-window RUN_ID --window-key day:2026-04-01 --allow-success --refresh force
       mix favn.backfill repair --pipeline-module MyApp.Pipelines.Daily --apply
+      mix favn.backfill repair --all --apply
 
   The local CLI submit path accepts explicit `--from`/`--to`/`--kind` ranges or
   compact `--window kind:FROM..TO` syntax for `hour`, `day`, `month`, and `year`
@@ -85,6 +86,7 @@ defmodule Mix.Tasks.Favn.Backfill do
   @repair_switches [
     root_dir: :string,
     apply: :boolean,
+    all: :boolean,
     backfill_run_id: :string,
     pipeline_module: :string
   ]
@@ -183,7 +185,8 @@ defmodule Mix.Tasks.Favn.Backfill do
         {:ok, {:repair, opts}}
 
       {[], [], _count} ->
-        {:error, "expected at most one repair scope: --backfill-run-id or --pipeline-module"}
+        {:error,
+         "expected at most one repair scope: --all, --backfill-run-id, or --pipeline-module"}
 
       {[], _many, _count} ->
         {:error, "unexpected argument for mix favn.backfill repair"}
@@ -294,9 +297,9 @@ defmodule Mix.Tasks.Favn.Backfill do
   end
 
   defp repair_scope_count(opts) do
-    Enum.count([:backfill_run_id, :pipeline_module], fn key ->
+    Enum.count([:all, :backfill_run_id, :pipeline_module], fn key ->
       value = Keyword.get(opts, key)
-      not (is_nil(value) or value == "")
+      not (is_nil(value) or value == false or value == "")
     end)
   end
 
@@ -321,6 +324,10 @@ defmodule Mix.Tasks.Favn.Backfill do
 
   defp error_message(:stack_not_healthy),
     do: "stack not healthy; use mix favn.stop then mix favn.dev"
+
+  defp error_message(:replacement_scope_required),
+    do:
+      "--apply requires an explicit repair scope: --all, --backfill-run-id, or --pipeline-module"
 
   defp error_message({:pipeline_not_found, requested, available}),
     do: pipeline_not_found_message(requested, available)

--- a/apps/favn/test/mix_tasks/public_tasks_test.exs
+++ b/apps/favn/test/mix_tasks/public_tasks_test.exs
@@ -749,7 +749,8 @@ defmodule Mix.Tasks.Favn.PublicTasksTest do
                "Example.Pipeline"
              ])
 
-    assert message == "expected at most one repair scope: --backfill-run-id or --pipeline-module"
+    assert message ==
+             "expected at most one repair scope: --all, --backfill-run-id, or --pipeline-module"
 
     assert {:error, message} = BackfillTask.parse_args(["repair", "extra"])
     assert message == "unexpected argument for mix favn.backfill repair"

--- a/apps/favn_orchestrator/lib/favn/storage/adapter.ex
+++ b/apps/favn_orchestrator/lib/favn/storage/adapter.ex
@@ -39,6 +39,7 @@ defmodule Favn.Storage.Adapter do
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
+  alias FavnOrchestrator.CursorPage
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -52,6 +53,8 @@ defmodule Favn.Storage.Adapter do
   @type child_spec_result :: {:ok, Supervisor.child_spec()} | :none | {:error, error()}
   @type readiness_diagnostics :: map()
   @type diagnostics :: map()
+  @type cursor_scan_opts :: keyword()
+  @type read_model_replacement_scope :: :all | {:backfill_run, String.t()} | {:pipeline, module()}
 
   @callback child_spec(adapter_opts()) :: child_spec_result()
   @callback readiness(adapter_opts()) :: {:ok, readiness_diagnostics()} | {:error, error()}
@@ -141,6 +144,8 @@ defmodule Favn.Storage.Adapter do
               {:ok, BackfillWindow.t()} | {:error, error()}
   @callback list_backfill_windows(filter_opts(), adapter_opts()) ::
               {:ok, Page.t(BackfillWindow.t())} | {:error, error()}
+  @callback scan_backfill_windows(filter_opts(), cursor_scan_opts(), adapter_opts()) ::
+              {:ok, CursorPage.t(BackfillWindow.t())} | {:error, error()}
   @callback apply_backfill_child_projection(
               BackfillWindow.t(),
               [AssetWindowState.t()],
@@ -166,9 +171,11 @@ defmodule Favn.Storage.Adapter do
               {:ok, %{freshness_state_key() => AssetFreshnessState.t()}} | {:error, error()}
   @callback list_asset_freshness_states(filter_opts(), adapter_opts()) ::
               {:ok, Page.t(AssetFreshnessState.t())} | {:error, error()}
+  @callback scan_asset_freshness_states(filter_opts(), cursor_scan_opts(), adapter_opts()) ::
+              {:ok, CursorPage.t(AssetFreshnessState.t())} | {:error, error()}
 
   @callback replace_backfill_read_models(
-              filter_opts(),
+              read_model_replacement_scope(),
               [CoverageBaseline.t()],
               [BackfillWindow.t()],
               [AssetWindowState.t()],

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill/projector.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill/projector.ex
@@ -171,21 +171,23 @@ defmodule FavnOrchestrator.Backfill.Projector do
   @doc false
   @spec list_all_backfill_windows(keyword()) :: {:ok, [BackfillWindow.t()]} | {:error, term()}
   def list_all_backfill_windows(filters) when is_list(filters) do
-    fetch_backfill_window_pages(filters, 0, [])
+    fetch_backfill_window_pages(filters, nil, [])
   end
 
-  defp fetch_backfill_window_pages(filters, offset, acc) do
+  defp fetch_backfill_window_pages(filters, cursor, acc) do
     with {:ok, page} <-
-           Storage.list_backfill_windows(Keyword.merge(filters, limit: 500, offset: offset)) do
-      acc = acc ++ page.items
+           Storage.scan_backfill_windows(filters, [{:limit, 500}, {:after, cursor}]) do
+      acc = prepend_page_items(page.items, acc)
 
       if page.has_more? do
-        fetch_backfill_window_pages(filters, page.next_offset, acc)
+        fetch_backfill_window_pages(filters, page.next_cursor, acc)
       else
-        {:ok, acc}
+        {:ok, Enum.reverse(acc)}
       end
     end
   end
+
+  defp prepend_page_items(items, acc), do: Enum.reduce(items, acc, &[&1 | &2])
 
   @doc false
   @spec parent_status([BackfillWindow.t()]) ::

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill/repair.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill/repair.ex
@@ -31,11 +31,13 @@ defmodule FavnOrchestrator.Backfill.Repair do
   def repair(opts \\ []) when is_list(opts) do
     apply? = Keyword.get(opts, :apply, false)
 
-    with {:ok, raw_scope} <- normalize_scope(opts),
+    with :ok <- validate_scope_selection(opts),
+         {:ok, raw_scope} <- normalize_scope(opts),
          {:ok, runs} <- Storage.list_runs(),
          {:ok, scope} <- resolve_scope(raw_scope, runs),
          {:ok, plan} <- plan(runs, scope),
-         :ok <- maybe_apply(apply?, scope, plan) do
+         {:ok, replacement_scope} <- replacement_scope(apply?, scope, opts),
+         :ok <- maybe_apply(apply?, replacement_scope, plan) do
       {:ok, report(apply?, scope, plan)}
     end
   end
@@ -69,6 +71,17 @@ defmodule FavnOrchestrator.Backfill.Repair do
     )
   end
 
+  defp validate_scope_selection(opts) do
+    count =
+      Enum.count([:all, :backfill_run_id, :pipeline_module], fn key ->
+        value = Keyword.get(opts, key)
+        not (is_nil(value) or value == false or value == "")
+      end) +
+        if(Keyword.get(opts, :scope) == :all, do: 1, else: 0)
+
+    if count <= 1, do: :ok, else: {:error, :invalid_repair_scope}
+  end
+
   defp normalize_scope(opts) do
     scope =
       []
@@ -76,6 +89,30 @@ defmodule FavnOrchestrator.Backfill.Repair do
       |> maybe_put_scope(:pipeline_module, Keyword.get(opts, :pipeline_module))
 
     if length(scope) <= 1, do: {:ok, scope}, else: {:error, :invalid_repair_scope}
+  end
+
+  defp replacement_scope(false, _scope, _opts), do: {:ok, nil}
+
+  defp replacement_scope(true, scope, opts) do
+    cond do
+      Keyword.get(opts, :all, false) ->
+        {:ok, :all}
+
+      Keyword.get(opts, :scope) == :all ->
+        {:ok, :all}
+
+      match?([backfill_run_id: _id], scope) ->
+        {:ok, {:backfill_run, Keyword.fetch!(scope, :backfill_run_id)}}
+
+      match?([pipeline_module: _module], scope) ->
+        {:ok, {:pipeline, Keyword.fetch!(scope, :pipeline_module)}}
+
+      scope == [] ->
+        {:error, :replacement_scope_required}
+
+      true ->
+        {:error, {:unsupported_replacement_scope, scope}}
+    end
   end
 
   defp maybe_put_scope(scope, _key, nil), do: scope

--- a/apps/favn_orchestrator/lib/favn_orchestrator/cursor_page.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/cursor_page.ex
@@ -1,0 +1,73 @@
+defmodule FavnOrchestrator.CursorPage do
+  @moduledoc """
+  Bounded cursor page returned by internal storage scan APIs.
+
+  `FavnOrchestrator.Page` remains the public offset-pagination contract for
+  operator/UI reads. `CursorPage` is for orchestrator-owned full walks and repair
+  paths that need stable keyset traversal over mutable persisted truth.
+  """
+
+  alias FavnOrchestrator.Page
+
+  @enforce_keys [:items, :limit, :after_cursor, :has_more?, :next_cursor]
+  defstruct [:items, :limit, :after_cursor, :has_more?, :next_cursor]
+
+  @type cursor :: map() | nil
+
+  @type t(item) :: %__MODULE__{
+          items: [item],
+          limit: pos_integer(),
+          after_cursor: cursor(),
+          has_more?: boolean(),
+          next_cursor: cursor()
+        }
+
+  @type opts :: [limit: pos_integer(), after: cursor()]
+
+  @doc "Normalizes internal cursor scan options."
+  @spec normalize_opts(keyword()) :: {:ok, opts()} | {:error, :invalid_cursor_pagination}
+  def normalize_opts(opts) when is_list(opts) do
+    with :ok <- reject_unknown_opts(opts),
+         {:ok, limit} <- normalize_limit(Keyword.get(opts, :limit, Page.default_limit())),
+         {:ok, after_cursor} <- normalize_after(Keyword.get(opts, :after)) do
+      {:ok, [limit: limit, after: after_cursor]}
+    else
+      {:error, :invalid_cursor_pagination} -> {:error, :invalid_cursor_pagination}
+    end
+  end
+
+  @doc "Builds a cursor page from rows fetched with `limit + 1`."
+  @spec from_fetched([item], opts(), (item -> cursor())) :: t(item) when item: term()
+  def from_fetched(items, opts, cursor_fun)
+      when is_list(items) and is_list(opts) and is_function(cursor_fun, 1) do
+    limit = Keyword.fetch!(opts, :limit)
+    page_items = Enum.take(items, limit)
+    has_more? = length(items) > limit
+
+    %__MODULE__{
+      items: page_items,
+      limit: limit,
+      after_cursor: Keyword.get(opts, :after),
+      has_more?: has_more?,
+      next_cursor: if(has_more? and page_items != [], do: cursor_fun.(List.last(page_items)))
+    }
+  end
+
+  defp reject_unknown_opts(opts) do
+    if Enum.all?(opts, fn {key, _value} -> key in [:limit, :after] end) do
+      :ok
+    else
+      {:error, :invalid_cursor_pagination}
+    end
+  end
+
+  defp normalize_limit(value) when is_integer(value) and value >= 1 do
+    if value <= Page.max_limit(), do: {:ok, value}, else: {:error, :invalid_cursor_pagination}
+  end
+
+  defp normalize_limit(_value), do: {:error, :invalid_cursor_pagination}
+
+  defp normalize_after(nil), do: {:ok, nil}
+  defp normalize_after(value) when is_map(value), do: {:ok, value}
+  defp normalize_after(_value), do: {:error, :invalid_cursor_pagination}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/freshness/query.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/freshness/query.ex
@@ -84,17 +84,17 @@ defmodule FavnOrchestrator.Freshness.Query do
   defp current_upstream_states(upstream_node_keys) do
     upstream_node_keys
     |> MapSet.new()
-    |> fetch_current_upstream_states(0, %{})
+    |> fetch_current_upstream_states(nil, %{})
   end
 
-  defp fetch_current_upstream_states(upstream_node_keys, offset, acc) do
+  defp fetch_current_upstream_states(upstream_node_keys, cursor, acc) do
     with {:ok, page} <-
-           Storage.list_asset_freshness_states(limit: Page.max_limit(), offset: offset) do
+           Storage.scan_asset_freshness_states([], [{:limit, Page.max_limit()}, {:after, cursor}]) do
       acc = collect_current_upstream_states(page.items, upstream_node_keys, acc)
 
       cond do
         MapSet.size(upstream_node_keys) == map_size(acc) -> {:ok, acc}
-        page.has_more? -> fetch_current_upstream_states(upstream_node_keys, page.next_offset, acc)
+        page.has_more? -> fetch_current_upstream_states(upstream_node_keys, page.next_cursor, acc)
         true -> {:ok, acc}
       end
     end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -1080,23 +1080,24 @@ defmodule FavnOrchestrator.RunReadModel do
     end
   end
 
-  defp list_all_backfill_windows(backfill_run_id, offset \\ 0, acc \\ []) do
-    case Storage.list_backfill_windows(
-           backfill_run_id: backfill_run_id,
-           limit: Page.max_limit(),
-           offset: offset
+  defp list_all_backfill_windows(backfill_run_id, cursor \\ nil, acc \\ []) do
+    case Storage.scan_backfill_windows(
+           [backfill_run_id: backfill_run_id],
+           [{:limit, Page.max_limit()}, {:after, cursor}]
          ) do
-      {:ok, %Page{items: items, has_more?: true, next_offset: next_offset}}
-      when is_integer(next_offset) ->
-        list_all_backfill_windows(backfill_run_id, next_offset, acc ++ items)
+      {:ok, %{items: items, has_more?: true, next_cursor: next_cursor}}
+      when is_map(next_cursor) ->
+        list_all_backfill_windows(backfill_run_id, next_cursor, prepend_page_items(items, acc))
 
-      {:ok, %Page{items: items}} ->
-        {:ok, acc ++ items}
+      {:ok, %{items: items}} ->
+        {:ok, Enum.reverse(prepend_page_items(items, acc))}
 
       {:error, _reason} = error ->
         error
     end
   end
+
+  defp prepend_page_items(items, acc), do: Enum.reduce(items, acc, &[&1 | &2])
 
   defp detail_backfill_windows(%RunState{} = run) do
     case classify(run) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -16,12 +16,14 @@ defmodule FavnOrchestrator.Storage do
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
+  alias FavnOrchestrator.CursorPage
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.RunState
 
   @type freshness_state_key :: StorageAdapter.freshness_state_key()
+  @type read_model_replacement_scope :: StorageAdapter.read_model_replacement_scope()
 
   @spec child_specs() :: {:ok, [Supervisor.child_spec()]} | {:error, term()}
   @spec child_specs(RuntimeConfig.t()) :: {:ok, [Supervisor.child_spec()]} | {:error, term()}
@@ -348,6 +350,15 @@ defmodule FavnOrchestrator.Storage do
     end)
   end
 
+  @spec scan_backfill_windows(keyword(), keyword()) ::
+          {:ok, CursorPage.t(BackfillWindow.t())} | {:error, term()}
+  def scan_backfill_windows(filters \\ [], scan_opts \\ [])
+      when is_list(filters) and is_list(scan_opts) do
+    cursor_adapter_call(filters, scan_opts, fn adapter, filters, scan_opts, opts ->
+      adapter.scan_backfill_windows(filters, scan_opts, opts)
+    end)
+  end
+
   @spec apply_backfill_child_projection(BackfillWindow.t(), [AssetWindowState.t()]) ::
           {:ok, BackfillProgress.t()} | {:error, term()}
   def apply_backfill_child_projection(%BackfillWindow{} = window, asset_window_states)
@@ -429,8 +440,17 @@ defmodule FavnOrchestrator.Storage do
     end
   end
 
+  @spec scan_asset_freshness_states(keyword(), keyword()) ::
+          {:ok, CursorPage.t(AssetFreshnessState.t())} | {:error, term()}
+  def scan_asset_freshness_states(filters \\ [], scan_opts \\ [])
+      when is_list(filters) and is_list(scan_opts) do
+    cursor_adapter_call(filters, scan_opts, fn adapter, filters, scan_opts, opts ->
+      adapter.scan_asset_freshness_states(filters, scan_opts, opts)
+    end)
+  end
+
   @spec replace_backfill_read_models(
-          keyword(),
+          read_model_replacement_scope(),
           [CoverageBaseline.t()],
           [BackfillWindow.t()],
           [AssetWindowState.t()]
@@ -441,17 +461,26 @@ defmodule FavnOrchestrator.Storage do
         backfill_windows,
         asset_window_states
       )
-      when is_list(scope) and is_list(coverage_baselines) and is_list(backfill_windows) and
+      when is_list(coverage_baselines) and is_list(backfill_windows) and
              is_list(asset_window_states) do
-    adapter_call(fn adapter, opts ->
-      adapter.replace_backfill_read_models(
-        scope,
-        coverage_baselines,
-        backfill_windows,
-        asset_window_states,
-        opts
-      )
-    end)
+    with {:ok, scope} <- normalize_replacement_scope(scope),
+         :ok <-
+           validate_replacement_rows(
+             scope,
+             coverage_baselines,
+             backfill_windows,
+             asset_window_states
+           ) do
+      adapter_call(fn adapter, opts ->
+        adapter.replace_backfill_read_models(
+          scope,
+          coverage_baselines,
+          backfill_windows,
+          asset_window_states,
+          opts
+        )
+      end)
+    end
   end
 
   @spec put_auth_actor(map()) :: :ok | {:error, term()}
@@ -684,6 +713,47 @@ defmodule FavnOrchestrator.Storage do
       adapter_call(fn adapter, opts -> fun.(adapter, Keyword.merge(filters, page_opts), opts) end)
     end
   end
+
+  defp cursor_adapter_call(filters, scan_opts, fun)
+       when is_list(filters) and is_list(scan_opts) and is_function(fun, 4) do
+    with {:ok, scan_opts} <- CursorPage.normalize_opts(scan_opts) do
+      adapter_call(fn adapter, opts -> fun.(adapter, filters, scan_opts, opts) end)
+    end
+  end
+
+  defp normalize_replacement_scope(:all), do: {:ok, :all}
+
+  defp normalize_replacement_scope({:backfill_run, id}) when is_binary(id) and id != "",
+    do: {:ok, {:backfill_run, id}}
+
+  defp normalize_replacement_scope({:pipeline, module}) when is_atom(module),
+    do: {:ok, {:pipeline, module}}
+
+  defp normalize_replacement_scope(scope),
+    do: {:error, {:unsupported_replacement_scope, scope}}
+
+  defp validate_replacement_rows(:all, _coverage_baselines, _backfill_windows, _asset_states),
+    do: :ok
+
+  defp validate_replacement_rows({:pipeline, module} = scope, baselines, windows, states) do
+    if Enum.all?(baselines ++ windows ++ states, &match_pipeline_scope?(&1, module)) do
+      :ok
+    else
+      {:error, {:replacement_row_out_of_scope, scope}}
+    end
+  end
+
+  defp validate_replacement_rows({:backfill_run, id} = scope, baselines, windows, states) do
+    valid? =
+      Enum.all?(baselines, &(&1.created_by_run_id == id)) and
+        Enum.all?(windows, &(&1.backfill_run_id == id)) and
+        Enum.all?(states, &(&1.latest_parent_run_id == id))
+
+    if valid?, do: :ok, else: {:error, {:replacement_row_out_of_scope, scope}}
+  end
+
+  defp match_pipeline_scope?(%{pipeline_module: module}, module), do: true
+  defp match_pipeline_scope?(_value, _module), do: false
 
   defp maybe_child_to_list(:none), do: []
   defp maybe_child_to_list(value), do: [value]

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -12,6 +12,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
+  alias FavnOrchestrator.CursorPage
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -451,6 +452,13 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   @impl true
+  def scan_backfill_windows(filters, scan_opts, opts)
+      when is_list(filters) and is_list(scan_opts) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:scan_backfill_windows, filters, scan_opts})
+  end
+
+  @impl true
   def apply_backfill_child_projection(%BackfillWindow{} = window, asset_window_states, opts)
       when is_list(asset_window_states) and is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
@@ -520,6 +528,13 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   @impl true
+  def scan_asset_freshness_states(filters, scan_opts, opts)
+      when is_list(filters) and is_list(scan_opts) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:scan_asset_freshness_states, filters, scan_opts})
+  end
+
+  @impl true
   def get_asset_freshness_states_by_keys(keys, opts) when is_list(keys) and is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
     GenServer.call(server, {:get_asset_freshness_states_by_keys, keys})
@@ -533,7 +548,8 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
         asset_window_states,
         opts
       )
-      when is_list(scope) and is_list(coverage_baselines) and is_list(backfill_windows) and
+      when (scope == :all or is_tuple(scope)) and is_list(coverage_baselines) and
+             is_list(backfill_windows) and
              is_list(asset_window_states) and is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
 
@@ -1208,6 +1224,25 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     {:reply, {:ok, Page.from_fetched(rows, page_opts(filters))}, state}
   end
 
+  def handle_call({:scan_backfill_windows, filters, scan_opts}, _from, state) do
+    case backfill_window_cursor(Keyword.get(scan_opts, :after)) do
+      {:ok, after_key} ->
+        rows =
+          state.backfill_windows
+          |> Map.values()
+          |> filter_by(filters)
+          |> Enum.sort_by(&backfill_window_sort_key/1)
+          |> cursor_drop(after_key, &backfill_window_sort_key/1)
+          |> Enum.take(Keyword.fetch!(scan_opts, :limit) + 1)
+
+        page = CursorPage.from_fetched(rows, scan_opts, &backfill_window_cursor!/1)
+        {:reply, {:ok, page}, state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
   def handle_call(
         {:apply_backfill_child_projection, %BackfillWindow{} = window, asset_window_states},
         _from,
@@ -1320,6 +1355,24 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     end
   end
 
+  def handle_call({:scan_asset_freshness_states, filters, scan_opts}, _from, state) do
+    with :ok <- validate_filters(filters, @asset_freshness_state_filters),
+         {:ok, after_key} <- asset_freshness_cursor(Keyword.get(scan_opts, :after)) do
+      rows =
+        state.asset_freshness_states
+        |> Map.values()
+        |> filter_by(filters)
+        |> Enum.sort_by(&asset_freshness_sort_key/1)
+        |> cursor_drop(after_key, &asset_freshness_sort_key/1)
+        |> Enum.take(Keyword.fetch!(scan_opts, :limit) + 1)
+
+      page = CursorPage.from_fetched(rows, scan_opts, &asset_freshness_cursor!/1)
+      {:reply, {:ok, page}, state}
+    else
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
   def handle_call({:get_asset_freshness_states_by_keys, keys}, _from, state) do
     rows =
       keys
@@ -1339,31 +1392,38 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
         _from,
         state
       ) do
-    next_state = %{
-      state
-      | coverage_baselines:
-          state.coverage_baselines
-          |> reject_scoped(scope)
-          |> put_coverage_baselines(coverage_baselines),
-        backfill_windows:
+    case replacement_scope(scope) do
+      {:ok, scope} ->
+        next_backfill_windows =
           state.backfill_windows
-          |> reject_scoped(scope)
-          |> put_backfill_windows(backfill_windows),
-        backfill_progress:
-          state.backfill_progress
-          |> reject_scoped_progress(scope)
-          |> rebuild_all_progress(
-            state.backfill_windows
-            |> reject_scoped(scope)
-            |> put_backfill_windows(backfill_windows)
-          ),
-        asset_window_states:
-          state.asset_window_states
-          |> reject_scoped(scope)
-          |> put_asset_window_states(asset_window_states)
-    }
+          |> reject_replacement_scope(scope)
+          |> put_backfill_windows(backfill_windows)
 
-    {:reply, :ok, next_state}
+        affected_backfill_ids =
+          affected_backfill_ids(state.backfill_windows, scope, backfill_windows)
+
+        next_state = %{
+          state
+          | coverage_baselines:
+              state.coverage_baselines
+              |> reject_replacement_scope(scope)
+              |> put_coverage_baselines(coverage_baselines),
+            backfill_windows: next_backfill_windows,
+            backfill_progress:
+              state.backfill_progress
+              |> reject_replacement_progress(scope)
+              |> rebuild_progress_for_ids(next_backfill_windows, affected_backfill_ids),
+            asset_window_states:
+              state.asset_window_states
+              |> reject_replacement_scope(scope)
+              |> put_asset_window_states(asset_window_states)
+        }
+
+        {:reply, :ok, next_state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
   end
 
   def handle_call({:put_auth_actor, actor}, _from, state) do
@@ -1942,24 +2002,64 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   defp validate_replay_limit(limit) when is_integer(limit) and limit > 0, do: :ok
   defp validate_replay_limit(_limit), do: {:error, :cursor_invalid}
 
-  defp reject_scoped(_values, []), do: %{}
+  defp replacement_scope(:all), do: {:ok, :all}
+  defp replacement_scope({:backfill_run, id}) when is_binary(id), do: {:ok, {:backfill_run, id}}
+  defp replacement_scope({:pipeline, module}) when is_atom(module), do: {:ok, {:pipeline, module}}
 
-  defp reject_scoped(values, scope) when is_map(values) do
+  defp replacement_scope(scope),
+    do: {:error, {:unsupported_replacement_scope, scope}}
+
+  defp reject_replacement_scope(_values, :all), do: %{}
+
+  defp reject_replacement_scope(values, scope) when is_map(values) do
     values
-    |> Enum.reject(fn {_key, value} -> scoped?(value, scope) end)
+    |> Enum.reject(fn {_key, value} -> in_replacement_scope?(value, scope) end)
     |> Map.new()
   end
 
-  defp reject_scoped_progress(_values, []), do: %{}
+  defp reject_replacement_progress(_values, :all), do: %{}
 
-  defp reject_scoped_progress(values, backfill_run_id: backfill_run_id) do
-    Map.delete(values, backfill_run_id)
+  defp reject_replacement_progress(values, {:backfill_run, backfill_run_id}),
+    do: Map.delete(values, backfill_run_id)
+
+  defp reject_replacement_progress(values, {:pipeline, _module}), do: values
+
+  defp in_replacement_scope?(_value, :all), do: true
+
+  defp in_replacement_scope?(%CoverageBaseline{created_by_run_id: id}, {:backfill_run, id}),
+    do: true
+
+  defp in_replacement_scope?(%BackfillWindow{backfill_run_id: id}, {:backfill_run, id}),
+    do: true
+
+  defp in_replacement_scope?(%AssetWindowState{latest_parent_run_id: id}, {:backfill_run, id}),
+    do: true
+
+  defp in_replacement_scope?(%{pipeline_module: module}, {:pipeline, module}), do: true
+  defp in_replacement_scope?(_value, _scope), do: false
+
+  defp affected_backfill_ids(backfill_windows, :all, replacement_windows) do
+    backfill_windows
+    |> Map.values()
+    |> Enum.map(& &1.backfill_run_id)
+    |> Kernel.++(Enum.map(replacement_windows, & &1.backfill_run_id))
+    |> Enum.uniq()
   end
 
-  defp reject_scoped_progress(_values, _scope), do: %{}
+  defp affected_backfill_ids(_backfill_windows, {:backfill_run, id}, replacement_windows) do
+    [id | Enum.map(replacement_windows, & &1.backfill_run_id)]
+    |> Enum.uniq()
+  end
 
-  defp scoped?(value, scope) do
-    Enum.all?(scope, fn {key, expected} -> Map.get(value, key) == expected end)
+  defp affected_backfill_ids(backfill_windows, {:pipeline, module}, replacement_windows) do
+    deleted_ids =
+      backfill_windows
+      |> Map.values()
+      |> Enum.filter(&(&1.pipeline_module == module))
+      |> Enum.map(& &1.backfill_run_id)
+
+    (deleted_ids ++ Enum.map(replacement_windows, & &1.backfill_run_id))
+    |> Enum.uniq()
   end
 
   defp put_coverage_baselines(values, baselines) do
@@ -2020,17 +2120,110 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     end
   end
 
-  defp rebuild_all_progress(progress, backfill_windows) do
-    backfill_windows
-    |> Map.values()
-    |> Enum.map(& &1.backfill_run_id)
-    |> Enum.uniq()
-    |> Enum.reduce(progress, fn backfill_run_id, acc ->
+  defp rebuild_progress_for_ids(progress, backfill_windows, ids) do
+    Enum.reduce(ids, progress, fn backfill_run_id, acc ->
       case rebuild_progress_from_windows(backfill_windows, backfill_run_id) do
         {:ok, %BackfillProgress{} = rebuilt} -> Map.put(acc, backfill_run_id, rebuilt)
+        {:error, :not_found} -> Map.delete(acc, backfill_run_id)
         {:error, _reason} -> acc
       end
     end)
+  end
+
+  defp cursor_drop(rows, nil, _sort_fun), do: rows
+
+  defp cursor_drop(rows, after_key, sort_fun) do
+    Enum.drop_while(rows, &(sort_fun.(&1) <= after_key))
+  end
+
+  defp backfill_window_cursor(nil), do: {:ok, nil}
+
+  defp backfill_window_cursor(%{
+         kind: :backfill_window,
+         window_start_at: %DateTime{} = window_start_at,
+         backfill_run_id: backfill_run_id,
+         pipeline_module: pipeline_module,
+         window_key: window_key
+       })
+       when is_binary(backfill_run_id) and is_atom(pipeline_module) and is_binary(window_key),
+       do:
+         {:ok,
+          backfill_window_sort_key(window_start_at, backfill_run_id, pipeline_module, window_key)}
+
+  defp backfill_window_cursor(_cursor), do: {:error, :invalid_cursor_pagination}
+
+  defp backfill_window_cursor!(%BackfillWindow{} = window) do
+    %{
+      kind: :backfill_window,
+      window_start_at: window.window_start_at,
+      backfill_run_id: window.backfill_run_id,
+      pipeline_module: window.pipeline_module,
+      window_key: window.window_key
+    }
+  end
+
+  defp backfill_window_sort_key(%BackfillWindow{} = window) do
+    backfill_window_sort_key(
+      window.window_start_at,
+      window.backfill_run_id,
+      window.pipeline_module,
+      window.window_key
+    )
+  end
+
+  defp backfill_window_sort_key(
+         %DateTime{} = window_start_at,
+         backfill_run_id,
+         pipeline_module,
+         window_key
+       ) do
+    {DateTime.to_unix(window_start_at, :microsecond), backfill_run_id,
+     Atom.to_string(pipeline_module), window_key}
+  end
+
+  defp asset_freshness_cursor(nil), do: {:ok, nil}
+
+  defp asset_freshness_cursor(%{
+         kind: :asset_freshness_state,
+         updated_at: %DateTime{} = updated_at,
+         asset_ref_module: asset_ref_module,
+         asset_ref_name: asset_ref_name,
+         freshness_key: freshness_key
+       })
+       when is_atom(asset_ref_module) and is_atom(asset_ref_name) and is_binary(freshness_key),
+       do:
+         {:ok,
+          asset_freshness_sort_key(updated_at, asset_ref_module, asset_ref_name, freshness_key)}
+
+  defp asset_freshness_cursor(_cursor), do: {:error, :invalid_cursor_pagination}
+
+  defp asset_freshness_cursor!(%AssetFreshnessState{} = state) do
+    %{
+      kind: :asset_freshness_state,
+      updated_at: state.updated_at,
+      asset_ref_module: state.asset_ref_module,
+      asset_ref_name: state.asset_ref_name,
+      freshness_key: state.freshness_key
+    }
+  end
+
+  defp asset_freshness_sort_key(%AssetFreshnessState{} = state) do
+    asset_freshness_sort_key(
+      state.updated_at,
+      state.asset_ref_module,
+      state.asset_ref_name,
+      state.freshness_key
+    )
+  end
+
+  defp asset_freshness_sort_key(
+         %DateTime{} = updated_at,
+         asset_ref_module,
+         asset_ref_name,
+         freshness_key
+       ) do
+    {DateTime.to_unix(updated_at, :microsecond) * -1, Atom.to_string(asset_ref_module),
+     Atom.to_string(asset_ref_name), freshness_key}
   end
 
   defp offset_and_fetch(values, filters) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -80,6 +80,16 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     :manifest_content_hash
   ]
 
+  @backfill_window_filters [
+    :backfill_run_id,
+    :pipeline_module,
+    :window_key,
+    :window_kind,
+    :status,
+    :coverage_baseline_id,
+    :manifest_version_id
+  ]
+
   @materialization_claim_filters [
     :claim_key,
     :asset_ref_module,
@@ -1225,21 +1235,20 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   def handle_call({:scan_backfill_windows, filters, scan_opts}, _from, state) do
-    case backfill_window_cursor(Keyword.get(scan_opts, :after)) do
-      {:ok, after_key} ->
-        rows =
-          state.backfill_windows
-          |> Map.values()
-          |> filter_by(filters)
-          |> Enum.sort_by(&backfill_window_sort_key/1)
-          |> cursor_drop(after_key, &backfill_window_sort_key/1)
-          |> Enum.take(Keyword.fetch!(scan_opts, :limit) + 1)
+    with :ok <- validate_filters(filters, @backfill_window_filters),
+         {:ok, after_key} <- backfill_window_cursor(Keyword.get(scan_opts, :after)) do
+      rows =
+        state.backfill_windows
+        |> Map.values()
+        |> filter_by(filters)
+        |> Enum.sort_by(&backfill_window_sort_key/1)
+        |> cursor_drop(after_key, &backfill_window_sort_key/1)
+        |> Enum.take(Keyword.fetch!(scan_opts, :limit) + 1)
 
-        page = CursorPage.from_fetched(rows, scan_opts, &backfill_window_cursor!/1)
-        {:reply, {:ok, page}, state}
-
-      {:error, reason} ->
-        {:reply, {:error, reason}, state}
+      page = CursorPage.from_fetched(rows, scan_opts, &backfill_window_cursor!/1)
+      {:reply, {:ok, page}, state}
+    else
+      {:error, reason} -> {:reply, {:error, reason}, state}
     end
   end
 

--- a/apps/favn_orchestrator/test/backfill_repair_test.exs
+++ b/apps/favn_orchestrator/test/backfill_repair_test.exs
@@ -30,7 +30,7 @@ defmodule FavnOrchestrator.Backfill.RepairTest do
     assert :ok = Storage.put_run(child)
     assert {:ok, before_events} = Storage.list_run_events(parent.id)
 
-    assert {:ok, report} = FavnOrchestrator.repair_backfill_projections(apply: true)
+    assert {:ok, report} = FavnOrchestrator.repair_backfill_projections(apply: true, all: true)
 
     assert report.counts.backfill_windows == 1
     assert report.counts.asset_window_states == 1
@@ -107,7 +107,7 @@ defmodule FavnOrchestrator.Backfill.RepairTest do
     assert :ok = Storage.put_run(rerun)
     assert :ok = Storage.put_run(failed)
 
-    assert {:ok, report} = FavnOrchestrator.repair_backfill_projections(apply: true)
+    assert {:ok, report} = FavnOrchestrator.repair_backfill_projections(apply: true, all: true)
 
     assert report.counts.backfill_windows == 1
     assert report.counts.asset_window_states == 1
@@ -148,6 +148,11 @@ defmodule FavnOrchestrator.Backfill.RepairTest do
 
     assert {:error, :not_found} =
              Storage.get_backfill_window(parent.id, MyApp.Pipelines.Daily, "day:2026-04-27")
+  end
+
+  test "apply requires an explicit destructive replacement scope" do
+    assert {:error, :replacement_scope_required} =
+             FavnOrchestrator.repair_backfill_projections(apply: true)
   end
 
   defp parent_run(run_id) do

--- a/apps/favn_orchestrator/test/diagnostics_test.exs
+++ b/apps/favn_orchestrator/test/diagnostics_test.exs
@@ -146,6 +146,10 @@ defmodule FavnOrchestrator.DiagnosticsTest do
     def list_backfill_windows(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def scan_backfill_windows(_filters, scan_opts, _opts),
+      do: {:ok, FavnOrchestrator.CursorPage.from_fetched([], scan_opts, fn _ -> nil end)}
+
+    @impl true
     def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
 
     @impl true
@@ -173,6 +177,10 @@ defmodule FavnOrchestrator.DiagnosticsTest do
 
     @impl true
     def list_asset_freshness_states(_filters, _opts), do: {:ok, []}
+
+    @impl true
+    def scan_asset_freshness_states(_filters, scan_opts, _opts),
+      do: {:ok, FavnOrchestrator.CursorPage.from_fetched([], scan_opts, fn _ -> nil end)}
 
     @impl true
     def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -438,6 +438,9 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert :ok = Storage.put_backfill_window(first_window)
     assert :ok = Storage.put_backfill_window(second_window)
 
+    assert {:error, {:unsupported_filter, :unknown}} =
+             Storage.scan_backfill_windows([unknown: :value], limit: 1)
+
     assert {:ok, first_page} =
              Storage.scan_backfill_windows([backfill_run_id: backfill_run_id], limit: 1)
 
@@ -488,6 +491,9 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
 
     assert :ok = Storage.put_asset_freshness_state(first_state)
     assert :ok = Storage.put_asset_freshness_state(second_state)
+
+    assert {:error, {:unsupported_filter, :unknown}} =
+             Storage.scan_asset_freshness_states([unknown: :value], limit: 1)
 
     assert {:ok, first_page} =
              Storage.scan_asset_freshness_states([manifest_version_id: manifest_version_id],

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -6,6 +6,7 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
   alias FavnOrchestrator.AssetFreshnessState
   alias FavnOrchestrator.Backfill.AssetWindowState
   alias FavnOrchestrator.Backfill.BackfillWindow
+  alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.Adapter.Memory
@@ -353,6 +354,8 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
 
     assert_freshness_lookup_contract(label, run)
     assert_backfill_progress_contract(label, run)
+    assert_cursor_scan_contract(label, run)
+    assert_replacement_scope_contract(label, run)
   end
 
   defp manifest_version(manifest_version_id) do
@@ -423,6 +426,158 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert Map.keys(states) == [key]
     refute Map.has_key?(states, unrelated_key)
     assert {:ok, %{}} = Storage.get_asset_freshness_states_by_keys([])
+  end
+
+  defp assert_cursor_scan_contract(label, run) do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    backfill_run_id = "cursor_backfill_#{label}_#{System.unique_integer([:positive])}"
+
+    assert {:ok, first_window} = backfill_window(backfill_run_id, run, "m", :pending, now)
+    assert {:ok, second_window} = backfill_window(backfill_run_id, run, "z", :pending, now)
+
+    assert :ok = Storage.put_backfill_window(first_window)
+    assert :ok = Storage.put_backfill_window(second_window)
+
+    assert {:ok, first_page} =
+             Storage.scan_backfill_windows([backfill_run_id: backfill_run_id], limit: 1)
+
+    assert Enum.map(first_page.items, & &1.window_key) == ["m"]
+    assert first_page.has_more?
+    assert is_map(first_page.next_cursor)
+
+    assert {:ok, before_cursor_window} =
+             backfill_window(backfill_run_id, run, "a", :pending, now)
+
+    assert :ok = Storage.put_backfill_window(before_cursor_window)
+
+    assert {:ok, second_page} =
+             Storage.scan_backfill_windows(
+               [backfill_run_id: backfill_run_id],
+               [{:limit, 10}, {:after, first_page.next_cursor}]
+             )
+
+    assert Enum.map(second_page.items, & &1.window_key) == ["z"]
+
+    assert_freshness_cursor_scan_contract(label, run, now)
+  end
+
+  defp assert_freshness_cursor_scan_contract(label, run, now) do
+    manifest_version_id = "cursor_freshness_#{label}_#{System.unique_integer([:positive])}"
+
+    assert {:ok, first_state} =
+             AssetFreshnessState.new(%{
+               asset_ref_module: MyApp.Asset,
+               asset_ref_name: :a,
+               freshness_key: "latest",
+               status: :ok,
+               latest_success_run_id: run.id,
+               manifest_version_id: manifest_version_id,
+               updated_at: now
+             })
+
+    assert {:ok, second_state} =
+             AssetFreshnessState.new(%{
+               asset_ref_module: MyApp.Asset,
+               asset_ref_name: :b,
+               freshness_key: "latest",
+               status: :ok,
+               latest_success_run_id: run.id,
+               manifest_version_id: manifest_version_id,
+               updated_at: now
+             })
+
+    assert :ok = Storage.put_asset_freshness_state(first_state)
+    assert :ok = Storage.put_asset_freshness_state(second_state)
+
+    assert {:ok, first_page} =
+             Storage.scan_asset_freshness_states([manifest_version_id: manifest_version_id],
+               limit: 1
+             )
+
+    assert Enum.map(first_page.items, & &1.asset_ref_name) == [:a]
+    assert first_page.has_more?
+
+    assert {:ok, before_cursor_state} =
+             AssetFreshnessState.new(%{
+               asset_ref_module: MyApp.Asset,
+               asset_ref_name: :_before,
+               freshness_key: "latest",
+               status: :ok,
+               latest_success_run_id: run.id,
+               manifest_version_id: manifest_version_id,
+               updated_at: now
+             })
+
+    assert :ok = Storage.put_asset_freshness_state(before_cursor_state)
+
+    assert {:ok, second_page} =
+             Storage.scan_asset_freshness_states(
+               [manifest_version_id: manifest_version_id],
+               [{:limit, 10}, {:after, first_page.next_cursor}]
+             )
+
+    assert Enum.map(second_page.items, & &1.asset_ref_name) == [:b]
+  end
+
+  defp assert_replacement_scope_contract(label, run) do
+    now = DateTime.utc_now() |> DateTime.truncate(:microsecond)
+    backfill_run_id = "replace_backfill_#{label}_#{System.unique_integer([:positive])}"
+    kept_backfill_run_id = "replace_kept_#{label}_#{System.unique_integer([:positive])}"
+
+    stale_baseline = coverage_baseline("baseline_#{backfill_run_id}", backfill_run_id, now)
+
+    kept_baseline =
+      coverage_baseline("baseline_#{kept_backfill_run_id}", kept_backfill_run_id, now)
+
+    assert {:ok, stale_window} =
+             backfill_window(backfill_run_id, run, "replace-stale", :pending, now)
+
+    assert {:ok, kept_window} =
+             backfill_window(kept_backfill_run_id, run, "replace-kept", :pending, now)
+
+    stale_window = %{stale_window | latest_attempt_run_id: "#{backfill_run_id}_child"}
+    kept_window = %{kept_window | latest_attempt_run_id: "#{kept_backfill_run_id}_child"}
+    assert {:ok, stale_state} = asset_window_state(stale_window, run, :ok)
+    assert {:ok, kept_state} = asset_window_state(kept_window, run, :ok)
+
+    for baseline <- [stale_baseline, kept_baseline],
+        do: assert(:ok = Storage.put_coverage_baseline(baseline))
+
+    for window <- [stale_window, kept_window],
+        do: assert(:ok = Storage.put_backfill_window(window))
+
+    for state <- [stale_state, kept_state],
+        do: assert(:ok = Storage.put_asset_window_state(state))
+
+    assert {:ok, _progress} = Storage.get_backfill_progress(backfill_run_id)
+
+    assert :ok =
+             Storage.replace_backfill_read_models({:backfill_run, backfill_run_id}, [], [], [])
+
+    assert {:error, :not_found} = Storage.get_coverage_baseline(stale_baseline.baseline_id)
+
+    assert {:error, :not_found} =
+             Storage.get_backfill_window(backfill_run_id, MyApp.Pipeline, stale_window.window_key)
+
+    assert {:error, :not_found} =
+             Storage.get_asset_window_state(MyApp.Asset, :asset, stale_state.window_key)
+
+    assert {:error, :not_found} = Storage.get_backfill_progress(backfill_run_id)
+
+    assert {:ok, ^kept_baseline} = Storage.get_coverage_baseline(kept_baseline.baseline_id)
+
+    assert {:ok, ^kept_window} =
+             Storage.get_backfill_window(
+               kept_backfill_run_id,
+               MyApp.Pipeline,
+               kept_window.window_key
+             )
+
+    assert {:error, {:unsupported_replacement_scope, {:asset, MyApp.Asset}}} =
+             Storage.replace_backfill_read_models({:asset, MyApp.Asset}, [], [], [])
+
+    assert :ok = Storage.replace_backfill_read_models(:all, [], [], [])
+    assert {:error, :not_found} = Storage.get_coverage_baseline(kept_baseline.baseline_id)
   end
 
   defp assert_backfill_progress_contract(label, run) do
@@ -538,6 +693,26 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert progress.pending_count == 1
     assert progress.ok_count + progress.error_count == 1
     assert progress.status == :running
+  end
+
+  defp coverage_baseline(baseline_id, created_by_run_id, now) do
+    %CoverageBaseline{
+      baseline_id: baseline_id,
+      pipeline_module: MyApp.Pipeline,
+      source_key: "orders",
+      segment_key_hash: "sha256:#{baseline_id}",
+      segment_key_redacted: nil,
+      window_kind: :day,
+      timezone: "Etc/UTC",
+      coverage_start_at: DateTime.add(now, -86_400, :second),
+      coverage_until: now,
+      created_by_run_id: created_by_run_id,
+      manifest_version_id: "mv_#{baseline_id}",
+      status: :ok,
+      metadata: %{},
+      created_at: now,
+      updated_at: now
+    }
   end
 
   defp backfill_window(backfill_run_id, run, window_key, status, now) do

--- a/apps/favn_orchestrator/test/readiness_test.exs
+++ b/apps/favn_orchestrator/test/readiness_test.exs
@@ -142,6 +142,10 @@ defmodule FavnOrchestrator.ReadinessTest do
     def list_backfill_windows(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def scan_backfill_windows(_filters, scan_opts, _opts),
+      do: {:ok, FavnOrchestrator.CursorPage.from_fetched([], scan_opts, fn _ -> nil end)}
+
+    @impl true
     def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
 
     @impl true
@@ -169,6 +173,10 @@ defmodule FavnOrchestrator.ReadinessTest do
 
     @impl true
     def list_asset_freshness_states(_filters, _opts), do: {:ok, []}
+
+    @impl true
+    def scan_asset_freshness_states(_filters, scan_opts, _opts),
+      do: {:ok, FavnOrchestrator.CursorPage.from_fetched([], scan_opts, fn _ -> nil end)}
 
     @impl true
     def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}

--- a/apps/favn_orchestrator/test/repair_runtime_state_test.exs
+++ b/apps/favn_orchestrator/test/repair_runtime_state_test.exs
@@ -45,6 +45,7 @@ defmodule FavnOrchestrator.Repair.RuntimeStateTest do
     defdelegate put_backfill_window(window, opts), to: Memory
     defdelegate get_backfill_window(backfill_id, module, window_key, opts), to: Memory
     defdelegate list_backfill_windows(filters, opts), to: Memory
+    defdelegate scan_backfill_windows(filters, scan_opts, opts), to: Memory
     defdelegate apply_backfill_child_projection(window, states, opts), to: Memory
     defdelegate get_backfill_progress(backfill_id, opts), to: Memory
     defdelegate rebuild_backfill_progress(backfill_id, opts), to: Memory
@@ -52,6 +53,7 @@ defmodule FavnOrchestrator.Repair.RuntimeStateTest do
     defdelegate get_asset_window_state(module, name, freshness_key, opts), to: Memory
     defdelegate list_asset_window_states(filters, opts), to: Memory
     defdelegate get_asset_freshness_states_by_keys(keys, opts), to: Memory
+    defdelegate scan_asset_freshness_states(filters, scan_opts, opts), to: Memory
 
     defdelegate replace_backfill_read_models(filters, baselines, windows, states, opts),
       to: Memory

--- a/apps/favn_orchestrator/test/run_server_test.exs
+++ b/apps/favn_orchestrator/test/run_server_test.exs
@@ -321,6 +321,7 @@ defmodule FavnOrchestrator.RunServerTest do
     defdelegate put_backfill_window(window, opts), to: Memory
     defdelegate get_backfill_window(backfill_id, module, window_key, opts), to: Memory
     defdelegate list_backfill_windows(filters, opts), to: Memory
+    defdelegate scan_backfill_windows(filters, scan_opts, opts), to: Memory
     defdelegate apply_backfill_child_projection(window, states, opts), to: Memory
     defdelegate get_backfill_progress(backfill_id, opts), to: Memory
     defdelegate rebuild_backfill_progress(backfill_id, opts), to: Memory
@@ -329,6 +330,9 @@ defmodule FavnOrchestrator.RunServerTest do
     defdelegate list_asset_window_states(filters, opts), to: Memory
 
     def get_asset_freshness_states_by_keys(_keys, _opts),
+      do: {:error, :freshness_lookup_unavailable}
+
+    def scan_asset_freshness_states(_filters, _scan_opts, _opts),
       do: {:error, :freshness_lookup_unavailable}
 
     defdelegate replace_backfill_read_models(filters, baselines, windows, states, opts),

--- a/apps/favn_orchestrator/test/storage_facade_test.exs
+++ b/apps/favn_orchestrator/test/storage_facade_test.exs
@@ -111,6 +111,10 @@ defmodule Favn.StorageFacadeTest do
     def list_backfill_windows(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def scan_backfill_windows(_filters, scan_opts, _opts),
+      do: {:ok, FavnOrchestrator.CursorPage.from_fetched([], scan_opts, fn _ -> nil end)}
+
+    @impl true
     def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
 
     @impl true
@@ -138,6 +142,10 @@ defmodule Favn.StorageFacadeTest do
 
     @impl true
     def list_asset_freshness_states(_filters, _opts), do: {:ok, []}
+
+    @impl true
+    def scan_asset_freshness_states(_filters, scan_opts, _opts),
+      do: {:ok, FavnOrchestrator.CursorPage.from_fetched([], scan_opts, fn _ -> nil end)}
 
     @impl true
     def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}
@@ -275,6 +283,10 @@ defmodule Favn.StorageFacadeTest do
     def list_backfill_windows(_filters, _opts), do: {:ok, []}
 
     @impl true
+    def scan_backfill_windows(_filters, scan_opts, _opts),
+      do: {:ok, FavnOrchestrator.CursorPage.from_fetched([], scan_opts, fn _ -> nil end)}
+
+    @impl true
     def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
 
     @impl true
@@ -302,6 +314,10 @@ defmodule Favn.StorageFacadeTest do
 
     @impl true
     def list_asset_freshness_states(_filters, _opts), do: {:ok, []}
+
+    @impl true
+    def scan_asset_freshness_states(_filters, scan_opts, _opts),
+      do: {:ok, FavnOrchestrator.CursorPage.from_fetched([], scan_opts, fn _ -> nil end)}
 
     @impl true
     def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -12,6 +12,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
+  alias FavnOrchestrator.CursorPage
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -758,6 +759,30 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   @impl true
+  def scan_backfill_windows(filters, scan_opts, opts)
+      when is_list(filters) and is_list(scan_opts) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, sql, params} <-
+           build_select_query(
+             backfill_window_select(),
+             read_filters(filters),
+             backfill_window_filter_specs(),
+             "ORDER BY window_start_at ASC, backfill_run_id ASC, pipeline_module ASC, window_key ASC"
+           ),
+         {:ok, sql, params} <-
+           append_backfill_window_cursor_sql(sql, params, Keyword.get(scan_opts, :after)) do
+      query_and_decode_cursor_page(
+        repo,
+        sql,
+        params,
+        scan_opts,
+        &decode_backfill_window_row/1,
+        &backfill_window_cursor!/1
+      )
+    end
+  end
+
+  @impl true
   def apply_backfill_child_projection(%BackfillWindow{} = window, asset_window_states, opts)
       when is_list(asset_window_states) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts) do
@@ -926,6 +951,30 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   @impl true
+  def scan_asset_freshness_states(filters, scan_opts, opts)
+      when is_list(filters) and is_list(scan_opts) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, sql, params} <-
+           build_select_query(
+             asset_freshness_state_select(),
+             read_filters(filters),
+             asset_freshness_state_filter_specs(),
+             "ORDER BY updated_at DESC, asset_ref_module ASC, asset_ref_name ASC, freshness_key ASC"
+           ),
+         {:ok, sql, params} <-
+           append_asset_freshness_cursor_sql(sql, params, Keyword.get(scan_opts, :after)) do
+      query_and_decode_cursor_page(
+        repo,
+        sql,
+        params,
+        scan_opts,
+        &decode_asset_freshness_state_row/1,
+        &asset_freshness_cursor!/1
+      )
+    end
+  end
+
+  @impl true
   def get_asset_freshness_states_by_keys(keys, opts) when is_list(keys) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts) do
       keys
@@ -948,32 +997,32 @@ defmodule Favn.Storage.Adapter.Postgres do
         asset_window_states,
         opts
       )
-      when is_list(scope) and is_list(coverage_baselines) and is_list(backfill_windows) and
+      when (scope == :all or is_tuple(scope)) and is_list(coverage_baselines) and
+             is_list(backfill_windows) and
              is_list(asset_window_states) and is_list(opts) do
-    with {:ok, repo} <- resolve_repo(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, scope} <- replacement_scope(scope) do
       repo.transact(fn ->
-        with :ok <-
-               delete_scoped(
+        with {:ok, affected_ids} <- affected_backfill_ids_for_scope(repo, scope),
+             :ok <-
+               delete_replacement_scope(
                  repo,
                  "favn_pipeline_coverage_baselines",
-                 scope,
-                 coverage_baseline_filter_specs()
+                 :coverage,
+                 scope
                ),
+             :ok <- delete_replacement_scope(repo, "favn_backfill_windows", :window, scope),
              :ok <-
-               delete_scoped(repo, "favn_backfill_windows", scope, backfill_window_filter_specs()),
-             :ok <-
-               delete_scoped(
-                 repo,
-                 "favn_asset_window_states",
-                 scope,
-                 asset_window_state_filter_specs()
-               ),
-             :ok <-
-               delete_scoped(repo, "favn_backfill_progress", [], backfill_progress_filter_specs()),
+               delete_replacement_scope(repo, "favn_asset_window_states", :asset_state, scope),
+             :ok <- delete_replacement_progress(repo, scope),
              :ok <- put_all(coverage_baselines, &put_coverage_baseline(&1, opts)),
              :ok <- put_all(backfill_windows, &put_backfill_window(&1, opts)),
              :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
-             :ok <- rebuild_all_backfill_progress(repo) do
+             :ok <-
+               rebuild_backfill_progress_for_ids(
+                 repo,
+                 affected_ids ++ Enum.map(backfill_windows, & &1.backfill_run_id)
+               ) do
           {:ok, :ok}
         else
           {:error, reason} -> repo.rollback(reason)
@@ -1181,7 +1230,8 @@ defmodule Favn.Storage.Adapter.Postgres do
       segment_key_hash: {"segment_key_hash", & &1},
       window_kind: {"window_kind", &Atom.to_string/1},
       status: {"status", &Atom.to_string/1},
-      manifest_version_id: {"manifest_version_id", & &1}
+      manifest_version_id: {"manifest_version_id", & &1},
+      created_by_run_id: {"created_by_run_id", & &1}
     }
   end
 
@@ -1197,13 +1247,6 @@ defmodule Favn.Storage.Adapter.Postgres do
     }
   end
 
-  defp backfill_progress_filter_specs do
-    %{
-      backfill_run_id: {"backfill_run_id", & &1},
-      status: {"status", &Atom.to_string/1}
-    }
-  end
-
   defp asset_window_state_filter_specs do
     %{
       asset_ref_module: {"asset_ref_module", &Atom.to_string/1},
@@ -1212,7 +1255,8 @@ defmodule Favn.Storage.Adapter.Postgres do
       window_key: {"window_key", & &1},
       window_kind: {"window_kind", &Atom.to_string/1},
       status: {"status", &Atom.to_string/1},
-      manifest_version_id: {"manifest_version_id", & &1}
+      manifest_version_id: {"manifest_version_id", & &1},
+      latest_parent_run_id: {"latest_parent_run_id", & &1}
     }
   end
 
@@ -1310,6 +1354,17 @@ defmodule Favn.Storage.Adapter.Postgres do
     end
   end
 
+  defp query_and_decode_cursor_page(repo, sql, params, scan_opts, decoder, cursor_fun)
+       when is_function(decoder, 1) and is_function(cursor_fun, 1) do
+    limit_placeholder = "$#{length(params) + 1}"
+    sql = sql <> "\nLIMIT #{limit_placeholder}"
+    params = params ++ [Keyword.fetch!(scan_opts, :limit) + 1]
+
+    with {:ok, rows} <- query_and_decode_rows(repo, sql, params, decoder) do
+      {:ok, CursorPage.from_fetched(rows, scan_opts, cursor_fun)}
+    end
+  end
+
   defp read_filters(filters), do: Keyword.drop(filters, [:limit, :offset])
 
   defp put_all(items, fun) when is_list(items) and is_function(fun, 1) do
@@ -1321,44 +1376,191 @@ defmodule Favn.Storage.Adapter.Postgres do
     end)
   end
 
-  defp delete_scoped(repo, table, [], _specs) do
-    case SQL.query(repo, "DELETE FROM #{table}", []) do
+  defp query_ok(repo, sql, params) do
+    case SQL.query(repo, sql, params) do
       {:ok, _} -> :ok
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp delete_scoped(repo, table, scope, specs) do
-    filters = Enum.filter(scope, fn {key, _value} -> Map.has_key?(specs, key) end)
+  defp replacement_scope(:all), do: {:ok, :all}
+  defp replacement_scope({:backfill_run, id}) when is_binary(id), do: {:ok, {:backfill_run, id}}
+  defp replacement_scope({:pipeline, module}) when is_atom(module), do: {:ok, {:pipeline, module}}
 
-    if filters == [] do
-      :ok
-    else
-      with {:ok, clauses, params} <- delete_filter_clauses(filters, specs) do
-        case SQL.query(repo, "DELETE FROM #{table} WHERE #{Enum.join(clauses, " AND ")}", params) do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
-      end
+  defp replacement_scope(scope),
+    do: {:error, {:unsupported_replacement_scope, scope}}
+
+  defp delete_replacement_scope(repo, table, kind, scope) do
+    case replacement_scope_filter(kind, scope) do
+      {:ok, nil, []} ->
+        query_ok(repo, "DELETE FROM #{table}", [])
+
+      {:ok, where_sql, params} ->
+        query_ok(repo, "DELETE FROM #{table} WHERE #{where_sql}", params)
+
+      {:error, reason} ->
+        {:error, reason}
     end
   end
 
-  defp delete_filter_clauses(filters, specs) do
-    filters
-    |> Enum.reduce_while({:ok, [], []}, fn {key, value}, {:ok, clauses, params} ->
-      case Map.fetch(specs, key) do
-        {:ok, {column, encoder}} ->
-          placeholder = "$#{length(params) + 1}"
-          {:cont, {:ok, ["#{column} = #{placeholder}" | clauses], params ++ [encoder.(value)]}}
+  defp replacement_scope_filter(_kind, :all), do: {:ok, nil, []}
 
-        :error ->
-          {:halt, {:error, {:unsupported_filter, key}}}
-      end
-    end)
-    |> case do
-      {:ok, clauses, params} -> {:ok, Enum.reverse(clauses), params}
+  defp replacement_scope_filter(:coverage, {:backfill_run, id}),
+    do: {:ok, "created_by_run_id = $1", [id]}
+
+  defp replacement_scope_filter(:window, {:backfill_run, id}),
+    do: {:ok, "backfill_run_id = $1", [id]}
+
+  defp replacement_scope_filter(:asset_state, {:backfill_run, id}),
+    do: {:ok, "latest_parent_run_id = $1", [id]}
+
+  defp replacement_scope_filter(kind, {:pipeline, module})
+       when kind in [:coverage, :window, :asset_state],
+       do: {:ok, "pipeline_module = $1", [Atom.to_string(module)]}
+
+  defp replacement_scope_filter(_kind, scope),
+    do: {:error, {:unsupported_replacement_scope, scope}}
+
+  defp delete_replacement_progress(repo, :all),
+    do: query_ok(repo, "DELETE FROM favn_backfill_progress", [])
+
+  defp delete_replacement_progress(repo, {:backfill_run, id}),
+    do: query_ok(repo, "DELETE FROM favn_backfill_progress WHERE backfill_run_id = $1", [id])
+
+  defp delete_replacement_progress(_repo, {:pipeline, _module}), do: :ok
+
+  defp affected_backfill_ids_for_scope(repo, :all) do
+    query_distinct_backfill_ids(
+      repo,
+      "SELECT DISTINCT backfill_run_id FROM favn_backfill_windows",
+      []
+    )
+  end
+
+  defp affected_backfill_ids_for_scope(_repo, {:backfill_run, id}), do: {:ok, [id]}
+
+  defp affected_backfill_ids_for_scope(repo, {:pipeline, module}) do
+    query_distinct_backfill_ids(
+      repo,
+      "SELECT DISTINCT backfill_run_id FROM favn_backfill_windows WHERE pipeline_module = $1",
+      [Atom.to_string(module)]
+    )
+  end
+
+  defp query_distinct_backfill_ids(repo, sql, params) do
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [id] -> id end)}
       {:error, reason} -> {:error, reason}
     end
+  end
+
+  defp rebuild_backfill_progress_for_ids(repo, ids) do
+    ids
+    |> Enum.uniq()
+    |> Enum.reduce_while(:ok, fn backfill_run_id, :ok ->
+      case rebuild_backfill_progress_with_repo(repo, backfill_run_id) do
+        {:ok, %BackfillProgress{}} ->
+          {:cont, :ok}
+
+        {:error, :not_found} ->
+          delete_backfill_progress(repo, backfill_run_id) |> reduce_query_result()
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp delete_backfill_progress(repo, backfill_run_id) do
+    query_ok(repo, "DELETE FROM favn_backfill_progress WHERE backfill_run_id = $1", [
+      backfill_run_id
+    ])
+  end
+
+  defp reduce_query_result(:ok), do: {:cont, :ok}
+  defp reduce_query_result({:error, reason}), do: {:halt, {:error, reason}}
+
+  defp append_backfill_window_cursor_sql(sql, params, nil), do: {:ok, sql, params}
+
+  defp append_backfill_window_cursor_sql(sql, params, %{
+         kind: :backfill_window,
+         window_start_at: %DateTime{} = window_start_at,
+         backfill_run_id: backfill_run_id,
+         pipeline_module: pipeline_module,
+         window_key: window_key
+       })
+       when is_binary(backfill_run_id) and is_atom(pipeline_module) and is_binary(window_key) do
+    offset = length(params)
+
+    cursor_sql =
+      "(window_start_at > $#{offset + 1} OR (window_start_at = $#{offset + 1} AND backfill_run_id > $#{offset + 2}) OR (window_start_at = $#{offset + 1} AND backfill_run_id = $#{offset + 2} AND pipeline_module > $#{offset + 3}) OR (window_start_at = $#{offset + 1} AND backfill_run_id = $#{offset + 2} AND pipeline_module = $#{offset + 3} AND window_key > $#{offset + 4}))"
+
+    {:ok, append_cursor_clause(sql, cursor_sql),
+     params ++ [window_start_at, backfill_run_id, Atom.to_string(pipeline_module), window_key]}
+  end
+
+  defp append_backfill_window_cursor_sql(_sql, _params, _cursor),
+    do: {:error, :invalid_cursor_pagination}
+
+  defp append_asset_freshness_cursor_sql(sql, params, nil), do: {:ok, sql, params}
+
+  defp append_asset_freshness_cursor_sql(sql, params, %{
+         kind: :asset_freshness_state,
+         updated_at: %DateTime{} = updated_at,
+         asset_ref_module: asset_ref_module,
+         asset_ref_name: asset_ref_name,
+         freshness_key: freshness_key
+       })
+       when is_atom(asset_ref_module) and is_atom(asset_ref_name) and is_binary(freshness_key) do
+    offset = length(params)
+
+    cursor_sql =
+      "(updated_at < $#{offset + 1} OR (updated_at = $#{offset + 1} AND asset_ref_module > $#{offset + 2}) OR (updated_at = $#{offset + 1} AND asset_ref_module = $#{offset + 2} AND asset_ref_name > $#{offset + 3}) OR (updated_at = $#{offset + 1} AND asset_ref_module = $#{offset + 2} AND asset_ref_name = $#{offset + 3} AND freshness_key > $#{offset + 4}))"
+
+    {:ok, append_cursor_clause(sql, cursor_sql),
+     params ++
+       [
+         updated_at,
+         Atom.to_string(asset_ref_module),
+         Atom.to_string(asset_ref_name),
+         freshness_key
+       ]}
+  end
+
+  defp append_asset_freshness_cursor_sql(_sql, _params, _cursor),
+    do: {:error, :invalid_cursor_pagination}
+
+  defp append_cursor_clause(sql, cursor_sql) do
+    [select_sql, order_sql] = String.split(sql, "\nORDER BY ", parts: 2)
+
+    select_sql =
+      if String.contains?(select_sql, "\nWHERE ") do
+        select_sql <> " AND " <> cursor_sql
+      else
+        select_sql <> "\nWHERE " <> cursor_sql
+      end
+
+    select_sql <> "\nORDER BY " <> order_sql
+  end
+
+  defp backfill_window_cursor!(%BackfillWindow{} = window) do
+    %{
+      kind: :backfill_window,
+      window_start_at: window.window_start_at,
+      backfill_run_id: window.backfill_run_id,
+      pipeline_module: window.pipeline_module,
+      window_key: window.window_key
+    }
+  end
+
+  defp asset_freshness_cursor!(%AssetFreshnessState{} = state) do
+    %{
+      kind: :asset_freshness_state,
+      updated_at: state.updated_at,
+      asset_ref_module: state.asset_ref_module,
+      asset_ref_name: state.asset_ref_name,
+      freshness_key: state.freshness_key
+    }
   end
 
   defp page_opts(filters), do: Page.normalize_opts(filters)
@@ -1473,23 +1675,6 @@ defmodule Favn.Storage.Adapter.Postgres do
             {:ok, progress}
           end
         end
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  defp rebuild_all_backfill_progress(repo) do
-    case SQL.query(repo, "SELECT DISTINCT backfill_run_id FROM favn_backfill_windows", []) do
-      {:ok, %{rows: rows}} ->
-        rows
-        |> Enum.map(fn [backfill_run_id] -> backfill_run_id end)
-        |> Enum.reduce_while(:ok, fn backfill_run_id, :ok ->
-          case rebuild_backfill_progress_with_repo(repo, backfill_run_id) do
-            {:ok, %BackfillProgress{}} -> {:cont, :ok}
-            {:error, reason} -> {:halt, {:error, reason}}
-          end
-        end)
 
       {:error, reason} ->
         {:error, reason}

--- a/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
+++ b/apps/favn_storage_postgres/test/integration/adapter_live_test.exs
@@ -572,7 +572,7 @@ defmodule FavnStoragePostgres.Integration.AdapterLiveTest do
 
         assert :ok =
                  Adapter.replace_backfill_read_models(
-                   [pipeline_module: MyApp.Pipeline],
+                   {:pipeline, MyApp.Pipeline},
                    [replacement_baseline],
                    [replacement_window],
                    [replacement_state],

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -12,6 +12,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
+  alias FavnOrchestrator.CursorPage
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -806,6 +807,29 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   @impl true
+  def scan_backfill_windows(filters, scan_opts, opts)
+      when is_list(filters) and is_list(scan_opts) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, {where_sql, params}} <-
+           build_filter_sql(read_filters(filters), backfill_window_filter_columns()),
+         {:ok, {cursor_sql, cursor_params}} <-
+           backfill_window_cursor_sql(Keyword.get(scan_opts, :after), length(params)),
+         {where_sql, params} <- append_cursor_sql(where_sql, params, cursor_sql, cursor_params) do
+      sql =
+        "SELECT #{backfill_window_columns()} FROM favn_backfill_windows#{where_sql} ORDER BY window_start_at ASC, backfill_run_id ASC, pipeline_module ASC, window_key ASC LIMIT ?#{length(params) + 1}"
+
+      decode_cursor_page(
+        repo,
+        sql,
+        params,
+        scan_opts,
+        &decode_backfill_window_row/1,
+        &backfill_window_cursor!/1
+      )
+    end
+  end
+
+  @impl true
   def apply_backfill_child_projection(%BackfillWindow{} = window, asset_window_states, opts)
       when is_list(asset_window_states) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts) do
@@ -1004,6 +1028,29 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   @impl true
+  def scan_asset_freshness_states(filters, scan_opts, opts)
+      when is_list(filters) and is_list(scan_opts) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, {where_sql, params}} <-
+           build_filter_sql(read_filters(filters), asset_freshness_state_filter_columns()),
+         {:ok, {cursor_sql, cursor_params}} <-
+           asset_freshness_cursor_sql(Keyword.get(scan_opts, :after), length(params)),
+         {where_sql, params} <- append_cursor_sql(where_sql, params, cursor_sql, cursor_params) do
+      sql =
+        "SELECT #{asset_freshness_state_columns()} FROM favn_asset_freshness_states#{where_sql} ORDER BY updated_at DESC, asset_ref_module ASC, asset_ref_name ASC, freshness_key ASC LIMIT ?#{length(params) + 1}"
+
+      decode_cursor_page(
+        repo,
+        sql,
+        params,
+        scan_opts,
+        &decode_asset_freshness_state_row/1,
+        &asset_freshness_cursor!/1
+      )
+    end
+  end
+
+  @impl true
   def get_asset_freshness_states_by_keys(keys, opts) when is_list(keys) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts) do
       keys
@@ -1026,42 +1073,32 @@ defmodule Favn.Storage.Adapter.SQLite do
         asset_window_states,
         opts
       )
-      when is_list(scope) and is_list(coverage_baselines) and is_list(backfill_windows) and
+      when (scope == :all or is_tuple(scope)) and is_list(coverage_baselines) and
+             is_list(backfill_windows) and
              is_list(asset_window_states) and is_list(opts) do
-    with {:ok, repo} <- repo_name(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, scope} <- replacement_scope(scope) do
       repo.transact(fn ->
-        with :ok <-
-               delete_scoped(
+        with {:ok, affected_ids} <- affected_backfill_ids_for_scope(repo, scope),
+             :ok <-
+               delete_replacement_scope(
                  repo,
                  "favn_pipeline_coverage_baselines",
-                 scope,
-                 coverage_baseline_filter_columns()
+                 :coverage,
+                 scope
                ),
+             :ok <- delete_replacement_scope(repo, "favn_backfill_windows", :window, scope),
              :ok <-
-               delete_scoped(
-                 repo,
-                 "favn_backfill_windows",
-                 scope,
-                 backfill_window_filter_columns()
-               ),
-             :ok <-
-               delete_scoped(
-                 repo,
-                 "favn_asset_window_states",
-                 scope,
-                 asset_window_state_filter_columns()
-               ),
-             :ok <-
-               delete_scoped(
-                 repo,
-                 "favn_backfill_progress",
-                 [],
-                 backfill_progress_filter_columns()
-               ),
+               delete_replacement_scope(repo, "favn_asset_window_states", :asset_state, scope),
+             :ok <- delete_replacement_progress(repo, scope),
              :ok <- put_all(coverage_baselines, &put_coverage_baseline(&1, opts)),
              :ok <- put_all(backfill_windows, &put_backfill_window(&1, opts)),
              :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
-             :ok <- rebuild_all_backfill_progress(repo) do
+             :ok <-
+               rebuild_backfill_progress_for_ids(
+                 repo,
+                 affected_ids ++ Enum.map(backfill_windows, & &1.backfill_run_id)
+               ) do
           {:ok, :ok}
         else
           {:error, reason} -> repo.rollback(reason)
@@ -1648,13 +1685,6 @@ defmodule Favn.Storage.Adapter.SQLite do
     }
   end
 
-  defp backfill_progress_filter_columns do
-    %{
-      backfill_run_id: {:text, "backfill_run_id"},
-      status: {:atom, "status"}
-    }
-  end
-
   defp asset_window_state_filter_columns do
     %{
       asset_ref_module: {:atom, "asset_ref_module"},
@@ -1831,23 +1861,6 @@ defmodule Favn.Storage.Adapter.SQLite do
     end
   end
 
-  defp rebuild_all_backfill_progress(repo) do
-    case SQL.query(repo, "SELECT DISTINCT backfill_run_id FROM favn_backfill_windows", []) do
-      {:ok, %{rows: rows}} ->
-        rows
-        |> Enum.map(fn [backfill_run_id] -> backfill_run_id end)
-        |> Enum.reduce_while(:ok, fn backfill_run_id, :ok ->
-          case rebuild_backfill_progress_with_repo(repo, backfill_run_id) do
-            {:ok, %BackfillProgress{}} -> {:cont, :ok}
-            {:error, reason} -> {:halt, {:error, reason}}
-          end
-        end)
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
   defp put_backfill_progress(repo, %BackfillProgress{} = progress) do
     sql = """
     INSERT INTO favn_backfill_progress (
@@ -1908,6 +1921,15 @@ defmodule Favn.Storage.Adapter.SQLite do
     end
   end
 
+  defp decode_cursor_page(repo, sql, params, scan_opts, decoder, cursor_fun)
+       when is_function(decoder, 1) and is_function(cursor_fun, 1) do
+    params = params ++ [Keyword.fetch!(scan_opts, :limit) + 1]
+
+    with {:ok, rows} <- decode_rows(repo, sql, params, decoder) do
+      {:ok, CursorPage.from_fetched(rows, scan_opts, cursor_fun)}
+    end
+  end
+
   defp read_filters(filters), do: Keyword.drop(filters, [:limit, :offset])
 
   defp put_all(items, fun) when is_list(items) and is_function(fun, 1) do
@@ -1926,26 +1948,185 @@ defmodule Favn.Storage.Adapter.SQLite do
     end
   end
 
-  defp delete_scoped(repo, table, [], _columns) do
-    case SQL.query(repo, "DELETE FROM #{table}", []) do
-      {:ok, _} -> :ok
+  defp replacement_scope(:all), do: {:ok, :all}
+  defp replacement_scope({:backfill_run, id}) when is_binary(id), do: {:ok, {:backfill_run, id}}
+  defp replacement_scope({:pipeline, module}) when is_atom(module), do: {:ok, {:pipeline, module}}
+
+  defp replacement_scope(scope),
+    do: {:error, {:unsupported_replacement_scope, scope}}
+
+  defp delete_replacement_scope(repo, table, kind, scope) do
+    case replacement_scope_filter(kind, scope) do
+      {:ok, nil, []} ->
+        query_ok(repo, "DELETE FROM #{table}", [])
+
+      {:ok, where_sql, params} ->
+        query_ok(repo, "DELETE FROM #{table} WHERE #{where_sql}", params)
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp replacement_scope_filter(_kind, :all), do: {:ok, nil, []}
+
+  defp replacement_scope_filter(:coverage, {:backfill_run, id}),
+    do: {:ok, "created_by_run_id = ?1", [id]}
+
+  defp replacement_scope_filter(:window, {:backfill_run, id}),
+    do: {:ok, "backfill_run_id = ?1", [id]}
+
+  defp replacement_scope_filter(:asset_state, {:backfill_run, id}),
+    do: {:ok, "latest_parent_run_id = ?1", [id]}
+
+  defp replacement_scope_filter(kind, {:pipeline, module})
+       when kind in [:coverage, :window, :asset_state],
+       do: {:ok, "pipeline_module = ?1", [encode_atom(module)]}
+
+  defp replacement_scope_filter(_kind, scope),
+    do: {:error, {:unsupported_replacement_scope, scope}}
+
+  defp delete_replacement_progress(repo, :all),
+    do: query_ok(repo, "DELETE FROM favn_backfill_progress", [])
+
+  defp delete_replacement_progress(repo, {:backfill_run, id}),
+    do: query_ok(repo, "DELETE FROM favn_backfill_progress WHERE backfill_run_id = ?1", [id])
+
+  defp delete_replacement_progress(_repo, {:pipeline, _module}), do: :ok
+
+  defp affected_backfill_ids_for_scope(repo, :all) do
+    query_distinct_backfill_ids(
+      repo,
+      "SELECT DISTINCT backfill_run_id FROM favn_backfill_windows",
+      []
+    )
+  end
+
+  defp affected_backfill_ids_for_scope(_repo, {:backfill_run, id}), do: {:ok, [id]}
+
+  defp affected_backfill_ids_for_scope(repo, {:pipeline, module}) do
+    query_distinct_backfill_ids(
+      repo,
+      "SELECT DISTINCT backfill_run_id FROM favn_backfill_windows WHERE pipeline_module = ?1",
+      [encode_atom(module)]
+    )
+  end
+
+  defp query_distinct_backfill_ids(repo, sql, params) do
+    case SQL.query(repo, sql, params) do
+      {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [id] -> id end)}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp delete_scoped(repo, table, scope, columns) do
-    filters = Enum.filter(scope, fn {key, _value} -> Map.has_key?(columns, key) end)
+  defp rebuild_backfill_progress_for_ids(repo, ids) do
+    ids
+    |> Enum.uniq()
+    |> Enum.reduce_while(:ok, fn backfill_run_id, :ok ->
+      case rebuild_backfill_progress_with_repo(repo, backfill_run_id) do
+        {:ok, %BackfillProgress{}} ->
+          {:cont, :ok}
 
-    if filters == [] do
-      :ok
-    else
-      with {:ok, {where_sql, params}} <- build_filter_sql(filters, columns) do
-        case SQL.query(repo, "DELETE FROM #{table}#{where_sql}", params) do
-          {:ok, _} -> :ok
-          {:error, reason} -> {:error, reason}
-        end
+        {:error, :not_found} ->
+          delete_backfill_progress(repo, backfill_run_id) |> reduce_query_result()
+
+        {:error, reason} ->
+          {:halt, {:error, reason}}
       end
-    end
+    end)
+  end
+
+  defp delete_backfill_progress(repo, backfill_run_id) do
+    query_ok(repo, "DELETE FROM favn_backfill_progress WHERE backfill_run_id = ?1", [
+      backfill_run_id
+    ])
+  end
+
+  defp reduce_query_result(:ok), do: {:cont, :ok}
+  defp reduce_query_result({:error, reason}), do: {:halt, {:error, reason}}
+
+  defp append_cursor_sql(where_sql, params, "", []), do: {where_sql, params}
+
+  defp append_cursor_sql("", params, cursor_sql, cursor_params),
+    do: {" WHERE #{cursor_sql}", params ++ cursor_params}
+
+  defp append_cursor_sql(where_sql, params, cursor_sql, cursor_params),
+    do: {where_sql <> " AND #{cursor_sql}", params ++ cursor_params}
+
+  defp backfill_window_cursor_sql(nil, _offset), do: {:ok, {"", []}}
+
+  defp backfill_window_cursor_sql(
+         %{
+           kind: :backfill_window,
+           window_start_at: %DateTime{} = window_start_at,
+           backfill_run_id: backfill_run_id,
+           pipeline_module: pipeline_module,
+           window_key: window_key
+         },
+         offset
+       )
+       when is_binary(backfill_run_id) and is_atom(pipeline_module) and is_binary(window_key) do
+    sql =
+      "(window_start_at > ?#{offset + 1} OR (window_start_at = ?#{offset + 1} AND backfill_run_id > ?#{offset + 2}) OR (window_start_at = ?#{offset + 1} AND backfill_run_id = ?#{offset + 2} AND pipeline_module > ?#{offset + 3}) OR (window_start_at = ?#{offset + 1} AND backfill_run_id = ?#{offset + 2} AND pipeline_module = ?#{offset + 3} AND window_key > ?#{offset + 4}))"
+
+    {:ok,
+     {sql,
+      [
+        encode_datetime(window_start_at),
+        backfill_run_id,
+        encode_atom(pipeline_module),
+        window_key
+      ]}}
+  end
+
+  defp backfill_window_cursor_sql(_cursor, _offset), do: {:error, :invalid_cursor_pagination}
+
+  defp backfill_window_cursor!(%BackfillWindow{} = window) do
+    %{
+      kind: :backfill_window,
+      window_start_at: window.window_start_at,
+      backfill_run_id: window.backfill_run_id,
+      pipeline_module: window.pipeline_module,
+      window_key: window.window_key
+    }
+  end
+
+  defp asset_freshness_cursor_sql(nil, _offset), do: {:ok, {"", []}}
+
+  defp asset_freshness_cursor_sql(
+         %{
+           kind: :asset_freshness_state,
+           updated_at: %DateTime{} = updated_at,
+           asset_ref_module: asset_ref_module,
+           asset_ref_name: asset_ref_name,
+           freshness_key: freshness_key
+         },
+         offset
+       )
+       when is_atom(asset_ref_module) and is_atom(asset_ref_name) and is_binary(freshness_key) do
+    sql =
+      "(updated_at < ?#{offset + 1} OR (updated_at = ?#{offset + 1} AND asset_ref_module > ?#{offset + 2}) OR (updated_at = ?#{offset + 1} AND asset_ref_module = ?#{offset + 2} AND asset_ref_name > ?#{offset + 3}) OR (updated_at = ?#{offset + 1} AND asset_ref_module = ?#{offset + 2} AND asset_ref_name = ?#{offset + 3} AND freshness_key > ?#{offset + 4}))"
+
+    {:ok,
+     {sql,
+      [
+        encode_datetime(updated_at),
+        encode_atom(asset_ref_module),
+        encode_atom(asset_ref_name),
+        freshness_key
+      ]}}
+  end
+
+  defp asset_freshness_cursor_sql(_cursor, _offset), do: {:error, :invalid_cursor_pagination}
+
+  defp asset_freshness_cursor!(%AssetFreshnessState{} = state) do
+    %{
+      kind: :asset_freshness_state,
+      updated_at: state.updated_at,
+      asset_ref_module: state.asset_ref_module,
+      asset_ref_name: state.asset_ref_name,
+      freshness_key: state.freshness_key
+    }
   end
 
   defp page_opts(filters), do: Page.normalize_opts(filters)

--- a/apps/favn_storage_sqlite/test/adapter_test.exs
+++ b/apps/favn_storage_sqlite/test/adapter_test.exs
@@ -427,7 +427,7 @@ defmodule FavnStorageSqlite.AdapterTest do
 
     assert :ok =
              Adapter.replace_backfill_read_models(
-               [pipeline_module: MyApp.Pipeline],
+               {:pipeline, MyApp.Pipeline},
                [replacement_baseline],
                [replacement_window],
                [replacement_state],

--- a/apps/favn_test_support/priv/fixtures/assets/runner_assets.ex
+++ b/apps/favn_test_support/priv/fixtures/assets/runner_assets.ex
@@ -340,6 +340,9 @@ defmodule Favn.Test.Fixtures.Assets.Runner.TerminalFailingStore do
   def list_backfill_windows(filters, _opts), do: {:ok, empty_page(filters)}
 
   @impl true
+  def scan_backfill_windows(_filters, scan_opts, _opts), do: {:ok, empty_cursor_page(scan_opts)}
+
+  @impl true
   def apply_backfill_child_projection(_window, _states, _opts), do: {:error, :not_found}
 
   @impl true
@@ -362,6 +365,9 @@ defmodule Favn.Test.Fixtures.Assets.Runner.TerminalFailingStore do
   def get_asset_freshness_states_by_keys(_keys, _opts), do: {:ok, %{}}
 
   @impl true
+  def scan_asset_freshness_states(_filters, scan_opts, _opts), do: {:ok, empty_cursor_page(scan_opts)}
+
+  @impl true
   def replace_backfill_read_models(
         _scope,
         _coverage_baselines,
@@ -378,5 +384,9 @@ defmodule Favn.Test.Fixtures.Assets.Runner.TerminalFailingStore do
       limit: Keyword.fetch!(filters, :limit),
       offset: Keyword.fetch!(filters, :offset)
     )
+  end
+
+  defp empty_cursor_page(scan_opts) do
+    FavnOrchestrator.CursorPage.from_fetched([], scan_opts, fn _item -> nil end)
   end
 end

--- a/docs/ISSUE_395_INTERNAL_PAGINATION_AND_REPLACEMENT_PLAN.md
+++ b/docs/ISSUE_395_INTERNAL_PAGINATION_AND_REPLACEMENT_PLAN.md
@@ -2,7 +2,7 @@
 
 Issue: #395
 
-Status: planned.
+Status: implemented by PR #411.
 
 ## Goal
 

--- a/docs/ISSUE_395_INTERNAL_PAGINATION_AND_REPLACEMENT_PLAN.md
+++ b/docs/ISSUE_395_INTERNAL_PAGINATION_AND_REPLACEMENT_PLAN.md
@@ -1,0 +1,341 @@
+# Issue 395 Internal Pagination And Replacement Scope Plan
+
+Issue: #395
+
+Status: planned.
+
+## Goal
+
+Make internal persisted-truth traversal stable under concurrent writes and make
+backfill read-model replacement scopes explicit, safe, and consistent across
+memory, SQLite, and Postgres adapters.
+
+This follows `docs/refactor_review_standard.md`: expose storage contracts that
+already exist implicitly, keep persisted truth behind the orchestrator storage
+boundary, and protect behavior with adapter-level contract tests.
+
+## Current Baseline
+
+- `FavnOrchestrator.Page` is offset-only and is used by public operator reads and
+  internal scans.
+- Public/API-facing list operations such as backfill windows, coverage baselines,
+  asset-window states, and asset freshness expose `:limit` and `:offset`. These
+  are acceptable UI-facing contracts and should not be replaced globally.
+- Internal full-walk helpers still use offset pagination:
+  `FavnOrchestrator.Backfill.Projector.list_all_backfill_windows/1`,
+  `FavnOrchestrator.RunReadModel` backfill-window hydration, and
+  `FavnOrchestrator.Freshness.Query` upstream freshness inspection.
+- Some full-walk helpers accumulate with `acc ++ items`, which makes repeated
+  page accumulation grow quadratically with row count.
+- SQL adapters order list pages deterministically, but they still use
+  `LIMIT/OFFSET`, so mutable tables can skip or duplicate rows between pages.
+- `replace_backfill_read_models/4` accepts a keyword scope where `[]` means
+  destructive replacement of all derived rows.
+- SQL adapter deletion silently filters unsupported non-empty scope keys out of
+  `delete_scoped/4`; an unsupported scope can therefore delete nothing while the
+  replacement rows are still inserted.
+- `favn_orchestrator` is the owner of the read-model contract. `favn_view` should
+  continue using public orchestrator facades and should not learn about cursor
+  scan internals.
+- Issue #394 has already added bounded freshness lookup and backfill progress
+  contracts on `main`; this issue should extend those contracts rather than
+  reintroducing broad scans into run startup or parent progress computation.
+
+## Architectural Decision
+
+Keep offset pagination for public operator pages and introduce separate internal
+cursor/keyset scan contracts under `FavnOrchestrator.Storage` and
+`Favn.Storage.Adapter`.
+
+Replace keyword replacement scopes with a tagged contract:
+
+```elixir
+@type read_model_replacement_scope ::
+        :all
+        | {:backfill_run, String.t()}
+        | {:pipeline, module()}
+```
+
+The facade should normalize and validate replacement scopes before adapter work.
+Adapters should reject unsupported scopes consistently with
+`{:error, {:unsupported_replacement_scope, scope}}` and must not partially mutate
+state after detecting an unsupported scope.
+
+Do not extend `FavnOrchestrator.Page` into a hybrid offset/cursor type. A separate
+cursor page keeps UI pagination and internal repair/traversal semantics explicit.
+
+## Cursor Scan Contract
+
+Add an orchestrator-owned cursor page, for example:
+
+```elixir
+defmodule FavnOrchestrator.CursorPage do
+  @type cursor :: map() | nil
+
+  @type t(item) :: %__MODULE__{
+          items: [item],
+          limit: pos_integer(),
+          after_cursor: cursor(),
+          has_more?: boolean(),
+          next_cursor: cursor()
+        }
+end
+```
+
+Cursor rules:
+
+- Cursors are adapter-neutral maps built from the deterministic order columns of
+  the last returned item.
+- Cursors are internal terms passed through the storage facade, not public HTTP
+  tokens.
+- `limit` should reuse the existing `Page.max_limit/0` cap unless a separate max
+  is needed later.
+- Empty result pages return `next_cursor: nil` and `has_more?: false`.
+- A page fetches `limit + 1` rows to compute `has_more?`, returns only `limit`
+  rows, and sets `next_cursor` from the last returned row.
+- Keyset traversal is not a snapshot isolation guarantee. Inserts that sort
+  before the current cursor may be missed until the next scan, but original rows
+  should not be skipped or duplicated because an earlier page changed size.
+
+Add scan callbacks only for internal traversal paths that need them now:
+
+```elixir
+@callback scan_backfill_windows(filter_opts(), keyword(), adapter_opts()) ::
+            {:ok, CursorPage.t(BackfillWindow.t())} | {:error, error()}
+
+@callback scan_asset_freshness_states(filter_opts(), keyword(), adapter_opts()) ::
+            {:ok, CursorPage.t(AssetFreshnessState.t())} | {:error, error()}
+```
+
+Scan option rules:
+
+- Supported scan options are `:limit` and `:after`.
+- `:after` is `nil` or a cursor previously returned by the same scan contract.
+- Unknown scan options return `{:error, :invalid_cursor_pagination}` or a tagged
+  unsupported option error before adapter work.
+- Filter support should match the corresponding list contract where practical,
+  but scan callbacks must reject unsupported filters rather than silently ignoring
+  them.
+
+## Backfill Window Cursor
+
+Use the existing deterministic order:
+
+```text
+window_start_at ASC,
+backfill_run_id ASC,
+pipeline_module ASC,
+window_key ASC
+```
+
+Cursor shape:
+
+```elixir
+%{
+  kind: :backfill_window,
+  window_start_at: DateTime.t(),
+  backfill_run_id: String.t(),
+  pipeline_module: module(),
+  window_key: String.t()
+}
+```
+
+SQL keyset predicate:
+
+```text
+(window_start_at, backfill_run_id, pipeline_module, window_key) >
+  (:window_start_at, :backfill_run_id, :pipeline_module, :window_key)
+```
+
+SQLite can express the comparison as equivalent `OR` clauses if row-value
+comparison support is not desirable for adapter portability.
+
+Memory implementation should sort with the same tuple and drop rows until the
+cursor tuple is passed. This remains in-memory but preserves adapter semantics.
+
+## Asset Freshness Cursor
+
+Use the existing deterministic order:
+
+```text
+updated_at DESC,
+asset_ref_module ASC,
+asset_ref_name ASC,
+freshness_key ASC
+```
+
+Cursor shape:
+
+```elixir
+%{
+  kind: :asset_freshness_state,
+  updated_at: DateTime.t(),
+  asset_ref_module: module(),
+  asset_ref_name: atom(),
+  freshness_key: String.t()
+}
+```
+
+SQL keyset predicate must account for the descending leading column:
+
+```text
+updated_at < :updated_at
+OR (updated_at = :updated_at AND asset_ref_module > :asset_ref_module)
+OR (updated_at = :updated_at AND asset_ref_module = :asset_ref_module AND asset_ref_name > :asset_ref_name)
+OR (updated_at = :updated_at AND asset_ref_module = :asset_ref_module AND asset_ref_name = :asset_ref_name AND freshness_key > :freshness_key)
+```
+
+This scan is a stability improvement for freshness inspection. It is not a
+replacement for exact-key freshness lookups added by issue #394.
+
+## Internal Call-Site Changes
+
+Change full-walk helpers to consume cursor scans and accumulate with prepend plus
+final reverse instead of repeated list append.
+
+Targeted changes:
+
+- Replace `Backfill.Projector.list_all_backfill_windows/1` internals with
+  `Storage.scan_backfill_windows/2`.
+- Replace `RunReadModel.list_all_backfill_windows/3` internals with
+  `Storage.scan_backfill_windows/2`.
+- Prefer `Storage.get_backfill_progress/1` for backfill progress summaries where
+  aggregate counts are enough, and scan windows only for detail/failure views that
+  require row-level data.
+- Replace `Freshness.Query.fetch_current_upstream_states/3` with
+  `Storage.scan_asset_freshness_states/2` while keeping early termination once all
+  requested upstream node keys have been found.
+- Keep public `FavnOrchestrator.list_backfill_windows/1`,
+  `list_coverage_baselines/1`, `list_asset_window_states/1`, and
+  `list_asset_freshness/1` offset-based for UI/API compatibility.
+
+`FavnOrchestrator.RunServer.Execution` already uses
+`Storage.get_asset_freshness_states_by_keys/1` after issue #394. It should remain
+on bounded exact-key lookup and should not move to cursor scans.
+
+## Replacement Scope Contract
+
+Change `Favn.Storage.Adapter.replace_backfill_read_models/5` and
+`FavnOrchestrator.Storage.replace_backfill_read_models/4` to accept
+`read_model_replacement_scope()` instead of keyword filters.
+
+Scope semantics:
+
+- `:all` deletes all coverage baselines, backfill windows, asset-window states,
+  and backfill progress rows before inserting replacement rows and rebuilding
+  progress.
+- `{:backfill_run, id}` deletes backfill windows and progress for `id`, deletes
+  asset-window states whose `latest_parent_run_id` is `id`, and deletes coverage
+  baselines whose `created_by_run_id` is `id`.
+- `{:pipeline, module}` deletes coverage baselines, backfill windows, and
+  asset-window states whose `pipeline_module` matches `module`.
+- Pipeline-scoped replacement should rebuild progress only for affected
+  `backfill_run_id`s rather than deleting all progress. Affected ids are the
+  union of ids from deleted windows and inserted replacement windows.
+- Replacement rows are still upserted using their natural keys after scoped
+  deletion.
+- Adapters must validate the scope before starting destructive work.
+- Adapters must perform scoped deletion, replacement insertion, and progress
+  cleanup/rebuild in one transaction or one memory-server call.
+
+`Backfill.Repair` should continue allowing a dry-run plan without a scope, but
+`apply: true` should require an explicit replacement scope. For full replacement,
+callers should pass `scope: :all`; an omitted apply scope should return a clear
+error such as `{:error, :replacement_scope_required}`.
+
+## Adapter Implementation Notes
+
+Memory:
+
+- Add shared cursor tuple builders for backfill windows and asset freshness.
+- Reject unsupported replacement scope terms before mutating GenServer state.
+- Rebuild only affected backfill progress rows for scoped replacement.
+
+SQLite:
+
+- Add keyset WHERE builders alongside the existing offset list builders; do not
+  change public offset list SQL.
+- Add `latest_parent_run_id` to the asset-window-state replacement predicate if
+  needed for `{:backfill_run, id}` parity.
+- Validate replacement scope before `repo.transact/1` or as the first transaction
+  step before any `DELETE`.
+- Replace the current empty-scope `DELETE FROM table` behavior with explicit
+  `:all` handling.
+
+Postgres:
+
+- Add keyset WHERE builders alongside `build_select_query/4`; keep public offset
+  list SQL unchanged.
+- Add missing replacement predicate support for `created_by_run_id`,
+  `latest_parent_run_id`, or other fields required by the tagged scopes.
+- Remove the silent unsupported-scope no-op path from `delete_scoped/4`.
+- Rebuild only affected progress rows for scoped replacement.
+
+## Landing Slices
+
+1. Add `FavnOrchestrator.CursorPage` and storage facade validation for cursor scan
+   options, with focused unit tests.
+2. Add `scan_backfill_windows/3` to the adapter behaviour, memory adapter, SQLite,
+   and Postgres, plus adapter contract tests for tie-break ordering and
+   mutation-between-pages behavior.
+3. Migrate backfill-window internal full walks to cursor scans and fix list
+   accumulation to prepend/reverse.
+4. Add `scan_asset_freshness_states/3` across adapters with contract tests for
+   descending `updated_at` tie-breaks.
+5. Migrate `Freshness.Query` upstream freshness inspection to cursor scans while
+   preserving early termination.
+6. Introduce the tagged `read_model_replacement_scope` type in the storage
+   behaviour/facade and update `Backfill.Repair` scope normalization.
+7. Update memory, SQLite, and Postgres replacement implementations to validate
+   scopes, reject unsupported scopes, and rebuild only affected progress rows.
+8. Add adapter contract tests for `:all`, `{:pipeline, module}`,
+   `{:backfill_run, id}`, unsupported scope rejection, and stale-row removal.
+9. Update docs and module docs to distinguish public offset pages from internal
+   cursor scans and to document destructive `:all` replacement as opt-in.
+
+## Tests
+
+- Cursor page validation rejects invalid limits, invalid cursors, and unknown scan
+  options.
+- Backfill-window scan returns deterministic pages with
+  `{window_start_at, backfill_run_id, pipeline_module, window_key}` tie-breaks.
+- Backfill-window scan does not skip or duplicate already-visible rows when a row
+  is inserted or deleted between page reads.
+- Asset-freshness scan returns deterministic pages with `updated_at DESC` plus
+  stable tie-breakers.
+- Internal full-walk helpers return the same rows as the offset list APIs for a
+  static dataset.
+- `Backfill.Repair.repair(apply: true)` without an explicit scope fails before
+  mutation.
+- `replace_backfill_read_models(:all, ...)` removes stale rows from all derived
+  read-model tables and rebuilds progress.
+- `replace_backfill_read_models({:pipeline, module}, ...)` removes only matching
+  pipeline rows and preserves other pipelines.
+- `replace_backfill_read_models({:backfill_run, id}, ...)` removes only rows tied
+  to the parent backfill run and preserves other backfills in the same pipeline.
+- Unsupported replacement scopes return the same tagged error across memory,
+  SQLite, and Postgres, with no partial mutation.
+- Progress rows are removed or rebuilt for affected backfills, including when a
+  replacement scope removes the last window for a backfill.
+
+## Risks And Tradeoffs
+
+- Cursor scans are internal terms, not public tokens. If they later become public,
+  they will need versioned encoding and validation.
+- Keyset scans over mutable tables provide stable traversal relative to the cursor,
+  not a database snapshot. This is the right tradeoff for repair and inspection
+  paths that can be rerun.
+- Pipeline-scoped progress rebuild is more complex than deleting all progress, but
+  it avoids unrelated progress churn and makes scoped repair semantics precise.
+- `{:backfill_run, id}` scope depends on `latest_parent_run_id` for
+  asset-window-state cleanup and `created_by_run_id` for coverage-baseline cleanup;
+  adapter indexes may need follow-up tuning if this becomes hot.
+
+## Non-Goals
+
+- Do not replace UI/API offset pagination in this issue.
+- Do not introduce public HTTP cursor tokens.
+- Do not move storage or repair semantics out of `favn_orchestrator`.
+- Do not rework run startup freshness lookup; issue #394 already moved that path
+  to bounded exact-key lookup.
+- Do not add snapshot isolation requirements for repair scans.


### PR DESCRIPTION
## Summary
- Add internal cursor/keyset scan contracts for backfill windows and asset freshness while preserving public offset pagination.
- Replace ambiguous backfill read-model replacement filters with explicit tagged scopes and require destructive repair apply to name a scope.
- Implement consistent memory, SQLite, and Postgres adapter behavior with shared storage contract coverage.

## Verification
- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/integration/storage_adapter_contract_test.exs test/backfill_repair_test.exs test/repair_runtime_state_test.exs test/storage_facade_test.exs`
- `MIX_ENV=test mix do --app favn_storage_sqlite cmd mix test test/adapter_test.exs`
- `MIX_ENV=test mix do --app favn cmd mix test test/mix_tasks/public_tasks_test.exs`

Closes #395