### PR TITLE
Use PubSub-driven LiveView refreshes

### DIFF
--- a/apps/favn_view/assets/js/app.js
+++ b/apps/favn_view/assets/js/app.js
@@ -49,10 +49,9 @@ const Hooks = {
         const button = event.target.closest("[data-copy-logs]")
         if (!button) return
 
-        const source = document.getElementById(this.el.dataset.copySource)
-        if (!source) return
-
-        navigator.clipboard?.writeText(source.value)
+        const rows = Array.from(this.el.querySelectorAll("[data-log-copy-row]"))
+        const text = rows.map(row => row.innerText.trim()).filter(Boolean).join("\n\n")
+        navigator.clipboard?.writeText(text)
       })
     },
     updated() {

--- a/apps/favn_view/assets/js/app.js
+++ b/apps/favn_view/assets/js/app.js
@@ -50,7 +50,7 @@ const Hooks = {
         if (!button) return
 
         const rows = Array.from(this.el.querySelectorAll("[data-log-copy-row]"))
-        const text = rows.map(row => row.innerText.trim()).filter(Boolean).join("\n\n")
+        const text = rows.map(row => row.dataset.logCopyText || "").filter(Boolean).join("\n\n")
         navigator.clipboard?.writeText(text)
       })
     },

--- a/apps/favn_view/lib/favn_view/components/log_viewer.ex
+++ b/apps/favn_view/lib/favn_view/components/log_viewer.ex
@@ -31,7 +31,6 @@ defmodule FavnView.Components.LogViewer do
       assigns
       |> assign(:levels, LogsViewModel.levels())
       |> assign(:sources, LogsViewModel.sources())
-      |> assign(:copy_text, LogsViewModel.plain_text(assigns.visible_logs))
 
     ~H"""
     <section
@@ -97,11 +96,8 @@ defmodule FavnView.Components.LogViewer do
           id="log-terminal"
           phx-hook="FavnLogViewer"
           data-live-tail={to_string(@live_tail?)}
-          data-copy-source="log-copy-text"
           class="relative flex min-h-0 flex-1 flex-col border-t border-base-content/10 bg-base-100/55 p-4 sm:p-5"
         >
-          <textarea id="log-copy-text" class="hidden" readonly>{@copy_text}</textarea>
-
           <div
             :if={@status == :loading}
             class="flex min-h-[16rem] flex-1 items-center justify-center rounded-box border border-dashed border-base-content/15 p-8 text-center text-sm text-base-content/55"
@@ -137,7 +133,7 @@ defmodule FavnView.Components.LogViewer do
             ]}
             data-testid="log-terminal-window"
           >
-            <div class="min-w-max space-y-5">
+            <div class="min-w-max space-y-5" data-log-copy-rows>
               <.log_row :for={log <- @visible_logs} log={log} wrap?={@wrap?} />
             </div>
           </div>
@@ -170,6 +166,7 @@ defmodule FavnView.Components.LogViewer do
             value={@search_query}
             placeholder="Search logs..."
             class="grow"
+            phx-debounce="250"
             data-testid="log-search-input"
           />
         </label>
@@ -319,6 +316,7 @@ defmodule FavnView.Components.LogViewer do
     <article
       class="grid gap-2 text-slate-100/90 sm:grid-cols-[9.5rem_4.5rem_13rem_minmax(0,1fr)]"
       data-testid="log-row"
+      data-log-copy-row
       title={sequence_title(@log)}
     >
       <time class="text-slate-400">{@log.timestamp}</time>

--- a/apps/favn_view/lib/favn_view/components/log_viewer.ex
+++ b/apps/favn_view/lib/favn_view/components/log_viewer.ex
@@ -317,6 +317,7 @@ defmodule FavnView.Components.LogViewer do
       class="grid gap-2 text-slate-100/90 sm:grid-cols-[9.5rem_4.5rem_13rem_minmax(0,1fr)]"
       data-testid="log-row"
       data-log-copy-row
+      data-log-copy-text={log_copy_text(@log)}
       title={sequence_title(@log)}
     >
       <time class="text-slate-400">{@log.timestamp}</time>

--- a/apps/favn_view/lib/favn_view/components/run_detail_page/timeline.ex
+++ b/apps/favn_view/lib/favn_view/components/run_detail_page/timeline.ex
@@ -111,6 +111,7 @@ defmodule FavnView.Components.RunDetailPage.Timeline do
           value={@timeline_state.search}
           placeholder="Search assets..."
           class="grow"
+          phx-debounce="250"
         />
       </label>
       <select

--- a/apps/favn_view/lib/favn_view/components/runs_list_page.ex
+++ b/apps/favn_view/lib/favn_view/components/runs_list_page.ex
@@ -174,6 +174,7 @@ defmodule FavnView.Components.RunsListPage do
             value={@filters["search"]}
             placeholder="Search runs..."
             class="grow"
+            phx-debounce="250"
             data-testid="execution-group-search"
           />
         </label>

--- a/apps/favn_view/lib/favn_view/live_refresh.ex
+++ b/apps/favn_view/lib/favn_view/live_refresh.ex
@@ -1,0 +1,36 @@
+defmodule FavnView.LiveRefresh do
+  @moduledoc false
+
+  import Phoenix.Component, only: [assign: 3]
+
+  @type assign_key :: atom()
+  @type message :: atom()
+  @type token :: reference()
+
+  @spec init(Phoenix.LiveView.Socket.t(), [assign_key()]) :: Phoenix.LiveView.Socket.t()
+  def init(socket, keys) when is_list(keys) do
+    Enum.reduce(keys, socket, &assign(&2, &1, nil))
+  end
+
+  @spec schedule_once(Phoenix.LiveView.Socket.t(), assign_key(), message(), non_neg_integer()) ::
+          Phoenix.LiveView.Socket.t()
+  def schedule_once(socket, key, message, delay_ms) do
+    if Map.get(socket.assigns, key) do
+      socket
+    else
+      token = make_ref()
+      Process.send_after(self(), {message, token}, delay_ms)
+      assign(socket, key, token)
+    end
+  end
+
+  @spec take(Phoenix.LiveView.Socket.t(), assign_key(), token()) ::
+          {:ok, Phoenix.LiveView.Socket.t()} | {:stale, Phoenix.LiveView.Socket.t()}
+  def take(socket, key, token) do
+    if Map.get(socket.assigns, key) == token do
+      {:ok, assign(socket, key, nil)}
+    else
+      {:stale, socket}
+    end
+  end
+end

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -386,7 +386,7 @@ defmodule FavnView.RunDetailLive do
          ) do
       {:ok, []} -> socket
       {:ok, events} -> reload_run_from_event(socket, latest_sequence(events, after_sequence))
-      {:error, _reason} -> socket
+      {:error, _reason} -> refresh_run(socket)
     end
   end
 

--- a/apps/favn_view/lib/favn_view/run_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/run_detail_live.ex
@@ -7,9 +7,11 @@ defmodule FavnView.RunDetailLive do
   alias FavnView.Auth.Scope
   alias FavnView.Components.AssetCataloguePage
   alias FavnView.Components.RunDetailPage
+  alias FavnView.LiveRefresh
   alias FavnView.LogsViewModel
 
   @refresh_interval_ms 1_500
+  @coalesce_refresh_ms 100
   @active_statuses [:pending, :running]
   @valid_modes ~w(overview timeline failures windows events)
   @timeline_zoom_levels ~w(5m 15m 30m 1h 6h full)
@@ -23,6 +25,7 @@ defmodule FavnView.RunDetailLive do
         run_id: run_id,
         run: run,
         run_event_sequence: latest_event_sequence(run),
+        pending_run_event_sequence: nil,
         run_events_live?: false,
         active_mode: :overview,
         timeline_state: default_timeline_state(run),
@@ -30,21 +33,40 @@ defmodule FavnView.RunDetailLive do
         selected_attempt_id: nil,
         nav_items: AssetCataloguePage.nav_items(:runs)
       )
+      |> LiveRefresh.init([:refresh_timer_ref, :fallback_poll_ref])
       |> maybe_subscribe_run()
-      |> maybe_schedule_refresh()
+      |> maybe_schedule_fallback_poll()
 
     {:ok, socket}
   end
 
   @impl true
-  def handle_info(:refresh_run, socket) do
-    run = load_run(socket.assigns.run_id, socket.assigns.run[:back_asset_href])
+  def handle_info({:refresh_run, token}, socket) do
+    case LiveRefresh.take(socket, :refresh_timer_ref, token) do
+      {:ok, socket} ->
+        {:noreply, refresh_run(socket)}
 
-    {:noreply,
-     socket
-     |> assign(:run, run)
-     |> assign(:run_event_sequence, latest_event_sequence(run, socket.assigns.run_event_sequence))
-     |> maybe_schedule_refresh()}
+      {:stale, socket} ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_info({:poll_run, token}, socket) do
+    case LiveRefresh.take(socket, :fallback_poll_ref, token) do
+      {:ok, socket} ->
+        {:noreply, socket |> refresh_run() |> maybe_schedule_fallback_poll()}
+
+      {:stale, socket} ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_info(:refresh_run, socket) do
+    {:noreply, refresh_run(socket)}
+  end
+
+  def handle_info(:poll_run, socket) do
+    {:noreply, socket |> refresh_run() |> maybe_schedule_fallback_poll()}
   end
 
   def handle_info(
@@ -53,7 +75,12 @@ defmodule FavnView.RunDetailLive do
       ) do
     socket =
       if fresh_run_event?(event, socket.assigns.run_event_sequence) do
-        reload_run_from_event(socket, Map.get(event, :sequence))
+        socket
+        |> assign(
+          :pending_run_event_sequence,
+          latest_sequence([event], socket.assigns.pending_run_event_sequence)
+        )
+        |> schedule_coalesced_refresh()
       else
         socket
       end
@@ -62,6 +89,19 @@ defmodule FavnView.RunDetailLive do
   end
 
   def handle_info({:favn_run_event, _event}, socket), do: {:noreply, socket}
+
+  defp refresh_run(socket) do
+    event_sequence =
+      socket.assigns.pending_run_event_sequence || socket.assigns.run_event_sequence
+
+    run = load_run(socket.assigns.run_id, socket.assigns.run[:back_asset_href])
+
+    socket
+    |> assign(:run, run)
+    |> assign(:pending_run_event_sequence, nil)
+    |> assign(:run_event_sequence, latest_event_sequence(run, event_sequence))
+    |> maybe_schedule_fallback_poll()
+  end
 
   @impl true
   def handle_event("set_mode", %{"mode" => mode}, socket) when mode in @valid_modes do
@@ -206,14 +246,14 @@ defmodule FavnView.RunDetailLive do
   @impl true
   def terminate(_reason, socket) do
     if socket.assigns[:run_events_live?] do
-      FavnOrchestrator.unsubscribe_run(socket.assigns.run.subscribed_run_id)
+      unsubscribe_run(socket.assigns.run.subscribed_run_id)
     end
 
     :ok
   end
 
   defp load_run(run_id, existing_back_asset_href \\ nil) do
-    case FavnOrchestrator.get_operator_run_detail(run_id, include: [:events], event_limit: 200) do
+    case get_operator_run_detail(run_id, include: [:events], event_limit: 200) do
       {:ok, detail} -> detail_from_execution_group(detail, run_id, existing_back_asset_href)
       {:error, reason} -> %{id: run_id, found?: false, error: error_label(reason)}
     end
@@ -299,16 +339,29 @@ defmodule FavnView.RunDetailLive do
     }
   end
 
-  defp maybe_schedule_refresh(%{assigns: %{run: %{active?: true}}} = socket) do
-    if connected?(socket), do: Process.send_after(self(), :refresh_run, @refresh_interval_ms)
-    socket
+  defp schedule_coalesced_refresh(socket) do
+    if connected?(socket) do
+      LiveRefresh.schedule_once(socket, :refresh_timer_ref, :refresh_run, @coalesce_refresh_ms)
+    else
+      socket
+    end
   end
 
-  defp maybe_schedule_refresh(socket), do: socket
+  defp maybe_schedule_fallback_poll(%{assigns: %{run_events_live?: true}} = socket), do: socket
+
+  defp maybe_schedule_fallback_poll(%{assigns: %{run: %{active?: true}}} = socket) do
+    if connected?(socket) do
+      LiveRefresh.schedule_once(socket, :fallback_poll_ref, :poll_run, @refresh_interval_ms)
+    else
+      socket
+    end
+  end
+
+  defp maybe_schedule_fallback_poll(socket), do: socket
 
   defp maybe_subscribe_run(%{assigns: %{run: %{subscribed_run_id: run_id}}} = socket) do
     if connected?(socket) do
-      case FavnOrchestrator.subscribe_run(run_id) do
+      case subscribe_run(run_id) do
         :ok -> socket |> assign(:run_events_live?, true) |> replay_run_event_gap()
         {:error, _reason} -> socket
       end
@@ -327,7 +380,7 @@ defmodule FavnView.RunDetailLive do
   defp replay_run_event_gap(socket) do
     after_sequence = socket.assigns.run_event_sequence || 0
 
-    case FavnOrchestrator.list_run_stream_events(socket.assigns.run.subscribed_run_id,
+    case list_run_stream_events(socket.assigns.run.subscribed_run_id,
            after_sequence: after_sequence,
            limit: 200
          ) do
@@ -338,12 +391,33 @@ defmodule FavnView.RunDetailLive do
   end
 
   defp reload_run_from_event(socket, event_sequence) do
-    run = load_run(socket.assigns.run_id, socket.assigns.run[:back_asset_href])
-
     socket
-    |> assign(:run, run)
-    |> assign(:run_event_sequence, latest_event_sequence(run, event_sequence))
-    |> maybe_schedule_refresh()
+    |> assign(:pending_run_event_sequence, event_sequence)
+    |> refresh_run()
+  end
+
+  defp get_operator_run_detail(run_id, opts) do
+    Application.get_env(
+      :favn_view,
+      :operator_run_detail_fun,
+      &FavnOrchestrator.get_operator_run_detail/2
+    ).(run_id, opts)
+  end
+
+  defp subscribe_run(run_id) do
+    Application.get_env(:favn_view, :run_subscribe_fun, &FavnOrchestrator.subscribe_run/1).(
+      run_id
+    )
+  end
+
+  defp unsubscribe_run(run_id), do: FavnOrchestrator.unsubscribe_run(run_id)
+
+  defp list_run_stream_events(run_id, opts) do
+    Application.get_env(
+      :favn_view,
+      :run_stream_events_fun,
+      &FavnOrchestrator.list_run_stream_events/2
+    ).(run_id, opts)
   end
 
   defp patch_run_state(socket, updates) do

--- a/apps/favn_view/lib/favn_view/runs_list_live.ex
+++ b/apps/favn_view/lib/favn_view/runs_list_live.ex
@@ -4,9 +4,11 @@ defmodule FavnView.RunsListLive do
   use FavnView, :live_view
 
   alias FavnView.Components.RunsListPage
+  alias FavnView.LiveRefresh
   alias FavnView.LogsViewModel
 
   @refresh_interval_ms 1_500
+  @coalesce_refresh_ms 100
   @active_statuses [:queued, :running, :incomplete]
   @valid_modes ~w(list)
   @default_filters %{
@@ -41,31 +43,53 @@ defmodule FavnView.RunsListLive do
         run_events_live?: false,
         nav_items: RunsListPage.nav_items(:runs)
       )
+      |> LiveRefresh.init([:refresh_timer_ref, :fallback_poll_ref])
       |> maybe_subscribe_runs()
-      |> maybe_schedule_refresh()
+      |> maybe_schedule_fallback_poll()
 
     {:ok, socket}
   end
 
   @impl true
-  def handle_info(:refresh_runs, socket) do
-    {groups, error} = load_groups(socket.assigns.filters)
+  def handle_info({:refresh_runs, token}, socket) do
+    case LiveRefresh.take(socket, :refresh_timer_ref, token) do
+      {:ok, socket} ->
+        {:noreply, refresh_runs(socket)}
 
-    {:noreply,
-     socket
-     |> assign_groups(groups, error)
-     |> refresh_expanded_details()
-     |> maybe_schedule_refresh()}
+      {:stale, socket} ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_info({:poll_runs, token}, socket) do
+    case LiveRefresh.take(socket, :fallback_poll_ref, token) do
+      {:ok, socket} ->
+        {:noreply, socket |> refresh_runs() |> maybe_schedule_fallback_poll()}
+
+      {:stale, socket} ->
+        {:noreply, socket}
+    end
+  end
+
+  def handle_info(:refresh_runs, socket) do
+    {:noreply, refresh_runs(socket)}
+  end
+
+  def handle_info(:poll_runs, socket) do
+    {:noreply, socket |> refresh_runs() |> maybe_schedule_fallback_poll()}
   end
 
   def handle_info({:favn_run_event, _event}, socket) do
+    {:noreply, schedule_coalesced_refresh(socket)}
+  end
+
+  defp refresh_runs(socket) do
     {groups, error} = load_groups(socket.assigns.filters)
 
-    {:noreply,
-     socket
-     |> assign_groups(groups, error)
-     |> refresh_expanded_details()
-     |> maybe_schedule_refresh()}
+    socket
+    |> assign_groups(groups, error)
+    |> refresh_expanded_details()
+    |> maybe_schedule_fallback_poll()
   end
 
   @impl true
@@ -134,32 +158,42 @@ defmodule FavnView.RunsListLive do
   @impl true
   def terminate(_reason, socket) do
     if socket.assigns[:run_events_live?] do
-      FavnOrchestrator.unsubscribe_runs()
+      unsubscribe_runs()
     end
 
     :ok
   end
 
   defp load_groups(filters) do
-    case FavnOrchestrator.page_execution_groups(orchestrator_filters(filters)) do
+    case page_execution_groups(orchestrator_filters(filters)) do
       {:ok, %{items: groups}} -> {Enum.map(groups, &group_from_public/1), nil}
       {:error, reason} -> {[], inspect(reason)}
     end
   end
 
-  defp maybe_schedule_refresh(%{assigns: %{groups: groups}} = socket) do
-    if connected?(socket) and Enum.any?(groups, &active_status?(&1.status)) do
-      Process.send_after(self(), :refresh_runs, @refresh_interval_ms)
+  defp schedule_coalesced_refresh(socket) do
+    if connected?(socket) do
+      LiveRefresh.schedule_once(socket, :refresh_timer_ref, :refresh_runs, @coalesce_refresh_ms)
+    else
+      socket
     end
-
-    socket
   end
 
-  defp maybe_schedule_refresh(socket), do: socket
+  defp maybe_schedule_fallback_poll(%{assigns: %{run_events_live?: true}} = socket), do: socket
+
+  defp maybe_schedule_fallback_poll(%{assigns: %{groups: groups}} = socket) do
+    if connected?(socket) and Enum.any?(groups, &active_status?(&1.status)) do
+      LiveRefresh.schedule_once(socket, :fallback_poll_ref, :poll_runs, @refresh_interval_ms)
+    else
+      socket
+    end
+  end
+
+  defp maybe_schedule_fallback_poll(socket), do: socket
 
   defp maybe_subscribe_runs(socket) do
     if connected?(socket) do
-      case FavnOrchestrator.subscribe_runs() do
+      case subscribe_runs() do
         :ok -> assign(socket, :run_events_live?, true)
         {:error, _reason} -> socket
       end
@@ -167,6 +201,20 @@ defmodule FavnView.RunsListLive do
       socket
     end
   end
+
+  defp page_execution_groups(opts) do
+    Application.get_env(
+      :favn_view,
+      :page_execution_groups_fun,
+      &FavnOrchestrator.page_execution_groups/1
+    ).(opts)
+  end
+
+  defp subscribe_runs do
+    Application.get_env(:favn_view, :runs_subscribe_fun, &FavnOrchestrator.subscribe_runs/0).()
+  end
+
+  defp unsubscribe_runs, do: FavnOrchestrator.unsubscribe_runs()
 
   defp assign_groups(socket, groups, error) do
     assign(socket,

--- a/apps/favn_view/lib/favn_view/runs_list_live.ex
+++ b/apps/favn_view/lib/favn_view/runs_list_live.ex
@@ -194,7 +194,7 @@ defmodule FavnView.RunsListLive do
   defp maybe_subscribe_runs(socket) do
     if connected?(socket) do
       case subscribe_runs() do
-        :ok -> assign(socket, :run_events_live?, true)
+        :ok -> socket |> assign(:run_events_live?, true) |> schedule_coalesced_refresh()
         {:error, _reason} -> socket
       end
     else

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -248,6 +248,7 @@ defmodule FavnView.PageLiveTest do
     end)
 
     {:ok, _view, _html} = live(conn, ~p"/runs")
+    Process.sleep(150)
     baseline = counter_value(counter)
 
     Process.sleep(1_700)
@@ -2493,8 +2494,9 @@ defmodule FavnView.PageLiveTest do
 
     html = render(view)
     assert html =~ "live append"
-    refute html =~ "log-copy-text"
+    refute html =~ ~s(id="log-copy-text")
     assert html =~ "data-log-copy-row"
+    assert html =~ "data-log-copy-text"
     assert Regex.scan(~r/data-testid="log-row"/, html) |> length() == 1
   end
 

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -90,6 +90,7 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="execution-groups-table"]))
     assert has_element?(view, ~s([data-testid="execution-group-card-list"]))
     assert has_element?(view, ~s([data-testid="runs-summary-band"]))
+    assert html =~ ~s(phx-debounce="250")
 
     assert has_element?(view, ~s(a[href="/runs/run_customer_orders_daily"]), "run_custo..._daily")
     assert html =~ "customer_orders_daily"
@@ -234,6 +235,42 @@ defmodule FavnView.PageLiveTest do
              ~s([data-testid="runs-filtered-empty-state"]),
              "No runs found"
            )
+  end
+
+  test "runs list does not poll when run event subscription succeeds", %{conn: conn} do
+    counter = start_counter!()
+
+    put_test_env(:runs_subscribe_fun, fn -> :ok end)
+
+    put_test_env(:page_execution_groups_fun, fn opts ->
+      bump_counter(counter)
+      FavnOrchestrator.page_execution_groups(opts)
+    end)
+
+    {:ok, _view, _html} = live(conn, ~p"/runs")
+    baseline = counter_value(counter)
+
+    Process.sleep(1_700)
+
+    assert counter_value(counter) == baseline
+  end
+
+  test "runs list uses fallback polling when run event subscription fails", %{conn: conn} do
+    counter = start_counter!()
+
+    put_test_env(:runs_subscribe_fun, fn -> {:error, :unavailable} end)
+
+    put_test_env(:page_execution_groups_fun, fn opts ->
+      bump_counter(counter)
+      FavnOrchestrator.page_execution_groups(opts)
+    end)
+
+    {:ok, _view, _html} = live(conn, ~p"/runs")
+    baseline = counter_value(counter)
+
+    Process.sleep(1_700)
+
+    assert counter_value(counter) > baseline
   end
 
   test "renders the pipelines list", %{conn: conn} do
@@ -1016,6 +1053,49 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="run-overview-panel"][data-run-active="false"]))
   end
 
+  test "run detail does not poll when run event subscription succeeds", %{conn: conn} do
+    counter = start_counter!()
+
+    put_test_env(:run_subscribe_fun, fn _run_id -> :ok end)
+    put_test_env(:run_stream_events_fun, fn _run_id, _opts -> {:ok, []} end)
+
+    put_test_env(:operator_run_detail_fun, fn run_id, opts ->
+      bump_counter(counter)
+      operator_run_detail(run_id, opts)
+    end)
+
+    {:ok, _view, html} = live(conn, ~p"/runs/run_empty_running?view=timeline")
+    assert html =~ ~s(phx-debounce="250")
+
+    baseline = counter_value(counter)
+
+    Process.sleep(1_700)
+
+    assert counter_value(counter) == baseline
+  end
+
+  test "run detail coalesces live run event bursts", %{conn: conn} do
+    counter = start_counter!()
+
+    put_test_env(:run_subscribe_fun, fn _run_id -> :ok end)
+    put_test_env(:run_stream_events_fun, fn _run_id, _opts -> {:ok, []} end)
+
+    put_test_env(:operator_run_detail_fun, fn run_id, opts ->
+      bump_counter(counter)
+      operator_run_detail(run_id, opts)
+    end)
+
+    {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
+    baseline = counter_value(counter)
+
+    send(view.pid, {:favn_run_event, %{run_id: "run_empty_running", sequence: 100}})
+    send(view.pid, {:favn_run_event, %{run_id: "run_empty_running", sequence: 101}})
+
+    Process.sleep(150)
+
+    assert counter_value(counter) == baseline + 1
+  end
+
   test "run detail reloads from live run events", %{conn: conn} do
     {:ok, view, _html} = live(conn, ~p"/runs/run_empty_running")
 
@@ -1040,6 +1120,7 @@ defmodule FavnView.PageLiveTest do
 
     assert :ok = Storage.persist_run_transition(terminal_run, event)
     send(view.pid, {:favn_run_event, RunEvent.from_map(event)})
+    Process.sleep(150)
 
     assert render(view) =~ "Succeeded"
     assert has_element?(view, ~s([data-testid="run-overview-panel"][data-run-active="false"]))
@@ -2412,6 +2493,8 @@ defmodule FavnView.PageLiveTest do
 
     html = render(view)
     assert html =~ "live append"
+    refute html =~ "log-copy-text"
+    assert html =~ "data-log-copy-row"
     assert Regex.scan(~r/data-testid="log-row"/, html) |> length() == 1
   end
 
@@ -3263,6 +3346,29 @@ defmodule FavnView.PageLiveTest do
     view
     |> element(~s([data-testid="run-selected-window"]), "Run asset")
     |> render_click()
+  end
+
+  defp start_counter! do
+    start_supervised!({Agent, fn -> 0 end})
+  end
+
+  defp bump_counter(counter), do: Agent.update(counter, &(&1 + 1))
+  defp counter_value(counter), do: Agent.get(counter, & &1)
+
+  defp put_test_env(key, value) do
+    original = Application.get_env(:favn_view, key, :__missing__)
+    Application.put_env(:favn_view, key, value)
+
+    on_exit(fn ->
+      case original do
+        :__missing__ -> Application.delete_env(:favn_view, key)
+        value -> Application.put_env(:favn_view, key, value)
+      end
+    end)
+  end
+
+  defp operator_run_detail(run_id, opts) do
+    apply(FavnOrchestrator, :get_operator_run_detail, [run_id, opts])
   end
 
   defp assert_submitted_refresh(run_path, dependencies, refresh_policy) do


### PR DESCRIPTION
## Summary
- Make run detail and runs list LiveViews use successful PubSub subscriptions as the primary refresh path, with polling retained only as fallback.
- Add coalesced refresh timer bookkeeping to collapse event bursts into one reload per LiveView process.
- Debounce search inputs and avoid rendering the full log copy payload on every log viewer render.

## Verification
- `MIX_ENV=test mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_view cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser`

Note: focused `favn_view` verification was used per issue scope.