### PR TITLE
Optimize storage reads for hot execution paths

### DIFF
--- a/apps/favn_core/lib/favn/log/filter.ex
+++ b/apps/favn_core/lib/favn/log/filter.ex
@@ -9,8 +9,10 @@ defmodule Favn.Log.Filter do
   @type t :: %__MODULE__{
           run_id: String.t() | nil,
           asset_step_id: String.t() | nil,
+          runner_execution_id: String.t() | nil,
           node_key: String.t() | nil,
           asset_ref: Ref.t() | nil,
+          stream: Entry.stream() | nil,
           levels: [Entry.level()],
           sources: [Entry.source()],
           since: DateTime.t() | nil,
@@ -19,8 +21,10 @@ defmodule Favn.Log.Filter do
 
   defstruct run_id: nil,
             asset_step_id: nil,
+            runner_execution_id: nil,
             node_key: nil,
             asset_ref: nil,
+            stream: nil,
             levels: [],
             sources: [],
             since: nil,
@@ -39,8 +43,10 @@ defmodule Favn.Log.Filter do
     struct!(__MODULE__, %{
       run_id: Map.get(attrs, :run_id),
       asset_step_id: Map.get(attrs, :asset_step_id),
+      runner_execution_id: Map.get(attrs, :runner_execution_id),
       node_key: Map.get(attrs, :node_key),
       asset_ref: Map.get(attrs, :asset_ref),
+      stream: normalize_optional_enum(Map.get(attrs, :stream), Entry.streams(), :stream),
       levels: normalize_list(Map.get(attrs, :levels, []), Entry.levels(), :level),
       sources: normalize_list(Map.get(attrs, :sources, []), Entry.sources(), :source),
       since: Map.get(attrs, :since),
@@ -89,4 +95,7 @@ defmodule Favn.Log.Filter do
       raise ArgumentError, "invalid #{field}: #{inspect(value)}"
     end
   end
+
+  defp normalize_optional_enum(nil, _allowed, _field), do: nil
+  defp normalize_optional_enum(value, allowed, field), do: normalize_enum(value, allowed, field)
 end

--- a/apps/favn_orchestrator/lib/favn/storage/adapter.ex
+++ b/apps/favn_orchestrator/lib/favn/storage/adapter.ex
@@ -87,6 +87,8 @@ defmodule Favn.Storage.Adapter do
               {:ok, Page.t(String.t())} | {:error, error()}
   @callback list_execution_group_summaries(filter_opts(), adapter_opts()) ::
               {:ok, Page.t(map())} | {:error, error()}
+  @callback rebuild_execution_group_summaries(adapter_opts()) ::
+              {:ok, non_neg_integer()} | {:error, error()}
   @callback persist_run_transition(RunState.t(), map(), adapter_opts()) ::
               :ok | :idempotent | {:error, error()}
 
@@ -264,6 +266,7 @@ defmodule Favn.Storage.Adapter do
                       list_execution_group_run_ids: 2,
                       list_execution_groups: 2,
                       list_execution_group_summaries: 2,
+                      rebuild_execution_group_summaries: 1,
                       list_run_events: 3,
                       list_execution_group_events: 3,
                       put_backfill_windows: 2,

--- a/apps/favn_orchestrator/lib/favn/storage/adapter.ex
+++ b/apps/favn_orchestrator/lib/favn/storage/adapter.ex
@@ -85,6 +85,8 @@ defmodule Favn.Storage.Adapter do
               {:ok, [String.t()]} | {:error, error()}
   @callback list_execution_groups(filter_opts(), adapter_opts()) ::
               {:ok, Page.t(String.t())} | {:error, error()}
+  @callback list_execution_group_summaries(filter_opts(), adapter_opts()) ::
+              {:ok, Page.t(map())} | {:error, error()}
   @callback persist_run_transition(RunState.t(), map(), adapter_opts()) ::
               :ok | :idempotent | {:error, error()}
 
@@ -134,6 +136,11 @@ defmodule Favn.Storage.Adapter do
               {:ok, [Favn.Log.Entry.t()]} | {:error, error()}
   @callback list_logs(Favn.Log.Filter.t() | map() | keyword(), keyword(), adapter_opts()) ::
               {:ok, Page.t(Favn.Log.Entry.t())} | {:error, error()}
+  @callback scan_logs(
+              Favn.Log.Filter.t() | map() | keyword(),
+              cursor_scan_opts(),
+              adapter_opts()
+            ) :: {:ok, CursorPage.t(Favn.Log.Entry.t())} | {:error, error()}
   @callback replay_logs_after(
               Favn.Log.Cursor.t() | String.t() | nil,
               Favn.Log.Filter.t() | map() | keyword(),
@@ -252,9 +259,11 @@ defmodule Favn.Storage.Adapter do
                       reserve_idempotency_record: 2,
                       complete_idempotency_record: 3,
                       get_idempotency_record: 2,
+                      scan_logs: 3,
                       list_execution_group_runs: 2,
                       list_execution_group_run_ids: 2,
                       list_execution_groups: 2,
+                      list_execution_group_summaries: 2,
                       list_run_events: 3,
                       list_execution_group_events: 3,
                       put_backfill_windows: 2,

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -302,6 +302,9 @@ defmodule FavnOrchestrator.RunReadModel do
     normalized_filters = normalize_execution_group_filters(filters)
 
     case Storage.list_execution_group_summaries(normalized_filters) do
+      {:ok, %Page{items: []} = page} ->
+        maybe_rebuild_empty_execution_group_summary_page(page, normalized_filters, filters)
+
       {:ok, %Page{} = page} ->
         {:ok, page}
 
@@ -311,6 +314,40 @@ defmodule FavnOrchestrator.RunReadModel do
       {:error, _reason} = error ->
         error
     end
+  end
+
+  defp maybe_rebuild_empty_execution_group_summary_page(
+         %Page{offset: 0, items: []} = page,
+         normalized_filters,
+         original_filters
+       ) do
+    case Storage.rebuild_execution_group_summaries() do
+      {:ok, count} when count > 0 ->
+        case Storage.list_execution_group_summaries(normalized_filters) do
+          {:ok, %Page{items: [_ | _]} = rebuilt_page} ->
+            {:ok, rebuilt_page}
+
+          {:ok, %Page{items: []}} ->
+            page_execution_groups_from_group_ids(normalized_filters, original_filters)
+
+          {:error, _reason} ->
+            page_execution_groups_from_group_ids(normalized_filters, original_filters)
+        end
+
+      {:ok, 0} ->
+        {:ok, page}
+
+      {:error, _reason} ->
+        page_execution_groups_from_group_ids(normalized_filters, original_filters)
+    end
+  end
+
+  defp maybe_rebuild_empty_execution_group_summary_page(
+         page,
+         _normalized_filters,
+         _original_filters
+       ) do
+    {:ok, page}
   end
 
   defp page_execution_groups_from_group_ids(normalized_filters, original_filters) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -321,6 +321,35 @@ defmodule FavnOrchestrator.RunReadModel do
          normalized_filters,
          original_filters
        ) do
+    case execution_group_summary_read_model_empty?() do
+      true ->
+        rebuild_empty_execution_group_summary_page(page, normalized_filters, original_filters)
+
+      false ->
+        {:ok, page}
+
+      :unknown ->
+        page_execution_groups_from_group_ids(normalized_filters, original_filters)
+    end
+  end
+
+  defp maybe_rebuild_empty_execution_group_summary_page(
+         page,
+         _normalized_filters,
+         _original_filters
+       ) do
+    {:ok, page}
+  end
+
+  defp execution_group_summary_read_model_empty? do
+    case Storage.list_execution_group_summaries(limit: 1, offset: 0) do
+      {:ok, %Page{items: []}} -> true
+      {:ok, %Page{items: [_ | _]}} -> false
+      {:error, _reason} -> :unknown
+    end
+  end
+
+  defp rebuild_empty_execution_group_summary_page(page, normalized_filters, original_filters) do
     case Storage.rebuild_execution_group_summaries() do
       {:ok, count} when count > 0 ->
         case Storage.list_execution_group_summaries(normalized_filters) do
@@ -340,14 +369,6 @@ defmodule FavnOrchestrator.RunReadModel do
       {:error, _reason} ->
         page_execution_groups_from_group_ids(normalized_filters, original_filters)
     end
-  end
-
-  defp maybe_rebuild_empty_execution_group_summary_page(
-         page,
-         _normalized_filters,
-         _original_filters
-       ) do
-    {:ok, page}
   end
 
   defp page_execution_groups_from_group_ids(normalized_filters, original_filters) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_read_model.ex
@@ -299,12 +299,27 @@ defmodule FavnOrchestrator.RunReadModel do
   @spec page_execution_groups(keyword()) ::
           {:ok, Page.t(execution_group_summary())} | {:error, term()}
   def page_execution_groups(filters \\ []) when is_list(filters) do
-    case Storage.list_execution_groups(normalize_execution_group_filters(filters)) do
+    normalized_filters = normalize_execution_group_filters(filters)
+
+    case Storage.list_execution_group_summaries(normalized_filters) do
+      {:ok, %Page{} = page} ->
+        {:ok, page}
+
+      {:error, :execution_group_summary_reads_not_supported} ->
+        page_execution_groups_from_group_ids(normalized_filters, filters)
+
+      {:error, _reason} = error ->
+        error
+    end
+  end
+
+  defp page_execution_groups_from_group_ids(normalized_filters, original_filters) do
+    case Storage.list_execution_groups(normalized_filters) do
       {:ok, %Page{} = page} ->
         hydrate_execution_group_page(page)
 
       {:error, :execution_group_reads_not_supported} ->
-        page_execution_groups_from_run_scan(filters)
+        page_execution_groups_from_run_scan(original_filters)
 
       {:error, _reason} = error ->
         error

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -150,6 +150,17 @@ defmodule FavnOrchestrator.Storage do
     end)
   end
 
+  @spec list_execution_group_summaries(keyword()) :: {:ok, Page.t(map())} | {:error, term()}
+  def list_execution_group_summaries(group_opts \\ []) when is_list(group_opts) do
+    paginated_adapter_call(group_opts, fn adapter, filters, opts ->
+      if function_exported?(adapter, :list_execution_group_summaries, 2) do
+        adapter.list_execution_group_summaries(filters, opts)
+      else
+        {:error, :execution_group_summary_reads_not_supported}
+      end
+    end)
+  end
+
   @spec append_run_event(String.t(), map()) :: :ok | {:error, term()}
   def append_run_event(run_id, event) when is_binary(run_id) and is_map(event) do
     adapter_call(fn adapter, opts -> adapter.append_run_event(run_id, event, opts) end)
@@ -319,6 +330,20 @@ defmodule FavnOrchestrator.Storage do
     with {:ok, page_opts} <- Page.normalize_opts(opts) do
       adapter_call(fn adapter, adapter_opts ->
         adapter.list_logs(filter, Keyword.merge(opts, page_opts), adapter_opts)
+      end)
+    end
+  end
+
+  @spec scan_logs(Favn.Log.Filter.t() | map() | keyword(), keyword()) ::
+          {:ok, CursorPage.t(Favn.Log.Entry.t())} | {:error, term()}
+  def scan_logs(filter \\ [], scan_opts \\ []) when is_list(scan_opts) do
+    with {:ok, normalized_opts} <- CursorPage.normalize_opts(scan_opts) do
+      adapter_call(fn adapter, adapter_opts ->
+        if function_exported?(adapter, :scan_logs, 3) do
+          adapter.scan_logs(filter, normalized_opts, adapter_opts)
+        else
+          {:error, :log_cursor_reads_not_supported}
+        end
       end)
     end
   end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -161,6 +161,17 @@ defmodule FavnOrchestrator.Storage do
     end)
   end
 
+  @spec rebuild_execution_group_summaries() :: {:ok, non_neg_integer()} | {:error, term()}
+  def rebuild_execution_group_summaries do
+    adapter_call(fn adapter, opts ->
+      if function_exported?(adapter, :rebuild_execution_group_summaries, 1) do
+        adapter.rebuild_execution_group_summaries(opts)
+      else
+        {:error, :execution_group_summary_reads_not_supported}
+      end
+    end)
+  end
+
   @spec append_run_event(String.t(), map()) :: :ok | {:error, term()}
   def append_run_event(run_id, event) when is_binary(run_id) and is_map(event) do
     adapter_call(fn adapter, opts -> adapter.append_run_event(run_id, event, opts) end)

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -18,6 +18,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.Storage.LogEntryCodec
   alias FavnOrchestrator.Storage.ExecutionAdmissionWaiterCodec
+  alias FavnOrchestrator.Storage.ExecutionGroupSummary
   alias FavnOrchestrator.Storage.MaterializationClaimCodec
   alias FavnOrchestrator.Storage.RunEventCodec
   alias FavnOrchestrator.Storage.RunQuery
@@ -45,6 +46,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
           manifests: %{required(String.t()) => Version.t()},
           active_manifest_version_id: String.t() | nil,
           runs: %{required(String.t()) => RunState.t()},
+          execution_group_summaries: %{required(String.t()) => map()},
           run_events: %{required(String.t()) => [map()]},
           run_event_global_sequence: non_neg_integer(),
           execution_leases: %{required(String.t()) => map()},
@@ -251,6 +253,13 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   @impl true
+  def list_execution_group_summaries(group_opts, opts)
+      when is_list(group_opts) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:list_execution_group_summaries, group_opts})
+  end
+
+  @impl true
   def append_run_event(run_id, event, opts \\ [])
       when is_binary(run_id) and is_map(event) and is_list(opts) do
     with {:ok, normalized} <- RunEventCodec.normalize(run_id, event) do
@@ -407,6 +416,13 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   def list_logs(filter, opts, adapter_opts) when is_list(opts) and is_list(adapter_opts) do
     server = Keyword.get(adapter_opts, :server, __MODULE__)
     GenServer.call(server, {:list_logs, filter, opts})
+  end
+
+  @impl true
+  def scan_logs(filter, scan_opts, adapter_opts)
+      when is_list(scan_opts) and is_list(adapter_opts) do
+    server = Keyword.get(adapter_opts, :server, __MODULE__)
+    GenServer.call(server, {:scan_logs, filter, scan_opts})
   end
 
   @impl true
@@ -751,6 +767,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       manifests: %{},
       active_manifest_version_id: nil,
       runs: %{},
+      execution_group_summaries: %{},
       run_events: %{},
       run_event_global_sequence: 0,
       execution_leases: %{},
@@ -867,7 +884,9 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
 
     normalized_reply = if reply == :idempotent, do: :ok, else: reply
 
-    {:reply, normalized_reply, %{state | runs: runs}}
+    next_state = %{state | runs: runs} |> refresh_execution_group_summary(incoming)
+
+    {:reply, normalized_reply, next_state}
   end
 
   def handle_call({:persist_run_transition, %RunState{} = run, event}, _from, state) do
@@ -879,12 +898,14 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
 
         case append_event_with_semantics(current, event, state.run_event_global_sequence) do
           {:ok, event_write_result, next_events, next_global_sequence} ->
-            next_state = %{
-              state
-              | runs: runs,
-                run_events: Map.put(state.run_events, run.id, next_events),
-                run_event_global_sequence: next_global_sequence
-            }
+            next_state =
+              %{
+                state
+                | runs: runs,
+                  run_events: Map.put(state.run_events, run.id, next_events),
+                  run_event_global_sequence: next_global_sequence
+              }
+              |> refresh_execution_group_summary(run)
 
             result =
               case {run_write_result, event_write_result} do
@@ -944,6 +965,21 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     page =
       state.runs
       |> execution_group_ids(group_opts)
+      |> Enum.drop(Keyword.fetch!(page_opts, :offset))
+      |> Enum.take(Keyword.fetch!(page_opts, :limit) + 1)
+      |> Page.from_fetched(page_opts)
+
+    {:reply, {:ok, page}, state}
+  end
+
+  def handle_call({:list_execution_group_summaries, group_opts}, _from, state) do
+    page_opts = page_opts(group_opts)
+
+    page =
+      state.execution_group_summaries
+      |> Map.values()
+      |> filter_execution_group_summaries(group_opts)
+      |> sort_execution_group_summaries(Keyword.get(group_opts, :sort, :started_desc))
       |> Enum.drop(Keyword.fetch!(page_opts, :offset))
       |> Enum.take(Keyword.fetch!(page_opts, :limit) + 1)
       |> Page.from_fetched(page_opts)
@@ -1227,6 +1263,22 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     {:reply, {:ok, Page.from_fetched(rows, page_opts)}, state}
   end
 
+  def handle_call({:scan_logs, filter, scan_opts}, _from, state) do
+    reply =
+      with {:ok, after_sequence} <- log_cursor_sequence(Keyword.get(scan_opts, :after)) do
+        rows =
+          log_entries(state)
+          |> filter_logs(filter)
+          |> Enum.filter(&(Map.get(&1, :global_sequence, 0) > after_sequence))
+          |> Enum.sort_by(&Map.get(&1, :global_sequence, 0))
+          |> Enum.take(Keyword.fetch!(scan_opts, :limit) + 1)
+
+        {:ok, CursorPage.from_fetched(rows, scan_opts, &log_entry_cursor!/1)}
+      end
+
+    {:reply, reply, state}
+  end
+
   def handle_call({:replay_logs_after, cursor, filter, opts}, _from, state) do
     limit = Keyword.get(opts, :limit, 200)
 
@@ -1316,12 +1368,21 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
 
   def handle_call({:put_backfill_window, %BackfillWindow{} = window}, _from, state) do
     key = {window.backfill_run_id, window.pipeline_module, window.window_key}
-    {:reply, :ok, put_in(state, [:backfill_windows, key], window)}
+
+    next_state =
+      state
+      |> put_in([:backfill_windows, key], window)
+      |> refresh_execution_group_summary(window.backfill_run_id)
+
+    {:reply, :ok, next_state}
   end
 
   def handle_call({:put_backfill_windows, windows}, _from, state) do
-    {:reply, :ok,
-     %{state | backfill_windows: put_backfill_window_values(state.backfill_windows, windows)}}
+    next_state =
+      %{state | backfill_windows: put_backfill_window_values(state.backfill_windows, windows)}
+      |> refresh_execution_group_summaries(Enum.map(windows, & &1.backfill_run_id))
+
+    {:reply, :ok, next_state}
   end
 
   def handle_call({:get_backfill_window, key}, _from, state) do
@@ -1791,6 +1852,104 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     |> Enum.map(& &1.id)
   end
 
+  defp refresh_execution_group_summary(state, %RunState{} = run) do
+    refresh_execution_group_summary(state, RunQuery.root_execution_group_id(run))
+  end
+
+  defp refresh_execution_group_summary(state, group_id) when is_binary(group_id) do
+    runs = execution_group_runs(state.runs, group_id)
+    windows = execution_group_windows(state.backfill_windows, group_id)
+
+    case ExecutionGroupSummary.build(runs, windows) do
+      {:ok, summary} ->
+        put_in(state, [:execution_group_summaries, group_id], summary)
+
+      {:error, :empty_execution_group} ->
+        update_in(state, [:execution_group_summaries], &Map.delete(&1, group_id))
+    end
+  end
+
+  defp refresh_execution_group_summaries(state, group_ids) do
+    group_ids
+    |> Enum.uniq()
+    |> Enum.reduce(state, &refresh_execution_group_summary(&2, &1))
+  end
+
+  defp execution_group_windows(windows, group_id) when is_map(windows) do
+    windows
+    |> Map.values()
+    |> Enum.filter(&(&1.backfill_run_id == group_id))
+  end
+
+  defp filter_execution_group_summaries(summaries, group_opts) do
+    Enum.filter(summaries, fn summary ->
+      matches_summary_status?(summary, Keyword.get(group_opts, :status)) and
+        matches_summary_trigger?(summary, Keyword.get(group_opts, :trigger_type)) and
+        matches_summary_target?(summary, Keyword.get(group_opts, :target_asset)) and
+        matches_summary_search?(summary, Keyword.get(group_opts, :search)) and
+        matches_summary_window?(summary, Keyword.get(group_opts, :window)) and
+        matches_summary_only_filters?(summary, group_opts)
+    end)
+  end
+
+  defp sort_execution_group_summaries(summaries, :failed_first),
+    do:
+      Enum.sort_by(summaries, &{if(&1.failure_count > 0, do: 0, else: 1), -summary_activity(&1)})
+
+  defp sort_execution_group_summaries(summaries, :running_first),
+    do: Enum.sort_by(summaries, &{if(&1.active?, do: 0, else: 1), -summary_activity(&1)})
+
+  defp sort_execution_group_summaries(summaries, :status_priority),
+    do: Enum.sort_by(summaries, &{summary_status_priority(&1), -summary_activity(&1)})
+
+  defp sort_execution_group_summaries(summaries, _sort),
+    do: Enum.sort_by(summaries, &summary_activity/1, :desc)
+
+  defp matches_summary_status?(_summary, nil), do: true
+  defp matches_summary_status?(summary, status), do: summary.root_status == status
+
+  defp matches_summary_trigger?(_summary, nil), do: true
+  defp matches_summary_trigger?(summary, trigger), do: summary.trigger_type == trigger
+
+  defp matches_summary_target?(_summary, nil), do: true
+  defp matches_summary_target?(summary, target), do: target in summary.target_assets
+
+  defp matches_summary_search?(_summary, value) when value in [nil, ""], do: true
+
+  defp matches_summary_search?(summary, search) do
+    search = String.downcase(to_string(search))
+
+    [summary.id, summary.trigger_type | summary.target_assets]
+    |> Enum.reject(&is_nil/1)
+    |> Enum.join(" ")
+    |> String.downcase()
+    |> String.contains?(search)
+  end
+
+  defp matches_summary_window?(_summary, nil), do: true
+  defp matches_summary_window?(summary, :has_window), do: summary.total_windows > 0
+  defp matches_summary_window?(summary, :no_window), do: summary.total_windows == 0
+  defp matches_summary_window?(_summary, _window), do: true
+
+  defp matches_summary_only_filters?(summary, opts) do
+    (not Keyword.get(opts, :only_failed, false) or summary.failure_count > 0) and
+      (not Keyword.get(opts, :only_running, false) or summary.active?) and
+      (not Keyword.get(opts, :only_incomplete, false) or summary.active?)
+  end
+
+  defp summary_activity(summary), do: datetime_sort_value(summary.last_activity_at)
+
+  defp summary_status_priority(summary) do
+    cond do
+      summary.failure_count > 0 -> 0
+      summary.active? -> 1
+      true -> 2
+    end
+  end
+
+  defp datetime_sort_value(%DateTime{} = datetime), do: DateTime.to_unix(datetime, :microsecond)
+  defp datetime_sort_value(_datetime), do: 0
+
   defp matches_execution_group_filters?(group, opts) do
     matches_execution_group_status?(group, Keyword.get(opts, :status)) and
       matches_execution_group_trigger?(group, Keyword.get(opts, :trigger_type)) and
@@ -2147,6 +2306,10 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   defp log_cursor_sequence(_cursor), do: {:error, :cursor_invalid}
+
+  defp log_entry_cursor!(%Favn.Log.Entry{} = entry) do
+    %{kind: :log_entry, global_sequence: entry.global_sequence}
+  end
 
   defp validate_replay_limit(limit) when is_integer(limit) and limit > 0, do: :ok
   defp validate_replay_limit(_limit), do: {:error, :cursor_invalid}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -260,6 +260,12 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   end
 
   @impl true
+  def rebuild_execution_group_summaries(opts) when is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, :rebuild_execution_group_summaries)
+  end
+
+  @impl true
   def append_run_event(run_id, event, opts \\ [])
       when is_binary(run_id) and is_map(event) and is_list(opts) do
     with {:ok, normalized} <- RunEventCodec.normalize(run_id, event) do
@@ -985,6 +991,18 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       |> Page.from_fetched(page_opts)
 
     {:reply, {:ok, page}, state}
+  end
+
+  def handle_call(:rebuild_execution_group_summaries, _from, state) do
+    group_ids =
+      state.runs
+      |> Map.values()
+      |> Enum.map(&RunQuery.root_execution_group_id/1)
+      |> Enum.uniq()
+
+    next_state = refresh_execution_group_summaries(state, group_ids)
+
+    {:reply, {:ok, length(group_ids)}, next_state}
   end
 
   def handle_call({:append_run_event, run_id, event}, _from, state) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/execution_group_summary.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/execution_group_summary.ex
@@ -42,6 +42,7 @@ defmodule FavnOrchestrator.Storage.ExecutionGroupSummary do
       |> Enum.sort_by(&run_started_sort_key/1)
 
     windows = Enum.filter(windows, &match?(%BackfillWindow{}, &1))
+    windows_by_child = Map.new(windows, &{&1.latest_attempt_run_id || &1.child_run_id, &1})
     attempt_counts = attempt_counts(root, children, windows)
     window_counts = window_counts(windows)
     public_root_status = public_status(root)
@@ -76,7 +77,8 @@ defmodule FavnOrchestrator.Storage.ExecutionGroupSummary do
        progress: progress(attempt_counts),
        summary_totals: %{windows: window_counts, asset_attempts: attempt_counts},
        last_activity_at: latest_datetime(Enum.flat_map(runs, &[&1.updated_at, &1.inserted_at])),
-       currently_running_asset_attempts: [],
+       currently_running_asset_attempts:
+         current_running_attempts([root | children], windows_by_child),
        child_run_ids: Enum.map(children, & &1.id)
      }}
   end
@@ -216,6 +218,47 @@ defmodule FavnOrchestrator.Storage.ExecutionGroupSummary do
   defp target_assets(%RunState{} = run),
     do: Enum.map(RunQuery.target_refs(run), &RunQuery.public_ref/1)
 
+  defp current_running_attempts(runs, windows_by_child) do
+    runs
+    |> Enum.reject(&backfill_parent?/1)
+    |> Enum.flat_map(fn run ->
+      window = Map.get(windows_by_child, run.id)
+
+      run
+      |> run_attempt_statuses(window)
+      |> Enum.filter(&running_status?/1)
+      |> Enum.map(&current_attempt(run, &1, window))
+    end)
+  end
+
+  defp current_attempt(%RunState{} = run, status, window) do
+    asset_key = run |> RunQuery.target_refs() |> List.first() |> RunQuery.public_ref()
+
+    %{
+      id: run.id,
+      root_execution_group_id: RunQuery.root_execution_group_id(run),
+      child_run_id: run.id,
+      run_id: run.id,
+      status: status_name(status),
+      asset_key: asset_key,
+      asset_ref: asset_key,
+      window: public_window(window)
+    }
+  end
+
+  defp public_window(%BackfillWindow{} = window) do
+    %{
+      key: window.window_key,
+      label: label(window.window_kind, window.window_start_at),
+      kind: window.window_kind,
+      start_at: window.window_start_at,
+      end_at: window.window_end_at,
+      timezone: window.timezone
+    }
+  end
+
+  defp public_window(_window), do: nil
+
   defp backfill_parent?(%RunState{submit_kind: kind})
        when kind in [:backfill_asset, :backfill_pipeline],
        do: true
@@ -251,6 +294,12 @@ defmodule FavnOrchestrator.Storage.ExecutionGroupSummary do
     do: DateTime.diff(finished_at, started_at, :millisecond)
 
   defp duration_ms(_started_at, _finished_at), do: nil
+
+  defp label(:hour, %DateTime{} = start_at), do: Calendar.strftime(start_at, "%b %-d %H:00")
+  defp label(:day, %DateTime{} = start_at), do: Calendar.strftime(start_at, "%b %-d")
+  defp label(:month, %DateTime{} = start_at), do: Calendar.strftime(start_at, "%b %Y")
+  defp label(:year, %DateTime{} = start_at), do: Calendar.strftime(start_at, "%Y")
+  defp label(_kind, _start_at), do: nil
 
   defp earliest_datetime(values), do: datetime_extreme(values, &(DateTime.compare(&1, &2) == :lt))
   defp latest_datetime(values), do: datetime_extreme(values, &(DateTime.compare(&1, &2) == :gt))

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/execution_group_summary.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/execution_group_summary.ex
@@ -1,0 +1,280 @@
+defmodule FavnOrchestrator.Storage.ExecutionGroupSummary do
+  @moduledoc """
+  Builds and serializes the persisted execution-group overview read model.
+
+  The summary is storage-owned data used to page operator execution-group lists
+  without repeatedly grouping all runs or hydrating every group one by one.
+  """
+
+  alias FavnOrchestrator.Backfill.BackfillWindow
+  alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.Storage.RunQuery
+
+  @terminal_statuses [
+    :ok,
+    :partial,
+    :error,
+    :blocked,
+    :cancelled,
+    :timed_out,
+    :skipped,
+    :skipped_fresh
+  ]
+  @failed_statuses [:error, :timed_out, :cancelled, :blocked]
+  @running_statuses [:running, :retrying]
+  @queued_statuses [:pending, :queued, nil]
+
+  @type t :: map()
+
+  @doc "Builds an execution-group summary map from the current group runs and windows."
+  @spec build([RunState.t()], [BackfillWindow.t()]) ::
+          {:ok, t()} | {:error, :empty_execution_group}
+  def build([], _windows), do: {:error, :empty_execution_group}
+
+  def build([%RunState{} | _] = runs, windows) when is_list(windows) do
+    group_id = runs |> List.first() |> RunQuery.root_execution_group_id()
+    runs_by_id = Map.new(runs, &{&1.id, &1})
+    root = Map.get(runs_by_id, group_id) || Enum.min_by(runs, &run_started_sort_key/1)
+
+    children =
+      runs
+      |> Enum.reject(&(&1.id == root.id))
+      |> Enum.sort_by(&run_started_sort_key/1)
+
+    windows = Enum.filter(windows, &match?(%BackfillWindow{}, &1))
+    attempt_counts = attempt_counts(root, children, windows)
+    window_counts = window_counts(windows)
+    public_root_status = public_status(root)
+    active? = active_group?(runs, windows, attempt_counts)
+    status = group_status(public_root_status, attempt_counts, window_counts, active?)
+    failure_count = attempt_counts.failed + window_counts.failed
+    timing = group_timing(runs, windows, active?)
+    target_assets = target_assets(root)
+
+    {:ok,
+     %{
+       id: root.id,
+       root_execution_group_id: root.id,
+       status: status,
+       health: group_health(status, failure_count, active?),
+       active?: active?,
+       trigger_type: RunQuery.trigger_type(root),
+       target_assets: target_assets,
+       root_status: public_root_status,
+       started_at: timing.started_at,
+       finished_at: timing.finished_at,
+       duration_ms: duration_ms(timing.started_at, timing.finished_at),
+       total_windows: window_counts.total,
+       completed_windows: window_counts.completed,
+       failed_windows: window_counts.failed,
+       total_asset_attempts: attempt_counts.total,
+       completed_asset_attempts: attempt_counts.completed,
+       failed_asset_attempts: attempt_counts.failed,
+       running_asset_attempts: attempt_counts.running,
+       queued_asset_attempts: attempt_counts.queued,
+       failure_count: failure_count,
+       progress: progress(attempt_counts),
+       summary_totals: %{windows: window_counts, asset_attempts: attempt_counts},
+       last_activity_at: latest_datetime(Enum.flat_map(runs, &[&1.updated_at, &1.inserted_at])),
+       currently_running_asset_attempts: [],
+       child_run_ids: Enum.map(children, & &1.id)
+     }}
+  end
+
+  @doc "Encodes a summary for adapter storage."
+  @spec encode(t()) :: binary()
+  def encode(summary) when is_map(summary), do: :erlang.term_to_binary(summary)
+
+  @doc "Decodes a stored summary payload."
+  @spec decode(binary()) :: {:ok, t()} | {:error, :invalid_execution_group_summary}
+  def decode(payload) when is_binary(payload) do
+    {:ok, :erlang.binary_to_term(payload, [:safe])}
+  rescue
+    ArgumentError -> {:error, :invalid_execution_group_summary}
+  end
+
+  defp attempt_counts(root, children, windows) do
+    windows_by_child = Map.new(windows, &{&1.latest_attempt_run_id || &1.child_run_id, &1})
+
+    [root | children]
+    |> Enum.reject(&backfill_parent?/1)
+    |> Enum.flat_map(&run_attempt_statuses(&1, Map.get(windows_by_child, &1.id)))
+    |> then(fn statuses ->
+      %{
+        total: length(statuses),
+        completed: Enum.count(statuses, &terminal_status?/1),
+        failed: Enum.count(statuses, &failed_status?/1),
+        running: Enum.count(statuses, &running_status?/1),
+        queued: Enum.count(statuses, &queued_status?/1)
+      }
+    end)
+  end
+
+  defp run_attempt_statuses(%RunState{} = run, window) do
+    statuses = persisted_result_statuses(run)
+
+    cond do
+      statuses != [] -> statuses
+      match?(%BackfillWindow{}, window) -> [status_name(window.status)]
+      active_status?(run.status) -> List.duplicate(run.status, max(expected_step_count(run), 1))
+      expected_step_count(run) > 0 -> List.duplicate(public_status(run), expected_step_count(run))
+      true -> []
+    end
+  end
+
+  defp persisted_result_statuses(%RunState{result: result}) when is_map(result) do
+    statuses = result_statuses(result, :node_results)
+
+    case statuses do
+      [] -> result_statuses(result, :asset_results)
+      [_ | _] -> statuses
+    end
+  end
+
+  defp persisted_result_statuses(_run), do: []
+
+  defp result_statuses(result, field) do
+    result
+    |> Map.get(field, Map.get(result, Atom.to_string(field), []))
+    |> result_values()
+    |> Enum.map(&(map_get(&1, :status) || map_get(&1, :state)))
+    |> Enum.map(&status_name/1)
+    |> Enum.reject(&is_nil/1)
+  end
+
+  defp result_values(value) when is_map(value), do: Map.values(value)
+  defp result_values(value) when is_list(value), do: value
+  defp result_values(_value), do: []
+
+  defp expected_step_count(%RunState{plan: %Favn.Plan{nodes: nodes}})
+       when is_map(nodes) and map_size(nodes) > 0,
+       do: map_size(nodes)
+
+  defp expected_step_count(%RunState{target_refs: refs}) when is_list(refs), do: length(refs)
+  defp expected_step_count(_run), do: 0
+
+  defp window_counts(windows) do
+    statuses = Enum.map(windows, &status_name(&1.status))
+
+    %{
+      total: length(windows),
+      completed: Enum.count(statuses, &terminal_status?/1),
+      failed: Enum.count(statuses, &failed_status?/1)
+    }
+  end
+
+  defp active_group?(runs, windows, attempt_counts) do
+    attempt_counts.running > 0 or attempt_counts.queued > 0 or
+      Enum.any?(runs, &(public_status(&1) in [:pending, :running])) or
+      Enum.any?(windows, &(status_name(&1.status) in [:pending, :queued, :running]))
+  end
+
+  defp group_status(root_status, attempt_counts, window_counts, active?) do
+    cond do
+      attempt_counts.failed > 0 or window_counts.failed > 0 -> :error
+      active? -> :running
+      root_status -> root_status
+      true -> :pending
+    end
+  end
+
+  defp group_health(_status, failure_count, _active?) when failure_count > 0, do: :error
+  defp group_health(_status, _failure_count, true), do: :active
+  defp group_health(:partial, _failure_count, _active?), do: :warning
+  defp group_health(_status, _failure_count, _active?), do: :ok
+
+  defp progress(%{total: 0}), do: nil
+
+  defp progress(counts) do
+    %{
+      unit: :assets,
+      label: "#{counts.completed} / #{counts.total} asset attempts",
+      counts: counts
+    }
+  end
+
+  defp group_timing(runs, windows, active?) do
+    started_at =
+      runs
+      |> Enum.map(& &1.inserted_at)
+      |> Kernel.++(Enum.map(windows, & &1.started_at))
+      |> earliest_datetime()
+
+    finished_at =
+      if active? do
+        nil
+      else
+        runs
+        |> Enum.map(&finished_at/1)
+        |> Kernel.++(Enum.map(windows, & &1.finished_at))
+        |> latest_datetime()
+      end
+
+    %{started_at: started_at, finished_at: finished_at}
+  end
+
+  defp target_assets(%RunState{} = run),
+    do: Enum.map(RunQuery.target_refs(run), &RunQuery.public_ref/1)
+
+  defp backfill_parent?(%RunState{submit_kind: kind})
+       when kind in [:backfill_asset, :backfill_pipeline],
+       do: true
+
+  defp backfill_parent?(_run), do: false
+
+  defp public_status(%RunState{status: status}), do: status_name(status)
+
+  defp status_name(nil), do: nil
+  defp status_name(status) when is_atom(status), do: status
+
+  defp status_name(status) when is_binary(status) do
+    try do
+      String.to_existing_atom(status)
+    rescue
+      ArgumentError -> status
+    end
+  end
+
+  defp terminal_status?(status), do: status_name(status) in @terminal_statuses
+  defp failed_status?(status), do: status_name(status) in @failed_statuses
+  defp running_status?(status), do: status_name(status) in @running_statuses
+  defp queued_status?(status), do: status_name(status) in @queued_statuses
+  defp active_status?(status), do: status_name(status) in [:pending, :running]
+
+  defp finished_at(%RunState{status: status, updated_at: updated_at})
+       when status in [:ok, :partial, :error, :cancelled, :timed_out],
+       do: updated_at
+
+  defp finished_at(_run), do: nil
+
+  defp duration_ms(%DateTime{} = started_at, %DateTime{} = finished_at),
+    do: DateTime.diff(finished_at, started_at, :millisecond)
+
+  defp duration_ms(_started_at, _finished_at), do: nil
+
+  defp earliest_datetime(values), do: datetime_extreme(values, &(DateTime.compare(&1, &2) == :lt))
+  defp latest_datetime(values), do: datetime_extreme(values, &(DateTime.compare(&1, &2) == :gt))
+
+  defp datetime_extreme(values, compare_fun) do
+    values
+    |> Enum.reject(&is_nil/1)
+    |> Enum.reduce(nil, fn
+      %DateTime{} = value, nil ->
+        value
+
+      %DateTime{} = value, %DateTime{} = current ->
+        if(compare_fun.(value, current), do: value, else: current)
+
+      _value, current ->
+        current
+    end)
+  end
+
+  defp run_started_sort_key(%RunState{inserted_at: %DateTime{} = inserted_at}),
+    do: DateTime.to_unix(inserted_at, :microsecond)
+
+  defp run_started_sort_key(_run), do: 0
+
+  defp map_get(map, key) when is_map(map),
+    do: Map.get(map, key) || Map.get(map, Atom.to_string(key))
+end

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -143,6 +143,13 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert {:ok, group_page} = Storage.list_execution_groups(search: run.id, limit: 10, offset: 0)
     assert run.id in group_page.items
 
+    assert {:ok, summary_page} =
+             Storage.list_execution_group_summaries(search: run.id, limit: 10, offset: 0)
+
+    assert [%{id: summary_id, child_run_ids: [child_id]}] = summary_page.items
+    assert summary_id == run.id
+    assert child_id == child.id
+
     schedule =
       RunState.new(
         id: "run_contract_#{label}_schedule_#{System.unique_integer([:positive])}",

--- a/apps/favn_orchestrator/test/storage/memory_adapter_test.exs
+++ b/apps/favn_orchestrator/test/storage/memory_adapter_test.exs
@@ -93,6 +93,79 @@ defmodule FavnOrchestrator.Storage.MemoryAdapterTest do
              Storage.put_scheduler_state(key, %{last_due_at: "bad", version: 2})
   end
 
+  test "stores execution group summaries as a paged read model" do
+    parent =
+      RunState.new(
+        id: "group_parent",
+        manifest_version_id: "mv_a",
+        manifest_content_hash: "hash",
+        asset_ref: {MyApp.Asset, :asset},
+        target_refs: [{MyApp.Asset, :asset}]
+      )
+
+    child =
+      RunState.new(
+        id: "group_child",
+        manifest_version_id: "mv_a",
+        manifest_content_hash: "hash",
+        asset_ref: {MyApp.Asset, :asset},
+        target_refs: [{MyApp.Asset, :asset}],
+        parent_run_id: parent.id,
+        root_run_id: parent.id,
+        lineage_depth: 1
+      )
+
+    assert :ok = Storage.put_run(parent)
+    assert :ok = Storage.put_run(child)
+
+    assert {:ok, page} = Storage.list_execution_group_summaries(limit: 10)
+    assert [summary] = page.items
+    assert summary.id == parent.id
+    assert summary.child_run_ids == [child.id]
+    assert summary.target_assets == ["MyApp.Asset.asset"]
+  end
+
+  test "scans logs with cursor pagination" do
+    now = DateTime.utc_now()
+
+    entries = [
+      Favn.Log.Entry.normalize(%{
+        run_id: "scan_logs_run",
+        runner_execution_id: "runner_a",
+        producer_id: "memory-scan",
+        producer_sequence: 1,
+        occurred_at: now,
+        stream: :stdout,
+        message: "first"
+      }),
+      Favn.Log.Entry.normalize(%{
+        run_id: "scan_logs_run",
+        runner_execution_id: "runner_a",
+        producer_id: "memory-scan",
+        producer_sequence: 2,
+        occurred_at: DateTime.add(now, 1, :second),
+        stream: :stderr,
+        message: "second"
+      })
+    ]
+
+    assert {:ok, [_first, _second]} = Storage.persist_log_entries(entries)
+
+    assert {:ok, page} =
+             Storage.scan_logs([runner_execution_id: "runner_a", stream: :stdout], limit: 1)
+
+    assert Enum.map(page.items, & &1.message) == ["first"]
+    refute page.has_more?
+
+    assert {:ok, next_page} =
+             Storage.scan_logs([runner_execution_id: "runner_a"],
+               after: %{global_sequence: 1},
+               limit: 10
+             )
+
+    assert Enum.map(next_page.items, & &1.message) == ["second"]
+  end
+
   test "uses nil scheduler schedule ids as exact keys" do
     daily_key = {MyApp.Pipeline, :daily}
     hourly_key = {MyApp.Pipeline, :hourly}

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -21,6 +21,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   alias FavnOrchestrator.Storage.Backfill.CoverageBaselineCodec
   alias FavnOrchestrator.Storage.Backfill.ProgressCodec
   alias FavnOrchestrator.Storage.ExecutionAdmissionWaiterCodec
+  alias FavnOrchestrator.Storage.ExecutionGroupSummary
   alias FavnOrchestrator.Storage.ExecutionLeaseCodec
   alias FavnOrchestrator.Storage.Freshness.AssetFreshnessStateCodec
   alias FavnOrchestrator.Storage.JsonSafe
@@ -209,8 +210,17 @@ defmodule Favn.Storage.Adapter.Postgres do
         case guarded_put_run(repo, normalized_run) do
           :ok ->
             case guarded_append_run_event(repo, run.id, normalized_event) do
-              result when result in [:ok, :idempotent] -> {:ok, result}
-              {:error, reason} -> repo.rollback(reason)
+              result when result in [:ok, :idempotent] ->
+                case refresh_execution_group_summary(
+                       repo,
+                       RunQuery.root_execution_group_id(normalized_run)
+                     ) do
+                  :ok -> {:ok, result}
+                  {:error, reason} -> repo.rollback(reason)
+                end
+
+              {:error, reason} ->
+                repo.rollback(reason)
             end
 
           {:error, reason} ->
@@ -303,6 +313,31 @@ defmodule Favn.Storage.Adapter.Postgres do
           |> Enum.map(fn [group_id] -> group_id end)
           |> Page.from_fetched(page_opts)
           |> then(&{:ok, &1})
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_execution_group_summaries(group_opts, opts)
+      when is_list(group_opts) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, query, params, page_opts} <- execution_group_summaries_query(group_opts) do
+      case SQL.query(repo, query, params) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> Enum.reduce_while({:ok, []}, fn [payload], {:ok, acc} ->
+            case ExecutionGroupSummary.decode(payload) do
+              {:ok, summary} -> {:cont, {:ok, [summary | acc]}}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+          |> case do
+            {:ok, summaries} -> {:ok, Page.from_fetched(Enum.reverse(summaries), page_opts)}
+            {:error, reason} -> {:error, reason}
+          end
 
         {:error, reason} ->
           {:error, reason}
@@ -665,6 +700,23 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   @impl true
+  def scan_logs(filter, scan_opts, adapter_opts)
+      when is_list(scan_opts) and is_list(adapter_opts) do
+    with {:ok, after_sequence} <- log_cursor_sequence(Keyword.get(scan_opts, :after)),
+         {:ok, repo} <- resolve_repo(adapter_opts),
+         {:ok, sql, params} <- scan_logs_query(filter, after_sequence) do
+      query_and_decode_cursor_page(
+        repo,
+        sql,
+        params,
+        scan_opts,
+        &decode_log_entry_row/1,
+        &log_entry_cursor!/1
+      )
+    end
+  end
+
+  @impl true
   def replay_logs_after(cursor, filter, opts, adapter_opts)
       when is_list(opts) and is_list(adapter_opts) do
     with {:ok, after_sequence} <- log_cursor_sequence(cursor),
@@ -751,14 +803,18 @@ defmodule Favn.Storage.Adapter.Postgres do
   @impl true
   def put_backfill_window(%BackfillWindow{} = window, opts) when is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts) do
-      upsert_backfill_windows(repo, [window])
+      with :ok <- upsert_backfill_windows(repo, [window]) do
+        refresh_execution_group_summary(repo, window.backfill_run_id)
+      end
     end
   end
 
   @impl true
   def put_backfill_windows(windows, opts) when is_list(windows) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts) do
-      upsert_backfill_windows(repo, windows)
+      with :ok <- upsert_backfill_windows(repo, windows) do
+        refresh_execution_group_summaries(repo, Enum.map(windows, & &1.backfill_run_id))
+      end
     end
   end
 
@@ -1856,11 +1912,114 @@ defmodule Favn.Storage.Adapter.Postgres do
 
   defp decode_log_entry_row([payload]), do: LogEntryCodec.decode(payload)
 
+  defp refresh_execution_group_summaries(repo, group_ids) do
+    group_ids
+    |> Enum.uniq()
+    |> Enum.reduce_while(:ok, fn group_id, :ok ->
+      case refresh_execution_group_summary(repo, group_id) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp refresh_execution_group_summary(_repo, nil), do: :ok
+
+  defp refresh_execution_group_summary(repo, group_id) when is_binary(group_id) do
+    with {:ok, runs} <- fetch_execution_group_runs(repo, group_id),
+         {:ok, windows} <- fetch_execution_group_windows(repo, group_id) do
+      case ExecutionGroupSummary.build(runs, windows) do
+        {:ok, summary} -> upsert_execution_group_summary(repo, summary)
+        {:error, :empty_execution_group} -> delete_execution_group_summary(repo, group_id)
+      end
+    else
+      {:error, {:missing_manifest_version, _manifest_version_id}} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_execution_group_runs(repo, group_id) do
+    sql =
+      run_snapshot_select() <>
+        " WHERE r.root_execution_group_id = $1 ORDER BY CASE WHEN r.run_id = r.root_execution_group_id THEN 0 ELSE 1 END, r.inserted_at ASC, r.run_id ASC"
+
+    case SQL.query(repo, sql, [group_id]) do
+      {:ok, %{rows: rows}} -> decode_run_rows(rows)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_execution_group_windows(repo, group_id) do
+    sql = backfill_window_select() <> "\nWHERE backfill_run_id = $1"
+    query_and_decode_rows(repo, sql, [group_id], &decode_backfill_window_row/1)
+  end
+
+  defp upsert_execution_group_summary(repo, summary) do
+    with {:ok, activity_seq} <- execution_group_activity_seq(repo, summary.id) do
+      sql = """
+      INSERT INTO favn_execution_group_summaries (
+        group_id, root_run_id, root_status, status, trigger_type, target_refs_text,
+        has_window, failed, running, activity_seq, summary_blob, updated_at
+      ) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+      ON CONFLICT(group_id) DO UPDATE SET
+        root_run_id = EXCLUDED.root_run_id,
+        root_status = EXCLUDED.root_status,
+        status = EXCLUDED.status,
+        trigger_type = EXCLUDED.trigger_type,
+        target_refs_text = EXCLUDED.target_refs_text,
+        has_window = EXCLUDED.has_window,
+        failed = EXCLUDED.failed,
+        running = EXCLUDED.running,
+        activity_seq = EXCLUDED.activity_seq,
+        summary_blob = EXCLUDED.summary_blob,
+        updated_at = EXCLUDED.updated_at
+      """
+
+      params = [
+        summary.id,
+        summary.root_execution_group_id,
+        Atom.to_string(summary.root_status),
+        Atom.to_string(summary.status),
+        Atom.to_string(summary.trigger_type),
+        Enum.join(summary.target_assets, "\n"),
+        summary.total_windows > 0,
+        summary.failure_count > 0,
+        summary.active?,
+        activity_seq,
+        ExecutionGroupSummary.encode(summary),
+        DateTime.utc_now()
+      ]
+
+      query_ok(repo, sql, params)
+    end
+  end
+
+  defp execution_group_activity_seq(repo, group_id) do
+    case SQL.query(
+           repo,
+           "SELECT COALESCE(MAX(updated_seq), 0) FROM favn_runs WHERE root_execution_group_id = $1",
+           [group_id]
+         ) do
+      {:ok, %{rows: [[seq]]}} when is_integer(seq) -> {:ok, seq}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp delete_execution_group_summary(repo, group_id) do
+    query_ok(repo, "DELETE FROM favn_execution_group_summaries WHERE group_id = $1", [group_id])
+  end
+
   defp persist_run(repo, run) do
     repo.transact(fn ->
       case guarded_put_run(repo, run) do
-        :ok -> {:ok, :ok}
-        {:error, reason} -> repo.rollback(reason)
+        :ok ->
+          case refresh_execution_group_summary(repo, RunQuery.root_execution_group_id(run)) do
+            :ok -> {:ok, :ok}
+            {:error, reason} -> repo.rollback(reason)
+          end
+
+        {:error, reason} ->
+          repo.rollback(reason)
       end
     end)
     |> case do
@@ -2548,6 +2707,82 @@ defmodule Favn.Storage.Adapter.Postgres do
     end
   end
 
+  defp execution_group_summaries_query(group_opts) do
+    with {:ok, page_opts} <- Page.normalize_opts(group_opts) do
+      filters = Keyword.drop(group_opts, [:limit, :offset, :sort])
+      {where_sql, params} = execution_group_summary_filter_sql(filters)
+      sort_sql = execution_group_summary_sort_sql(Keyword.get(group_opts, :sort, :started_desc))
+      limit_placeholder = "$#{length(params) + 1}"
+      offset_placeholder = "$#{length(params) + 2}"
+
+      {:ok,
+       """
+       SELECT summary_blob
+       FROM favn_execution_group_summaries
+       #{where_sql}
+       ORDER BY #{sort_sql}, group_id DESC
+       LIMIT #{limit_placeholder} OFFSET #{offset_placeholder}
+       """, params ++ [Keyword.fetch!(page_opts, :limit) + 1, Keyword.fetch!(page_opts, :offset)],
+       page_opts}
+    end
+  end
+
+  defp execution_group_summary_filter_sql(filters) do
+    filters
+    |> Enum.reduce({[], []}, fn
+      {:status, status}, {clauses, params} when not is_nil(status) ->
+        {clauses ++ ["root_status = $#{length(params) + 1}"], params ++ [Atom.to_string(status)]}
+
+      {:trigger_type, trigger}, {clauses, params} when not is_nil(trigger) ->
+        {clauses ++ ["trigger_type = $#{length(params) + 1}"],
+         params ++ [Atom.to_string(trigger)]}
+
+      {:target_asset, target}, {clauses, params} when is_binary(target) and target != "" ->
+        {clauses ++
+           [
+             "POSITION(E'\\n' || $#{length(params) + 1} || E'\\n' IN E'\\n' || target_refs_text || E'\\n') > 0"
+           ], params ++ [target]}
+
+      {:search, search}, {clauses, params} when is_binary(search) and search != "" ->
+        placeholder = "$#{length(params) + 1}"
+
+        {clauses ++
+           [
+             "(group_id LIKE #{placeholder} OR target_refs_text LIKE #{placeholder} OR trigger_type LIKE #{placeholder})"
+           ], params ++ ["%#{search}%"]}
+
+      {:window, :has_window}, {clauses, params} ->
+        {clauses ++ ["has_window = TRUE"], params}
+
+      {:window, :no_window}, {clauses, params} ->
+        {clauses ++ ["has_window = FALSE"], params}
+
+      {:only_failed, true}, {clauses, params} ->
+        {clauses ++ ["failed = TRUE"], params}
+
+      {:only_running, true}, {clauses, params} ->
+        {clauses ++ ["running = TRUE"], params}
+
+      {:only_incomplete, true}, {clauses, params} ->
+        {clauses ++ ["running = TRUE"], params}
+
+      _other, acc ->
+        acc
+    end)
+    |> case do
+      {[], params} -> {"", params}
+      {clauses, params} -> {"WHERE " <> Enum.join(clauses, " AND "), params}
+    end
+  end
+
+  defp execution_group_summary_sort_sql(:failed_first), do: "failed DESC, activity_seq DESC"
+  defp execution_group_summary_sort_sql(:running_first), do: "running DESC, activity_seq DESC"
+
+  defp execution_group_summary_sort_sql(:status_priority),
+    do: "failed DESC, running DESC, activity_seq DESC"
+
+  defp execution_group_summary_sort_sql(_sort), do: "activity_seq DESC"
+
   defp execution_group_filter_sql(filters) do
     filters
     |> Enum.reduce({[], []}, fn
@@ -2803,6 +3038,25 @@ defmodule Favn.Storage.Adapter.Postgres do
        LIMIT #{limit_placeholder}
        """, params ++ [after_sequence, limit]}
     end
+  end
+
+  defp scan_logs_query(filter, after_sequence) do
+    with {:ok, {where_sql, params}} <- build_log_filter_sql(filter) do
+      prefix = if where_sql == "", do: " WHERE ", else: where_sql <> " AND "
+      after_placeholder = "$#{length(params) + 1}"
+
+      {:ok,
+       """
+       SELECT log_blob
+       FROM favn_log_entries
+       #{prefix}global_sequence > #{after_placeholder}
+       ORDER BY global_sequence ASC
+       """, params ++ [after_sequence]}
+    end
+  end
+
+  defp log_entry_cursor!(%Favn.Log.Entry{} = entry) do
+    %{kind: :log_entry, global_sequence: entry.global_sequence}
   end
 
   defp build_log_filter_sql(filter) do

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -1935,12 +1935,14 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   defp execution_group_ids_for_rebuild(repo) do
-    sql =
-      "SELECT DISTINCT root_execution_group_id FROM favn_runs WHERE root_execution_group_id IS NOT NULL ORDER BY root_execution_group_id"
+    with :ok <- repair_missing_run_query_metadata(repo) do
+      sql =
+        "SELECT DISTINCT root_execution_group_id FROM favn_runs WHERE root_execution_group_id IS NOT NULL ORDER BY root_execution_group_id"
 
-    case SQL.query(repo, sql, []) do
-      {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [group_id] -> group_id end)}
-      {:error, reason} -> {:error, reason}
+      case SQL.query(repo, sql, []) do
+        {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [group_id] -> group_id end)}
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -346,6 +346,17 @@ defmodule Favn.Storage.Adapter.Postgres do
   end
 
   @impl true
+  def rebuild_execution_group_summaries(opts) when is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts),
+         {:ok, group_ids} <- execution_group_ids_for_rebuild(repo) do
+      case refresh_execution_group_summaries(repo, group_ids) do
+        :ok -> {:ok, length(group_ids)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
   def append_run_event(run_id, event, opts)
       when is_binary(run_id) and is_map(event) and is_list(opts) do
     with {:ok, repo} <- resolve_repo(opts),
@@ -1923,6 +1934,16 @@ defmodule Favn.Storage.Adapter.Postgres do
     end)
   end
 
+  defp execution_group_ids_for_rebuild(repo) do
+    sql =
+      "SELECT DISTINCT root_execution_group_id FROM favn_runs WHERE root_execution_group_id IS NOT NULL ORDER BY root_execution_group_id"
+
+    case SQL.query(repo, sql, []) do
+      {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [group_id] -> group_id end)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp refresh_execution_group_summary(_repo, nil), do: :ok
 
   defp refresh_execution_group_summary(repo, group_id) when is_binary(group_id) do
@@ -2748,8 +2769,8 @@ defmodule Favn.Storage.Adapter.Postgres do
 
         {clauses ++
            [
-             "(group_id LIKE #{placeholder} OR target_refs_text LIKE #{placeholder} OR trigger_type LIKE #{placeholder})"
-           ], params ++ ["%#{search}%"]}
+             "(LOWER(group_id) LIKE #{placeholder} OR LOWER(target_refs_text) LIKE #{placeholder} OR LOWER(trigger_type) LIKE #{placeholder})"
+           ], params ++ ["%#{String.downcase(search)}%"]}
 
       {:window, :has_window}, {clauses, params} ->
         {clauses ++ ["has_window = TRUE"], params}

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations.ex
@@ -4,6 +4,7 @@ defmodule FavnStoragePostgres.Migrations do
   alias Ecto.Adapters.SQL
   alias FavnStoragePostgres.Migrations.AddAssetFreshnessState
   alias FavnStoragePostgres.Migrations.AddExecutionAdmissionWaiters
+  alias FavnStoragePostgres.Migrations.AddExecutionGroupSummaries
   alias FavnStoragePostgres.Migrations.AddExecutionLeases
   alias FavnStoragePostgres.Migrations.AddLogEntries
   alias FavnStoragePostgres.Migrations.AddMaterializationClaims
@@ -25,7 +26,8 @@ defmodule FavnStoragePostgres.Migrations do
     {20_260_520_110_000, AddExecutionAdmissionWaiters},
     {20_260_521_100_000, AddMaterializationClaims},
     {20_260_521_200_000, AddRunGroupQueryColumns},
-    {20_260_522_100_000, AddBackfillProgress}
+    {20_260_522_100_000, AddBackfillProgress},
+    {20_260_524_100_000, AddExecutionGroupSummaries}
   ]
   @required_tables [
     "public.favn_manifest_versions",
@@ -45,7 +47,8 @@ defmodule FavnStoragePostgres.Migrations do
     "public.favn_execution_leases",
     "public.favn_execution_lease_scopes",
     "public.favn_execution_admission_waiters",
-    "public.favn_materialization_claims"
+    "public.favn_materialization_claims",
+    "public.favn_execution_group_summaries"
   ]
   @expected_versions Enum.map(@migrations, fn {version, _module} -> to_string(version) end)
 

--- a/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_execution_group_summaries.ex
+++ b/apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_execution_group_summaries.ex
@@ -1,0 +1,33 @@
+defmodule FavnStoragePostgres.Migrations.AddExecutionGroupSummaries do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists table(:favn_execution_group_summaries, primary_key: false) do
+      add(:group_id, :string, primary_key: true)
+      add(:root_run_id, :string, null: false)
+      add(:root_status, :string, null: false)
+      add(:status, :string, null: false)
+      add(:trigger_type, :string, null: false)
+      add(:target_refs_text, :text, null: false)
+      add(:has_window, :boolean, null: false, default: false)
+      add(:failed, :boolean, null: false, default: false)
+      add(:running, :boolean, null: false, default: false)
+      add(:activity_seq, :bigint, null: false)
+      add(:summary_blob, :binary, null: false)
+      add(:updated_at, :utc_datetime_usec, null: false)
+    end
+
+    create_if_not_exists(index(:favn_execution_group_summaries, [:activity_seq, :group_id]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:trigger_type, :activity_seq]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:root_status, :activity_seq]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:failed, :activity_seq]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:running, :activity_seq]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:has_window, :activity_seq]))
+
+    create_if_not_exists(index(:favn_log_entries, [:runner_execution_id, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:stream, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:node_key_hash, :global_sequence]))
+  end
+end

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -22,6 +22,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   alias FavnOrchestrator.Storage.Backfill.CoverageBaselineCodec
   alias FavnOrchestrator.Storage.Backfill.ProgressCodec
   alias FavnOrchestrator.Storage.ExecutionAdmissionWaiterCodec
+  alias FavnOrchestrator.Storage.ExecutionGroupSummary
   alias FavnOrchestrator.Storage.ExecutionLeaseCodec
   alias FavnOrchestrator.Storage.Freshness.AssetFreshnessStateCodec
   alias FavnOrchestrator.Storage.IdempotencyResponseCodec
@@ -214,8 +215,17 @@ defmodule Favn.Storage.Adapter.SQLite do
         case guarded_put_run(repo, normalized_run) do
           :ok ->
             case guarded_append_run_event(repo, run.id, normalized_event) do
-              result when result in [:ok, :idempotent] -> {:ok, result}
-              {:error, reason} -> repo.rollback(reason)
+              result when result in [:ok, :idempotent] ->
+                case refresh_execution_group_summary(
+                       repo,
+                       RunQuery.root_execution_group_id(normalized_run)
+                     ) do
+                  :ok -> {:ok, result}
+                  {:error, reason} -> repo.rollback(reason)
+                end
+
+              {:error, reason} ->
+                repo.rollback(reason)
             end
 
           {:error, reason} ->
@@ -308,6 +318,31 @@ defmodule Favn.Storage.Adapter.SQLite do
           |> Enum.map(fn [group_id] -> group_id end)
           |> Page.from_fetched(page_opts)
           |> then(&{:ok, &1})
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def list_execution_group_summaries(group_opts, opts)
+      when is_list(group_opts) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, query, params, page_opts} <- execution_group_summaries_query(group_opts) do
+      case SQL.query(repo, query, params) do
+        {:ok, %{rows: rows}} ->
+          rows
+          |> Enum.reduce_while({:ok, []}, fn [payload], {:ok, acc} ->
+            case ExecutionGroupSummary.decode(payload) do
+              {:ok, summary} -> {:cont, {:ok, [summary | acc]}}
+              {:error, reason} -> {:halt, {:error, reason}}
+            end
+          end)
+          |> case do
+            {:ok, summaries} -> {:ok, Page.from_fetched(Enum.reverse(summaries), page_opts)}
+            {:error, reason} -> {:error, reason}
+          end
 
         {:error, reason} ->
           {:error, reason}
@@ -674,6 +709,23 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   @impl true
+  def scan_logs(filter, scan_opts, adapter_opts)
+      when is_list(scan_opts) and is_list(adapter_opts) do
+    with {:ok, repo} <- repo_name(adapter_opts),
+         {:ok, after_sequence} <- log_cursor_sequence(Keyword.get(scan_opts, :after)),
+         {:ok, sql, params} <- scan_logs_query(filter, after_sequence) do
+      decode_cursor_page(
+        repo,
+        sql,
+        params,
+        scan_opts,
+        &decode_log_entry_row/1,
+        &log_entry_cursor!/1
+      )
+    end
+  end
+
+  @impl true
   def replay_logs_after(cursor, filter, opts, adapter_opts)
       when is_list(opts) and is_list(adapter_opts) do
     with {:ok, repo} <- repo_name(adapter_opts),
@@ -762,14 +814,18 @@ defmodule Favn.Storage.Adapter.SQLite do
   @impl true
   def put_backfill_window(%BackfillWindow{} = window, opts) when is_list(opts) do
     with {:ok, repo} <- repo_name(opts) do
-      upsert_backfill_windows(repo, [window])
+      with :ok <- upsert_backfill_windows(repo, [window]) do
+        refresh_execution_group_summary(repo, window.backfill_run_id)
+      end
     end
   end
 
   @impl true
   def put_backfill_windows(windows, opts) when is_list(windows) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts) do
-      upsert_backfill_windows(repo, windows)
+      with :ok <- upsert_backfill_windows(repo, windows) do
+        refresh_execution_group_summaries(repo, Enum.map(windows, & &1.backfill_run_id))
+      end
     end
   end
 
@@ -2366,8 +2422,14 @@ defmodule Favn.Storage.Adapter.SQLite do
   defp persist_run(repo, run) do
     repo.transact(fn ->
       case guarded_put_run(repo, run) do
-        :ok -> {:ok, :ok}
-        {:error, reason} -> repo.rollback(reason)
+        :ok ->
+          case refresh_execution_group_summary(repo, RunQuery.root_execution_group_id(run)) do
+            :ok -> {:ok, :ok}
+            {:error, reason} -> repo.rollback(reason)
+          end
+
+        {:error, reason} ->
+          repo.rollback(reason)
       end
     end)
     |> case do
@@ -3021,6 +3083,25 @@ defmodule Favn.Storage.Adapter.SQLite do
     end
   end
 
+  defp scan_logs_query(filter, after_sequence) do
+    with {:ok, {where_sql, params}} <- build_log_filter_sql(filter) do
+      prefix = if where_sql == "", do: " WHERE ", else: where_sql <> " AND "
+      after_placeholder = "?#{length(params) + 1}"
+
+      {:ok,
+       """
+       SELECT log_blob
+       FROM favn_log_entries
+       #{prefix}global_sequence > #{after_placeholder}
+       ORDER BY global_sequence ASC
+       """, params ++ [after_sequence]}
+    end
+  end
+
+  defp log_entry_cursor!(%Favn.Log.Entry{} = entry) do
+    %{kind: :log_entry, global_sequence: entry.global_sequence}
+  end
+
   defp build_log_filter_sql(filter) do
     filter
     |> normalize_log_filter()
@@ -3165,6 +3246,105 @@ defmodule Favn.Storage.Adapter.SQLite do
 
   defp decode_log_entry_row([payload]), do: LogEntryCodec.decode(payload)
 
+  defp refresh_execution_group_summaries(repo, group_ids) do
+    group_ids
+    |> Enum.uniq()
+    |> Enum.reduce_while(:ok, fn group_id, :ok ->
+      case refresh_execution_group_summary(repo, group_id) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  end
+
+  defp refresh_execution_group_summary(_repo, nil), do: :ok
+
+  defp refresh_execution_group_summary(repo, group_id) when is_binary(group_id) do
+    with {:ok, runs} <- fetch_execution_group_runs(repo, group_id),
+         {:ok, windows} <- fetch_execution_group_windows(repo, group_id) do
+      case ExecutionGroupSummary.build(runs, windows) do
+        {:ok, summary} -> upsert_execution_group_summary(repo, summary)
+        {:error, :empty_execution_group} -> delete_execution_group_summary(repo, group_id)
+      end
+    else
+      {:error, {:missing_manifest_version, _manifest_version_id}} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_execution_group_runs(repo, group_id) do
+    sql =
+      run_snapshot_select() <>
+        " WHERE r.root_execution_group_id = ?1 ORDER BY CASE WHEN r.run_id = r.root_execution_group_id THEN 0 ELSE 1 END, r.inserted_at ASC, r.run_id ASC"
+
+    case SQL.query(repo, sql, [group_id]) do
+      {:ok, %{rows: rows}} -> decode_run_rows(rows)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp fetch_execution_group_windows(repo, group_id) do
+    sql =
+      "SELECT #{backfill_window_columns()} FROM favn_backfill_windows WHERE backfill_run_id = ?1"
+
+    decode_rows(repo, sql, [group_id], &decode_backfill_window_row/1)
+  end
+
+  defp upsert_execution_group_summary(repo, summary) do
+    with {:ok, activity_seq} <- execution_group_activity_seq(repo, summary.id) do
+      sql = """
+      INSERT INTO favn_execution_group_summaries (
+        group_id, root_run_id, root_status, status, trigger_type, target_refs_text,
+        has_window, failed, running, activity_seq, summary_blob, updated_at
+      ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+      ON CONFLICT(group_id) DO UPDATE SET
+        root_run_id = excluded.root_run_id,
+        root_status = excluded.root_status,
+        status = excluded.status,
+        trigger_type = excluded.trigger_type,
+        target_refs_text = excluded.target_refs_text,
+        has_window = excluded.has_window,
+        failed = excluded.failed,
+        running = excluded.running,
+        activity_seq = excluded.activity_seq,
+        summary_blob = excluded.summary_blob,
+        updated_at = excluded.updated_at
+      """
+
+      params = [
+        summary.id,
+        summary.root_execution_group_id,
+        encode_atom(summary.root_status),
+        encode_atom(summary.status),
+        encode_atom(summary.trigger_type),
+        Enum.join(summary.target_assets, "\n"),
+        summary.total_windows > 0,
+        summary.failure_count > 0,
+        summary.active?,
+        activity_seq,
+        ExecutionGroupSummary.encode(summary),
+        encode_datetime(DateTime.utc_now())
+      ]
+
+      query_ok(repo, sql, params)
+    end
+  end
+
+  defp execution_group_activity_seq(repo, group_id) do
+    case SQL.query(
+           repo,
+           "SELECT COALESCE(MAX(updated_seq), 0) FROM favn_runs WHERE root_execution_group_id = ?1",
+           [group_id]
+         ) do
+      {:ok, %{rows: [[seq]]}} when is_integer(seq) -> {:ok, seq}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp delete_execution_group_summary(repo, group_id) do
+    query_ok(repo, "DELETE FROM favn_execution_group_summaries WHERE group_id = ?1", [group_id])
+  end
+
   defp decode_event_rows(rows) do
     Enum.reduce_while(rows, {:ok, []}, fn [global_sequence, payload], {:ok, acc} ->
       case decode_event_row(global_sequence, payload) do
@@ -3282,6 +3462,81 @@ defmodule Favn.Storage.Adapter.SQLite do
        page_opts}
     end
   end
+
+  defp execution_group_summaries_query(group_opts) do
+    with {:ok, page_opts} <- Page.normalize_opts(group_opts) do
+      filters = Keyword.drop(group_opts, [:limit, :offset, :sort])
+      {where_sql, params} = execution_group_summary_filter_sql(filters)
+      sort_sql = execution_group_summary_sort_sql(Keyword.get(group_opts, :sort, :started_desc))
+      limit_placeholder = "?#{length(params) + 1}"
+      offset_placeholder = "?#{length(params) + 2}"
+
+      {:ok,
+       """
+       SELECT summary_blob
+       FROM favn_execution_group_summaries
+       #{where_sql}
+       ORDER BY #{sort_sql}, group_id DESC
+       LIMIT #{limit_placeholder} OFFSET #{offset_placeholder}
+       """, params ++ [Keyword.fetch!(page_opts, :limit) + 1, Keyword.fetch!(page_opts, :offset)],
+       page_opts}
+    end
+  end
+
+  defp execution_group_summary_filter_sql(filters) do
+    filters
+    |> Enum.reduce({[], []}, fn
+      {:status, status}, {clauses, params} when not is_nil(status) ->
+        {clauses ++ ["root_status = ?#{length(params) + 1}"], params ++ [encode_atom(status)]}
+
+      {:trigger_type, trigger}, {clauses, params} when not is_nil(trigger) ->
+        {clauses ++ ["trigger_type = ?#{length(params) + 1}"], params ++ [encode_atom(trigger)]}
+
+      {:target_asset, target}, {clauses, params} when is_binary(target) and target != "" ->
+        {clauses ++
+           [
+             "instr(char(10) || target_refs_text || char(10), char(10) || ?#{length(params) + 1} || char(10)) > 0"
+           ], params ++ [target]}
+
+      {:search, search}, {clauses, params} when is_binary(search) and search != "" ->
+        placeholder = "?#{length(params) + 1}"
+
+        {clauses ++
+           [
+             "(group_id LIKE #{placeholder} OR target_refs_text LIKE #{placeholder} OR trigger_type LIKE #{placeholder})"
+           ], params ++ ["%#{search}%"]}
+
+      {:window, :has_window}, {clauses, params} ->
+        {clauses ++ ["has_window = 1"], params}
+
+      {:window, :no_window}, {clauses, params} ->
+        {clauses ++ ["has_window = 0"], params}
+
+      {:only_failed, true}, {clauses, params} ->
+        {clauses ++ ["failed = 1"], params}
+
+      {:only_running, true}, {clauses, params} ->
+        {clauses ++ ["running = 1"], params}
+
+      {:only_incomplete, true}, {clauses, params} ->
+        {clauses ++ ["running = 1"], params}
+
+      _other, acc ->
+        acc
+    end)
+    |> case do
+      {[], params} -> {"", params}
+      {clauses, params} -> {"WHERE " <> Enum.join(clauses, " AND "), params}
+    end
+  end
+
+  defp execution_group_summary_sort_sql(:failed_first), do: "failed DESC, activity_seq DESC"
+  defp execution_group_summary_sort_sql(:running_first), do: "running DESC, activity_seq DESC"
+
+  defp execution_group_summary_sort_sql(:status_priority),
+    do: "failed DESC, running DESC, activity_seq DESC"
+
+  defp execution_group_summary_sort_sql(_sort), do: "activity_seq DESC"
 
   defp execution_group_filter_sql(filters) do
     filters

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -3269,12 +3269,14 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   defp execution_group_ids_for_rebuild(repo) do
-    sql =
-      "SELECT DISTINCT root_execution_group_id FROM favn_runs WHERE root_execution_group_id IS NOT NULL ORDER BY root_execution_group_id"
+    with :ok <- repair_missing_run_query_metadata(repo) do
+      sql =
+        "SELECT DISTINCT root_execution_group_id FROM favn_runs WHERE root_execution_group_id IS NOT NULL ORDER BY root_execution_group_id"
 
-    case SQL.query(repo, sql, []) do
-      {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [group_id] -> group_id end)}
-      {:error, reason} -> {:error, reason}
+      case SQL.query(repo, sql, []) do
+        {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [group_id] -> group_id end)}
+        {:error, reason} -> {:error, reason}
+      end
     end
   end
 

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -351,6 +351,17 @@ defmodule Favn.Storage.Adapter.SQLite do
   end
 
   @impl true
+  def rebuild_execution_group_summaries(opts) when is_list(opts) do
+    with {:ok, repo} <- repo_name(opts),
+         {:ok, group_ids} <- execution_group_ids_for_rebuild(repo) do
+      case refresh_execution_group_summaries(repo, group_ids) do
+        :ok -> {:ok, length(group_ids)}
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
   def append_run_event(run_id, event, opts)
       when is_binary(run_id) and is_map(event) and is_list(opts) do
     with {:ok, repo} <- repo_name(opts),
@@ -3257,6 +3268,16 @@ defmodule Favn.Storage.Adapter.SQLite do
     end)
   end
 
+  defp execution_group_ids_for_rebuild(repo) do
+    sql =
+      "SELECT DISTINCT root_execution_group_id FROM favn_runs WHERE root_execution_group_id IS NOT NULL ORDER BY root_execution_group_id"
+
+    case SQL.query(repo, sql, []) do
+      {:ok, %{rows: rows}} -> {:ok, Enum.map(rows, fn [group_id] -> group_id end)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
   defp refresh_execution_group_summary(_repo, nil), do: :ok
 
   defp refresh_execution_group_summary(repo, group_id) when is_binary(group_id) do
@@ -3503,8 +3524,8 @@ defmodule Favn.Storage.Adapter.SQLite do
 
         {clauses ++
            [
-             "(group_id LIKE #{placeholder} OR target_refs_text LIKE #{placeholder} OR trigger_type LIKE #{placeholder})"
-           ], params ++ ["%#{search}%"]}
+             "(LOWER(group_id) LIKE #{placeholder} OR LOWER(target_refs_text) LIKE #{placeholder} OR LOWER(trigger_type) LIKE #{placeholder})"
+           ], params ++ ["%#{String.downcase(search)}%"]}
 
       {:window, :has_window}, {clauses, params} ->
         {clauses ++ ["has_window = 1"], params}

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations.ex
@@ -9,6 +9,7 @@ defmodule FavnStorageSqlite.Migrations do
   alias FavnStorageSqlite.Migrations.AddIdempotencyRecords
   alias FavnStorageSqlite.Migrations.AddExecutionLeases
   alias FavnStorageSqlite.Migrations.AddExecutionAdmissionWaiters
+  alias FavnStorageSqlite.Migrations.AddExecutionGroupSummaries
   alias FavnStorageSqlite.Migrations.AddLogEntries
   alias FavnStorageSqlite.Migrations.AddMaterializationClaims
   alias FavnStorageSqlite.Migrations.AddRunGroupQueryColumns
@@ -29,7 +30,8 @@ defmodule FavnStorageSqlite.Migrations do
     {20_260_520_110_000, AddExecutionAdmissionWaiters},
     {20_260_521_100_000, AddMaterializationClaims},
     {20_260_521_200_000, AddRunGroupQueryColumns},
-    {20_260_522_100_000, AddBackfillProgress}
+    {20_260_522_100_000, AddBackfillProgress},
+    {20_260_524_100_000, AddExecutionGroupSummaries}
   ]
   @required_tables [
     "favn_manifest_versions",
@@ -52,7 +54,8 @@ defmodule FavnStorageSqlite.Migrations do
     "favn_execution_leases",
     "favn_execution_lease_scopes",
     "favn_execution_admission_waiters",
-    "favn_materialization_claims"
+    "favn_materialization_claims",
+    "favn_execution_group_summaries"
   ]
   @expected_versions Enum.map(@migrations, fn {version, _module} -> to_string(version) end)
 

--- a/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_execution_group_summaries.ex
+++ b/apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_execution_group_summaries.ex
@@ -1,0 +1,33 @@
+defmodule FavnStorageSqlite.Migrations.AddExecutionGroupSummaries do
+  @moduledoc false
+
+  use Ecto.Migration
+
+  def change do
+    create_if_not_exists table(:favn_execution_group_summaries, primary_key: false) do
+      add(:group_id, :string, primary_key: true)
+      add(:root_run_id, :string, null: false)
+      add(:root_status, :string, null: false)
+      add(:status, :string, null: false)
+      add(:trigger_type, :string, null: false)
+      add(:target_refs_text, :text, null: false)
+      add(:has_window, :boolean, null: false, default: false)
+      add(:failed, :boolean, null: false, default: false)
+      add(:running, :boolean, null: false, default: false)
+      add(:activity_seq, :integer, null: false)
+      add(:summary_blob, :binary, null: false)
+      add(:updated_at, :text, null: false)
+    end
+
+    create_if_not_exists(index(:favn_execution_group_summaries, [:activity_seq, :group_id]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:trigger_type, :activity_seq]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:root_status, :activity_seq]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:failed, :activity_seq]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:running, :activity_seq]))
+    create_if_not_exists(index(:favn_execution_group_summaries, [:has_window, :activity_seq]))
+
+    create_if_not_exists(index(:favn_log_entries, [:runner_execution_id, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:stream, :global_sequence]))
+    create_if_not_exists(index(:favn_log_entries, [:node_key_hash, :global_sequence]))
+  end
+end

--- a/apps/favn_storage_sqlite/test/sqlite_readiness_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_readiness_test.exs
@@ -241,7 +241,8 @@ defmodule FavnStorageSqlite.ReadinessTest do
              "20260520110000",
              "20260521100000",
              "20260521200000",
-             "20260522100000"
+             "20260522100000",
+             "20260524100000"
            ]
 
     refute Migrations.schema_ready?(Repo)

--- a/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
+++ b/apps/favn_storage_sqlite/test/sqlite_storage_test.exs
@@ -105,6 +105,23 @@ defmodule Favn.SQLiteStorageTest do
     assert Enum.map(limited, & &1.id) == ["aaa-second-id"]
   end
 
+  test "rebuilds execution group summaries when upgraded databases have runs but no summaries" do
+    run = sample_run("sqlite-summary-upgrade-run", :running)
+
+    assert :ok = Storage.put_run(run)
+    assert %{} = SQL.query!(Repo, "DELETE FROM favn_execution_group_summaries", [])
+
+    assert {:ok, empty_page} = OrchestratorStorage.list_execution_group_summaries(limit: 10)
+    assert empty_page.items == []
+
+    assert {:ok, page} =
+             FavnOrchestrator.page_execution_groups(search: "SUMMARY-UPGRADE", limit: 10)
+
+    assert Enum.any?(page.items, &(&1.id == run.id))
+    assert {:ok, rebuilt_page} = OrchestratorStorage.list_execution_group_summaries(limit: 10)
+    assert Enum.any?(rebuilt_page.items, &(&1.id == run.id))
+  end
+
   test "returns :not_found for missing run id" do
     assert {:error, :not_found} = Storage.get_run("missing-sqlite-run")
   end

--- a/docs/structure/favn_storage_postgres.md
+++ b/docs/structure/favn_storage_postgres.md
@@ -3,7 +3,9 @@
 Purpose: Postgres implementation of the orchestrator storage adapter, including
 managed/external repo modes, schema readiness, migrations, JSON-safe
 run/event/backfill, freshness, and materialization-claim DTO persistence, and
-canonical payload persistence.
+canonical payload persistence. High-growth operator reads use indexed log cursor
+scans and a persisted execution-group summary read model rather than repeated
+full run aggregation.
 
 Code:
 - `apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex`
@@ -11,6 +13,7 @@ Code:
 - Run-event global sequence migration: `apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_run_event_global_sequence.ex`
 - Asset freshness state migration: `apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_asset_freshness_state.ex`
 - Materialization claim migration: `apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_materialization_claims.ex`
+- Execution-group summaries and log cursor indexes: `apps/favn_storage_postgres/lib/favn_storage_postgres/migrations/add_execution_group_summaries.ex`
 
 Tests:
 - `apps/favn_storage_postgres/test/`

--- a/docs/structure/favn_storage_sqlite.md
+++ b/docs/structure/favn_storage_sqlite.md
@@ -3,7 +3,9 @@
 Purpose: SQLite implementation of the orchestrator storage adapter, including
 schema migrations, command idempotency records, JSON-safe run/event/backfill,
 freshness, and materialization-claim DTO persistence, and canonical payload
-persistence.
+persistence. High-growth operator reads use indexed log cursor scans and a
+persisted execution-group summary read model rather than repeated full run
+aggregation.
 
 Code:
 - `apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex`
@@ -13,6 +15,7 @@ Code:
 - Run-event global sequence migration: `apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_run_event_global_sequence.ex`
 - Asset freshness state migration: `apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_asset_freshness_state.ex`
 - Materialization claim migration: `apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_materialization_claims.ex`
+- Execution-group summaries and log cursor indexes: `apps/favn_storage_sqlite/lib/favn_storage_sqlite/migrations/add_execution_group_summaries.ex`
 - `apps/favn_storage_sqlite/lib/favn_storage_sqlite/diagnostics.ex`
 
 Tests:


### PR DESCRIPTION
## Summary
- Add indexed cursor-oriented log reads for high-growth replay and streaming paths.
- Add persisted execution-group summaries across memory, SQLite, and Postgres to avoid repeated run aggregation and N+1 group hydration.
- Document the storage read-model changes and cover adapter parity with focused tests.

## Verification
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_storage_sqlite cmd mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_storage_postgres cmd mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/storage/memory_adapter_test.exs test/run_read_model_test.exs`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/integration/storage_adapter_contract_test.exs`
- `MIX_ENV=test mix do --app favn_storage_sqlite cmd mix test test/adapter_test.exs test/sqlite_storage_test.exs`
- `MIX_ENV=test mix do --app favn_storage_postgres cmd mix test test/adapter_test.exs`
- `mix format`

Closes #418