### PR TITLE
Extract runner execution lifecycle ownership

### DIFF
--- a/apps/favn_runner/lib/favn_runner.ex
+++ b/apps/favn_runner/lib/favn_runner.ex
@@ -48,7 +48,7 @@ defmodule FavnRunner do
   def register_manifest(version, opts \\ [])
 
   def register_manifest(%Version{} = version, opts) when is_list(opts),
-    do: Server.register_manifest(version)
+    do: Server.register_manifest(version, opts)
 
   @doc """
   Submits one manifest-pinned work request for asynchronous execution.
@@ -67,7 +67,7 @@ defmodule FavnRunner do
 
   def await_result(execution_id, timeout, opts)
       when is_binary(execution_id) and is_integer(timeout) and timeout > 0 and is_list(opts) do
-    Server.await_result(execution_id, timeout)
+    Server.await_result(execution_id, timeout, opts)
   end
 
   def await_result(_execution_id, _timeout, _opts), do: {:error, :invalid_await_args}
@@ -81,7 +81,7 @@ defmodule FavnRunner do
 
   def cancel_work(execution_id, reason, opts)
       when is_binary(execution_id) and is_map(reason) and is_list(opts) do
-    Server.cancel_work(execution_id, RunnerCancellation.from_map(reason))
+    Server.cancel_work(execution_id, RunnerCancellation.from_map(reason), opts)
   end
 
   def cancel_work(_execution_id, _reason, _opts) do

--- a/apps/favn_runner/lib/favn_runner/application.ex
+++ b/apps/favn_runner/lib/favn_runner/application.ex
@@ -24,7 +24,7 @@ defmodule FavnRunner.Application do
           {FavnRunner.ManifestStore, name: FavnRunner.ManifestStore},
           {FavnRunner.Server,
            name: FavnRunner.Server,
-           retention: Application.get_env(:favn, :runner_execution_retention, [])}
+           retention: Application.get_env(:favn_runner, :execution_retention, [])}
         ]
 
     opts = [strategy: :one_for_one, name: FavnRunner.Supervisor]

--- a/apps/favn_runner/lib/favn_runner/application.ex
+++ b/apps/favn_runner/lib/favn_runner/application.ex
@@ -22,7 +22,9 @@ defmodule FavnRunner.Application do
           {Registry, keys: :unique, name: FavnRunner.ExecutionRegistry},
           {DynamicSupervisor, strategy: :one_for_one, name: FavnRunner.WorkerSupervisor},
           {FavnRunner.ManifestStore, name: FavnRunner.ManifestStore},
-          {FavnRunner.Server, name: FavnRunner.Server}
+          {FavnRunner.Server,
+           name: FavnRunner.Server,
+           retention: Application.get_env(:favn, :runner_execution_retention, [])}
         ]
 
     opts = [strategy: :one_for_one, name: FavnRunner.Supervisor]

--- a/apps/favn_runner/lib/favn_runner/execution_lifecycle.ex
+++ b/apps/favn_runner/lib/favn_runner/execution_lifecycle.ex
@@ -1,0 +1,563 @@
+defmodule FavnRunner.ExecutionLifecycle do
+  @moduledoc false
+
+  alias Favn.Contracts.RunnerResult
+  alias Favn.Contracts.RunnerWork
+  alias FavnRunner.ExecutionLifecycle.Execution
+
+  @default_max_completed_executions 1_000
+  @default_max_logs_per_execution 500
+  @default_max_events_per_execution 500
+
+  @type execution_id :: String.t()
+
+  @type waiter :: %{
+          required(:from) => GenServer.from(),
+          required(:timer_ref) => reference(),
+          required(:monitor_ref) => reference()
+        }
+
+  @type retention_policy :: %{
+          required(:max_completed_executions) => non_neg_integer(),
+          required(:max_logs_per_execution) => non_neg_integer(),
+          required(:max_events_per_execution) => non_neg_integer()
+        }
+
+  @type counters :: %{
+          required(:evicted_completed_executions) => non_neg_integer(),
+          required(:dropped_logs) => non_neg_integer(),
+          required(:dropped_events) => non_neg_integer()
+        }
+
+  @type t :: %__MODULE__{
+          executions: %{optional(execution_id()) => Execution.t()},
+          monitor_to_execution: %{optional(reference()) => execution_id()},
+          waiters: %{optional(execution_id()) => [waiter()]},
+          waiter_monitor_to_waiter: %{optional(reference()) => {execution_id(), GenServer.from()}},
+          log_subscribers: %{optional(execution_id()) => MapSet.t(pid())},
+          subscriber_to_monitor: %{optional(pid()) => reference()},
+          subscriber_monitor_to_pid: %{optional(reference()) => pid()},
+          subscriber_executions: %{optional(pid()) => MapSet.t(execution_id())},
+          completed_order: :queue.queue(execution_id()),
+          retention: retention_policy(),
+          counters: counters()
+        }
+
+  defstruct executions: %{},
+            monitor_to_execution: %{},
+            waiters: %{},
+            waiter_monitor_to_waiter: %{},
+            log_subscribers: %{},
+            subscriber_to_monitor: %{},
+            subscriber_monitor_to_pid: %{},
+            subscriber_executions: %{},
+            completed_order: :queue.new(),
+            retention: %{
+              max_completed_executions: @default_max_completed_executions,
+              max_logs_per_execution: @default_max_logs_per_execution,
+              max_events_per_execution: @default_max_events_per_execution
+            },
+            counters: %{evicted_completed_executions: 0, dropped_logs: 0, dropped_events: 0}
+
+  @spec new(keyword()) :: t()
+  def new(opts \\ []) when is_list(opts) do
+    %__MODULE__{retention: retention_policy(opts)}
+  end
+
+  @spec fetch_execution(t(), execution_id()) :: {:ok, Execution.t()} | :error
+  def fetch_execution(%__MODULE__{} = lifecycle, execution_id) when is_binary(execution_id) do
+    Map.fetch(lifecycle.executions, execution_id)
+  end
+
+  @spec fetch_result(t(), execution_id()) ::
+          {:ok, RunnerResult.t()} | {:error, :execution_not_found | :not_completed}
+  def fetch_result(%__MODULE__{} = lifecycle, execution_id) when is_binary(execution_id) do
+    case Map.fetch(lifecycle.executions, execution_id) do
+      {:ok, %Execution{status: :completed, result: %RunnerResult{} = result}} -> {:ok, result}
+      {:ok, %Execution{status: :running}} -> {:error, :not_completed}
+      :error -> {:error, :execution_not_found}
+    end
+  end
+
+  @spec put_running(t(), execution_id(), RunnerWork.t(), pid(), reference()) :: t()
+  def put_running(%__MODULE__{} = lifecycle, execution_id, %RunnerWork{} = work, pid, monitor_ref)
+      when is_binary(execution_id) and is_pid(pid) and is_reference(monitor_ref) do
+    execution = Execution.running(execution_id, work, pid, monitor_ref, DateTime.utc_now())
+
+    %{
+      lifecycle
+      | executions: Map.put(lifecycle.executions, execution_id, execution),
+        monitor_to_execution: Map.put(lifecycle.monitor_to_execution, monitor_ref, execution_id)
+    }
+  end
+
+  @spec put_completed(t(), execution_id(), RunnerWork.t(), RunnerResult.t()) :: t()
+  def put_completed(
+        %__MODULE__{} = lifecycle,
+        execution_id,
+        %RunnerWork{} = work,
+        %RunnerResult{} = result
+      )
+      when is_binary(execution_id) do
+    execution = Execution.completed(execution_id, work, result, DateTime.utc_now())
+
+    lifecycle
+    |> put_completed_execution(execution_id, execution)
+    |> prune_completed()
+  end
+
+  @spec add_waiter(t(), execution_id(), GenServer.from(), reference(), reference()) :: t()
+  def add_waiter(%__MODULE__{} = lifecycle, execution_id, from, timer_ref, monitor_ref)
+      when is_binary(execution_id) and is_reference(timer_ref) and is_reference(monitor_ref) do
+    waiter = %{from: from, timer_ref: timer_ref, monitor_ref: monitor_ref}
+
+    %{
+      lifecycle
+      | waiters: Map.update(lifecycle.waiters, execution_id, [waiter], &[waiter | &1]),
+        waiter_monitor_to_waiter:
+          Map.put(lifecycle.waiter_monitor_to_waiter, monitor_ref, {execution_id, from})
+    }
+  end
+
+  @spec pop_waiter(t(), execution_id(), GenServer.from()) :: {[waiter()], t()}
+  def pop_waiter(%__MODULE__{} = lifecycle, execution_id, from) when is_binary(execution_id) do
+    {matched, remaining_waiters} =
+      split_waiters(lifecycle.waiters, execution_id, &(&1.from == from))
+
+    waiter_monitor_to_waiter =
+      Enum.reduce(matched, lifecycle.waiter_monitor_to_waiter, fn waiter, acc ->
+        Map.delete(acc, waiter.monitor_ref)
+      end)
+
+    {matched,
+     %{lifecycle | waiters: remaining_waiters, waiter_monitor_to_waiter: waiter_monitor_to_waiter}}
+  end
+
+  @spec remove_waiter_monitor(t(), reference()) :: {[waiter()], t()}
+  def remove_waiter_monitor(%__MODULE__{} = lifecycle, monitor_ref)
+      when is_reference(monitor_ref) do
+    case Map.pop(lifecycle.waiter_monitor_to_waiter, monitor_ref) do
+      {nil, waiter_monitor_to_waiter} ->
+        {[], %{lifecycle | waiter_monitor_to_waiter: waiter_monitor_to_waiter}}
+
+      {{execution_id, from}, waiter_monitor_to_waiter} ->
+        {matched, waiters} = split_waiters(lifecycle.waiters, execution_id, &(&1.from == from))
+
+        {matched,
+         %{lifecycle | waiters: waiters, waiter_monitor_to_waiter: waiter_monitor_to_waiter}}
+    end
+  end
+
+  @spec subscribe_logs(t(), execution_id(), pid(), reference()) ::
+          {:ok, [term()], [reference()], t()} | {:error, term(), [reference()], t()}
+  def subscribe_logs(%__MODULE__{} = lifecycle, execution_id, subscriber, monitor_ref)
+      when is_binary(execution_id) and is_pid(subscriber) and is_reference(monitor_ref) do
+    case Map.fetch(lifecycle.executions, execution_id) do
+      {:ok, %Execution{status: :running, logs: logs}} ->
+        {lifecycle, unused_monitor_refs} =
+          add_log_subscriber(lifecycle, execution_id, subscriber, monitor_ref)
+
+        {:ok, Enum.reverse(logs), unused_monitor_refs, lifecycle}
+
+      {:ok, %Execution{status: :completed, logs: logs}} ->
+        {:ok, Enum.reverse(logs), [monitor_ref], lifecycle}
+
+      :error ->
+        {:error, :execution_not_found, [monitor_ref], lifecycle}
+    end
+  end
+
+  @spec unsubscribe_logs(t(), execution_id(), pid()) :: {[reference()], t()}
+  def unsubscribe_logs(%__MODULE__{} = lifecycle, execution_id, subscriber)
+      when is_binary(execution_id) and is_pid(subscriber) do
+    remove_log_subscription(lifecycle, execution_id, subscriber)
+  end
+
+  @spec remove_subscriber_monitor(t(), reference()) :: t()
+  def remove_subscriber_monitor(%__MODULE__{} = lifecycle, monitor_ref)
+      when is_reference(monitor_ref) do
+    case Map.pop(lifecycle.subscriber_monitor_to_pid, monitor_ref) do
+      {nil, subscriber_monitor_to_pid} ->
+        %{lifecycle | subscriber_monitor_to_pid: subscriber_monitor_to_pid}
+
+      {subscriber, subscriber_monitor_to_pid} ->
+        execution_ids = Map.get(lifecycle.subscriber_executions, subscriber, MapSet.new())
+
+        log_subscribers =
+          Enum.reduce(execution_ids, lifecycle.log_subscribers, fn execution_id, acc ->
+            update_execution_subscribers(acc, execution_id, &MapSet.delete(&1, subscriber))
+          end)
+
+        %{
+          lifecycle
+          | log_subscribers: log_subscribers,
+            subscriber_to_monitor: Map.delete(lifecycle.subscriber_to_monitor, subscriber),
+            subscriber_monitor_to_pid: subscriber_monitor_to_pid,
+            subscriber_executions: Map.delete(lifecycle.subscriber_executions, subscriber)
+        }
+    end
+  end
+
+  @spec append_log(t(), execution_id(), term()) :: {[pid()], t()}
+  def append_log(%__MODULE__{} = lifecycle, execution_id, entry) when is_binary(execution_id) do
+    subscribers =
+      lifecycle.log_subscribers |> Map.get(execution_id, MapSet.new()) |> MapSet.to_list()
+
+    lifecycle =
+      update_execution(lifecycle, execution_id, fn execution ->
+        {logs, dropped} =
+          bounded_prepend(execution.logs, entry, lifecycle.retention.max_logs_per_execution)
+
+        {%{execution | logs: logs, dropped_log_count: execution.dropped_log_count + dropped},
+         :dropped_logs, dropped}
+      end)
+
+    {subscribers, lifecycle}
+  end
+
+  @spec append_event(t(), execution_id(), term()) :: t()
+  def append_event(%__MODULE__{} = lifecycle, execution_id, event) when is_binary(execution_id) do
+    update_execution(lifecycle, execution_id, fn execution ->
+      {events, dropped} =
+        bounded_prepend(execution.events, event, lifecycle.retention.max_events_per_execution)
+
+      {%{
+         execution
+         | events: events,
+           dropped_event_count: execution.dropped_event_count + dropped
+       }, :dropped_events, dropped}
+    end)
+  end
+
+  @spec finalize(t(), execution_id(), RunnerResult.t()) :: {[waiter()], [reference()], t()}
+  def finalize(%__MODULE__{} = lifecycle, execution_id, %RunnerResult{} = result)
+      when is_binary(execution_id) do
+    case Map.fetch(lifecycle.executions, execution_id) do
+      {:ok, %Execution{status: :running} = execution} ->
+        completed = Execution.complete(execution, result, DateTime.utc_now())
+        {waiters, lifecycle} = pop_all_waiters(lifecycle, execution_id)
+
+        {subscriber_monitor_refs, lifecycle} =
+          remove_all_execution_subscribers(lifecycle, execution_id)
+
+        lifecycle =
+          %{
+            lifecycle
+            | monitor_to_execution:
+                Map.delete(lifecycle.monitor_to_execution, execution.monitor_ref)
+          }
+          |> put_completed_execution(execution_id, completed)
+          |> prune_completed()
+
+        worker_monitor_refs =
+          if is_reference(execution.monitor_ref), do: [execution.monitor_ref], else: []
+
+        {waiters, worker_monitor_refs ++ subscriber_monitor_refs, lifecycle}
+
+      _other ->
+        {[], [], lifecycle}
+    end
+  end
+
+  @spec pop_worker_monitor(t(), reference()) :: {execution_id() | nil, t()}
+  def pop_worker_monitor(%__MODULE__{} = lifecycle, monitor_ref) when is_reference(monitor_ref) do
+    {execution_id, monitor_to_execution} = Map.pop(lifecycle.monitor_to_execution, monitor_ref)
+    {execution_id, %{lifecycle | monitor_to_execution: monitor_to_execution}}
+  end
+
+  @spec diagnostics(t()) :: map()
+  def diagnostics(%__MODULE__{} = lifecycle) do
+    executions = Map.values(lifecycle.executions)
+
+    %{
+      in_flight_executions: Enum.count(executions, &(&1.status == :running)),
+      completed_executions: Enum.count(executions, &(&1.status == :completed)),
+      waiters: map_size(lifecycle.waiter_monitor_to_waiter),
+      log_subscribers: map_size(lifecycle.subscriber_to_monitor),
+      log_subscriptions:
+        lifecycle.log_subscribers
+        |> Map.values()
+        |> Enum.reduce(0, &(MapSet.size(&1) + &2)),
+      retention: Map.merge(lifecycle.retention, lifecycle.counters)
+    }
+  end
+
+  defp retention_policy(opts) do
+    opts
+    |> Keyword.get(:retention, [])
+    |> then(fn retention ->
+      %{
+        max_completed_executions:
+          retention_value(retention, :max_completed_executions, @default_max_completed_executions),
+        max_logs_per_execution:
+          retention_value(retention, :max_logs_per_execution, @default_max_logs_per_execution),
+        max_events_per_execution:
+          retention_value(retention, :max_events_per_execution, @default_max_events_per_execution)
+      }
+    end)
+  end
+
+  defp retention_value(retention, key, default) when is_list(retention) do
+    retention
+    |> Keyword.get(key, default)
+    |> normalize_non_negative_integer(default)
+  end
+
+  defp retention_value(retention, key, default) when is_map(retention) do
+    retention
+    |> Map.get(key, default)
+    |> normalize_non_negative_integer(default)
+  end
+
+  defp retention_value(_retention, _key, default), do: default
+
+  defp normalize_non_negative_integer(value, _default) when is_integer(value) and value >= 0,
+    do: value
+
+  defp normalize_non_negative_integer(_value, default), do: default
+
+  defp put_completed_execution(lifecycle, execution_id, execution) do
+    %{
+      lifecycle
+      | executions: Map.put(lifecycle.executions, execution_id, execution),
+        completed_order: :queue.in(execution_id, lifecycle.completed_order)
+    }
+  end
+
+  defp prune_completed(%__MODULE__{} = lifecycle) do
+    if completed_count(lifecycle) > lifecycle.retention.max_completed_executions do
+      case :queue.out(lifecycle.completed_order) do
+        {{:value, execution_id}, completed_order} ->
+          lifecycle = %{lifecycle | completed_order: completed_order}
+
+          case Map.fetch(lifecycle.executions, execution_id) do
+            {:ok, %Execution{status: :completed}} ->
+              lifecycle
+              |> evict_completed_execution(execution_id)
+              |> prune_completed()
+
+            _other ->
+              prune_completed(lifecycle)
+          end
+
+        {:empty, _queue} ->
+          lifecycle
+      end
+    else
+      lifecycle
+    end
+  end
+
+  defp completed_count(%__MODULE__{} = lifecycle) do
+    Enum.count(lifecycle.executions, fn {_id, execution} -> execution.status == :completed end)
+  end
+
+  defp evict_completed_execution(%__MODULE__{} = lifecycle, execution_id) do
+    %{
+      lifecycle
+      | executions: Map.delete(lifecycle.executions, execution_id),
+        waiters: Map.delete(lifecycle.waiters, execution_id),
+        log_subscribers: Map.delete(lifecycle.log_subscribers, execution_id),
+        counters: Map.update!(lifecycle.counters, :evicted_completed_executions, &(&1 + 1))
+    }
+  end
+
+  defp split_waiters(waiters, execution_id, fun) do
+    case Map.fetch(waiters, execution_id) do
+      {:ok, execution_waiters} ->
+        {matched, remaining} = Enum.split_with(execution_waiters, fun)
+
+        waiters =
+          if remaining == [] do
+            Map.delete(waiters, execution_id)
+          else
+            Map.put(waiters, execution_id, remaining)
+          end
+
+        {matched, waiters}
+
+      :error ->
+        {[], waiters}
+    end
+  end
+
+  defp pop_all_waiters(%__MODULE__{} = lifecycle, execution_id) do
+    {waiters, remaining_waiters} = Map.pop(lifecycle.waiters, execution_id, [])
+
+    waiter_monitor_to_waiter =
+      Enum.reduce(waiters, lifecycle.waiter_monitor_to_waiter, fn waiter, acc ->
+        Map.delete(acc, waiter.monitor_ref)
+      end)
+
+    {waiters,
+     %{lifecycle | waiters: remaining_waiters, waiter_monitor_to_waiter: waiter_monitor_to_waiter}}
+  end
+
+  defp add_log_subscriber(lifecycle, execution_id, subscriber, monitor_ref) do
+    case Map.fetch(lifecycle.subscriber_to_monitor, subscriber) do
+      {:ok, _existing_monitor_ref} ->
+        {[monitor_ref], lifecycle}
+
+      :error ->
+        lifecycle = %{
+          lifecycle
+          | subscriber_to_monitor:
+              Map.put(lifecycle.subscriber_to_monitor, subscriber, monitor_ref),
+            subscriber_monitor_to_pid:
+              Map.put(lifecycle.subscriber_monitor_to_pid, monitor_ref, subscriber)
+        }
+
+        {[], lifecycle}
+    end
+    |> then(fn {unused_monitor_refs, lifecycle} ->
+      log_subscribers =
+        Map.update(
+          lifecycle.log_subscribers,
+          execution_id,
+          MapSet.new([subscriber]),
+          fn subscribers ->
+            MapSet.put(subscribers, subscriber)
+          end
+        )
+
+      subscriber_executions =
+        Map.update(
+          lifecycle.subscriber_executions,
+          subscriber,
+          MapSet.new([execution_id]),
+          fn execution_ids ->
+            MapSet.put(execution_ids, execution_id)
+          end
+        )
+
+      {%{
+         lifecycle
+         | log_subscribers: log_subscribers,
+           subscriber_executions: subscriber_executions
+       }, unused_monitor_refs}
+    end)
+  end
+
+  defp remove_log_subscription(lifecycle, execution_id, subscriber) do
+    log_subscribers =
+      update_execution_subscribers(
+        lifecycle.log_subscribers,
+        execution_id,
+        &MapSet.delete(&1, subscriber)
+      )
+
+    subscriber_executions =
+      update_subscriber_executions(
+        lifecycle.subscriber_executions,
+        subscriber,
+        &MapSet.delete(&1, execution_id)
+      )
+
+    lifecycle = %{
+      lifecycle
+      | log_subscribers: log_subscribers,
+        subscriber_executions: subscriber_executions
+    }
+
+    maybe_remove_subscriber_monitor(lifecycle, subscriber)
+  end
+
+  defp remove_all_execution_subscribers(lifecycle, execution_id) do
+    subscribers = Map.get(lifecycle.log_subscribers, execution_id, MapSet.new())
+
+    Enum.reduce(subscribers, {[], lifecycle}, fn subscriber, {monitor_refs, lifecycle} ->
+      {removed_monitor_refs, lifecycle} =
+        remove_log_subscription(lifecycle, execution_id, subscriber)
+
+      {monitor_refs ++ removed_monitor_refs, lifecycle}
+    end)
+  end
+
+  defp maybe_remove_subscriber_monitor(lifecycle, subscriber) do
+    execution_ids = Map.get(lifecycle.subscriber_executions, subscriber, MapSet.new())
+
+    if MapSet.size(execution_ids) == 0 do
+      case Map.pop(lifecycle.subscriber_to_monitor, subscriber) do
+        {nil, subscriber_to_monitor} ->
+          {[], %{lifecycle | subscriber_to_monitor: subscriber_to_monitor}}
+
+        {monitor_ref, subscriber_to_monitor} ->
+          lifecycle = %{
+            lifecycle
+            | subscriber_to_monitor: subscriber_to_monitor,
+              subscriber_monitor_to_pid:
+                Map.delete(lifecycle.subscriber_monitor_to_pid, monitor_ref),
+              subscriber_executions: Map.delete(lifecycle.subscriber_executions, subscriber)
+          }
+
+          {[monitor_ref], lifecycle}
+      end
+    else
+      {[], lifecycle}
+    end
+  end
+
+  defp update_execution_subscribers(log_subscribers, execution_id, fun) do
+    case Map.fetch(log_subscribers, execution_id) do
+      {:ok, subscribers} ->
+        subscribers = fun.(subscribers)
+
+        if MapSet.size(subscribers) == 0 do
+          Map.delete(log_subscribers, execution_id)
+        else
+          Map.put(log_subscribers, execution_id, subscribers)
+        end
+
+      :error ->
+        log_subscribers
+    end
+  end
+
+  defp update_subscriber_executions(subscriber_executions, subscriber, fun) do
+    case Map.fetch(subscriber_executions, subscriber) do
+      {:ok, execution_ids} ->
+        execution_ids = fun.(execution_ids)
+
+        if MapSet.size(execution_ids) == 0 do
+          Map.delete(subscriber_executions, subscriber)
+        else
+          Map.put(subscriber_executions, subscriber, execution_ids)
+        end
+
+      :error ->
+        subscriber_executions
+    end
+  end
+
+  defp update_execution(%__MODULE__{} = lifecycle, execution_id, fun) do
+    case Map.fetch(lifecycle.executions, execution_id) do
+      {:ok, %Execution{} = execution} ->
+        {execution, counter_key, dropped} = fun.(execution)
+
+        %{
+          lifecycle
+          | executions: Map.put(lifecycle.executions, execution_id, execution),
+            counters: Map.update!(lifecycle.counters, counter_key, &(&1 + dropped))
+        }
+
+      :error ->
+        lifecycle
+    end
+  end
+
+  defp bounded_prepend(entries, entry, max_entries) do
+    entries = [entry | entries]
+
+    case max_entries do
+      0 ->
+        {[], length(entries)}
+
+      max_entries when length(entries) > max_entries ->
+        {kept, dropped} = Enum.split(entries, max_entries)
+        {kept, length(dropped)}
+
+      _max_entries ->
+        {entries, 0}
+    end
+  end
+end

--- a/apps/favn_runner/lib/favn_runner/execution_lifecycle/execution.ex
+++ b/apps/favn_runner/lib/favn_runner/execution_lifecycle/execution.ex
@@ -1,0 +1,74 @@
+defmodule FavnRunner.ExecutionLifecycle.Execution do
+  @moduledoc false
+
+  alias Favn.Contracts.RunnerResult
+  alias Favn.Contracts.RunnerWork
+
+  @type status :: :running | :completed
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          work: RunnerWork.t(),
+          status: status(),
+          pid: pid() | nil,
+          monitor_ref: reference() | nil,
+          result: RunnerResult.t() | nil,
+          events: [term()],
+          logs: [term()],
+          started_at: DateTime.t(),
+          completed_at: DateTime.t() | nil,
+          dropped_event_count: non_neg_integer(),
+          dropped_log_count: non_neg_integer()
+        }
+
+  defstruct id: nil,
+            work: nil,
+            status: :running,
+            pid: nil,
+            monitor_ref: nil,
+            result: nil,
+            events: [],
+            logs: [],
+            started_at: nil,
+            completed_at: nil,
+            dropped_event_count: 0,
+            dropped_log_count: 0
+
+  @spec running(String.t(), RunnerWork.t(), pid(), reference(), DateTime.t()) :: t()
+  def running(id, %RunnerWork{} = work, pid, monitor_ref, %DateTime{} = started_at)
+      when is_binary(id) and is_pid(pid) and is_reference(monitor_ref) do
+    %__MODULE__{
+      id: id,
+      work: work,
+      status: :running,
+      pid: pid,
+      monitor_ref: monitor_ref,
+      started_at: started_at
+    }
+  end
+
+  @spec completed(String.t(), RunnerWork.t(), RunnerResult.t(), DateTime.t()) :: t()
+  def completed(id, %RunnerWork{} = work, %RunnerResult{} = result, %DateTime{} = completed_at)
+      when is_binary(id) do
+    %__MODULE__{
+      id: id,
+      work: work,
+      status: :completed,
+      result: result,
+      started_at: completed_at,
+      completed_at: completed_at
+    }
+  end
+
+  @spec complete(t(), RunnerResult.t(), DateTime.t()) :: t()
+  def complete(%__MODULE__{} = execution, %RunnerResult{} = result, %DateTime{} = completed_at) do
+    %{
+      execution
+      | status: :completed,
+        pid: nil,
+        monitor_ref: nil,
+        result: result,
+        completed_at: completed_at
+    }
+  end
+end

--- a/apps/favn_runner/lib/favn_runner/execution_lifecycle/execution.ex
+++ b/apps/favn_runner/lib/favn_runner/execution_lifecycle/execution.ex
@@ -15,7 +15,7 @@ defmodule FavnRunner.ExecutionLifecycle.Execution do
           result: RunnerResult.t() | nil,
           events: [term()],
           logs: [term()],
-          started_at: DateTime.t(),
+          started_at: DateTime.t() | nil,
           completed_at: DateTime.t() | nil,
           dropped_event_count: non_neg_integer(),
           dropped_log_count: non_neg_integer()
@@ -55,7 +55,6 @@ defmodule FavnRunner.ExecutionLifecycle.Execution do
       work: work,
       status: :completed,
       result: result,
-      started_at: completed_at,
       completed_at: completed_at
     }
   end

--- a/apps/favn_runner/lib/favn_runner/server.ex
+++ b/apps/favn_runner/lib/favn_runner/server.ex
@@ -14,6 +14,7 @@ defmodule FavnRunner.Server do
   alias Favn.Contracts.RunnerWork
   alias Favn.Manifest.Version
   alias Favn.SQL.SessionPool
+  alias FavnRunner.ExecutionLifecycle
   alias FavnRunner.Inspection
   alias FavnRunner.ManifestResolver
   alias FavnRunner.ManifestStore
@@ -22,32 +23,14 @@ defmodule FavnRunner.Server do
 
   @type execution_id :: String.t()
 
-  @type waiter :: %{
-          required(:from) => GenServer.from(),
-          required(:timer_ref) => reference()
-        }
-
-  @type execution_state :: %{
-          required(:work) => RunnerWork.t(),
-          required(:status) => :running | :completed,
-          optional(:pid) => pid(),
-          optional(:monitor_ref) => reference(),
-          optional(:result) => RunnerResult.t(),
-          optional(:events) => [term()],
-          optional(:logs) => [term()]
-        }
-
   @type state :: %{
-          executions: %{required(execution_id()) => execution_state()},
-          monitor_to_execution: %{required(reference()) => execution_id()},
-          waiters: %{required(execution_id()) => [waiter()]},
-          log_subscribers: %{required(execution_id()) => MapSet.t(pid())}
+          lifecycle: ExecutionLifecycle.t()
         }
 
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, %{}, name: name)
+    GenServer.start_link(__MODULE__, opts, name: name)
   end
 
   @spec register_manifest(Version.t(), keyword()) :: :ok | {:error, term()}
@@ -134,8 +117,8 @@ defmodule FavnRunner.Server do
   end
 
   @impl true
-  def init(_args) do
-    {:ok, %{executions: %{}, monitor_to_execution: %{}, waiters: %{}, log_subscribers: %{}}}
+  def init(opts) do
+    {:ok, %{lifecycle: ExecutionLifecycle.new(opts)}}
   end
 
   @impl true
@@ -158,34 +141,28 @@ defmodule FavnRunner.Server do
             with {:ok, pid} <- start_worker(execution_id, work, version, asset) do
               monitor_ref = Process.monitor(pid)
 
-              execution = %{
-                work: work,
-                status: :running,
-                pid: pid,
-                monitor_ref: monitor_ref,
-                events: [],
-                logs: []
-              }
+              lifecycle =
+                ExecutionLifecycle.put_running(
+                  state.lifecycle,
+                  execution_id,
+                  work,
+                  pid,
+                  monitor_ref
+                )
 
-              next_state =
-                state
-                |> put_in([:executions, execution_id], execution)
-                |> put_in([:monitor_to_execution, monitor_ref], execution_id)
-
-              {{:ok, execution_id}, next_state}
+              {{:ok, execution_id}, %{state | lifecycle: lifecycle}}
             end
 
           {:error, diagnostic} ->
-            execution = %{
-              work: work,
-              status: :completed,
-              result: preflight_failed_result(work, version, diagnostic),
-              events: [],
-              logs: []
-            }
+            lifecycle =
+              ExecutionLifecycle.put_completed(
+                state.lifecycle,
+                execution_id,
+                work,
+                preflight_failed_result(work, version, diagnostic)
+              )
 
-            next_state = put_in(state, [:executions, execution_id], execution)
-            {{:ok, execution_id}, next_state}
+            {{:ok, execution_id}, %{state | lifecycle: lifecycle}}
         end
       end
 
@@ -196,36 +173,41 @@ defmodule FavnRunner.Server do
   end
 
   def handle_call({:await_result, execution_id, timeout}, from, state) do
-    case Map.fetch(state.executions, execution_id) do
-      {:ok, %{status: :completed, result: %RunnerResult{} = result}} ->
+    case ExecutionLifecycle.fetch_result(state.lifecycle, execution_id) do
+      {:ok, %RunnerResult{} = result} ->
         {:reply, {:ok, result}, state}
 
-      {:ok, %{status: :running}} ->
+      {:error, :not_completed} ->
+        waiter_monitor_ref = Process.monitor(elem(from, 0))
         timer_ref = Process.send_after(self(), {:await_timeout, execution_id, from}, timeout)
-        waiters = [%{from: from, timer_ref: timer_ref} | Map.get(state.waiters, execution_id, [])]
-        {:noreply, put_in(state, [:waiters, execution_id], waiters)}
 
-      :error ->
+        lifecycle =
+          ExecutionLifecycle.add_waiter(
+            state.lifecycle,
+            execution_id,
+            from,
+            timer_ref,
+            waiter_monitor_ref
+          )
+
+        {:noreply, %{state | lifecycle: lifecycle}}
+
+      {:error, :execution_not_found} ->
         {:reply, {:error, :execution_not_found}, state}
     end
   end
 
   def handle_call({:cancel_work, execution_id, reason}, _from, state) do
-    case Map.fetch(state.executions, execution_id) do
+    case ExecutionLifecycle.fetch_execution(state.lifecycle, execution_id) do
       {:ok, %{status: :completed}} ->
         {:reply,
          {:ok, RunnerCancellation.outcome(:already_completed, execution_id: execution_id)}, state}
 
-      {:ok, %{status: :running, pid: pid, work: work, monitor_ref: monitor_ref}} ->
+      {:ok, %{status: :running, pid: pid, work: work}} ->
         _ = DynamicSupervisor.terminate_child(FavnRunner.WorkerSupervisor, pid)
 
         result = cancelled_result(work, reason)
         next_state = finalize_execution(state, execution_id, result)
-
-        next_state = %{
-          next_state
-          | monitor_to_execution: Map.delete(next_state.monitor_to_execution, monitor_ref)
-        }
 
         {:reply, {:ok, RunnerCancellation.outcome(:acknowledged, execution_id: execution_id)},
          next_state}
@@ -236,39 +218,30 @@ defmodule FavnRunner.Server do
   end
 
   def handle_call({:subscribe_execution_logs, execution_id, subscriber}, _from, state) do
-    case Map.fetch(state.executions, execution_id) do
-      {:ok, %{status: status} = execution} when status in [:running, :completed] ->
-        subscribers =
-          state.log_subscribers
-          |> Map.get(execution_id, MapSet.new())
-          |> MapSet.put(subscriber)
+    monitor_ref = Process.monitor(subscriber)
 
-        execution
-        |> Map.get(:logs, [])
-        |> Enum.reverse()
-        |> Enum.each(fn entry -> send(subscriber, {:runner_log_entry, execution_id, entry}) end)
+    case ExecutionLifecycle.subscribe_logs(state.lifecycle, execution_id, subscriber, monitor_ref) do
+      {:ok, replay_entries, cleanup_monitor_refs, lifecycle} ->
+        cleanup_monitor_refs(cleanup_monitor_refs)
 
-        {:reply, :ok, put_in(state, [:log_subscribers, execution_id], subscribers)}
+        Enum.each(replay_entries, fn entry ->
+          send(subscriber, {:runner_log_entry, execution_id, entry})
+        end)
 
-      :error ->
-        {:reply, {:error, :execution_not_found}, state}
+        {:reply, :ok, %{state | lifecycle: lifecycle}}
+
+      {:error, :execution_not_found, cleanup_monitor_refs, lifecycle} ->
+        cleanup_monitor_refs(cleanup_monitor_refs)
+        {:reply, {:error, :execution_not_found}, %{state | lifecycle: lifecycle}}
     end
   end
 
   def handle_call({:unsubscribe_execution_logs, execution_id, subscriber}, _from, state) do
-    subscribers =
-      state.log_subscribers
-      |> Map.get(execution_id, MapSet.new())
-      |> MapSet.delete(subscriber)
+    {cleanup_monitor_refs, lifecycle} =
+      ExecutionLifecycle.unsubscribe_logs(state.lifecycle, execution_id, subscriber)
 
-    log_subscribers =
-      if MapSet.size(subscribers) == 0 do
-        Map.delete(state.log_subscribers, execution_id)
-      else
-        Map.put(state.log_subscribers, execution_id, subscribers)
-      end
-
-    {:reply, :ok, %{state | log_subscribers: log_subscribers}}
+    cleanup_monitor_refs(cleanup_monitor_refs)
+    {:reply, :ok, %{state | lifecycle: lifecycle}}
   end
 
   def handle_call({:inspect_relation, %RelationInspectionRequest{} = request}, _from, state) do
@@ -284,52 +257,37 @@ defmodule FavnRunner.Server do
   end
 
   def handle_call(:diagnostics, _from, state) do
-    executions = Map.values(state.executions)
-
     reply =
       {:ok,
-       %{
+       state.lifecycle
+       |> ExecutionLifecycle.diagnostics()
+       |> Map.merge(%{
          available?: true,
          server: __MODULE__,
-         in_flight_executions: Enum.count(executions, &(&1.status == :running)),
-         completed_executions: Enum.count(executions, &(&1.status == :completed)),
          data_plane: data_plane_diagnostics()
-       }}
+       })}
 
     {:reply, reply, state}
   end
 
   @impl true
   def handle_info({:runner_event, execution_id, event}, state) do
-    next_state =
-      update_in(state, [:executions, execution_id, :events], fn
-        nil -> [event]
-        events -> [event | events]
-      end)
-
-    {:noreply, next_state}
+    lifecycle = ExecutionLifecycle.append_event(state.lifecycle, execution_id, event)
+    {:noreply, %{state | lifecycle: lifecycle}}
   end
 
   def handle_info({:runner_log_entry, execution_id, entry}, state) do
-    state.log_subscribers
-    |> Map.get(execution_id, MapSet.new())
-    |> Enum.each(fn subscriber -> send(subscriber, {:runner_log_entry, execution_id, entry}) end)
+    {subscribers, lifecycle} = ExecutionLifecycle.append_log(state.lifecycle, execution_id, entry)
 
-    next_state =
-      if Map.has_key?(state.executions, execution_id) do
-        update_in(state, [:executions, execution_id, :logs], fn
-          nil -> [entry]
-          logs -> [entry | logs]
-        end)
-      else
-        state
-      end
+    Enum.each(subscribers, fn subscriber ->
+      send(subscriber, {:runner_log_entry, execution_id, entry})
+    end)
 
-    {:noreply, next_state}
+    {:noreply, %{state | lifecycle: lifecycle}}
   end
 
   def handle_info({:runner_result, execution_id, %RunnerResult{} = result}, state) do
-    case Map.fetch(state.executions, execution_id) do
+    case ExecutionLifecycle.fetch_execution(state.lifecycle, execution_id) do
       {:ok, %{status: :running}} ->
         {:noreply, finalize_execution(state, execution_id, result)}
 
@@ -342,30 +300,42 @@ defmodule FavnRunner.Server do
   end
 
   def handle_info({:await_timeout, execution_id, from}, state) do
-    {waiters, remaining_waiters} = pop_waiter(state.waiters, execution_id, from)
+    {waiters, lifecycle} = ExecutionLifecycle.pop_waiter(state.lifecycle, execution_id, from)
 
-    Enum.each(waiters, fn %{from: waiter_from} ->
+    Enum.each(waiters, fn %{from: waiter_from, monitor_ref: monitor_ref} ->
+      cleanup_monitor_refs([monitor_ref])
       GenServer.reply(waiter_from, {:error, :timeout})
     end)
 
-    {:noreply, %{state | waiters: remaining_waiters}}
+    {:noreply, %{state | lifecycle: lifecycle}}
   end
 
   def handle_info({:DOWN, monitor_ref, :process, _pid, reason}, state) do
-    case Map.pop(state.monitor_to_execution, monitor_ref) do
-      {nil, monitor_to_execution} ->
-        {:noreply, %{state | monitor_to_execution: monitor_to_execution}}
+    {execution_id, lifecycle} =
+      ExecutionLifecycle.pop_worker_monitor(state.lifecycle, monitor_ref)
 
-      {execution_id, monitor_to_execution} ->
-        next_state = %{state | monitor_to_execution: monitor_to_execution}
+    state = %{state | lifecycle: lifecycle}
 
-        case Map.fetch(next_state.executions, execution_id) do
+    cond do
+      is_binary(execution_id) ->
+        case ExecutionLifecycle.fetch_execution(state.lifecycle, execution_id) do
           {:ok, %{status: :running, work: work}} ->
-            crash_result = crashed_result(work, reason)
-            {:noreply, finalize_execution(next_state, execution_id, crash_result)}
+            {:noreply, finalize_execution(state, execution_id, crashed_result(work, reason))}
 
           _other ->
-            {:noreply, next_state}
+            {:noreply, state}
+        end
+
+      true ->
+        {waiters, lifecycle} =
+          ExecutionLifecycle.remove_waiter_monitor(state.lifecycle, monitor_ref)
+
+        if waiters != [] do
+          Enum.each(waiters, fn %{timer_ref: timer_ref} -> Process.cancel_timer(timer_ref) end)
+          {:noreply, %{state | lifecycle: lifecycle}}
+        else
+          lifecycle = ExecutionLifecycle.remove_subscriber_monitor(lifecycle, monitor_ref)
+          {:noreply, %{state | lifecycle: lifecycle}}
         end
     end
   end
@@ -393,50 +363,22 @@ defmodule FavnRunner.Server do
   end
 
   defp finalize_execution(state, execution_id, %RunnerResult{} = result) do
-    execution = Map.get(state.executions, execution_id, %{})
+    {waiters, monitor_refs, lifecycle} =
+      ExecutionLifecycle.finalize(state.lifecycle, execution_id, result)
 
-    next_state =
-      put_in(state, [:executions, execution_id], %{
-        work: execution[:work],
-        status: :completed,
-        result: result,
-        events: execution[:events] || [],
-        logs: execution[:logs] || []
-      })
+    cleanup_monitor_refs(monitor_refs)
 
-    next_state = %{
-      next_state
-      | log_subscribers: Map.delete(next_state.log_subscribers, execution_id)
-    }
-
-    {waiters, remaining_waiters} = Map.pop(next_state.waiters, execution_id, [])
-
-    Enum.each(waiters, fn %{from: from, timer_ref: timer_ref} ->
+    Enum.each(waiters, fn %{from: from, timer_ref: timer_ref, monitor_ref: monitor_ref} ->
       _ = Process.cancel_timer(timer_ref)
+      cleanup_monitor_refs([monitor_ref])
       GenServer.reply(from, {:ok, result})
     end)
 
-    %{next_state | waiters: remaining_waiters}
+    %{state | lifecycle: lifecycle}
   end
 
-  defp pop_waiter(waiters, execution_id, from) do
-    case Map.fetch(waiters, execution_id) do
-      {:ok, execution_waiters} ->
-        {matched, remaining} = Enum.split_with(execution_waiters, &(&1.from == from))
-
-        next_waiters =
-          if remaining == [] do
-            Map.delete(waiters, execution_id)
-          else
-            Map.put(waiters, execution_id, remaining)
-          end
-
-        {matched, next_waiters}
-
-      :error ->
-        {[], waiters}
-    end
-  end
+  defp cleanup_monitor_refs(monitor_refs) when is_list(monitor_refs),
+    do: Enum.each(monitor_refs, &Process.demonitor(&1, [:flush]))
 
   defp cancelled_result(work, reason) do
     %RunnerResult{

--- a/apps/favn_runner/test/execution_lifecycle_test.exs
+++ b/apps/favn_runner/test/execution_lifecycle_test.exs
@@ -1,0 +1,130 @@
+defmodule FavnRunner.ExecutionLifecycleTest do
+  use ExUnit.Case, async: true
+
+  alias Favn.Contracts.RunnerResult
+  alias Favn.Contracts.RunnerWork
+  alias FavnRunner.ExecutionLifecycle
+
+  test "finalize returns waiters and makes result awaitable" do
+    lifecycle = ExecutionLifecycle.new()
+    work = work("run_1")
+    execution_id = "rx_1"
+    worker_monitor_ref = make_ref()
+    waiter_monitor_ref = make_ref()
+    timer_ref = make_ref()
+    from = {self(), make_ref()}
+
+    lifecycle =
+      lifecycle
+      |> ExecutionLifecycle.put_running(execution_id, work, self(), worker_monitor_ref)
+      |> ExecutionLifecycle.add_waiter(execution_id, from, timer_ref, waiter_monitor_ref)
+
+    result = result(work)
+
+    assert {[waiter], [^worker_monitor_ref], lifecycle} =
+             ExecutionLifecycle.finalize(lifecycle, execution_id, result)
+
+    assert waiter.from == from
+    assert waiter.timer_ref == timer_ref
+    assert waiter.monitor_ref == waiter_monitor_ref
+    assert {:ok, ^result} = ExecutionLifecycle.fetch_result(lifecycle, execution_id)
+    assert ExecutionLifecycle.diagnostics(lifecycle).waiters == 0
+  end
+
+  test "completed retention evicts oldest completed execution but keeps running execution" do
+    lifecycle = ExecutionLifecycle.new(retention: [max_completed_executions: 1])
+    running_work = work("run_running")
+    first_work = work("run_first")
+    second_work = work("run_second")
+
+    lifecycle =
+      lifecycle
+      |> ExecutionLifecycle.put_running("rx_running", running_work, self(), make_ref())
+      |> ExecutionLifecycle.put_completed("rx_first", first_work, result(first_work))
+      |> ExecutionLifecycle.put_completed("rx_second", second_work, result(second_work))
+
+    assert {:error, :execution_not_found} = ExecutionLifecycle.fetch_result(lifecycle, "rx_first")
+    assert {:ok, _execution} = ExecutionLifecycle.fetch_execution(lifecycle, "rx_running")
+    assert {:ok, _result} = ExecutionLifecycle.fetch_result(lifecycle, "rx_second")
+
+    diagnostics = ExecutionLifecycle.diagnostics(lifecycle)
+    assert diagnostics.in_flight_executions == 1
+    assert diagnostics.completed_executions == 1
+    assert diagnostics.retention.evicted_completed_executions == 1
+  end
+
+  test "log and event buffers drop oldest entries under configured bounds" do
+    lifecycle =
+      ExecutionLifecycle.new(retention: [max_logs_per_execution: 2, max_events_per_execution: 1])
+
+    work = work("run_buffers")
+    execution_id = "rx_buffers"
+
+    lifecycle = ExecutionLifecycle.put_running(lifecycle, execution_id, work, self(), make_ref())
+
+    {_subscribers, lifecycle} =
+      ExecutionLifecycle.append_log(lifecycle, execution_id, %{sequence: 1})
+
+    {_subscribers, lifecycle} =
+      ExecutionLifecycle.append_log(lifecycle, execution_id, %{sequence: 2})
+
+    {_subscribers, lifecycle} =
+      ExecutionLifecycle.append_log(lifecycle, execution_id, %{sequence: 3})
+
+    lifecycle = ExecutionLifecycle.append_event(lifecycle, execution_id, %{sequence: 1})
+    lifecycle = ExecutionLifecycle.append_event(lifecycle, execution_id, %{sequence: 2})
+
+    execution = lifecycle.executions[execution_id]
+    assert Enum.reverse(execution.logs) == [%{sequence: 2}, %{sequence: 3}]
+    assert Enum.reverse(execution.events) == [%{sequence: 2}]
+
+    diagnostics = ExecutionLifecycle.diagnostics(lifecycle)
+    assert diagnostics.retention.dropped_logs == 1
+    assert diagnostics.retention.dropped_events == 1
+  end
+
+  test "subscriber monitor cleanup removes all execution memberships" do
+    lifecycle = ExecutionLifecycle.new()
+    work = work("run_subscriber")
+    subscriber = self()
+    monitor_ref = make_ref()
+
+    lifecycle = ExecutionLifecycle.put_running(lifecycle, "rx_1", work, self(), make_ref())
+    lifecycle = ExecutionLifecycle.put_running(lifecycle, "rx_2", work, self(), make_ref())
+
+    assert {:ok, [], [], lifecycle} =
+             ExecutionLifecycle.subscribe_logs(lifecycle, "rx_1", subscriber, monitor_ref)
+
+    assert {:ok, [], [unused_monitor_ref], lifecycle} =
+             ExecutionLifecycle.subscribe_logs(lifecycle, "rx_2", subscriber, make_ref())
+
+    assert is_reference(unused_monitor_ref)
+    assert ExecutionLifecycle.diagnostics(lifecycle).log_subscriptions == 2
+
+    lifecycle = ExecutionLifecycle.remove_subscriber_monitor(lifecycle, monitor_ref)
+
+    diagnostics = ExecutionLifecycle.diagnostics(lifecycle)
+    assert diagnostics.log_subscribers == 0
+    assert diagnostics.log_subscriptions == 0
+  end
+
+  defp work(run_id) do
+    %RunnerWork{
+      run_id: run_id,
+      manifest_version_id: "mv_" <> run_id,
+      manifest_content_hash: "hash_" <> run_id,
+      asset_ref: {__MODULE__, :asset}
+    }
+  end
+
+  defp result(%RunnerWork{} = work) do
+    %RunnerResult{
+      run_id: work.run_id,
+      manifest_version_id: work.manifest_version_id,
+      manifest_content_hash: work.manifest_content_hash,
+      status: :ok,
+      asset_results: [],
+      metadata: %{}
+    }
+  end
+end

--- a/apps/favn_runner/test/execution_lifecycle_test.exs
+++ b/apps/favn_runner/test/execution_lifecycle_test.exs
@@ -53,6 +53,18 @@ defmodule FavnRunner.ExecutionLifecycleTest do
     assert diagnostics.retention.evicted_completed_executions == 1
   end
 
+  test "pre-completed execution has no worker start timestamp" do
+    lifecycle = ExecutionLifecycle.new()
+    work = work("run_preflight_failed")
+    result = result(work)
+
+    lifecycle = ExecutionLifecycle.put_completed(lifecycle, "rx_preflight_failed", work, result)
+
+    assert {:ok, execution} = ExecutionLifecycle.fetch_execution(lifecycle, "rx_preflight_failed")
+    assert execution.started_at == nil
+    assert %DateTime{} = execution.completed_at
+  end
+
   test "log and event buffers drop oldest entries under configured bounds" do
     lifecycle =
       ExecutionLifecycle.new(retention: [max_logs_per_execution: 2, max_events_per_execution: 1])

--- a/apps/favn_runner/test/server_test.exs
+++ b/apps/favn_runner/test/server_test.exs
@@ -92,7 +92,7 @@ defmodule FavnRunner.ServerTest do
     assert {:ok, execution_id} = FavnRunner.submit_work(work)
 
     state = :sys.get_state(FavnRunner.Server)
-    worker_pid = get_in(state, [:executions, execution_id, :pid])
+    worker_pid = state.lifecycle.executions[execution_id].pid
     assert is_pid(worker_pid)
     Process.exit(worker_pid, :kill)
 
@@ -129,6 +129,151 @@ defmodule FavnRunner.ServerTest do
     assert {:error, :execution_not_found} = FavnRunner.await_result("rx_missing", 50)
   end
 
+  test "completed execution retention evicts the oldest retained result" do
+    server = start_runner_server(max_completed_executions: 1)
+
+    {:ok, version} =
+      Version.new(build_manifest(FavnRunner.ServerTest.FastAsset),
+        manifest_version_id: unique_id("mv")
+      )
+
+    assert :ok = FavnRunner.register_manifest(version, server: server)
+
+    first_work = build_work(version, FavnRunner.ServerTest.FastAsset)
+    second_work = build_work(version, FavnRunner.ServerTest.FastAsset)
+
+    assert {:ok, first_execution_id} = FavnRunner.submit_work(first_work, server: server)
+
+    assert {:ok, first_result} =
+             FavnRunner.await_result(first_execution_id, 1_000, server: server)
+
+    assert first_result.status == :ok
+
+    assert {:ok, second_execution_id} = FavnRunner.submit_work(second_work, server: server)
+
+    assert {:ok, second_result} =
+             FavnRunner.await_result(second_execution_id, 1_000, server: server)
+
+    assert second_result.status == :ok
+
+    assert {:error, :execution_not_found} =
+             FavnRunner.await_result(first_execution_id, 50, server: server)
+
+    assert {:ok, diagnostics} = FavnRunner.diagnostics(server: server)
+    assert diagnostics.completed_executions == 1
+    assert diagnostics.retention.evicted_completed_executions == 1
+  end
+
+  test "log replay is bounded to newest entries in chronological order" do
+    server = start_runner_server(max_logs_per_execution: 2)
+
+    {:ok, version} =
+      Version.new(build_manifest(FavnRunner.ServerTest.SlowAsset),
+        manifest_version_id: unique_id("mv")
+      )
+
+    assert :ok = FavnRunner.register_manifest(version, server: server)
+
+    work = build_work(version, FavnRunner.ServerTest.SlowAsset)
+    assert {:ok, execution_id} = FavnRunner.submit_work(work, server: server)
+
+    wait_until(fn ->
+      state = :sys.get_state(server)
+      execution = state.lifecycle.executions[execution_id]
+      execution && length(execution.logs) > 0
+    end)
+
+    send(server, {:runner_log_entry, execution_id, %{sequence: 1}})
+    send(server, {:runner_log_entry, execution_id, %{sequence: 2}})
+    send(server, {:runner_log_entry, execution_id, %{sequence: 3}})
+
+    wait_until(fn ->
+      state = :sys.get_state(server)
+      execution = state.lifecycle.executions[execution_id]
+      length(execution.logs) == 2 and execution.dropped_log_count >= 1
+    end)
+
+    assert :ok = FavnRunner.subscribe_execution_logs(execution_id, self(), server: server)
+    assert_receive {:runner_log_entry, ^execution_id, %{sequence: 2}}
+    assert_receive {:runner_log_entry, ^execution_id, %{sequence: 3}}
+    refute_receive {:runner_log_entry, ^execution_id, %{sequence: 1}}, 50
+
+    assert {:ok, %{status: :acknowledged}} =
+             FavnRunner.cancel_work(execution_id, %{}, server: server)
+  end
+
+  test "dead log subscribers are removed from diagnostics" do
+    server = start_runner_server()
+
+    {:ok, version} =
+      Version.new(build_manifest(FavnRunner.ServerTest.SlowAsset),
+        manifest_version_id: unique_id("mv")
+      )
+
+    assert :ok = FavnRunner.register_manifest(version, server: server)
+
+    work = build_work(version, FavnRunner.ServerTest.SlowAsset)
+    assert {:ok, execution_id} = FavnRunner.submit_work(work, server: server)
+
+    subscriber =
+      spawn(fn ->
+        :ok = FavnRunner.subscribe_execution_logs(execution_id, self(), server: server)
+
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    wait_until(fn ->
+      {:ok, diagnostics} = FavnRunner.diagnostics(server: server)
+      diagnostics.log_subscribers == 1
+    end)
+
+    Process.exit(subscriber, :kill)
+
+    wait_until(fn ->
+      {:ok, diagnostics} = FavnRunner.diagnostics(server: server)
+      diagnostics.log_subscribers == 0 and diagnostics.log_subscriptions == 0
+    end)
+
+    assert {:ok, %{status: :acknowledged}} =
+             FavnRunner.cancel_work(execution_id, %{}, server: server)
+  end
+
+  test "abandoned await callers are removed from diagnostics" do
+    server = start_runner_server()
+
+    {:ok, version} =
+      Version.new(build_manifest(FavnRunner.ServerTest.SlowAsset),
+        manifest_version_id: unique_id("mv")
+      )
+
+    assert :ok = FavnRunner.register_manifest(version, server: server)
+
+    work = build_work(version, FavnRunner.ServerTest.SlowAsset)
+    assert {:ok, execution_id} = FavnRunner.submit_work(work, server: server)
+
+    waiter =
+      spawn(fn ->
+        _ = FavnRunner.await_result(execution_id, 5_000, server: server)
+      end)
+
+    wait_until(fn ->
+      {:ok, diagnostics} = FavnRunner.diagnostics(server: server)
+      diagnostics.waiters == 1
+    end)
+
+    Process.exit(waiter, :kill)
+
+    wait_until(fn ->
+      {:ok, diagnostics} = FavnRunner.diagnostics(server: server)
+      diagnostics.waiters == 0
+    end)
+
+    assert {:ok, %{status: :acknowledged}} =
+             FavnRunner.cancel_work(execution_id, %{}, server: server)
+  end
+
   test "favn runner facade validates await and cancel arguments" do
     assert {:error, :invalid_await_args} = FavnRunner.await_result(:bad, 10)
     assert {:error, :invalid_await_args} = FavnRunner.await_result("rx", -1)
@@ -160,6 +305,39 @@ defmodule FavnRunner.ServerTest do
 
   defp unique_id(prefix),
     do: prefix <> "_" <> Base.encode16(:crypto.strong_rand_bytes(8), case: :lower)
+
+  defp build_work(%Version{} = version, asset_module) do
+    %RunnerWork{
+      run_id: unique_id("run"),
+      manifest_version_id: version.manifest_version_id,
+      manifest_content_hash: version.content_hash,
+      asset_ref: {asset_module, :asset}
+    }
+  end
+
+  defp start_runner_server(retention \\ []) do
+    server = String.to_atom(unique_id("runner_server"))
+    start_supervised!({FavnRunner.Server, name: server, retention: retention})
+    server
+  end
+
+  defp wait_until(fun, attempts \\ 50)
+
+  defp wait_until(fun, attempts) when attempts > 0 do
+    if fun.() do
+      :ok
+    else
+      Process.sleep(20)
+      wait_until(fun, attempts - 1)
+    end
+  end
+
+  defp wait_until(fun, 0), do: assert(fun.())
+end
+
+defmodule FavnRunner.ServerTest.FastAsset do
+  @spec asset(Favn.Run.Context.t()) :: :ok
+  def asset(_ctx), do: :ok
 end
 
 defmodule FavnRunner.ServerTest.SlowAsset do

--- a/docs/ISSUE_392_RUNNER_EXECUTION_LIFECYCLE_PLAN.md
+++ b/docs/ISSUE_392_RUNNER_EXECUTION_LIFECYCLE_PLAN.md
@@ -1,0 +1,395 @@
+# Issue 392 Runner Execution Lifecycle Plan
+
+Issue: #392
+
+Status: implemented in this branch.
+
+## Goal
+
+Extract explicit runner-owned lifecycle state from `FavnRunner.Server` without
+changing the public runner facade or the shared `Favn.Contracts.RunnerClient`
+contract. The refactor should make running executions, completed executions,
+worker monitors, await waiters, log subscribers, buffered logs, buffered events,
+retention, and cleanup visible as one internal runtime contract.
+
+This follows `docs/refactor_review_standard.md`: expose a real lifecycle
+contract that already exists implicitly, separate GenServer protocol mechanics
+from runtime state transitions, improve cleanup and bounded memory behavior, and
+avoid splitting modules only by size.
+
+## Current Baseline
+
+`FavnRunner.Server` currently owns several different contracts at once:
+
+- Public protocol calls for manifest registration, work submission, result
+  awaits, cancellation, log subscription, relation inspection, and diagnostics.
+- Manifest target resolution, manifest lookup, SQL runtime preflight, execution
+  id creation, worker child specs, and worker monitoring.
+- Lifecycle state in anonymous maps: `executions`, `monitor_to_execution`,
+  `waiters`, and `log_subscribers`.
+- Running execution state with work, worker pid, monitor ref, buffered events,
+  and buffered logs.
+- Completed execution state with result, buffered events, and buffered logs.
+- Waiter timers and waiter replies.
+- Log subscription replay and live fanout.
+- Cancellation result construction and worker termination.
+- Worker crash result construction.
+- Diagnostics counts derived directly from anonymous execution maps.
+
+The current behavior is simple but hides lifecycle ownership:
+
+- Completed executions are retained indefinitely in memory.
+- Per-execution log and event buffers are retained indefinitely while the
+  execution is retained.
+- Log subscribers are not monitored, so dead subscriber pids remain in
+  `log_subscribers` until the execution completes or is explicitly
+  unsubscribed.
+- Waiter callers are not monitored, so abandoned waits are cleaned only by
+  timeout or execution finalization.
+- Finalization, cancellation, worker crash handling, waiter cleanup, subscriber
+  cleanup, and monitor cleanup are split across GenServer callbacks.
+- Diagnostics report only running and completed execution counts, not retention,
+  waiter, subscriber, or buffer pressure.
+
+## Architectural Decision
+
+Introduce an internal runner lifecycle component and keep `FavnRunner.Server` as
+the single GenServer protocol/process owner in the first implementation.
+
+Recommended modules:
+
+- `FavnRunner.ExecutionLifecycle`
+- `FavnRunner.ExecutionLifecycle.Execution`
+
+Do not introduce a new supervised lifecycle process in the first pass. The
+current `FavnRunner.Server` already serializes lifecycle messages correctly, and
+adding another process would create a second ownership boundary before there is
+a concurrency need. The extraction should be a state contract plus pure-ish
+transition functions that the server applies from `handle_call/3` and
+`handle_info/2`.
+
+Keep these boundaries stable:
+
+- `FavnRunner` remains the public runner facade.
+- `Favn.Contracts.RunnerClient` remains unchanged.
+- `Favn.Contracts.RunnerWork`, `RunnerResult`, `RunnerError`,
+  `RunnerCancellation`, and `RunnerEvent` remain the shared boundary shapes.
+- `FavnRunner.Worker` continues to execute one asset and send
+  `{:runner_result, execution_id, result}`, `{:runner_log_entry, execution_id,
+  entry}`, and `{:runner_event, execution_id, event}` messages to the server.
+- Manifest lookup, SQL preflight, relation inspection, and data-plane
+  diagnostics stay outside the lifecycle component because they are not
+  execution retention or process cleanup state.
+
+## Lifecycle Contract
+
+`FavnRunner.ExecutionLifecycle` should own the state currently spread through
+server maps:
+
+```elixir
+%FavnRunner.ExecutionLifecycle{
+  executions: %{optional(String.t()) => Execution.t()},
+  monitor_to_execution: %{optional(reference()) => String.t()},
+  waiters: %{optional(String.t()) => [waiter()]},
+  waiter_monitor_to_execution: %{optional(reference()) => String.t()},
+  log_subscribers: %{optional(String.t()) => MapSet.t(pid())},
+  subscriber_to_monitor: %{optional(pid()) => reference()},
+  subscriber_monitor_to_pid: %{optional(reference()) => pid()},
+  subscriber_executions: %{optional(pid()) => MapSet.t(String.t())},
+  completed_order: :queue.queue({DateTime.t(), String.t()}),
+  retention: retention_policy(),
+  counters: counters()
+}
+```
+
+`FavnRunner.ExecutionLifecycle.Execution` should make one execution's state
+explicit:
+
+```elixir
+%FavnRunner.ExecutionLifecycle.Execution{
+  id: String.t(),
+  work: Favn.Contracts.RunnerWork.t(),
+  status: :running | :completed,
+  pid: pid() | nil,
+  monitor_ref: reference() | nil,
+  result: Favn.Contracts.RunnerResult.t() | nil,
+  events: [term()],
+  logs: [term()],
+  started_at: DateTime.t(),
+  completed_at: DateTime.t() | nil,
+  dropped_event_count: non_neg_integer(),
+  dropped_log_count: non_neg_integer()
+}
+```
+
+The lifecycle module should expose only operations that map to real runtime
+events:
+
+```elixir
+new(opts) :: t()
+put_running(t(), execution_id, work, pid, monitor_ref) :: t()
+put_completed(t(), execution_id, work, result) :: t()
+fetch_result(t(), execution_id) :: {:ok, RunnerResult.t()} | {:error, :execution_not_found | :not_completed}
+add_waiter(t(), execution_id, from, timer_ref, waiter_monitor_ref) :: t()
+pop_waiter(t(), execution_id, from) :: {[waiter()], t()}
+remove_waiter_monitor(t(), monitor_ref) :: {[waiter()], t()}
+subscribe_logs(t(), execution_id, subscriber, monitor_ref) :: {:ok, replay_entries, t()} | {:error, term()}
+unsubscribe_logs(t(), execution_id, subscriber) :: {demonitor_refs, t()}
+remove_subscriber_monitor(t(), monitor_ref) :: t()
+append_log(t(), execution_id, entry) :: {subscribers, t()}
+append_event(t(), execution_id, event) :: t()
+finalize(t(), execution_id, result) :: {waiters, cleanup, t()}
+cancel_running(t(), execution_id) :: {:ok, execution, cleanup, t()} | {:completed, t()} | {:not_found, t()}
+pop_worker_monitor(t(), monitor_ref) :: {execution_id | nil, t()}
+diagnostics(t()) :: map()
+```
+
+The exact function names can change during implementation, but the contract
+should remain centered on lifecycle events, not generic map manipulation.
+
+## Retention Semantics
+
+Use bounded retention by default. Retention should be explicit server state, not
+an unbounded anonymous side effect of `await_result/3`.
+
+Recommended defaults:
+
+```elixir
+%{
+  max_completed_executions: 1_000,
+  max_logs_per_execution: 500,
+  max_events_per_execution: 500
+}
+```
+
+Rules:
+
+- Completed executions remain awaitable only while retained.
+- `await_result/3` for an evicted execution returns `{:error,
+  :execution_not_found}`.
+- `subscribe_execution_logs/3` can replay logs only while the execution is
+  retained.
+- Running executions are never evicted by completed-execution retention.
+- Log and event buffers are bounded independently for running and completed
+  executions.
+- Buffer pruning should drop the oldest entries and increment explicit dropped
+  counters.
+- Completed-execution pruning should remove execution state, waiter state,
+  subscriber state, and completed-order entries together.
+- Time-based retention can be added later if there is a concrete product need;
+  count-based retention is enough to remove unbounded memory growth in the first
+  pass.
+
+Configure retention through `FavnRunner.Server.start_link/1` options and read
+application config only once in `FavnRunner.Application` if defaults need to be
+overridden. Do not repeatedly read global application env in lifecycle
+transitions.
+
+## Cleanup Semantics
+
+Waiters:
+
+- Monitor waiter caller pids when a call is parked.
+- On waiter timeout, reply `{:error, :timeout}`, cancel or remove that waiter's
+  monitor, and remove the waiter entry.
+- On execution finalization, cancel waiter timers, demonitor waiter pids, and
+  reply `{:ok, result}` once.
+- On waiter process `:DOWN`, cancel that waiter's timer and remove the waiter
+  without replying.
+
+Log subscribers:
+
+- Monitor a subscriber pid once no matter how many executions it subscribes to.
+- Track subscriber-to-execution membership explicitly.
+- On subscriber `:DOWN`, remove the pid from all execution subscriber sets and
+  remove monitor bookkeeping.
+- On unsubscribe, remove only that execution membership and demonitor the pid
+  only when it has no remaining execution subscriptions.
+- On execution finalization, stop live fanout for that execution, but keep
+  buffered logs replayable until retention evicts the completed execution.
+
+Worker monitors:
+
+- `monitor_to_execution` remains lifecycle-owned.
+- Normal worker `:DOWN` after a result should only remove stale monitor
+  bookkeeping.
+- Abnormal worker `:DOWN` while running should finalize exactly once with a
+  worker-crash result.
+- Cancellation should terminate the worker, finalize with a cancellation result,
+  and ignore a later worker result or monitor message.
+
+## Server Responsibilities After Refactor
+
+`FavnRunner.Server` should still own process mechanics and side effects:
+
+- `GenServer.call/3` and `GenServer.reply/2` protocol handling.
+- `Process.send_after/3`, `Process.cancel_timer/1`, `Process.monitor/1`, and
+  `Process.demonitor/2` calls.
+- `DynamicSupervisor.start_child/2` and `DynamicSupervisor.terminate_child/2`.
+- Manifest resolution and SQL preflight before lifecycle insertion.
+- Relation inspection and data-plane diagnostics.
+- Creating `RunnerResult` values for preflight failure, cancellation, and worker
+  crash unless those result builders are moved to a small runner-result helper as
+  part of the same lifecycle contract.
+
+`FavnRunner.Server` should stop owning direct map updates for lifecycle state.
+Its callbacks should read as protocol dispatch plus lifecycle transition
+application.
+
+## Diagnostics Contract
+
+Extend runner diagnostics to expose lifecycle pressure without leaking raw work,
+logs, events, or secrets:
+
+```elixir
+%{
+  available?: true,
+  server: FavnRunner.Server,
+  in_flight_executions: non_neg_integer(),
+  completed_executions: non_neg_integer(),
+  waiters: non_neg_integer(),
+  log_subscribers: non_neg_integer(),
+  retention: %{
+    max_completed_executions: pos_integer(),
+    max_logs_per_execution: non_neg_integer(),
+    max_events_per_execution: non_neg_integer(),
+    evicted_completed_executions: non_neg_integer(),
+    dropped_logs: non_neg_integer(),
+    dropped_events: non_neg_integer()
+  },
+  data_plane: map()
+}
+```
+
+Keep current diagnostics keys working where practical, but do not preserve
+unbounded retention behavior for compatibility. This is private pre-v1 software,
+and bounded memory is the more important contract.
+
+## Implementation Plan
+
+1. Add lifecycle structs and focused unit tests.
+
+Create `FavnRunner.ExecutionLifecycle` and
+`FavnRunner.ExecutionLifecycle.Execution`. Move only state operations first:
+running insertion, completed insertion, finalization, result lookup, worker
+monitor mapping, waiter storage, log subscriber membership, log append, event
+append, and diagnostics counts. Keep behavior equivalent except for explicit
+state shapes.
+
+2. Move `FavnRunner.Server` to lifecycle-owned state.
+
+Change server state from anonymous maps to `%ExecutionLifecycle{}` plus any
+non-lifecycle fields that remain. Server callbacks should delegate state changes
+to lifecycle functions and perform process side effects around returned cleanup
+instructions.
+
+3. Add bounded completed-execution and buffer retention.
+
+Implement count-based completed retention and per-execution log/event limits.
+Apply retention on finalization and on append. Return cleanup instructions for
+evicted subscribers and waiters if any retained state is removed. Add diagnostics
+counters for evicted completed executions and dropped log/event entries.
+
+4. Add explicit waiter and subscriber cleanup.
+
+Monitor waiter caller pids and subscriber pids. Handle waiter `:DOWN` and
+subscriber `:DOWN` separately from worker `:DOWN`. Ensure monitors are
+demonitored when no longer needed.
+
+5. Tighten server tests around race behavior.
+
+Preserve existing cancellation, late result, worker crash, await timeout,
+invalid argument, and log forwarding tests. Add regression tests for retention,
+dead subscribers, abandoned waiters, and concurrent diagnostics.
+
+6. Update structure documentation if the module lands.
+
+After implementation, update `docs/structure/favn_runner.md` to name
+`FavnRunner.ExecutionLifecycle` as the owner of runner execution lifecycle state,
+retention, waiter cleanup, subscriber cleanup, and diagnostics counts.
+
+## Test Plan
+
+Add focused tests at the runner layer:
+
+- `ExecutionLifecycle` unit tests for running insertion, finalization,
+  idempotent late result handling, monitor lookup, waiter add/pop, subscriber
+  add/remove, and diagnostics counts.
+- Retention tests proving the oldest completed executions are evicted and
+  running executions are never evicted.
+- Log buffer tests proving replay order is chronological and oldest entries are
+  dropped after `max_logs_per_execution`.
+- Event buffer tests proving oldest entries are dropped after
+  `max_events_per_execution`.
+- Server tests proving `await_result/3` returns retained results and returns
+  `{:error, :execution_not_found}` after retention eviction.
+- Server tests proving dead log subscribers are removed on process death and do
+  not receive later entries.
+- Server tests proving abandoned await callers are removed on process death and
+  do not leave stale waiters.
+- Server tests proving worker crash finalizes once and a late result cannot
+  overwrite crash or cancellation terminal state.
+- Diagnostics tests proving counts reflect concurrent running executions,
+  retained completed executions, waiters, subscribers, evictions, and dropped
+  buffers.
+
+Run the narrow runner checks first:
+
+```bash
+MIX_ENV=test mix do --app favn_runner cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser
+```
+
+Before finishing the implementation branch, run:
+
+```bash
+mix format
+mix compile --warnings-as-errors
+mix test
+```
+
+## Out Of Scope
+
+- Changing `Favn.Contracts.RunnerClient` or orchestrator-to-runner public return
+  shapes.
+- Moving lifecycle state into `favn_core`.
+- Introducing admission control or execution concurrency limits. The lifecycle
+  extraction should make that future work easier, but it should not implement it.
+- Reworking worker asset execution, SQL runtime behavior, SQL session pooling,
+  manifest registration, or relation inspection.
+- Adding a second supervised lifecycle process unless a later design identifies
+  a concrete concurrency or isolation need.
+- Removing the currently unused `FavnRunner.ExecutionRegistry` application child
+  unless implementation confirms it has no planned role in the lifecycle design.
+
+## Risks And Mitigations
+
+- Risk: Retention eviction can surprise callers that await very late.
+  Mitigation: Use generous count defaults, document the behavior in diagnostics,
+  and keep orchestrator usage on submit-then-await paths.
+- Risk: Monitor bookkeeping can become more complex than the current maps.
+  Mitigation: centralize monitor ownership in `ExecutionLifecycle` and test each
+  cleanup path directly.
+- Risk: Extracting too many helpers recreates the same ambiguity in more files.
+  Mitigation: start with one lifecycle module and one execution struct; add
+  smaller modules only when a real contract appears.
+- Risk: Log replay semantics can change while adding bounds.
+  Mitigation: test chronological replay order and oldest-entry pruning explicitly.
+- Risk: A new lifecycle process would create message-ordering races.
+  Mitigation: keep lifecycle as server-owned state in phase 1.
+
+## Acceptance Criteria
+
+- `FavnRunner.Server` no longer directly mutates execution, waiter, subscriber,
+  monitor, or retention maps.
+- `FavnRunner.ExecutionLifecycle` owns all runner execution lifecycle state and
+  exposes typed transition functions.
+- Completed executions and per-execution log/event buffers are bounded by
+  explicit retention policy.
+- Dead log subscribers and abandoned waiters are cleaned through monitors.
+- Cancellation, worker crash, timeout, late result, and completion races finalize
+  executions exactly once.
+- Diagnostics expose lifecycle counts and retention pressure.
+- `FavnRunner`, `Favn.Contracts.RunnerClient`, and orchestrator-facing runner
+  behavior stay stable except for documented bounded retention eviction.
+- Focused runner tests cover lifecycle transitions, retention, cleanup, races,
+  and diagnostics.

--- a/docs/ISSUE_392_RUNNER_EXECUTION_LIFECYCLE_PLAN.md
+++ b/docs/ISSUE_392_RUNNER_EXECUTION_LIFECYCLE_PLAN.md
@@ -162,6 +162,9 @@ Recommended defaults:
 }
 ```
 
+Production runner supervision reads these values from
+`config :favn_runner, :execution_retention, ...`.
+
 Rules:
 
 - Completed executions remain awaitable only while retained.

--- a/docs/structure/favn_runner.md
+++ b/docs/structure/favn_runner.md
@@ -12,6 +12,10 @@ Code:
 - `apps/favn_runner/lib/favn_runner/sql_runtime_preflight.ex` validates planned SQL
   connection runtime config from explicit runner work planned scope before worker
   execution begins
+- `apps/favn_runner/lib/favn_runner/execution_lifecycle.ex` owns runner execution
+  lifecycle state, worker/waiter/subscriber monitor bookkeeping, bounded
+  completed-execution retention, bounded log/event buffers, and lifecycle
+  diagnostics counts
 - `apps/favn_runner/lib/favn_runner/runtime_config_diagnostic.ex` normalizes
   runner runtime-config failures into stable redacted run diagnostics
 - `apps/favn_runner/lib/favn_runner/sql/materialization_planner.ex` owns runner SQL

--- a/docs/structure/favn_runner.md
+++ b/docs/structure/favn_runner.md
@@ -15,7 +15,8 @@ Code:
 - `apps/favn_runner/lib/favn_runner/execution_lifecycle.ex` owns runner execution
   lifecycle state, worker/waiter/subscriber monitor bookkeeping, bounded
   completed-execution retention, bounded log/event buffers, and lifecycle
-  diagnostics counts
+  diagnostics counts. Production retention is configured with
+  `config :favn_runner, :execution_retention, ...`.
 - `apps/favn_runner/lib/favn_runner/runtime_config_diagnostic.ex` normalizes
   runner runtime-config failures into stable redacted run diagnostics
 - `apps/favn_runner/lib/favn_runner/sql/materialization_planner.ex` owns runner SQL


### PR DESCRIPTION
## Summary
- Extract runner execution lifecycle state into explicit internal structs owned by `FavnRunner.ExecutionLifecycle`.
- Add bounded completed-execution retention plus bounded per-execution log and event buffers.
- Add waiter/subscriber monitor cleanup and lifecycle diagnostics for production memory pressure.

## Verification
- `mix format`
- `mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_runner cmd mix test --exclude acceptance --exclude slow --exclude browser`

Closes #392