### PR TITLE
Bound scheduler and backfill dispatch

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/application.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/application.ex
@@ -6,6 +6,7 @@ defmodule FavnOrchestrator.Application do
   alias FavnOrchestrator.API.Config, as: APIConfig
   alias FavnOrchestrator.Auth
   alias FavnOrchestrator.Auth.Store, as: AuthStore
+  alias FavnOrchestrator.BoundedDispatcher
   alias FavnOrchestrator.ExecutionAdmission.Coordinator, as: AdmissionCoordinator
   alias FavnOrchestrator.OperationalEvents
   alias FavnOrchestrator.ProductionRuntimeConfig
@@ -41,7 +42,8 @@ defmodule FavnOrchestrator.Application do
             {AdmissionCoordinator, []},
             {RunRecovery, []},
             {DynamicSupervisor, strategy: :one_for_one, name: FavnOrchestrator.RunSupervisor},
-            {RunManager, []}
+            {RunManager, []},
+            {BoundedDispatcher, []}
           ] ++ scheduler_children() ++ api_children()
 
       with {:ok, supervisor} <-

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill/projector.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill/projector.ex
@@ -146,7 +146,7 @@ defmodule FavnOrchestrator.Backfill.Projector do
 
   defp project_parent_from_progress(%BackfillProgress{} = progress) do
     with {:ok, parent} <- Storage.get_run(progress.backfill_run_id),
-         status <- progress.status,
+         status <- projected_parent_status(progress.status, parent.status),
          error <- parent_error(status, parent),
          true <- status != parent.status or error != parent.error do
       event_type = parent_event_type(status)
@@ -198,13 +198,19 @@ defmodule FavnOrchestrator.Backfill.Projector do
     statuses = Enum.map(windows, & &1.status)
 
     cond do
-      Enum.any?(statuses, &(&1 in [:pending, :running])) -> :running
       Enum.all?(statuses, &(&1 == :ok)) -> :ok
       Enum.all?(statuses, &(&1 == :cancelled)) -> :cancelled
       Enum.all?(statuses, &(&1 == :timed_out)) -> :timed_out
       Enum.any?(statuses, &(&1 == :ok)) -> :partial
+      mixed_terminal_failure?(statuses) -> :partial
+      Enum.any?(statuses, &(&1 in [:pending, :running])) -> :running
       true -> :error
     end
+  end
+
+  defp mixed_terminal_failure?(statuses) do
+    Enum.any?(statuses, &(&1 in [:error, :cancelled, :timed_out])) and
+      Enum.any?(statuses, &(&1 in [:pending, :running]))
   end
 
   defp parent_event_type(:running), do: :backfill_progressed
@@ -216,6 +222,12 @@ defmodule FavnOrchestrator.Backfill.Projector do
 
   defp parent_error(:ok, _parent), do: nil
   defp parent_error(_status, %RunState{} = parent), do: parent.error
+
+  defp projected_parent_status(:running, status)
+       when status in [:partial, :error, :cancelled, :timed_out],
+       do: status
+
+  defp projected_parent_status(status, _parent_status), do: status
 
   defp build_asset_window_states(%BackfillWindow{} = window, %RunState{} = run_state) do
     run_state

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill_manager.ex
@@ -23,6 +23,7 @@ defmodule FavnOrchestrator.BackfillManager do
   alias Favn.Manifest.PipelineResolver
   alias Favn.Window.Key, as: WindowKey
   alias Favn.Window.Runtime, as: RuntimeWindow
+  alias FavnOrchestrator.BoundedDispatcher
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Projector, as: BackfillProjector
@@ -33,6 +34,7 @@ defmodule FavnOrchestrator.BackfillManager do
   alias FavnOrchestrator.TransitionWriter
 
   @default_max_windows 500
+  @default_dispatch_concurrency 4
 
   @doc """
   Submits a parent pipeline backfill run and one child pipeline run per resolved anchor.
@@ -328,44 +330,86 @@ defmodule FavnOrchestrator.BackfillManager do
   end
 
   defp submit_child_runs(%RunState{} = parent, pipeline_module, range, opts) do
-    Enum.reduce_while(range.anchors, :ok, fn anchor, :ok ->
-      submit_child_run_for_anchor(parent, pipeline_module, anchor, opts)
-    end)
+    range.anchors
+    |> BoundedDispatcher.run_many(
+      fn anchor ->
+        submit_child_run_for_anchor(parent, pipeline_module, anchor, opts)
+      end,
+      max_concurrency: backfill_dispatch_concurrency(opts)
+    )
+    |> dispatch_result_to_ok()
   end
 
   defp submit_asset_child_runs(%RunState{} = parent, %Asset{} = asset, range, opts) do
-    Enum.reduce_while(range.anchors, :ok, fn anchor, :ok ->
-      window_key = WindowKey.encode(anchor.key)
+    range.anchors
+    |> BoundedDispatcher.run_many(
+      fn anchor ->
+        submit_asset_child_run_for_anchor(parent, asset, anchor, opts)
+      end,
+      max_concurrency: backfill_dispatch_concurrency(opts)
+    )
+    |> dispatch_result_to_ok()
+  end
 
-      child_opts =
+  defp submit_asset_child_run_for_anchor(%RunState{} = parent, %Asset{} = asset, anchor, opts) do
+    window_key = WindowKey.encode(anchor.key)
+
+    child_opts =
+      opts
+      |> Keyword.drop([:range_request, :run_id, :coverage_baseline_id, :dispatch_concurrency])
+      |> default_child_refresh()
+      |> Keyword.put(:manifest_version_id, parent.manifest_version_id)
+      |> Keyword.put(:anchor_window, anchor)
+      |> Keyword.put(:exact_windows, %{asset.ref => [runtime_window!(anchor)]})
+      |> Keyword.put(:parent_run_id, parent.id)
+      |> Keyword.put(:root_run_id, parent.id)
+      |> Keyword.put(:lineage_depth, 1)
+      |> Keyword.put(:trigger, %{
+        kind: :backfill,
+        backfill_run_id: parent.id,
+        pipeline_module: asset.module,
+        window_key: window_key
+      })
+      |> Keyword.update(
+        :metadata,
+        asset_child_metadata(asset, anchor, window_key),
+        fn metadata ->
+          Map.merge(metadata, asset_child_metadata(asset, anchor, window_key))
+        end
+      )
+
+    submit_asset_child_run(asset.ref, child_opts, opts)
+  end
+
+  defp dispatch_result_to_ok({:ok, _values}), do: :ok
+  defp dispatch_result_to_ok({:error, _reason} = error), do: error
+
+  defp backfill_dispatch_concurrency(opts) do
+    opts
+    |> Keyword.get(:dispatch_concurrency, configured_backfill_dispatch_concurrency())
+    |> positive_integer(@default_dispatch_concurrency)
+  end
+
+  defp configured_backfill_dispatch_concurrency do
+    case Application.get_env(:favn_orchestrator, :backfill, []) do
+      opts when is_list(opts) ->
         opts
-        |> Keyword.drop([:range_request, :run_id, :coverage_baseline_id])
-        |> default_child_refresh()
-        |> Keyword.put(:manifest_version_id, parent.manifest_version_id)
-        |> Keyword.put(:anchor_window, anchor)
-        |> Keyword.put(:exact_windows, %{asset.ref => [runtime_window!(anchor)]})
-        |> Keyword.put(:parent_run_id, parent.id)
-        |> Keyword.put(:root_run_id, parent.id)
-        |> Keyword.put(:lineage_depth, 1)
-        |> Keyword.put(:trigger, %{
-          kind: :backfill,
-          backfill_run_id: parent.id,
-          pipeline_module: asset.module,
-          window_key: window_key
-        })
-        |> Keyword.update(
-          :metadata,
-          asset_child_metadata(asset, anchor, window_key),
-          fn metadata ->
-            Map.merge(metadata, asset_child_metadata(asset, anchor, window_key))
-          end
-        )
+        |> Keyword.get(:dispatch_concurrency, @default_dispatch_concurrency)
+        |> positive_integer(@default_dispatch_concurrency)
 
-      case submit_asset_child_run(asset.ref, child_opts, opts) do
-        {:ok, _child_run_id} -> {:cont, :ok}
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
+      _other ->
+        @default_dispatch_concurrency
+    end
+  end
+
+  defp positive_integer(value, _default) when is_integer(value) and value > 0, do: value
+  defp positive_integer(_value, default), do: default
+
+  defp submit_child_run_for_anchor(%RunState{} = parent, pipeline_module, anchor, opts) do
+    case submit_child_run(pipeline_module, child_opts(parent, anchor, opts), opts) do
+      {:ok, _child_run_id} -> :ok
+      {:error, _reason} = error -> error
+    end
   end
 
   defp runtime_window!(anchor) do
@@ -402,13 +446,6 @@ defmodule FavnOrchestrator.BackfillManager do
     end
   end
 
-  defp submit_child_run_for_anchor(%RunState{} = parent, pipeline_module, anchor, opts) do
-    case submit_child_run(pipeline_module, child_opts(parent, anchor, opts), opts) do
-      {:ok, _child_run_id} -> {:cont, :ok}
-      {:error, _reason} = error -> {:halt, error}
-    end
-  end
-
   defp child_opts(%RunState{} = parent, anchor, opts) do
     window_key = WindowKey.encode(anchor.key)
 
@@ -416,7 +453,8 @@ defmodule FavnOrchestrator.BackfillManager do
     |> Keyword.drop([
       :range_request,
       :run_id,
-      :coverage_baseline_id
+      :coverage_baseline_id,
+      :dispatch_concurrency
     ])
     |> default_child_refresh()
     |> Keyword.put(:manifest_version_id, parent.manifest_version_id)

--- a/apps/favn_orchestrator/lib/favn_orchestrator/backfill_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/backfill_manager.ex
@@ -68,9 +68,8 @@ defmodule FavnOrchestrator.BackfillManager do
              version.manifest_version_id,
              range,
              opts
-           ),
-         :ok <- submit_child_runs(parent, pipeline_module, range, opts) do
-      {:ok, parent.id}
+           ) do
+      submit_backfill_children(parent, pipeline_module, range, opts)
     else
       {:error, reason} = error ->
         case maybe_compensate_submit_failure(run_id, pipeline_module, reason, opts) do
@@ -109,9 +108,8 @@ defmodule FavnOrchestrator.BackfillManager do
              version.manifest_version_id,
              range,
              opts
-           ),
-         :ok <- submit_asset_child_runs(parent, asset, range, opts) do
-      {:ok, parent.id}
+           ) do
+      submit_asset_backfill_children(parent, asset, range, opts)
     else
       {:error, reason} = error ->
         case maybe_compensate_submit_failure(run_id, module, reason, opts) do
@@ -331,24 +329,51 @@ defmodule FavnOrchestrator.BackfillManager do
 
   defp submit_child_runs(%RunState{} = parent, pipeline_module, range, opts) do
     range.anchors
-    |> BoundedDispatcher.run_many(
+    |> BoundedDispatcher.run_many_results(
       fn anchor ->
         submit_child_run_for_anchor(parent, pipeline_module, anchor, opts)
       end,
       max_concurrency: backfill_dispatch_concurrency(opts)
     )
-    |> dispatch_result_to_ok()
+    |> dispatch_results_to_submit_result()
   end
 
   defp submit_asset_child_runs(%RunState{} = parent, %Asset{} = asset, range, opts) do
     range.anchors
-    |> BoundedDispatcher.run_many(
+    |> BoundedDispatcher.run_many_results(
       fn anchor ->
         submit_asset_child_run_for_anchor(parent, asset, anchor, opts)
       end,
       max_concurrency: backfill_dispatch_concurrency(opts)
     )
-    |> dispatch_result_to_ok()
+    |> dispatch_results_to_submit_result()
+  end
+
+  defp submit_backfill_children(%RunState{} = parent, pipeline_module, range, opts) do
+    case submit_child_runs(parent, pipeline_module, range, opts) do
+      :ok ->
+        {:ok, parent.id}
+
+      {:error, reason, failures} ->
+        handle_child_dispatch_failure(parent, pipeline_module, reason, failures, opts)
+    end
+  end
+
+  defp submit_asset_backfill_children(%RunState{} = parent, %Asset{} = asset, range, opts) do
+    case submit_asset_child_runs(parent, asset, range, opts) do
+      :ok ->
+        {:ok, parent.id}
+
+      {:error, reason, failures} ->
+        handle_child_dispatch_failure(parent, asset.module, reason, failures, opts)
+    end
+  end
+
+  defp handle_child_dispatch_failure(parent, pipeline_module, reason, failures, opts) do
+    case compensate_existing_backfill(parent, pipeline_module, reason, opts, failures) do
+      :ok -> {:error, reason}
+      {:error, _reason} = error -> error
+    end
   end
 
   defp submit_asset_child_run_for_anchor(%RunState{} = parent, %Asset{} = asset, anchor, opts) do
@@ -378,11 +403,24 @@ defmodule FavnOrchestrator.BackfillManager do
         end
       )
 
-    submit_asset_child_run(asset.ref, child_opts, opts)
+    with {:ok, _child_run_id} <- submit_asset_child_run(asset.ref, child_opts, opts) do
+      {:ok, window_key}
+    end
   end
 
-  defp dispatch_result_to_ok({:ok, _values}), do: :ok
-  defp dispatch_result_to_ok({:error, _reason} = error), do: error
+  defp dispatch_results_to_submit_result({:ok, results}) do
+    failures =
+      results
+      |> Enum.filter(&(&1.status == :error))
+      |> Enum.map(fn %{item: anchor, reason: reason} ->
+        %{window_key: WindowKey.encode(anchor.key), reason: reason}
+      end)
+
+    case failures do
+      [] -> :ok
+      [%{reason: reason} | _rest] -> {:error, reason, failures}
+    end
+  end
 
   defp backfill_dispatch_concurrency(opts) do
     opts
@@ -406,9 +444,9 @@ defmodule FavnOrchestrator.BackfillManager do
   defp positive_integer(_value, default), do: default
 
   defp submit_child_run_for_anchor(%RunState{} = parent, pipeline_module, anchor, opts) do
-    case submit_child_run(pipeline_module, child_opts(parent, anchor, opts), opts) do
-      {:ok, _child_run_id} -> :ok
-      {:error, _reason} = error -> error
+    with {:ok, _child_run_id} <-
+           submit_child_run(pipeline_module, child_opts(parent, anchor, opts), opts) do
+      {:ok, WindowKey.encode(anchor.key)}
     end
   end
 
@@ -690,13 +728,16 @@ defmodule FavnOrchestrator.BackfillManager do
     end
   end
 
-  defp compensate_existing_backfill(%RunState{} = parent, pipeline_module, reason, opts) do
+  defp compensate_existing_backfill(parent, pipeline_module, reason, opts, failures \\ :all)
+
+  defp compensate_existing_backfill(%RunState{} = parent, pipeline_module, reason, opts, failures) do
     with {:ok, windows} <- BackfillProjector.list_all_backfill_windows(backfill_run_id: parent.id),
          now <- DateTime.utc_now(),
          error <- {:backfill_child_submission_failed, reason},
          {:ok, updated_windows} <-
-           windows_with_compensation(windows, pipeline_module, error, now, opts) do
-      status = BackfillProjector.parent_status(updated_windows)
+           windows_with_compensation(windows, pipeline_module, error, now, opts, failures),
+         {:ok, parent} <- Storage.get_run(parent.id) do
+      status = compensated_parent_status(updated_windows, pipeline_module, failures)
 
       parent
       |> RunState.transition(
@@ -714,10 +755,12 @@ defmodule FavnOrchestrator.BackfillManager do
     end
   end
 
-  defp windows_with_compensation(windows, pipeline_module, error, now, opts) do
+  defp windows_with_compensation(windows, pipeline_module, error, now, opts, failures) do
     result =
       Enum.reduce_while(windows, {:ok, []}, fn window, {:ok, acc} ->
-        if window.pipeline_module == pipeline_module and window.status in [:pending, :running] do
+        if compensate_window?(window, pipeline_module, failures) do
+          error = window_compensation_error(error, window.window_key, failures)
+
           updated = %{
             window
             | status: :error,
@@ -739,6 +782,46 @@ defmodule FavnOrchestrator.BackfillManager do
     case result do
       {:ok, windows} -> {:ok, Enum.reverse(windows)}
       {:error, _reason} = error -> error
+    end
+  end
+
+  defp compensated_parent_status(windows, _pipeline_module, :all) do
+    BackfillProjector.parent_status(windows)
+  end
+
+  defp compensated_parent_status(windows, pipeline_module, failures) when is_list(failures) do
+    failed_window_keys = MapSet.new(failures, & &1.window_key)
+
+    submitted_or_pending_count =
+      Enum.count(windows, fn window ->
+        window.pipeline_module == pipeline_module and
+          not MapSet.member?(failed_window_keys, window.window_key)
+      end)
+
+    if submitted_or_pending_count > 0 do
+      :partial
+    else
+      BackfillProjector.parent_status(windows)
+    end
+  end
+
+  defp compensate_window?(%BackfillWindow{} = window, pipeline_module, :all) do
+    window.pipeline_module == pipeline_module and window.status in [:pending, :running]
+  end
+
+  defp compensate_window?(%BackfillWindow{} = window, pipeline_module, failures)
+       when is_list(failures) do
+    window.pipeline_module == pipeline_module and
+      window.status in [:pending, :running] and
+      Enum.any?(failures, &(&1.window_key == window.window_key))
+  end
+
+  defp window_compensation_error(error, _window_key, :all), do: error
+
+  defp window_compensation_error(_error, window_key, failures) when is_list(failures) do
+    case Enum.find(failures, &(&1.window_key == window_key)) do
+      %{reason: reason} -> {:backfill_child_submission_failed, reason}
+      nil -> {:backfill_child_submission_failed, :unknown_child_submission_failure}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/bounded_dispatcher.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/bounded_dispatcher.ex
@@ -9,9 +9,12 @@ defmodule FavnOrchestrator.BoundedDispatcher do
   """
 
   @default_max_concurrency 4
-  @default_timeout :infinity
+  @default_timeout_ms 15_000
 
   @type dispatch_result(value) :: {:ok, [value]} | {:error, term()}
+  @type item_result(value) ::
+          %{item: term(), status: :ok, value: value}
+          | %{item: term(), status: :error, reason: term()}
 
   @doc false
   @spec child_spec(keyword()) :: Supervisor.child_spec()
@@ -42,13 +45,30 @@ defmodule FavnOrchestrator.BoundedDispatcher do
   Runs a collection through supervised tasks with a bounded concurrency limit.
 
   The worker may return `:ok`, `{:ok, value}`, or `{:error, reason}`. The first
-  error stops result collection and is returned to the caller. Already-started
-  tasks are still owned by the task supervisor.
+  error is returned to the caller.
   """
   @spec run_many(Enumerable.t(), (term() -> {:ok, value} | {:error, term()} | value), keyword()) ::
           dispatch_result(value | :ok)
         when value: term()
   def run_many(items, worker, opts \\ []) when is_function(worker, 1) and is_list(opts) do
+    {:ok, results} = run_many_results(items, worker, opts)
+    collect_results(results)
+  end
+
+  @doc """
+  Runs a collection and returns one result per input item.
+
+  This is useful for callers that need deterministic compensation after partial
+  failure. Timeouts are finite by default and are reported as
+  `{:dispatcher_timeout, timeout_ms}` for the affected item.
+  """
+  @spec run_many_results(
+          Enumerable.t(),
+          (term() -> {:ok, value} | {:error, term()} | value),
+          keyword()
+        ) :: {:ok, [item_result(value | :ok)]}
+        when value: term()
+  def run_many_results(items, worker, opts \\ []) when is_function(worker, 1) and is_list(opts) do
     items = Enum.to_list(items)
 
     if items == [] do
@@ -56,20 +76,20 @@ defmodule FavnOrchestrator.BoundedDispatcher do
     else
       supervisor = Keyword.get(opts, :supervisor, task_supervisor_name())
       max_concurrency = max_concurrency(opts)
-      timeout = Keyword.get(opts, :timeout, @default_timeout)
+      timeout_ms = timeout_ms(opts)
 
-      supervisor
-      |> Task.Supervisor.async_stream_nolink(items, worker,
-        max_concurrency: max_concurrency,
-        ordered: true,
-        timeout: timeout,
-        on_timeout: :kill_task
-      )
-      |> Enum.reduce_while({:ok, []}, &collect_result/2)
-      |> case do
-        {:ok, values} -> {:ok, Enum.reverse(values)}
-        {:error, _reason} = error -> error
-      end
+      results =
+        supervisor
+        |> Task.Supervisor.async_stream_nolink(items, worker,
+          max_concurrency: max_concurrency,
+          ordered: true,
+          timeout: timeout_ms,
+          on_timeout: :kill_task
+        )
+        |> Stream.zip(items)
+        |> Enum.map(fn {result, item} -> item_result(item, result, timeout_ms) end)
+
+      {:ok, results}
     end
   end
 
@@ -85,18 +105,59 @@ defmodule FavnOrchestrator.BoundedDispatcher do
     end
   end
 
-  defp collect_result({:ok, {:ok, value}}, {:ok, acc}), do: {:cont, {:ok, [value | acc]}}
-  defp collect_result({:ok, :ok}, {:ok, acc}), do: {:cont, {:ok, [:ok | acc]}}
-  defp collect_result({:ok, {:error, reason}}, {:ok, _acc}), do: {:halt, {:error, reason}}
-  defp collect_result({:ok, value}, {:ok, acc}), do: {:cont, {:ok, [value | acc]}}
+  @doc "Returns the configured default dispatcher timeout in milliseconds."
+  @spec configured_timeout_ms() :: pos_integer()
+  def configured_timeout_ms do
+    case Application.get_env(:favn_orchestrator, :dispatcher, []) do
+      opts when is_list(opts) ->
+        positive_integer(opts[:timeout_ms], @default_timeout_ms)
 
-  defp collect_result({:exit, reason}, {:ok, _acc}),
-    do: {:halt, {:error, {:dispatcher_task_exit, reason}}}
+      _other ->
+        @default_timeout_ms
+    end
+  end
+
+  defp collect_results(results) do
+    results
+    |> Enum.reduce_while({:ok, []}, fn
+      %{status: :ok, value: value}, {:ok, acc} ->
+        {:cont, {:ok, [value | acc]}}
+
+      %{status: :error, reason: reason}, {:ok, _acc} ->
+        {:halt, {:error, reason}}
+    end)
+    |> case do
+      {:ok, values} -> {:ok, Enum.reverse(values)}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp item_result(item, {:ok, {:ok, value}}, _timeout_ms),
+    do: %{item: item, status: :ok, value: value}
+
+  defp item_result(item, {:ok, :ok}, _timeout_ms), do: %{item: item, status: :ok, value: :ok}
+
+  defp item_result(item, {:ok, {:error, reason}}, _timeout_ms),
+    do: %{item: item, status: :error, reason: reason}
+
+  defp item_result(item, {:ok, value}, _timeout_ms), do: %{item: item, status: :ok, value: value}
+
+  defp item_result(item, {:exit, :timeout}, timeout_ms),
+    do: %{item: item, status: :error, reason: {:dispatcher_timeout, timeout_ms}}
+
+  defp item_result(item, {:exit, reason}, _timeout_ms),
+    do: %{item: item, status: :error, reason: {:dispatcher_task_exit, reason}}
 
   defp max_concurrency(opts) do
     opts
     |> Keyword.get(:max_concurrency, configured_max_concurrency())
     |> positive_integer(@default_max_concurrency)
+  end
+
+  defp timeout_ms(opts) do
+    opts
+    |> Keyword.get(:timeout_ms, configured_timeout_ms())
+    |> positive_integer(@default_timeout_ms)
   end
 
   defp positive_integer(value, _default) when is_integer(value) and value > 0, do: value

--- a/apps/favn_orchestrator/lib/favn_orchestrator/bounded_dispatcher.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/bounded_dispatcher.ex
@@ -1,0 +1,106 @@
+defmodule FavnOrchestrator.BoundedDispatcher do
+  @moduledoc """
+  Supervised bounded task dispatch for orchestrator control-plane submissions.
+
+  The dispatcher is intentionally small: callers own durable intent and lifecycle
+  state, while this module provides a supervised execution boundary with explicit
+  concurrency limits. Actual run creation must still go through the public
+  orchestrator submission APIs.
+  """
+
+  @default_max_concurrency 4
+  @default_timeout :infinity
+
+  @type dispatch_result(value) :: {:ok, [value]} | {:error, term()}
+
+  @doc false
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    name = Keyword.get(opts, :name, task_supervisor_name())
+
+    Supervisor.child_spec(
+      {Task.Supervisor, name: name},
+      id: __MODULE__,
+      restart: :permanent
+    )
+  end
+
+  @doc """
+  Runs one dispatched task under the bounded task supervisor.
+  """
+  @spec run((-> {:ok, value} | {:error, term()} | value), keyword()) ::
+          {:ok, value} | {:error, term()}
+        when value: term()
+  def run(fun, opts \\ []) when is_function(fun, 0) and is_list(opts) do
+    case run_many([:job], fn :job -> fun.() end, Keyword.put(opts, :max_concurrency, 1)) do
+      {:ok, [value]} -> {:ok, value}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  @doc """
+  Runs a collection through supervised tasks with a bounded concurrency limit.
+
+  The worker may return `:ok`, `{:ok, value}`, or `{:error, reason}`. The first
+  error stops result collection and is returned to the caller. Already-started
+  tasks are still owned by the task supervisor.
+  """
+  @spec run_many(Enumerable.t(), (term() -> {:ok, value} | {:error, term()} | value), keyword()) ::
+          dispatch_result(value | :ok)
+        when value: term()
+  def run_many(items, worker, opts \\ []) when is_function(worker, 1) and is_list(opts) do
+    items = Enum.to_list(items)
+
+    if items == [] do
+      {:ok, []}
+    else
+      supervisor = Keyword.get(opts, :supervisor, task_supervisor_name())
+      max_concurrency = max_concurrency(opts)
+      timeout = Keyword.get(opts, :timeout, @default_timeout)
+
+      supervisor
+      |> Task.Supervisor.async_stream_nolink(items, worker,
+        max_concurrency: max_concurrency,
+        ordered: true,
+        timeout: timeout,
+        on_timeout: :kill_task
+      )
+      |> Enum.reduce_while({:ok, []}, &collect_result/2)
+      |> case do
+        {:ok, values} -> {:ok, Enum.reverse(values)}
+        {:error, _reason} = error -> error
+      end
+    end
+  end
+
+  @doc "Returns the configured default dispatcher concurrency."
+  @spec configured_max_concurrency() :: pos_integer()
+  def configured_max_concurrency do
+    case Application.get_env(:favn_orchestrator, :dispatcher, []) do
+      opts when is_list(opts) ->
+        positive_integer(opts[:max_concurrency], @default_max_concurrency)
+
+      _other ->
+        @default_max_concurrency
+    end
+  end
+
+  defp collect_result({:ok, {:ok, value}}, {:ok, acc}), do: {:cont, {:ok, [value | acc]}}
+  defp collect_result({:ok, :ok}, {:ok, acc}), do: {:cont, {:ok, [:ok | acc]}}
+  defp collect_result({:ok, {:error, reason}}, {:ok, _acc}), do: {:halt, {:error, reason}}
+  defp collect_result({:ok, value}, {:ok, acc}), do: {:cont, {:ok, [value | acc]}}
+
+  defp collect_result({:exit, reason}, {:ok, _acc}),
+    do: {:halt, {:error, {:dispatcher_task_exit, reason}}}
+
+  defp max_concurrency(opts) do
+    opts
+    |> Keyword.get(:max_concurrency, configured_max_concurrency())
+    |> positive_integer(@default_max_concurrency)
+  end
+
+  defp positive_integer(value, _default) when is_integer(value) and value > 0, do: value
+  defp positive_integer(_value, default), do: default
+
+  defp task_supervisor_name, do: Module.concat(__MODULE__, TaskSupervisor)
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/scheduler/runtime.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/scheduler/runtime.ex
@@ -7,6 +7,7 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
   alias Favn.Manifest.PipelineResolver
   alias Favn.Scheduler.State
   alias Favn.Window.Policy
+  alias FavnOrchestrator.BoundedDispatcher
   alias FavnOrchestrator.ManifestStore
   alias FavnOrchestrator.OperationalEvents
   alias FavnOrchestrator.Scheduler.Cron
@@ -16,6 +17,7 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
 
   @default_tick_ms 15_000
   @default_max_missed_all_occurrences 1_000
+  @default_submission_budget 25
 
   def start_link(opts \\ []) do
     name = Keyword.get(opts, :name, __MODULE__)
@@ -297,39 +299,49 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
   defp evaluate_all(state) do
     now = DateTime.utc_now()
 
-    next_states =
-      Enum.reduce(state.entries, state.states, fn {pipeline_module, entry}, acc ->
-        current = Map.get(acc, pipeline_module, %State{pipeline_module: pipeline_module})
+    {next_states, _remaining_budget} =
+      Enum.reduce(state.entries, {state.states, configured_submission_budget()}, fn
+        {pipeline_module, entry}, {acc, remaining_budget} ->
+          current = Map.get(acc, pipeline_module, %State{pipeline_module: pipeline_module})
 
-        updated =
-          if entry.schedule.active do
-            evaluate_entry(entry, state.index, state.version, current, now)
-          else
-            %{current | last_evaluated_at: now, updated_at: now}
-          end
+          {updated, remaining_budget} =
+            cond do
+              not entry.schedule.active ->
+                {%{current | last_evaluated_at: now, updated_at: now}, remaining_budget}
 
-        if persist_state_change?(current, updated) do
-          persisted = persisted_scheduler_state(current, updated)
-          :ok = Storage.put_scheduler_state({pipeline_module, entry.schedule.name}, persisted)
-          Map.put(acc, pipeline_module, persisted)
-        else
-          Map.put(acc, pipeline_module, updated)
-        end
+              remaining_budget <= 0 ->
+                {%{current | last_evaluated_at: now, updated_at: now}, remaining_budget}
+
+              true ->
+                evaluate_entry(entry, state.index, state.version, current, now, remaining_budget)
+            end
+
+          next_acc =
+            if persist_state_change?(current, updated) do
+              persisted = persisted_scheduler_state(current, updated)
+              :ok = Storage.put_scheduler_state({pipeline_module, entry.schedule.name}, persisted)
+              Map.put(acc, pipeline_module, persisted)
+            else
+              Map.put(acc, pipeline_module, updated)
+            end
+
+          {next_acc, remaining_budget}
       end)
 
     %{state | states: next_states}
   end
 
-  defp evaluate_entry(entry, index, version, state, now) do
+  defp evaluate_entry(entry, index, version, state, now, remaining_budget) do
     state = reconcile_in_flight(state)
     latest_due = Cron.latest_due(entry.schedule.cron, entry.schedule.timezone, now)
 
     cond do
       is_nil(latest_due) ->
-        %{state | last_evaluated_at: now, updated_at: now}
+        {%{state | last_evaluated_at: now, updated_at: now}, remaining_budget}
 
       is_nil(state.last_due_at) ->
-        %{state | last_due_at: latest_due, last_evaluated_at: now, updated_at: now}
+        {%{state | last_due_at: latest_due, last_evaluated_at: now, updated_at: now},
+         remaining_budget}
 
       true ->
         selected =
@@ -342,28 +354,43 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
             latest_due
           )
 
-        {next_state, submitted_due_ats_reversed} =
+        {next_state, submitted_due_ats_reversed, remaining_budget} =
           state
-          |> maybe_submit_queued(entry, index, version, latest_due, now)
+          |> maybe_submit_queued(entry, index, version, latest_due, now, remaining_budget)
           |> submit_due_occurrences(entry, index, version, selected, latest_due, now)
 
         submitted_due_ats = Enum.reverse(submitted_due_ats_reversed)
 
-        next_state
-        |> Map.put(
-          :last_due_at,
-          next_cursor_due(
-            entry.schedule.missed,
-            state.last_due_at,
-            latest_due,
-            selected,
-            submitted_due_ats
+        next_state =
+          next_state
+          |> Map.put(
+            :last_due_at,
+            next_cursor_due(
+              entry.schedule.missed,
+              state.last_due_at,
+              latest_due,
+              selected,
+              submitted_due_ats
+            )
           )
-        )
-        |> Map.put(:last_evaluated_at, now)
-        |> Map.put(:updated_at, now)
+          |> Map.put(:last_evaluated_at, now)
+          |> Map.put(:updated_at, now)
+
+        {next_state, remaining_budget}
     end
   end
+
+  defp maybe_submit_queued(
+         state,
+         _entry,
+         _index,
+         _version,
+         _latest_due,
+         _now,
+         remaining_budget
+       )
+       when remaining_budget <= 0,
+       do: {state, [], remaining_budget}
 
   defp maybe_submit_queued(
          %State{queued_due_at: nil} = state,
@@ -371,9 +398,10 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
          _index,
          _version,
          _latest_due,
-         _now
+         _now,
+         remaining_budget
        ),
-       do: {state, []}
+       do: {state, [], remaining_budget}
 
   defp maybe_submit_queued(
          %State{in_flight_run_id: run_id} = state,
@@ -381,19 +409,20 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
          _index,
          _version,
          _latest_due,
-         _now
+         _now,
+         remaining_budget
        )
-       when is_binary(run_id), do: {state, []}
+       when is_binary(run_id), do: {state, [], remaining_budget}
 
-  defp maybe_submit_queued(state, entry, index, version, latest_due, now) do
+  defp maybe_submit_queued(state, entry, index, version, latest_due, now, remaining_budget) do
     case submit_occurrence(state, entry, index, version, state.queued_due_at, latest_due, now) do
-      {:ok, next} -> {%{next | queued_due_at: nil}, [state.queued_due_at]}
-      {:error, _reason} -> {state, []}
+      {:ok, next} -> {%{next | queued_due_at: nil}, [state.queued_due_at], remaining_budget - 1}
+      {:error, _reason} -> {state, [], remaining_budget - 1}
     end
   end
 
   defp submit_due_occurrences(
-         {state, submitted_reversed},
+         {state, submitted_reversed, remaining_budget},
          _entry,
          _index,
          _version,
@@ -401,10 +430,22 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
          _latest_due,
          _now
        ),
-       do: {state, submitted_reversed}
+       do: {state, submitted_reversed, remaining_budget}
 
   defp submit_due_occurrences(
-         {state, submitted_reversed},
+         {state, submitted_reversed, remaining_budget},
+         _entry,
+         _index,
+         _version,
+         _occurrences,
+         _latest_due,
+         _now
+       )
+       when remaining_budget <= 0,
+       do: {state, submitted_reversed, remaining_budget}
+
+  defp submit_due_occurrences(
+         {state, submitted_reversed, remaining_budget},
          entry,
          index,
          version,
@@ -425,7 +466,7 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
           end
 
         submit_due_occurrences(
-          {next, submitted_next},
+          {next, submitted_next, remaining_budget - 1},
           entry,
           index,
           version,
@@ -436,25 +477,26 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
 
       :forbid ->
         if is_binary(state.in_flight_run_id) do
-          {state, submitted_reversed}
+          {state, submitted_reversed, remaining_budget}
         else
           case submit_occurrence(state, entry, index, version, due, latest_due, now) do
-            {:ok, value} -> {value, [due | submitted_reversed]}
-            {:error, _reason} -> {state, submitted_reversed}
+            {:ok, value} -> {value, [due | submitted_reversed], remaining_budget - 1}
+            {:error, _reason} -> {state, submitted_reversed, remaining_budget - 1}
           end
         end
 
       :queue_one ->
         if is_binary(state.in_flight_run_id) do
-          {%{state | queued_due_at: List.last([due | rest])}, submitted_reversed}
+          {%{state | queued_due_at: List.last([due | rest])}, submitted_reversed,
+           remaining_budget}
         else
           case submit_occurrence(state, entry, index, version, due, latest_due, now) do
             {:ok, value} ->
               next = if rest == [], do: value, else: %{value | queued_due_at: List.last(rest)}
-              {next, [due | submitted_reversed]}
+              {next, [due | submitted_reversed], remaining_budget - 1}
 
             {:error, _reason} ->
-              {state, submitted_reversed}
+              {state, submitted_reversed, remaining_budget - 1}
           end
         end
     end
@@ -469,15 +511,17 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
          {:ok, resolution} <-
            PipelineResolver.resolve(index, entry.pipeline, resolve_opts(trigger, anchor_window)),
          {:ok, run_id} <-
-           FavnOrchestrator.submit_pipeline_run(resolution.target_refs,
-             manifest_version_id: version.manifest_version_id,
-             trigger: trigger,
-             dependencies: resolution.dependencies,
-             anchor_window: anchor_window,
-             _pipeline_context: resolution.pipeline_ctx,
-             _submit_ref: entry.module,
-             _submit_kind: :pipeline
-           ) do
+           BoundedDispatcher.run(fn ->
+             FavnOrchestrator.submit_pipeline_run(resolution.target_refs,
+               manifest_version_id: version.manifest_version_id,
+               trigger: trigger,
+               dependencies: resolution.dependencies,
+               anchor_window: anchor_window,
+               _pipeline_context: resolution.pipeline_ctx,
+               _submit_ref: entry.module,
+               _submit_kind: :pipeline
+             )
+           end) do
       next =
         if track_in_flight? do
           %{state | in_flight_run_id: run_id, last_submitted_due_at: due_at, updated_at: now}
@@ -650,6 +694,19 @@ defmodule FavnOrchestrator.Scheduler.Runtime do
 
       _other ->
         @default_max_missed_all_occurrences
+    end
+  end
+
+  defp configured_submission_budget do
+    case Application.get_env(:favn_orchestrator, :scheduler, []) do
+      opts when is_list(opts) ->
+        case Keyword.get(opts, :submission_budget, @default_submission_budget) do
+          value when is_integer(value) and value > 0 -> value
+          _other -> @default_submission_budget
+        end
+
+      _other ->
+        @default_submission_budget
     end
   end
 

--- a/apps/favn_orchestrator/test/backfill_manager_test.exs
+++ b/apps/favn_orchestrator/test/backfill_manager_test.exs
@@ -287,6 +287,40 @@ defmodule FavnOrchestrator.BackfillManagerTest do
     refute Keyword.has_key?(child_opts, :refresh)
   end
 
+  test "bounds child pipeline submission concurrency" do
+    version = manifest_version("mv_backfill_bounded_child_submission")
+    {:ok, tracker} = Agent.start_link(fn -> %{active: 0, max_active: 0} end)
+
+    on_exit(fn ->
+      if Process.alive?(tracker), do: Agent.stop(tracker)
+    end)
+
+    submitter = fn _pipeline_module, _child_opts ->
+      Agent.update(tracker, fn state ->
+        active = state.active + 1
+        %{active: active, max_active: max(state.max_active, active)}
+      end)
+
+      Process.sleep(20)
+
+      Agent.update(tracker, fn state -> %{state | active: state.active - 1} end)
+      {:ok, "child_#{System.unique_integer([:positive])}"}
+    end
+
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    assert {:ok, "run_backfill_bounded_child_submission"} =
+             FavnOrchestrator.submit_pipeline_backfill(MyApp.Pipelines.Daily,
+               run_id: "run_backfill_bounded_child_submission",
+               range_request: %{kind: :day, from: "2026-04-24", to: "2026-04-27"},
+               dispatch_concurrency: 2,
+               _child_submitter: submitter
+             )
+
+    assert Agent.get(tracker, & &1.max_active) <= 2
+  end
+
   for option <- [:lookback, :lookback_policy] do
     @option option
 

--- a/apps/favn_orchestrator/test/backfill_manager_test.exs
+++ b/apps/favn_orchestrator/test/backfill_manager_test.exs
@@ -321,6 +321,44 @@ defmodule FavnOrchestrator.BackfillManagerTest do
     assert Agent.get(tracker, & &1.max_active) <= 2
   end
 
+  test "concurrent child submission failure only compensates failed windows" do
+    version = manifest_version("mv_backfill_concurrent_partial_compensation")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    submitter = fn pipeline_module, child_opts ->
+      anchor = Keyword.fetch!(child_opts, :anchor_window)
+
+      if DateTime.compare(anchor.start_at, ~U[2026-04-26 00:00:00Z]) == :eq do
+        RunManager.submit_pipeline_module_run(pipeline_module, child_opts)
+      else
+        {:error, :synthetic_concurrent_child_submit_failed}
+      end
+    end
+
+    assert {:error, :synthetic_concurrent_child_submit_failed} =
+             FavnOrchestrator.submit_pipeline_backfill(MyApp.Pipelines.Daily,
+               run_id: "run_backfill_concurrent_partial_compensation",
+               range_request: %{kind: :day, from: "2026-04-26", to: "2026-04-27"},
+               dispatch_concurrency: 2,
+               _child_submitter: submitter
+             )
+
+    eventually(fn ->
+      assert {:ok, parent} = Storage.get_run("run_backfill_concurrent_partial_compensation")
+      assert parent.status == :partial
+
+      windows = list_backfill_windows(backfill_run_id: parent.id)
+      assert Enum.map(windows, & &1.status) |> Enum.sort() == [:error, :ok]
+
+      ok_window = Enum.find(windows, &(&1.status == :ok))
+      error_window = Enum.find(windows, &(&1.status == :error))
+
+      assert is_binary(ok_window.child_run_id)
+      assert is_nil(error_window.child_run_id)
+    end)
+  end
+
   for option <- [:lookback, :lookback_policy] do
     @option option
 

--- a/apps/favn_orchestrator/test/bounded_dispatcher_test.exs
+++ b/apps/favn_orchestrator/test/bounded_dispatcher_test.exs
@@ -1,0 +1,30 @@
+defmodule FavnOrchestrator.BoundedDispatcherTest do
+  use ExUnit.Case, async: false
+
+  alias FavnOrchestrator.BoundedDispatcher
+
+  test "run_many honors explicit concurrency" do
+    {:ok, tracker} = Agent.start_link(fn -> %{active: 0, max_active: 0} end)
+
+    on_exit(fn ->
+      if Process.alive?(tracker), do: Agent.stop(tracker)
+    end)
+
+    assert {:ok, [:ok, :ok, :ok, :ok, :ok]} =
+             BoundedDispatcher.run_many(
+               1..5,
+               fn _item ->
+                 Agent.update(tracker, fn state ->
+                   active = state.active + 1
+                   %{active: active, max_active: max(state.max_active, active)}
+                 end)
+
+                 Process.sleep(20)
+
+                 Agent.update(tracker, fn state -> %{state | active: state.active - 1} end)
+                 :ok
+               end, max_concurrency: 2)
+
+    assert Agent.get(tracker, & &1.max_active) <= 2
+  end
+end

--- a/apps/favn_orchestrator/test/bounded_dispatcher_test.exs
+++ b/apps/favn_orchestrator/test/bounded_dispatcher_test.exs
@@ -23,8 +23,26 @@ defmodule FavnOrchestrator.BoundedDispatcherTest do
 
                  Agent.update(tracker, fn state -> %{state | active: state.active - 1} end)
                  :ok
-               end, max_concurrency: 2)
+               end,
+               max_concurrency: 2
+             )
 
     assert Agent.get(tracker, & &1.max_active) <= 2
+  end
+
+  test "run returns explicit timeout error" do
+    assert {:error, {:dispatcher_timeout, 1}} =
+             BoundedDispatcher.run(
+               fn ->
+                 Process.sleep(50)
+                 :ok
+               end,
+               timeout_ms: 1
+             )
+  end
+
+  test "run returns task exit error" do
+    assert {:error, {:dispatcher_task_exit, {%RuntimeError{message: "boom"}, _stack}}} =
+             BoundedDispatcher.run(fn -> raise "boom" end, timeout_ms: 1_000)
   end
 end

--- a/apps/favn_orchestrator/test/scheduler/runtime_test.exs
+++ b/apps/favn_orchestrator/test/scheduler/runtime_test.exs
@@ -380,6 +380,19 @@ defmodule FavnOrchestrator.Scheduler.RuntimeTest do
 
     budgeted_runs = Enum.filter(runs, &(&1.manifest_version_id == version.manifest_version_id))
     assert length(budgeted_runs) == 2
+
+    first_occurrence_keys = occurrence_keys(budgeted_runs)
+    assert length(first_occurrence_keys) == 2
+
+    assert :ok = Runtime.tick(name)
+    assert {:ok, runs} = Storage.list_runs()
+
+    continued_runs = Enum.filter(runs, &(&1.manifest_version_id == version.manifest_version_id))
+    continued_occurrence_keys = occurrence_keys(continued_runs)
+
+    assert length(continued_runs) == 4
+    assert length(continued_occurrence_keys) == 4
+    assert Enum.uniq(continued_occurrence_keys) == continued_occurrence_keys
   end
 
   test "windowed scheduled pipelines carry anchor window into run pipeline context" do
@@ -551,6 +564,12 @@ defmodule FavnOrchestrator.Scheduler.RuntimeTest do
     {:ok, runs} = Storage.list_runs()
     GenServer.stop(pid)
     length(runs)
+  end
+
+  defp occurrence_keys(runs) do
+    runs
+    |> Enum.map(& &1.trigger.occurrence.occurrence_key)
+    |> Enum.sort()
   end
 
   defp running_run_state(run_id, version, trigger) do

--- a/apps/favn_orchestrator/test/scheduler/runtime_test.exs
+++ b/apps/favn_orchestrator/test/scheduler/runtime_test.exs
@@ -344,6 +344,44 @@ defmodule FavnOrchestrator.Scheduler.RuntimeTest do
     assert length(capped_runs) == 3
   end
 
+  test "missed all honors per-tick submission budget below catch-up cap" do
+    Application.put_env(:favn_orchestrator, :scheduler,
+      max_missed_all_occurrences: 10,
+      submission_budget: 2
+    )
+
+    version =
+      scheduler_manifest_version("mv_scheduler_submission_budget",
+        cron: "* * * * * *",
+        missed: :all,
+        overlap: :allow
+      )
+
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    name = unique_runtime_name()
+    start_runtime(name)
+    [entry] = Runtime.scheduled(name)
+
+    state = %State{
+      pipeline_module: entry.module,
+      schedule_id: entry.schedule.name,
+      schedule_fingerprint: entry.schedule_fingerprint,
+      last_due_at: DateTime.add(DateTime.utc_now(), -10, :second),
+      version: 1
+    }
+
+    assert :ok = Storage.put_scheduler_state({entry.module, entry.schedule.name}, state)
+    assert :ok = Runtime.reload(name)
+    assert :ok = Runtime.tick(name)
+
+    assert {:ok, runs} = Storage.list_runs()
+
+    budgeted_runs = Enum.filter(runs, &(&1.manifest_version_id == version.manifest_version_id))
+    assert length(budgeted_runs) == 2
+  end
+
   test "windowed scheduled pipelines carry anchor window into run pipeline context" do
     version = scheduler_manifest_version("mv_scheduler_window", window: :hour)
     assert :ok = FavnOrchestrator.register_manifest(version)


### PR DESCRIPTION
## Summary
- Add a supervised bounded dispatcher for orchestrator control-plane submission work.
- Apply scheduler per-tick submission budgeting so missed catch-up cannot submit all due runs in one tick.
- Route backfill child submissions through bounded dispatch while preserving the existing synchronous return/error shape.

## Verification
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/bounded_dispatcher_test.exs test/scheduler/runtime_test.exs test/backfill_manager_test.exs --exclude acceptance --exclude slow --exclude browser`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile --exclude acceptance --exclude slow --exclude browser`
- `mix format`
- `mix compile --warnings-as-errors`

## Notes
- I started `mix test` before your clarification to use focused tests only; it exceeded the 120s tool timeout during the umbrella run and was not continued.

Closes #416