### PR TITLE
Batch backfill storage writes

### DIFF
--- a/apps/favn_orchestrator/lib/favn/storage/adapter.ex
+++ b/apps/favn_orchestrator/lib/favn/storage/adapter.ex
@@ -150,6 +150,8 @@ defmodule Favn.Storage.Adapter do
 
   @callback put_backfill_window(BackfillWindow.t(), adapter_opts()) ::
               :ok | {:error, error()}
+  @callback put_backfill_windows([BackfillWindow.t()], adapter_opts()) ::
+              :ok | {:error, error()}
   @callback get_backfill_window(String.t(), module(), String.t(), adapter_opts()) ::
               {:ok, BackfillWindow.t()} | {:error, error()}
   @callback list_backfill_windows(filter_opts(), adapter_opts()) ::
@@ -167,6 +169,8 @@ defmodule Favn.Storage.Adapter do
               {:ok, BackfillProgress.t()} | {:error, error()}
 
   @callback put_asset_window_state(AssetWindowState.t(), adapter_opts()) ::
+              :ok | {:error, error()}
+  @callback put_asset_window_states([AssetWindowState.t()], adapter_opts()) ::
               :ok | {:error, error()}
   @callback get_asset_window_state(module(), atom(), String.t(), adapter_opts()) ::
               {:ok, AssetWindowState.t()} | {:error, error()}
@@ -247,6 +251,8 @@ defmodule Favn.Storage.Adapter do
                       list_execution_groups: 2,
                       list_run_events: 3,
                       list_execution_group_events: 3,
+                      put_backfill_windows: 2,
+                      put_asset_window_states: 2,
                       put_asset_freshness_state: 2,
                       get_asset_freshness_state: 4,
                       list_asset_freshness_states: 2,

--- a/apps/favn_orchestrator/lib/favn/storage/adapter.ex
+++ b/apps/favn_orchestrator/lib/favn/storage/adapter.ex
@@ -12,6 +12,12 @@ defmodule Favn.Storage.Adapter do
   state. Adapters should preserve the same upsert and filtering semantics across
   memory, SQLite, and Postgres.
 
+  Bulk read-model callbacks must be semantically equivalent to applying the
+  corresponding single-row put callback to each row in list order. When a bulk
+  input contains duplicate natural keys, the last row in the list wins. Adapters
+  may coalesce duplicates before writing, but the externally visible result must
+  not depend on chunk size or database-specific duplicate handling.
+
   Adapter startup is optional. `child_spec/1` returns `:none` when no supervised
   process is required or when the adapter runtime is already started, and may
   return `{:error, reason}` for recoverable configuration errors.

--- a/apps/favn_orchestrator/lib/favn_orchestrator/asset_window_projector.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/asset_window_projector.ex
@@ -23,12 +23,17 @@ defmodule FavnOrchestrator.AssetWindowProjector do
       when event_type in @terminal_events do
     run_state
     |> node_results()
-    |> Enum.reduce_while(:ok, fn result, :ok ->
-      case put_asset_window_state(run_state, result) do
-        :ok -> {:cont, :ok}
+    |> Enum.reduce_while({:ok, []}, fn result, {:ok, acc} ->
+      case asset_window_state(run_state, result) do
+        {:ok, nil} -> {:cont, {:ok, acc}}
+        {:ok, state} -> {:cont, {:ok, [state | acc]}}
         {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
+    |> case do
+      {:ok, states} -> Storage.put_asset_window_states(Enum.reverse(states))
+      {:error, reason} -> {:error, reason}
+    end
   end
 
   def project_transition(%RunState{}, _event_type, _data), do: :ok
@@ -38,25 +43,25 @@ defmodule FavnOrchestrator.AssetWindowProjector do
 
   defp node_results(_run_state), do: []
 
-  defp put_asset_window_state(
+  defp asset_window_state(
          %RunState{} = run_state,
          %NodeResult{window: %Runtime{} = window} = result
        ) do
-    put_asset_window_state(run_state, Map.from_struct(result), window)
+    asset_window_state(run_state, Map.from_struct(result), window)
   end
 
-  defp put_asset_window_state(%RunState{} = run_state, %{window: %Runtime{} = window} = result) do
-    put_asset_window_state(run_state, result, window)
+  defp asset_window_state(%RunState{} = run_state, %{window: %Runtime{} = window} = result) do
+    asset_window_state(run_state, result, window)
   end
 
-  defp put_asset_window_state(_run_state, _result), do: :ok
+  defp asset_window_state(_run_state, _result), do: {:ok, nil}
 
-  defp put_asset_window_state(%RunState{} = run_state, result, %Runtime{} = window) do
+  defp asset_window_state(%RunState{} = run_state, result, %Runtime{} = window) do
     with {:ok, {module, name}} <- result_ref(result),
          {:ok, status} <- result_status(result),
          {:ok, existing} <- existing_state(module, name, Key.encode(window.key)),
          {:ok, state} <- build_state(run_state, result, window, module, name, status, existing) do
-      Storage.put_asset_window_state(state)
+      {:ok, state}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill_manager.ex
@@ -298,32 +298,53 @@ defmodule FavnOrchestrator.BackfillManager do
     now = DateTime.utc_now()
     coverage_baseline_id = Keyword.get(opts, :coverage_baseline_id)
 
-    with :ok <-
-           Enum.reduce_while(range.anchors, :ok, fn anchor, :ok ->
-             with {:ok, window} <-
-                    BackfillWindow.new(%{
-                      backfill_run_id: backfill_run_id,
-                      pipeline_module: pipeline_module,
-                      manifest_version_id: manifest_version_id,
-                      coverage_baseline_id: coverage_baseline_id,
-                      window_kind: anchor.kind,
-                      window_start_at: anchor.start_at,
-                      window_end_at: anchor.end_at,
-                      timezone: anchor.timezone,
-                      window_key: WindowKey.encode(anchor.key),
-                      status: :pending,
-                      attempt_count: 0,
-                      created_at: now,
-                      updated_at: now
-                    }),
-                  :ok <- Storage.put_backfill_window(window) do
-               {:cont, :ok}
-             else
-               {:error, _reason} = error -> {:halt, error}
-             end
-           end),
+    with {:ok, windows} <-
+           build_pending_windows(
+             backfill_run_id,
+             pipeline_module,
+             manifest_version_id,
+             range.anchors,
+             coverage_baseline_id,
+             now
+           ),
+         :ok <- Storage.put_backfill_windows(windows),
          {:ok, _progress} <- Storage.rebuild_backfill_progress(backfill_run_id) do
       :ok
+    end
+  end
+
+  defp build_pending_windows(
+         backfill_run_id,
+         pipeline_module,
+         manifest_version_id,
+         anchors,
+         coverage_baseline_id,
+         now
+       ) do
+    anchors
+    |> Enum.reduce_while({:ok, []}, fn anchor, {:ok, acc} ->
+      case BackfillWindow.new(%{
+             backfill_run_id: backfill_run_id,
+             pipeline_module: pipeline_module,
+             manifest_version_id: manifest_version_id,
+             coverage_baseline_id: coverage_baseline_id,
+             window_kind: anchor.kind,
+             window_start_at: anchor.start_at,
+             window_end_at: anchor.end_at,
+             timezone: anchor.timezone,
+             window_key: WindowKey.encode(anchor.key),
+             status: :pending,
+             attempt_count: 0,
+             created_at: now,
+             updated_at: now
+           }) do
+        {:ok, window} -> {:cont, {:ok, [window | acc]}}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+    |> case do
+      {:ok, windows} -> {:ok, Enum.reverse(windows)}
+      {:error, reason} -> {:error, reason}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -370,6 +370,21 @@ defmodule FavnOrchestrator.Storage do
     adapter_call(fn adapter, opts -> adapter.put_backfill_window(window, opts) end)
   end
 
+  @spec put_backfill_windows([BackfillWindow.t()]) :: :ok | {:error, term()}
+  def put_backfill_windows(windows) when is_list(windows) do
+    if Enum.all?(windows, &match?(%BackfillWindow{}, &1)) do
+      adapter_call(fn adapter, opts ->
+        if function_exported?(adapter, :put_backfill_windows, 2) do
+          adapter.put_backfill_windows(windows, opts)
+        else
+          put_all_adapter(windows, &adapter.put_backfill_window(&1, opts))
+        end
+      end)
+    else
+      {:error, :invalid_backfill_window}
+    end
+  end
+
   @spec get_backfill_window(String.t(), module(), String.t()) ::
           {:ok, BackfillWindow.t()} | {:error, term()}
   def get_backfill_window(backfill_run_id, pipeline_module, window_key)
@@ -418,6 +433,21 @@ defmodule FavnOrchestrator.Storage do
   @spec put_asset_window_state(AssetWindowState.t()) :: :ok | {:error, term()}
   def put_asset_window_state(%AssetWindowState{} = state) do
     adapter_call(fn adapter, opts -> adapter.put_asset_window_state(state, opts) end)
+  end
+
+  @spec put_asset_window_states([AssetWindowState.t()]) :: :ok | {:error, term()}
+  def put_asset_window_states(states) when is_list(states) do
+    if Enum.all?(states, &match?(%AssetWindowState{}, &1)) do
+      adapter_call(fn adapter, opts ->
+        if function_exported?(adapter, :put_asset_window_states, 2) do
+          adapter.put_asset_window_states(states, opts)
+        else
+          put_all_adapter(states, &adapter.put_asset_window_state(&1, opts))
+        end
+      end)
+    else
+      {:error, :invalid_asset_window_state}
+    end
   end
 
   @spec get_asset_window_state(module(), atom(), String.t()) ::
@@ -756,6 +786,15 @@ defmodule FavnOrchestrator.Storage do
     with {:ok, scan_opts} <- CursorPage.normalize_opts(scan_opts) do
       adapter_call(fn adapter, opts -> fun.(adapter, filters, scan_opts, opts) end)
     end
+  end
+
+  defp put_all_adapter(items, fun) when is_list(items) and is_function(fun, 1) do
+    Enum.reduce_while(items, :ok, fn item, :ok ->
+      case fun.(item) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
   end
 
   defp normalize_replacement_scope(:all), do: {:ok, :all}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -491,6 +491,12 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   @impl true
+  def put_backfill_windows(windows, opts) when is_list(windows) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:put_backfill_windows, windows})
+  end
+
+  @impl true
   def get_backfill_window(backfill_run_id, pipeline_module, window_key, opts)
       when is_binary(backfill_run_id) and is_atom(pipeline_module) and is_binary(window_key) and
              is_list(opts) do
@@ -536,6 +542,12 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   def put_asset_window_state(%AssetWindowState{} = state, opts) when is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
     GenServer.call(server, {:put_asset_window_state, state})
+  end
+
+  @impl true
+  def put_asset_window_states(states, opts) when is_list(states) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:put_asset_window_states, states})
   end
 
   @impl true
@@ -1307,6 +1319,11 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     {:reply, :ok, put_in(state, [:backfill_windows, key], window)}
   end
 
+  def handle_call({:put_backfill_windows, windows}, _from, state) do
+    {:reply, :ok,
+     %{state | backfill_windows: put_backfill_window_values(state.backfill_windows, windows)}}
+  end
+
   def handle_call({:get_backfill_window, key}, _from, state) do
     {:reply, fetch_or_not_found(state.backfill_windows, key), state}
   end
@@ -1355,7 +1372,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       state
       | backfill_windows: Map.put(state.backfill_windows, key, window),
         asset_window_states:
-          put_asset_window_states(state.asset_window_states, asset_window_states)
+          put_asset_window_state_values(state.asset_window_states, asset_window_states)
     }
 
     case next_progress(next_state, window.backfill_run_id, old_status, window.status) do
@@ -1398,6 +1415,15 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   def handle_call({:put_asset_window_state, %AssetWindowState{} = window_state}, _from, state) do
     key = {window_state.asset_ref_module, window_state.asset_ref_name, window_state.window_key}
     {:reply, :ok, put_in(state, [:asset_window_states, key], window_state)}
+  end
+
+  def handle_call({:put_asset_window_states, window_states}, _from, state) do
+    {:reply, :ok,
+     %{
+       state
+       | asset_window_states:
+           put_asset_window_state_values(state.asset_window_states, window_states)
+     }}
   end
 
   def handle_call({:get_asset_window_state, key}, _from, state) do
@@ -1497,7 +1523,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
         next_backfill_windows =
           state.backfill_windows
           |> reject_replacement_scope(scope)
-          |> put_backfill_windows(backfill_windows)
+          |> put_backfill_window_values(backfill_windows)
 
         affected_backfill_ids =
           affected_backfill_ids(state.backfill_windows, scope, backfill_windows)
@@ -1507,7 +1533,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
           | coverage_baselines:
               state.coverage_baselines
               |> reject_replacement_scope(scope)
-              |> put_coverage_baselines(coverage_baselines),
+              |> put_coverage_baseline_values(coverage_baselines),
             backfill_windows: next_backfill_windows,
             backfill_progress:
               state.backfill_progress
@@ -1516,7 +1542,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
             asset_window_states:
               state.asset_window_states
               |> reject_replacement_scope(scope)
-              |> put_asset_window_states(asset_window_states)
+              |> put_asset_window_state_values(asset_window_states)
         }
 
         {:reply, :ok, next_state}
@@ -2185,19 +2211,19 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     |> Enum.uniq()
   end
 
-  defp put_coverage_baselines(values, baselines) do
+  defp put_coverage_baseline_values(values, baselines) do
     Enum.reduce(baselines, values, fn %CoverageBaseline{} = baseline, acc ->
       Map.put(acc, baseline.baseline_id, baseline)
     end)
   end
 
-  defp put_backfill_windows(values, windows) do
+  defp put_backfill_window_values(values, windows) do
     Enum.reduce(windows, values, fn %BackfillWindow{} = window, acc ->
       Map.put(acc, {window.backfill_run_id, window.pipeline_module, window.window_key}, window)
     end)
   end
 
-  defp put_asset_window_states(values, states) do
+  defp put_asset_window_state_values(values, states) do
     Enum.reduce(states, values, fn %AssetWindowState{} = window_state, acc ->
       Map.put(
         acc,

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -654,8 +654,7 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert {:ok, first} = backfill_window(backfill_run_id, run, "window-1", :pending, now)
     assert {:ok, second} = backfill_window(backfill_run_id, run, "window-2", :pending, now)
 
-    assert :ok = Storage.put_backfill_window(first)
-    assert :ok = Storage.put_backfill_window(second)
+    assert :ok = Storage.put_backfill_windows([first, second])
 
     assert {:ok, progress} = Storage.get_backfill_progress(backfill_run_id)
     assert progress.total_count == 2
@@ -688,6 +687,12 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
 
     assert {:ok, ^asset_state} =
              Storage.get_asset_window_state(MyApp.Asset, :asset, ok_window.window_key)
+
+    bulk_state = %{asset_state | window_key: "bulk-window-#{label}", updated_at: now}
+    assert :ok = Storage.put_asset_window_states([bulk_state])
+
+    assert {:ok, ^bulk_state} =
+             Storage.get_asset_window_state(MyApp.Asset, :asset, bulk_state.window_key)
 
     assert {:ok, repeated} = Storage.apply_backfill_child_projection(ok_window, [asset_state])
     assert repeated.total_count == 2

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -616,6 +616,21 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
 
     assert {:ok, _progress} = Storage.get_backfill_progress(backfill_run_id)
 
+    out_of_scope_window = %{kept_window | window_key: "replace-out-of-scope"}
+
+    assert {:error, {:replacement_row_out_of_scope, {:backfill_run, ^backfill_run_id}}} =
+             Storage.replace_backfill_read_models(
+               {:backfill_run, backfill_run_id},
+               [],
+               [out_of_scope_window],
+               []
+             )
+
+    assert {:ok, ^stale_baseline} = Storage.get_coverage_baseline(stale_baseline.baseline_id)
+
+    assert {:ok, ^stale_window} =
+             Storage.get_backfill_window(backfill_run_id, MyApp.Pipeline, stale_window.window_key)
+
     assert :ok =
              Storage.replace_backfill_read_models({:backfill_run, backfill_run_id}, [], [], [])
 
@@ -653,8 +668,17 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
 
     assert {:ok, first} = backfill_window(backfill_run_id, run, "window-1", :pending, now)
     assert {:ok, second} = backfill_window(backfill_run_id, run, "window-2", :pending, now)
+    duplicate_first = %{first | attempt_count: 3, latest_attempt_run_id: "duplicate-latest"}
 
-    assert :ok = Storage.put_backfill_windows([first, second])
+    assert {:error, :invalid_backfill_window} = Storage.put_backfill_windows([first, :invalid])
+
+    assert {:error, :not_found} =
+             Storage.get_backfill_window(backfill_run_id, MyApp.Pipeline, first.window_key)
+
+    assert :ok = Storage.put_backfill_windows([first, duplicate_first, second])
+
+    assert {:ok, ^duplicate_first} =
+             Storage.get_backfill_window(backfill_run_id, MyApp.Pipeline, first.window_key)
 
     assert {:ok, progress} = Storage.get_backfill_progress(backfill_run_id)
     assert progress.total_count == 2
@@ -689,9 +713,25 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
              Storage.get_asset_window_state(MyApp.Asset, :asset, ok_window.window_key)
 
     bulk_state = %{asset_state | window_key: "bulk-window-#{label}", updated_at: now}
-    assert :ok = Storage.put_asset_window_states([bulk_state])
 
-    assert {:ok, ^bulk_state} =
+    duplicate_bulk_state = %{
+      bulk_state
+      | latest_run_id: "bulk-latest-#{label}",
+        latest_success_run_id: "bulk-latest-#{label}",
+        rows_written: 123
+    }
+
+    invalid_bulk_state = %{bulk_state | window_key: "invalid-bulk-window-#{label}"}
+
+    assert {:error, :invalid_asset_window_state} =
+             Storage.put_asset_window_states([invalid_bulk_state, :invalid])
+
+    assert {:error, :not_found} =
+             Storage.get_asset_window_state(MyApp.Asset, :asset, invalid_bulk_state.window_key)
+
+    assert :ok = Storage.put_asset_window_states([bulk_state, duplicate_bulk_state])
+
+    assert {:ok, ^duplicate_bulk_state} =
              Storage.get_asset_window_state(MyApp.Asset, :asset, bulk_state.window_key)
 
     assert {:ok, repeated} = Storage.apply_backfill_child_projection(ok_window, [asset_state])

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -54,6 +54,7 @@ defmodule Favn.Storage.Adapter.Postgres do
     :asset_ref,
     :node_key
   ]
+  @read_model_chunk_size 250
 
   @impl true
   def child_spec(opts) when is_list(opts) do
@@ -715,34 +716,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   @impl true
   def put_coverage_baseline(%CoverageBaseline{} = baseline, opts) when is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts) do
-      sql =
-        """
-        INSERT INTO favn_pipeline_coverage_baselines (
-          baseline_id, pipeline_module, source_key, segment_key_hash, segment_key_redacted,
-          window_kind, timezone, coverage_start_at, coverage_until, created_by_run_id,
-          manifest_version_id, status, record_payload, created_at, updated_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)
-        ON CONFLICT(baseline_id) DO UPDATE SET
-          pipeline_module = EXCLUDED.pipeline_module,
-          source_key = EXCLUDED.source_key,
-          segment_key_hash = EXCLUDED.segment_key_hash,
-          segment_key_redacted = EXCLUDED.segment_key_redacted,
-          window_kind = EXCLUDED.window_kind,
-          timezone = EXCLUDED.timezone,
-          coverage_start_at = EXCLUDED.coverage_start_at,
-          coverage_until = EXCLUDED.coverage_until,
-          created_by_run_id = EXCLUDED.created_by_run_id,
-          manifest_version_id = EXCLUDED.manifest_version_id,
-          status = EXCLUDED.status,
-          record_payload = EXCLUDED.record_payload,
-          created_at = EXCLUDED.created_at,
-          updated_at = EXCLUDED.updated_at
-        """
-
-      case SQL.query(repo, sql, coverage_baseline_params(baseline)) do
-        {:ok, _} -> :ok
-        {:error, reason} -> {:error, reason}
-      end
+      upsert_coverage_baselines(repo, [baseline])
     end
   end
 
@@ -777,37 +751,14 @@ defmodule Favn.Storage.Adapter.Postgres do
   @impl true
   def put_backfill_window(%BackfillWindow{} = window, opts) when is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts) do
-      sql =
-        """
-        INSERT INTO favn_backfill_windows (
-          backfill_run_id, child_run_id, pipeline_module, manifest_version_id, coverage_baseline_id,
-          window_kind, window_start_at, window_end_at, timezone, window_key, status,
-          attempt_count, latest_attempt_run_id, last_success_run_id, record_payload,
-          started_at, finished_at, created_at, updated_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16, $17, $18, $19)
-        ON CONFLICT(backfill_run_id, pipeline_module, window_key) DO UPDATE SET
-          child_run_id = EXCLUDED.child_run_id,
-          manifest_version_id = EXCLUDED.manifest_version_id,
-          coverage_baseline_id = EXCLUDED.coverage_baseline_id,
-          window_kind = EXCLUDED.window_kind,
-          window_start_at = EXCLUDED.window_start_at,
-          window_end_at = EXCLUDED.window_end_at,
-          timezone = EXCLUDED.timezone,
-          status = EXCLUDED.status,
-          attempt_count = EXCLUDED.attempt_count,
-          latest_attempt_run_id = EXCLUDED.latest_attempt_run_id,
-          last_success_run_id = EXCLUDED.last_success_run_id,
-          record_payload = EXCLUDED.record_payload,
-          started_at = EXCLUDED.started_at,
-          finished_at = EXCLUDED.finished_at,
-          created_at = EXCLUDED.created_at,
-          updated_at = EXCLUDED.updated_at
-        """
+      upsert_backfill_windows(repo, [window])
+    end
+  end
 
-      case SQL.query(repo, sql, backfill_window_params(window)) do
-        {:ok, _} -> :ok
-        {:error, reason} -> {:error, reason}
-      end
+  @impl true
+  def put_backfill_windows(windows, opts) when is_list(windows) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      upsert_backfill_windows(repo, windows)
     end
   end
 
@@ -875,8 +826,8 @@ defmodule Favn.Storage.Adapter.Postgres do
     with {:ok, repo} <- resolve_repo(opts) do
       repo.transact(fn ->
         with {:ok, old_status} <- lock_and_fetch_backfill_window_status(repo, window),
-             :ok <- put_backfill_window(window, opts),
-             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
+             :ok <- upsert_backfill_windows(repo, [window]),
+             :ok <- upsert_asset_window_states(repo, asset_window_states),
              {:ok, progress} <-
                upsert_backfill_progress_after_window_change(repo, window, old_status) do
           {:ok, progress}
@@ -910,33 +861,14 @@ defmodule Favn.Storage.Adapter.Postgres do
   @impl true
   def put_asset_window_state(%AssetWindowState{} = state, opts) when is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts) do
-      sql =
-        """
-        INSERT INTO favn_asset_window_states (
-          asset_ref_module, asset_ref_name, pipeline_module, manifest_version_id, window_kind,
-          window_start_at, window_end_at, timezone, window_key, status, latest_run_id,
-          latest_parent_run_id, latest_success_run_id, rows_written, record_payload, updated_at
-        ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15, $16)
-        ON CONFLICT(asset_ref_module, asset_ref_name, window_key) DO UPDATE SET
-          pipeline_module = EXCLUDED.pipeline_module,
-          manifest_version_id = EXCLUDED.manifest_version_id,
-          window_kind = EXCLUDED.window_kind,
-          window_start_at = EXCLUDED.window_start_at,
-          window_end_at = EXCLUDED.window_end_at,
-          timezone = EXCLUDED.timezone,
-          status = EXCLUDED.status,
-          latest_run_id = EXCLUDED.latest_run_id,
-          latest_parent_run_id = EXCLUDED.latest_parent_run_id,
-          latest_success_run_id = EXCLUDED.latest_success_run_id,
-          rows_written = EXCLUDED.rows_written,
-          record_payload = EXCLUDED.record_payload,
-          updated_at = EXCLUDED.updated_at
-        """
+      upsert_asset_window_states(repo, [state])
+    end
+  end
 
-      case SQL.query(repo, sql, asset_window_state_params(state)) do
-        {:ok, _} -> :ok
-        {:error, reason} -> {:error, reason}
-      end
+  @impl true
+  def put_asset_window_states(states, opts) when is_list(states) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      upsert_asset_window_states(repo, states)
     end
   end
 
@@ -1102,9 +1034,9 @@ defmodule Favn.Storage.Adapter.Postgres do
              :ok <-
                delete_replacement_scope(repo, "favn_asset_window_states", :asset_state, scope),
              :ok <- delete_replacement_progress(repo, scope),
-             :ok <- put_all(coverage_baselines, &put_coverage_baseline(&1, opts)),
-             :ok <- put_all(backfill_windows, &put_backfill_window(&1, opts)),
-             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
+             :ok <- upsert_coverage_baselines(repo, coverage_baselines),
+             :ok <- upsert_backfill_windows(repo, backfill_windows),
+             :ok <- upsert_asset_window_states(repo, asset_window_states),
              :ok <-
                rebuild_backfill_progress_for_ids(
                  repo,
@@ -1233,6 +1165,119 @@ defmodule Favn.Storage.Adapter.Postgres do
       encode_asset_window_state(state),
       state.updated_at
     ]
+  end
+
+  defp upsert_coverage_baselines(_repo, []), do: :ok
+
+  defp upsert_coverage_baselines(repo, baselines) do
+    sql = """
+    INSERT INTO favn_pipeline_coverage_baselines (
+      baseline_id, pipeline_module, source_key, segment_key_hash, segment_key_redacted,
+      window_kind, timezone, coverage_start_at, coverage_until, created_by_run_id,
+      manifest_version_id, status, record_payload, created_at, updated_at
+    ) VALUES __VALUES__
+    ON CONFLICT(baseline_id) DO UPDATE SET
+      pipeline_module = EXCLUDED.pipeline_module,
+      source_key = EXCLUDED.source_key,
+      segment_key_hash = EXCLUDED.segment_key_hash,
+      segment_key_redacted = EXCLUDED.segment_key_redacted,
+      window_kind = EXCLUDED.window_kind,
+      timezone = EXCLUDED.timezone,
+      coverage_start_at = EXCLUDED.coverage_start_at,
+      coverage_until = EXCLUDED.coverage_until,
+      created_by_run_id = EXCLUDED.created_by_run_id,
+      manifest_version_id = EXCLUDED.manifest_version_id,
+      status = EXCLUDED.status,
+      record_payload = EXCLUDED.record_payload,
+      created_at = EXCLUDED.created_at,
+      updated_at = EXCLUDED.updated_at
+    """
+
+    bulk_query_ok(repo, sql, baselines, &coverage_baseline_params/1)
+  end
+
+  defp upsert_backfill_windows(_repo, []), do: :ok
+
+  defp upsert_backfill_windows(repo, windows) do
+    sql = """
+    INSERT INTO favn_backfill_windows (
+      backfill_run_id, child_run_id, pipeline_module, manifest_version_id, coverage_baseline_id,
+      window_kind, window_start_at, window_end_at, timezone, window_key, status,
+      attempt_count, latest_attempt_run_id, last_success_run_id, record_payload,
+      started_at, finished_at, created_at, updated_at
+    ) VALUES __VALUES__
+    ON CONFLICT(backfill_run_id, pipeline_module, window_key) DO UPDATE SET
+      child_run_id = EXCLUDED.child_run_id,
+      manifest_version_id = EXCLUDED.manifest_version_id,
+      coverage_baseline_id = EXCLUDED.coverage_baseline_id,
+      window_kind = EXCLUDED.window_kind,
+      window_start_at = EXCLUDED.window_start_at,
+      window_end_at = EXCLUDED.window_end_at,
+      timezone = EXCLUDED.timezone,
+      status = EXCLUDED.status,
+      attempt_count = EXCLUDED.attempt_count,
+      latest_attempt_run_id = EXCLUDED.latest_attempt_run_id,
+      last_success_run_id = EXCLUDED.last_success_run_id,
+      record_payload = EXCLUDED.record_payload,
+      started_at = EXCLUDED.started_at,
+      finished_at = EXCLUDED.finished_at,
+      created_at = EXCLUDED.created_at,
+      updated_at = EXCLUDED.updated_at
+    """
+
+    bulk_query_ok(repo, sql, windows, &backfill_window_params/1)
+  end
+
+  defp upsert_asset_window_states(_repo, []), do: :ok
+
+  defp upsert_asset_window_states(repo, states) do
+    sql = """
+    INSERT INTO favn_asset_window_states (
+      asset_ref_module, asset_ref_name, pipeline_module, manifest_version_id, window_kind,
+      window_start_at, window_end_at, timezone, window_key, status, latest_run_id,
+      latest_parent_run_id, latest_success_run_id, rows_written, record_payload, updated_at
+    ) VALUES __VALUES__
+    ON CONFLICT(asset_ref_module, asset_ref_name, window_key) DO UPDATE SET
+      pipeline_module = EXCLUDED.pipeline_module,
+      manifest_version_id = EXCLUDED.manifest_version_id,
+      window_kind = EXCLUDED.window_kind,
+      window_start_at = EXCLUDED.window_start_at,
+      window_end_at = EXCLUDED.window_end_at,
+      timezone = EXCLUDED.timezone,
+      status = EXCLUDED.status,
+      latest_run_id = EXCLUDED.latest_run_id,
+      latest_parent_run_id = EXCLUDED.latest_parent_run_id,
+      latest_success_run_id = EXCLUDED.latest_success_run_id,
+      rows_written = EXCLUDED.rows_written,
+      record_payload = EXCLUDED.record_payload,
+      updated_at = EXCLUDED.updated_at
+    """
+
+    bulk_query_ok(repo, sql, states, &asset_window_state_params/1)
+  end
+
+  defp bulk_query_ok(repo, sql_template, rows, params_fun) do
+    rows
+    |> Enum.chunk_every(@read_model_chunk_size)
+    |> Enum.reduce_while(:ok, fn chunk, :ok ->
+      params = Enum.map(chunk, params_fun)
+      sql = String.replace(sql_template, "__VALUES__", postgres_values_sql(params))
+
+      case SQL.query(repo, sql, List.flatten(params)) do
+        {:ok, _} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp postgres_values_sql(rows) do
+    rows
+    |> Enum.map_reduce(1, fn row, index ->
+      placeholders = Enum.map(index..(index + length(row) - 1), &"$#{&1}")
+      {"(" <> Enum.join(placeholders, ", ") <> ")", index + length(row)}
+    end)
+    |> elem(0)
+    |> Enum.join(", ")
   end
 
   defp asset_freshness_state_params(%AssetFreshnessState{} = state) do
@@ -1453,15 +1498,6 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   defp read_filters(filters), do: Keyword.drop(filters, [:limit, :offset])
-
-  defp put_all(items, fun) when is_list(items) and is_function(fun, 1) do
-    Enum.reduce_while(items, :ok, fn item, :ok ->
-      case fun.(item) do
-        :ok -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
-  end
 
   defp query_ok(repo, sql, params) do
     case SQL.query(repo, sql, params) do
@@ -2085,9 +2121,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   defp persist_log_entry(repo, entry) do
-    with {:ok, existing} <- fetch_log_entry_by_producer(repo, entry),
-         nil <- existing,
-         {:ok, global_sequence} <- next_log_global_sequence(repo) do
+    with {:ok, global_sequence} <- next_log_global_sequence(repo) do
       entry = LogEntryCodec.assign_global_sequence(entry, global_sequence)
       {node_key_hash, node_key_blob} = LogEntryCodec.node_key_storage(Map.get(entry, :node_key))
 
@@ -2141,7 +2175,6 @@ defmodule Favn.Storage.Adapter.Postgres do
           {:error, reason}
       end
     else
-      %_{} = existing -> {:ok, existing}
       {:error, reason} -> {:error, reason}
       other -> {:error, {:invalid_log_entry_insert, other}}
     end

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -1193,6 +1193,7 @@ defmodule Favn.Storage.Adapter.Postgres do
       updated_at = EXCLUDED.updated_at
     """
 
+    baselines = dedupe_last_by(baselines, & &1.baseline_id)
     bulk_query_ok(repo, sql, baselines, &coverage_baseline_params/1)
   end
 
@@ -1225,6 +1226,7 @@ defmodule Favn.Storage.Adapter.Postgres do
       updated_at = EXCLUDED.updated_at
     """
 
+    windows = dedupe_last_by(windows, &{&1.backfill_run_id, &1.pipeline_module, &1.window_key})
     bulk_query_ok(repo, sql, windows, &backfill_window_params/1)
   end
 
@@ -1253,7 +1255,15 @@ defmodule Favn.Storage.Adapter.Postgres do
       updated_at = EXCLUDED.updated_at
     """
 
+    states = dedupe_last_by(states, &{&1.asset_ref_module, &1.asset_ref_name, &1.window_key})
     bulk_query_ok(repo, sql, states, &asset_window_state_params/1)
+  end
+
+  defp dedupe_last_by(rows, key_fun) when is_function(key_fun, 1) do
+    rows
+    |> Enum.reverse()
+    |> Enum.uniq_by(key_fun)
+    |> Enum.reverse()
   end
 
   defp bulk_query_ok(repo, sql_template, rows, params_fun) do

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -59,6 +59,7 @@ defmodule Favn.Storage.Adapter.SQLite do
     :asset_ref,
     :node_key
   ]
+  @read_model_chunk_size 50
 
   @impl true
   def child_spec(opts) when is_list(opts) do
@@ -727,52 +728,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def put_coverage_baseline(%CoverageBaseline{} = baseline, opts) when is_list(opts) do
     with {:ok, repo} <- repo_name(opts) do
-      sql =
-        """
-        INSERT INTO favn_pipeline_coverage_baselines (
-          baseline_id, pipeline_module, source_key, segment_key_hash, segment_key_redacted,
-          window_kind, timezone, coverage_start_at, coverage_until, created_by_run_id,
-          manifest_version_id, status, record_payload, created_at, updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15)
-        ON CONFLICT(baseline_id) DO UPDATE SET
-          pipeline_module = excluded.pipeline_module,
-          source_key = excluded.source_key,
-          segment_key_hash = excluded.segment_key_hash,
-          segment_key_redacted = excluded.segment_key_redacted,
-          window_kind = excluded.window_kind,
-          timezone = excluded.timezone,
-          coverage_start_at = excluded.coverage_start_at,
-          coverage_until = excluded.coverage_until,
-          created_by_run_id = excluded.created_by_run_id,
-          manifest_version_id = excluded.manifest_version_id,
-          status = excluded.status,
-          record_payload = excluded.record_payload,
-          created_at = excluded.created_at,
-          updated_at = excluded.updated_at
-        """
-
-      params = [
-        baseline.baseline_id,
-        encode_atom(baseline.pipeline_module),
-        baseline.source_key,
-        baseline.segment_key_hash,
-        baseline.segment_key_redacted,
-        encode_atom(baseline.window_kind),
-        baseline.timezone,
-        encode_datetime(baseline.coverage_start_at),
-        encode_datetime(baseline.coverage_until),
-        baseline.created_by_run_id,
-        baseline.manifest_version_id,
-        encode_atom(baseline.status),
-        encode_coverage_baseline(baseline),
-        encode_datetime(baseline.created_at),
-        encode_datetime(baseline.updated_at)
-      ]
-
-      case SQL.query(repo, sql, params) do
-        {:ok, _} -> :ok
-        {:error, reason} -> {:error, reason}
-      end
+      upsert_coverage_baselines(repo, [baseline])
     end
   end
 
@@ -806,59 +762,14 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def put_backfill_window(%BackfillWindow{} = window, opts) when is_list(opts) do
     with {:ok, repo} <- repo_name(opts) do
-      sql =
-        """
-        INSERT INTO favn_backfill_windows (
-          backfill_run_id, child_run_id, pipeline_module, manifest_version_id,
-          coverage_baseline_id, window_kind, window_start_at, window_end_at, timezone,
-          window_key, status, attempt_count, latest_attempt_run_id, last_success_run_id,
-          record_payload, started_at, finished_at, created_at, updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16, ?17, ?18, ?19)
-        ON CONFLICT(backfill_run_id, pipeline_module, window_key) DO UPDATE SET
-          child_run_id = excluded.child_run_id,
-          manifest_version_id = excluded.manifest_version_id,
-          coverage_baseline_id = excluded.coverage_baseline_id,
-          window_kind = excluded.window_kind,
-          window_start_at = excluded.window_start_at,
-          window_end_at = excluded.window_end_at,
-          timezone = excluded.timezone,
-          status = excluded.status,
-          attempt_count = excluded.attempt_count,
-          latest_attempt_run_id = excluded.latest_attempt_run_id,
-          last_success_run_id = excluded.last_success_run_id,
-          record_payload = excluded.record_payload,
-          started_at = excluded.started_at,
-          finished_at = excluded.finished_at,
-          created_at = excluded.created_at,
-          updated_at = excluded.updated_at
-        """
+      upsert_backfill_windows(repo, [window])
+    end
+  end
 
-      params = [
-        window.backfill_run_id,
-        window.child_run_id,
-        encode_atom(window.pipeline_module),
-        window.manifest_version_id,
-        window.coverage_baseline_id,
-        encode_atom(window.window_kind),
-        encode_datetime(window.window_start_at),
-        encode_datetime(window.window_end_at),
-        window.timezone,
-        window.window_key,
-        encode_atom(window.status),
-        window.attempt_count,
-        window.latest_attempt_run_id,
-        window.last_success_run_id,
-        encode_backfill_window(window),
-        encode_datetime(window.started_at),
-        encode_datetime(window.finished_at),
-        encode_datetime(window.created_at),
-        encode_datetime(window.updated_at)
-      ]
-
-      case SQL.query(repo, sql, params) do
-        {:ok, _} -> :ok
-        {:error, reason} -> {:error, reason}
-      end
+  @impl true
+  def put_backfill_windows(windows, opts) when is_list(windows) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      upsert_backfill_windows(repo, windows)
     end
   end
 
@@ -923,8 +834,8 @@ defmodule Favn.Storage.Adapter.SQLite do
       repo.transact(fn ->
         with :ok <- lock_backfill_window(repo, window),
              old_status <- fetch_backfill_window_status(repo, window),
-             :ok <- put_backfill_window(window, opts),
-             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
+             :ok <- upsert_backfill_windows(repo, [window]),
+             :ok <- upsert_asset_window_states(repo, asset_window_states),
              {:ok, progress} <-
                upsert_backfill_progress_after_window_change(repo, window, old_status) do
           {:ok, progress}
@@ -958,53 +869,14 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def put_asset_window_state(%AssetWindowState{} = state, opts) when is_list(opts) do
     with {:ok, repo} <- repo_name(opts) do
-      sql =
-        """
-        INSERT INTO favn_asset_window_states (
-          asset_ref_module, asset_ref_name, pipeline_module, manifest_version_id,
-          window_kind, window_start_at, window_end_at, timezone, window_key, status,
-          latest_run_id, latest_parent_run_id, latest_success_run_id, rows_written,
-          record_payload, updated_at
-        ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12, ?13, ?14, ?15, ?16)
-        ON CONFLICT(asset_ref_module, asset_ref_name, window_key) DO UPDATE SET
-          pipeline_module = excluded.pipeline_module,
-          manifest_version_id = excluded.manifest_version_id,
-          window_kind = excluded.window_kind,
-          window_start_at = excluded.window_start_at,
-          window_end_at = excluded.window_end_at,
-          timezone = excluded.timezone,
-          status = excluded.status,
-          latest_run_id = excluded.latest_run_id,
-          latest_parent_run_id = excluded.latest_parent_run_id,
-          latest_success_run_id = excluded.latest_success_run_id,
-          rows_written = excluded.rows_written,
-          record_payload = excluded.record_payload,
-          updated_at = excluded.updated_at
-        """
+      upsert_asset_window_states(repo, [state])
+    end
+  end
 
-      params = [
-        encode_atom(state.asset_ref_module),
-        encode_atom(state.asset_ref_name),
-        encode_atom(state.pipeline_module),
-        state.manifest_version_id,
-        encode_atom(state.window_kind),
-        encode_datetime(state.window_start_at),
-        encode_datetime(state.window_end_at),
-        state.timezone,
-        state.window_key,
-        encode_atom(state.status),
-        state.latest_run_id,
-        state.latest_parent_run_id,
-        state.latest_success_run_id,
-        state.rows_written,
-        encode_asset_window_state(state),
-        encode_datetime(state.updated_at)
-      ]
-
-      case SQL.query(repo, sql, params) do
-        {:ok, _} -> :ok
-        {:error, reason} -> {:error, reason}
-      end
+  @impl true
+  def put_asset_window_states(states, opts) when is_list(states) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      upsert_asset_window_states(repo, states)
     end
   end
 
@@ -1178,9 +1050,9 @@ defmodule Favn.Storage.Adapter.SQLite do
              :ok <-
                delete_replacement_scope(repo, "favn_asset_window_states", :asset_state, scope),
              :ok <- delete_replacement_progress(repo, scope),
-             :ok <- put_all(coverage_baselines, &put_coverage_baseline(&1, opts)),
-             :ok <- put_all(backfill_windows, &put_backfill_window(&1, opts)),
-             :ok <- put_all(asset_window_states, &put_asset_window_state(&1, opts)),
+             :ok <- upsert_coverage_baselines(repo, coverage_baselines),
+             :ok <- upsert_backfill_windows(repo, backfill_windows),
+             :ok <- upsert_asset_window_states(repo, asset_window_states),
              :ok <-
                rebuild_backfill_progress_for_ids(
                  repo,
@@ -2022,13 +1894,183 @@ defmodule Favn.Storage.Adapter.SQLite do
 
   defp read_filters(filters), do: Keyword.drop(filters, [:limit, :offset])
 
-  defp put_all(items, fun) when is_list(items) and is_function(fun, 1) do
-    Enum.reduce_while(items, :ok, fn item, :ok ->
-      case fun.(item) do
-        :ok -> {:cont, :ok}
+  defp upsert_coverage_baselines(_repo, []), do: :ok
+
+  defp upsert_coverage_baselines(repo, baselines) do
+    sql = """
+    INSERT INTO favn_pipeline_coverage_baselines (
+      baseline_id, pipeline_module, source_key, segment_key_hash, segment_key_redacted,
+      window_kind, timezone, coverage_start_at, coverage_until, created_by_run_id,
+      manifest_version_id, status, record_payload, created_at, updated_at
+    ) VALUES __VALUES__
+    ON CONFLICT(baseline_id) DO UPDATE SET
+      pipeline_module = excluded.pipeline_module,
+      source_key = excluded.source_key,
+      segment_key_hash = excluded.segment_key_hash,
+      segment_key_redacted = excluded.segment_key_redacted,
+      window_kind = excluded.window_kind,
+      timezone = excluded.timezone,
+      coverage_start_at = excluded.coverage_start_at,
+      coverage_until = excluded.coverage_until,
+      created_by_run_id = excluded.created_by_run_id,
+      manifest_version_id = excluded.manifest_version_id,
+      status = excluded.status,
+      record_payload = excluded.record_payload,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at
+    """
+
+    bulk_query_ok(repo, sql, baselines, &coverage_baseline_params/1)
+  end
+
+  defp upsert_backfill_windows(_repo, []), do: :ok
+
+  defp upsert_backfill_windows(repo, windows) do
+    sql = """
+    INSERT INTO favn_backfill_windows (
+      backfill_run_id, child_run_id, pipeline_module, manifest_version_id,
+      coverage_baseline_id, window_kind, window_start_at, window_end_at, timezone,
+      window_key, status, attempt_count, latest_attempt_run_id, last_success_run_id,
+      record_payload, started_at, finished_at, created_at, updated_at
+    ) VALUES __VALUES__
+    ON CONFLICT(backfill_run_id, pipeline_module, window_key) DO UPDATE SET
+      child_run_id = excluded.child_run_id,
+      manifest_version_id = excluded.manifest_version_id,
+      coverage_baseline_id = excluded.coverage_baseline_id,
+      window_kind = excluded.window_kind,
+      window_start_at = excluded.window_start_at,
+      window_end_at = excluded.window_end_at,
+      timezone = excluded.timezone,
+      status = excluded.status,
+      attempt_count = excluded.attempt_count,
+      latest_attempt_run_id = excluded.latest_attempt_run_id,
+      last_success_run_id = excluded.last_success_run_id,
+      record_payload = excluded.record_payload,
+      started_at = excluded.started_at,
+      finished_at = excluded.finished_at,
+      created_at = excluded.created_at,
+      updated_at = excluded.updated_at
+    """
+
+    bulk_query_ok(repo, sql, windows, &backfill_window_params/1)
+  end
+
+  defp upsert_asset_window_states(_repo, []), do: :ok
+
+  defp upsert_asset_window_states(repo, states) do
+    sql = """
+    INSERT INTO favn_asset_window_states (
+      asset_ref_module, asset_ref_name, pipeline_module, manifest_version_id,
+      window_kind, window_start_at, window_end_at, timezone, window_key, status,
+      latest_run_id, latest_parent_run_id, latest_success_run_id, rows_written,
+      record_payload, updated_at
+    ) VALUES __VALUES__
+    ON CONFLICT(asset_ref_module, asset_ref_name, window_key) DO UPDATE SET
+      pipeline_module = excluded.pipeline_module,
+      manifest_version_id = excluded.manifest_version_id,
+      window_kind = excluded.window_kind,
+      window_start_at = excluded.window_start_at,
+      window_end_at = excluded.window_end_at,
+      timezone = excluded.timezone,
+      status = excluded.status,
+      latest_run_id = excluded.latest_run_id,
+      latest_parent_run_id = excluded.latest_parent_run_id,
+      latest_success_run_id = excluded.latest_success_run_id,
+      rows_written = excluded.rows_written,
+      record_payload = excluded.record_payload,
+      updated_at = excluded.updated_at
+    """
+
+    bulk_query_ok(repo, sql, states, &asset_window_state_params/1)
+  end
+
+  defp bulk_query_ok(repo, sql_template, rows, params_fun) do
+    rows
+    |> Enum.chunk_every(@read_model_chunk_size)
+    |> Enum.reduce_while(:ok, fn chunk, :ok ->
+      params = Enum.map(chunk, params_fun)
+      sql = String.replace(sql_template, "__VALUES__", sqlite_values_sql(params))
+
+      case SQL.query(repo, sql, List.flatten(params)) do
+        {:ok, _} -> {:cont, :ok}
         {:error, reason} -> {:halt, {:error, reason}}
       end
     end)
+  end
+
+  defp sqlite_values_sql(rows) do
+    rows
+    |> Enum.map_reduce(1, fn row, index ->
+      placeholders = Enum.map(index..(index + length(row) - 1), &"?#{&1}")
+      {"(" <> Enum.join(placeholders, ", ") <> ")", index + length(row)}
+    end)
+    |> elem(0)
+    |> Enum.join(", ")
+  end
+
+  defp coverage_baseline_params(%CoverageBaseline{} = baseline) do
+    [
+      baseline.baseline_id,
+      encode_atom(baseline.pipeline_module),
+      baseline.source_key,
+      baseline.segment_key_hash,
+      baseline.segment_key_redacted,
+      encode_atom(baseline.window_kind),
+      baseline.timezone,
+      encode_datetime(baseline.coverage_start_at),
+      encode_datetime(baseline.coverage_until),
+      baseline.created_by_run_id,
+      baseline.manifest_version_id,
+      encode_atom(baseline.status),
+      encode_coverage_baseline(baseline),
+      encode_datetime(baseline.created_at),
+      encode_datetime(baseline.updated_at)
+    ]
+  end
+
+  defp backfill_window_params(%BackfillWindow{} = window) do
+    [
+      window.backfill_run_id,
+      window.child_run_id,
+      encode_atom(window.pipeline_module),
+      window.manifest_version_id,
+      window.coverage_baseline_id,
+      encode_atom(window.window_kind),
+      encode_datetime(window.window_start_at),
+      encode_datetime(window.window_end_at),
+      window.timezone,
+      window.window_key,
+      encode_atom(window.status),
+      window.attempt_count,
+      window.latest_attempt_run_id,
+      window.last_success_run_id,
+      encode_backfill_window(window),
+      encode_datetime(window.started_at),
+      encode_datetime(window.finished_at),
+      encode_datetime(window.created_at),
+      encode_datetime(window.updated_at)
+    ]
+  end
+
+  defp asset_window_state_params(%AssetWindowState{} = state) do
+    [
+      encode_atom(state.asset_ref_module),
+      encode_atom(state.asset_ref_name),
+      encode_atom(state.pipeline_module),
+      state.manifest_version_id,
+      encode_atom(state.window_kind),
+      encode_datetime(state.window_start_at),
+      encode_datetime(state.window_end_at),
+      state.timezone,
+      state.window_key,
+      encode_atom(state.status),
+      state.latest_run_id,
+      state.latest_parent_run_id,
+      state.latest_success_run_id,
+      state.rows_written,
+      encode_asset_window_state(state),
+      encode_datetime(state.updated_at)
+    ]
   end
 
   defp query_ok(repo, sql, params) do
@@ -2628,9 +2670,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   defp persist_log_entry(repo, entry) do
-    with {:ok, existing} <- fetch_log_entry_by_producer(repo, entry),
-         nil <- existing,
-         {:ok, global_sequence} <- next_log_global_sequence(repo) do
+    with {:ok, global_sequence} <- next_log_global_sequence(repo) do
       entry = LogEntryCodec.assign_global_sequence(entry, global_sequence)
       {node_key_hash, node_key_blob} = LogEntryCodec.node_key_storage(Map.get(entry, :node_key))
 
@@ -2691,7 +2731,6 @@ defmodule Favn.Storage.Adapter.SQLite do
           {:error, reason}
       end
     else
-      %_{} = existing -> {:ok, existing}
       {:error, reason} -> {:error, reason}
       other -> {:error, {:invalid_log_entry_insert, other}}
     end

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -1920,6 +1920,7 @@ defmodule Favn.Storage.Adapter.SQLite do
       updated_at = excluded.updated_at
     """
 
+    baselines = dedupe_last_by(baselines, & &1.baseline_id)
     bulk_query_ok(repo, sql, baselines, &coverage_baseline_params/1)
   end
 
@@ -1952,6 +1953,7 @@ defmodule Favn.Storage.Adapter.SQLite do
       updated_at = excluded.updated_at
     """
 
+    windows = dedupe_last_by(windows, &{&1.backfill_run_id, &1.pipeline_module, &1.window_key})
     bulk_query_ok(repo, sql, windows, &backfill_window_params/1)
   end
 
@@ -1981,7 +1983,15 @@ defmodule Favn.Storage.Adapter.SQLite do
       updated_at = excluded.updated_at
     """
 
+    states = dedupe_last_by(states, &{&1.asset_ref_module, &1.asset_ref_name, &1.window_key})
     bulk_query_ok(repo, sql, states, &asset_window_state_params/1)
+  end
+
+  defp dedupe_last_by(rows, key_fun) when is_function(key_fun, 1) do
+    rows
+    |> Enum.reverse()
+    |> Enum.uniq_by(key_fun)
+    |> Enum.reverse()
   end
 
   defp bulk_query_ok(repo, sql_template, rows, params_fun) do


### PR DESCRIPTION
## Summary
- Adds narrow bulk storage callbacks for backfill windows and asset window states while preserving single-row APIs.
- Batches Postgres and SQLite backfill read-model upserts with adapter-local chunked multi-row SQL.
- Refactors orchestrator projection call sites to build rows first and persist them through the storage facade.

## Verification
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/integration/storage_adapter_contract_test.exs`
- `MIX_ENV=test mix do --app favn_storage_sqlite cmd mix test test/adapter_test.exs`
- `MIX_ENV=test mix do --app favn_storage_postgres cmd mix test test/integration/adapter_live_test.exs`
- `mix compile --warnings-as-errors`
- `git diff --check`

Closes #415