### PR TITLE
Release execution leases by run

### DIFF
--- a/apps/favn_orchestrator/lib/favn/storage/adapter.ex
+++ b/apps/favn_orchestrator/lib/favn/storage/adapter.ex
@@ -36,7 +36,8 @@ defmodule Favn.Storage.Adapter do
 
   Execution lease callbacks are required. They enforce orchestrator-owned asset
   execution admission across run concurrency and shared execution pools before
-  runner work is submitted.
+  runner work is submitted. Run-scoped release must use keyed storage operations
+  and return released scopes so wakeups stay targeted without global lease scans.
   """
 
   alias Favn.Manifest.Version
@@ -46,6 +47,7 @@ defmodule Favn.Storage.Adapter do
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
   alias FavnOrchestrator.CursorPage
+  alias FavnOrchestrator.ExecutionAdmission.LeaseRelease
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -100,6 +102,8 @@ defmodule Favn.Storage.Adapter do
   @callback try_acquire_execution_lease(map(), adapter_opts()) ::
               {:ok, map()} | {:error, {:execution_capacity_exceeded, map()} | error()}
   @callback release_execution_lease(String.t(), adapter_opts()) :: :ok | {:error, error()}
+  @callback release_execution_leases_for_run(String.t(), adapter_opts()) ::
+              {:ok, LeaseRelease.t()} | {:error, error()}
   @callback expire_execution_leases(DateTime.t(), adapter_opts()) ::
               {:ok, non_neg_integer()} | {:error, error()}
   @callback list_execution_leases(adapter_opts()) :: {:ok, [map()]} | {:error, error()}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission.ex
@@ -119,22 +119,21 @@ defmodule FavnOrchestrator.ExecutionAdmission do
 
   @spec release_run(String.t()) :: :ok | {:error, term()}
   def release_run(run_id) when is_binary(run_id) do
-    case Storage.list_execution_leases() do
-      {:ok, leases} ->
-        leases
-        |> Enum.filter(&(Map.get(&1, :run_id) == run_id || Map.get(&1, "run_id") == run_id))
-        |> Enum.each(fn lease ->
-          lease_id = Map.get(lease, :lease_id) || Map.get(lease, "lease_id")
+    wait_cleanup = cancel_run_waits(run_id)
 
-          if is_binary(lease_id) do
-            release(lease)
-          end
-        end)
+    case Storage.release_execution_leases_for_run(run_id) do
+      {:ok, release} ->
+        Coordinator.notify_scopes(release.scopes)
+        wait_cleanup
 
-        cancel_run_waits(run_id)
+      {:error, reason} ->
+        case wait_cleanup do
+          :ok ->
+            {:error, reason}
 
-      {:error, _reason} ->
-        cancel_run_waits(run_id)
+          {:error, wait_reason} ->
+            {:error, {:execution_admission_release_failed, reason, wait_reason}}
+        end
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission/coordinator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission/coordinator.ex
@@ -10,6 +10,7 @@ defmodule FavnOrchestrator.ExecutionAdmission.Coordinator do
 
   alias FavnOrchestrator.ExecutionAdmission.Waiter
   alias FavnOrchestrator.Storage
+  alias FavnOrchestrator.Storage.ExecutionLeaseCodec
 
   @name __MODULE__
   @candidate_limit 100
@@ -58,7 +59,13 @@ defmodule FavnOrchestrator.ExecutionAdmission.Coordinator do
 
   @impl true
   def handle_cast({:notify_scopes, scopes}, state) do
-    Enum.each(scopes, &wake_scope(&1, state))
+    scopes = unique_scopes(scopes)
+
+    with [_ | _] <- scopes,
+         {:ok, _expired} <- Storage.expire_execution_admission_waiters(DateTime.utc_now()) do
+      Enum.each(scopes, &wake_scope(&1, state))
+    end
+
     {:noreply, state}
   end
 
@@ -108,8 +115,7 @@ defmodule FavnOrchestrator.ExecutionAdmission.Coordinator do
   end
 
   defp wake_scope(scope, state) do
-    with {:ok, _expired} <- Storage.expire_execution_admission_waiters(DateTime.utc_now()),
-         {:ok, waiters} <-
+    with {:ok, waiters} <-
            Storage.list_execution_admission_waiters_for_scope(scope, limit: @candidate_limit),
          %Waiter{} = waiter <- first_registered_waiter(waiters, state.subscribers) do
       subscriber = Map.fetch!(state.subscribers, waiter.waiter_id)
@@ -121,6 +127,20 @@ defmodule FavnOrchestrator.ExecutionAdmission.Coordinator do
     else
       _other -> :ok
     end
+  end
+
+  defp unique_scopes(scopes) do
+    scopes
+    |> Enum.reduce(%{}, fn scope, acc ->
+      case ExecutionLeaseCodec.normalize_scope(scope) do
+        {:ok, normalized} ->
+          Map.put_new(acc, ExecutionLeaseCodec.scope_identity(normalized), normalized)
+
+        {:error, _reason} ->
+          acc
+      end
+    end)
+    |> Map.values()
   end
 
   defp first_registered_waiter(waiters, subscribers) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission/lease_release.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission/lease_release.ex
@@ -1,0 +1,27 @@
+defmodule FavnOrchestrator.ExecutionAdmission.LeaseRelease do
+  @moduledoc """
+  Result returned after releasing execution admission leases for a run.
+
+  Storage adapters return the scopes that were freed so the admission coordinator
+  can wake only waiters that may now make progress.
+  """
+
+  @enforce_keys [:run_id, :released_count, :scopes]
+  defstruct [:run_id, :released_count, :scopes]
+
+  @type t :: %__MODULE__{
+          run_id: String.t(),
+          released_count: non_neg_integer(),
+          scopes: [map()]
+        }
+
+  @doc """
+  Builds a lease release result.
+  """
+  @spec new(String.t(), non_neg_integer(), [map()]) :: t()
+  def new(run_id, released_count, scopes)
+      when is_binary(run_id) and is_integer(released_count) and released_count >= 0 and
+             is_list(scopes) do
+    %__MODULE__{run_id: run_id, released_count: released_count, scopes: scopes}
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage.ex
@@ -16,6 +16,7 @@ defmodule FavnOrchestrator.Storage do
   alias FavnOrchestrator.Backfill.BackfillWindow
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
+  alias FavnOrchestrator.ExecutionAdmission.LeaseRelease
   alias FavnOrchestrator.ExecutionAdmission.Waiter, as: AdmissionWaiter
   alias FavnOrchestrator.CursorPage
   alias FavnOrchestrator.MaterializationClaim
@@ -193,6 +194,11 @@ defmodule FavnOrchestrator.Storage do
   @spec release_execution_lease(String.t()) :: :ok | {:error, term()}
   def release_execution_lease(lease_id) when is_binary(lease_id) do
     adapter_call(fn adapter, opts -> adapter.release_execution_lease(lease_id, opts) end)
+  end
+
+  @spec release_execution_leases_for_run(String.t()) :: {:ok, LeaseRelease.t()} | {:error, term()}
+  def release_execution_leases_for_run(run_id) when is_binary(run_id) do
+    adapter_call(fn adapter, opts -> adapter.release_execution_leases_for_run(run_id, opts) end)
   end
 
   @spec expire_execution_leases(DateTime.t()) :: {:ok, non_neg_integer()} | {:error, term()}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/adapter/memory.ex
@@ -16,6 +16,8 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
+  alias FavnOrchestrator.ExecutionAdmission.LeaseRelease
+  alias FavnOrchestrator.Storage.ExecutionLeaseCodec
   alias FavnOrchestrator.Storage.LogEntryCodec
   alias FavnOrchestrator.Storage.ExecutionAdmissionWaiterCodec
   alias FavnOrchestrator.Storage.MaterializationClaimCodec
@@ -48,6 +50,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
           run_events: %{required(String.t()) => [map()]},
           run_event_global_sequence: non_neg_integer(),
           execution_leases: %{required(String.t()) => map()},
+          execution_lease_ids_by_run: %{required(String.t()) => MapSet.t(String.t())},
           execution_admission_waiters: %{required(String.t()) => map()},
           materialization_claims: %{required(String.t()) => MaterializationClaim.t()},
           log_entries: [Favn.Log.Entry.t()],
@@ -298,6 +301,12 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
   def release_execution_lease(lease_id, opts) when is_binary(lease_id) and is_list(opts) do
     server = Keyword.get(opts, :server, __MODULE__)
     GenServer.call(server, {:release_execution_lease, lease_id})
+  end
+
+  @impl true
+  def release_execution_leases_for_run(run_id, opts) when is_binary(run_id) and is_list(opts) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    GenServer.call(server, {:release_execution_leases_for_run, run_id})
   end
 
   @impl true
@@ -754,6 +763,7 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
       run_events: %{},
       run_event_global_sequence: 0,
       execution_leases: %{},
+      execution_lease_ids_by_run: %{},
       execution_admission_waiters: %{},
       materialization_claims: %{},
       log_entries: [],
@@ -1044,26 +1054,75 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
     {expired_count, active_leases} =
       prune_execution_leases(state.execution_leases, lease.acquired_at)
 
+    active_lease_ids_by_run = execution_lease_ids_by_run(active_leases)
+
     reply = execution_lease_capacity(active_leases, lease.scopes)
 
     case reply do
       :ok ->
         next_leases = Map.put(active_leases, lease.lease_id, lease)
-        {:reply, {:ok, lease}, %{state | execution_leases: next_leases}}
+        next_lease_ids_by_run = put_execution_lease_id(active_lease_ids_by_run, lease)
+
+        {:reply, {:ok, lease},
+         %{
+           state
+           | execution_leases: next_leases,
+             execution_lease_ids_by_run: next_lease_ids_by_run
+         }}
 
       {:error, reason} ->
         _ = expired_count
-        {:reply, {:error, reason}, %{state | execution_leases: active_leases}}
+
+        {:reply, {:error, reason},
+         %{
+           state
+           | execution_leases: active_leases,
+             execution_lease_ids_by_run: active_lease_ids_by_run
+         }}
     end
   end
 
   def handle_call({:release_execution_lease, lease_id}, _from, state) do
-    {:reply, :ok, %{state | execution_leases: Map.delete(state.execution_leases, lease_id)}}
+    {lease, execution_leases} = Map.pop(state.execution_leases, lease_id)
+
+    execution_lease_ids_by_run =
+      if lease do
+        delete_execution_lease_id(state.execution_lease_ids_by_run, lease)
+      else
+        state.execution_lease_ids_by_run
+      end
+
+    {:reply, :ok,
+     %{
+       state
+       | execution_leases: execution_leases,
+         execution_lease_ids_by_run: execution_lease_ids_by_run
+     }}
+  end
+
+  def handle_call({:release_execution_leases_for_run, run_id}, _from, state) do
+    lease_ids = Map.get(state.execution_lease_ids_by_run, run_id, MapSet.new())
+
+    {released, execution_leases} = pop_execution_leases(state.execution_leases, lease_ids)
+    reply = lease_release(run_id, released)
+
+    {:reply, {:ok, reply},
+     %{
+       state
+       | execution_leases: execution_leases,
+         execution_lease_ids_by_run: Map.delete(state.execution_lease_ids_by_run, run_id)
+     }}
   end
 
   def handle_call({:expire_execution_leases, now}, _from, state) do
     {expired_count, active_leases} = prune_execution_leases(state.execution_leases, now)
-    {:reply, {:ok, expired_count}, %{state | execution_leases: active_leases}}
+
+    {:reply, {:ok, expired_count},
+     %{
+       state
+       | execution_leases: active_leases,
+         execution_lease_ids_by_run: execution_lease_ids_by_run(active_leases)
+     }}
   end
 
   def handle_call(:list_execution_leases, _from, state) do
@@ -2483,6 +2542,51 @@ defmodule FavnOrchestrator.Storage.Adapter.Memory do
         {expired_count + 1, active}
       end
     end)
+  end
+
+  defp execution_lease_ids_by_run(leases) do
+    Enum.reduce(leases, %{}, fn {_lease_id, lease}, index ->
+      put_execution_lease_id(index, lease)
+    end)
+  end
+
+  defp put_execution_lease_id(index, lease) do
+    Map.update(index, lease.run_id, MapSet.new([lease.lease_id]), &MapSet.put(&1, lease.lease_id))
+  end
+
+  defp delete_execution_lease_id(index, lease) do
+    Map.update(index, lease.run_id, MapSet.new(), fn lease_ids ->
+      MapSet.delete(lease_ids, lease.lease_id)
+    end)
+    |> drop_empty_execution_lease_run(lease.run_id)
+  end
+
+  defp drop_empty_execution_lease_run(index, run_id) do
+    case Map.fetch(index, run_id) do
+      {:ok, lease_ids} ->
+        if MapSet.size(lease_ids) == 0, do: Map.delete(index, run_id), else: index
+
+      _other ->
+        index
+    end
+  end
+
+  defp pop_execution_leases(leases, lease_ids) do
+    Enum.reduce(lease_ids, {[], leases}, fn lease_id, {released, active} ->
+      case Map.pop(active, lease_id) do
+        {nil, next_active} -> {released, next_active}
+        {lease, next_active} -> {[lease | released], next_active}
+      end
+    end)
+  end
+
+  defp lease_release(run_id, leases) do
+    scopes =
+      leases
+      |> Enum.flat_map(& &1.scopes)
+      |> Enum.uniq_by(&ExecutionLeaseCodec.scope_identity/1)
+
+    LeaseRelease.new(run_id, length(leases), scopes)
   end
 
   defp next_execution_admission_waiter(waiter, waiters) do

--- a/apps/favn_orchestrator/test/diagnostics_test.exs
+++ b/apps/favn_orchestrator/test/diagnostics_test.exs
@@ -97,6 +97,11 @@ defmodule FavnOrchestrator.DiagnosticsTest do
     def release_execution_lease(_lease_id, _opts), do: :ok
 
     @impl true
+    def release_execution_leases_for_run(run_id, _opts) do
+      {:ok, FavnOrchestrator.ExecutionAdmission.LeaseRelease.new(run_id, 0, [])}
+    end
+
+    @impl true
     def expire_execution_leases(_now, _opts), do: {:ok, 0}
 
     @impl true

--- a/apps/favn_orchestrator/test/execution_admission_test.exs
+++ b/apps/favn_orchestrator/test/execution_admission_test.exs
@@ -37,6 +37,81 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
     end
   end
 
+  defmodule NoGlobalLeaseScanStorageAdapter do
+    @moduledoc false
+    @behaviour Favn.Storage.Adapter
+
+    callbacks =
+      Favn.Storage.Adapter.behaviour_info(:callbacks) --
+        Favn.Storage.Adapter.behaviour_info(:optional_callbacks)
+
+    excluded = [:list_execution_leases, :release_execution_leases_for_run]
+
+    for {name, arity} <- callbacks, name not in excluded do
+      args = Macro.generate_arguments(arity, __MODULE__)
+
+      @impl true
+      def unquote(name)(unquote_splicing(args)) do
+        apply(FavnOrchestrator.Storage.Adapter.Memory, unquote(name), [unquote_splicing(args)])
+      end
+    end
+
+    @impl true
+    def list_execution_leases(opts) when is_list(opts) do
+      if owner = Keyword.get(opts, :owner), do: send(owner, :global_lease_scan)
+      {:error, :global_lease_scan_not_allowed}
+    end
+
+    @impl true
+    def release_execution_leases_for_run(run_id, opts) when is_binary(run_id) and is_list(opts) do
+      if owner = Keyword.get(opts, :owner), do: send(owner, {:release_leases_for_run, run_id})
+      FavnOrchestrator.Storage.Adapter.Memory.release_execution_leases_for_run(run_id, opts)
+    end
+  end
+
+  defmodule WakeCountingStorageAdapter do
+    @moduledoc false
+    @behaviour Favn.Storage.Adapter
+
+    callbacks =
+      Favn.Storage.Adapter.behaviour_info(:callbacks) --
+        Favn.Storage.Adapter.behaviour_info(:optional_callbacks)
+
+    excluded = [
+      :expire_execution_admission_waiters,
+      :list_execution_admission_waiters_for_scope
+    ]
+
+    for {name, arity} <- callbacks, name not in excluded do
+      args = Macro.generate_arguments(arity, __MODULE__)
+
+      @impl true
+      def unquote(name)(unquote_splicing(args)) do
+        apply(FavnOrchestrator.Storage.Adapter.Memory, unquote(name), [unquote_splicing(args)])
+      end
+    end
+
+    @impl true
+    def expire_execution_admission_waiters(now, opts) when is_list(opts) do
+      if owner = Keyword.get(opts, :owner), do: send(owner, :expired_waiters)
+      FavnOrchestrator.Storage.Adapter.Memory.expire_execution_admission_waiters(now, opts)
+    end
+
+    @impl true
+    def list_execution_admission_waiters_for_scope(scope, waiter_opts, opts)
+        when is_map(scope) and is_list(waiter_opts) and is_list(opts) do
+      if owner = Keyword.get(opts, :owner) do
+        send(owner, {:listed_waiters, {to_string(scope.kind), scope.key}})
+      end
+
+      FavnOrchestrator.Storage.Adapter.Memory.list_execution_admission_waiters_for_scope(
+        scope,
+        waiter_opts,
+        opts
+      )
+    end
+  end
+
   setup do
     Memory.reset()
 
@@ -136,6 +211,69 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
 
     assert :ok = ExecutionAdmission.cancel_wait(waiter)
     assert {:ok, []} = Storage.list_execution_admission_waiters_for_scope(waiter.blocked_scope)
+  end
+
+  test "release_run releases keyed leases without listing every lease" do
+    Application.put_env(:favn_orchestrator, :storage_adapter, NoGlobalLeaseScanStorageAdapter)
+    Application.put_env(:favn_orchestrator, :storage_adapter_opts, owner: self())
+
+    run_a = run(id: "run-a", max_concurrency: 3)
+    run_b = run(id: "run-b", max_concurrency: 3)
+
+    assert {:ok, _lease_a1} = ExecutionAdmission.acquire(run_a, %{asset_step_id: "step-a1"})
+    assert {:ok, _lease_a2} = ExecutionAdmission.acquire(run_a, %{asset_step_id: "step-a2"})
+    assert {:ok, lease_b} = ExecutionAdmission.acquire(run_b, %{asset_step_id: "step-b"})
+
+    assert :ok = ExecutionAdmission.release_run(run_a.id)
+    assert_receive {:release_leases_for_run, "run-a"}, 1_000
+    refute_received :global_lease_scan
+
+    assert {:ok, [remaining]} = Memory.list_execution_leases([])
+    assert remaining.lease_id == lease_b.lease_id
+  end
+
+  test "release_run wakes waiters blocked by scopes freed by the run" do
+    Application.put_env(:favn, :execution_pools, github_api: [max_concurrency: 1])
+
+    run_a = run(id: "run-a", max_concurrency: 10)
+    run_b = run(id: "run-b", max_concurrency: 10)
+    entry = %{asset_step_id: "step-1", execution_pool: :github_api}
+
+    assert {:ok, _lease} = ExecutionAdmission.acquire(run_a, entry)
+
+    assert {:waiting, waiter} =
+             ExecutionAdmission.acquire_or_wait(run_b, %{entry | asset_step_id: "step-2"},
+               stage: 0,
+               attempt: 1
+             )
+
+    assert waiter.queue_reason == :execution_pool
+    assert :ok = ExecutionAdmission.release_run(run_a.id)
+
+    assert_receive {:execution_admission_wakeup, waiter_id, generation}, 1_000
+    assert waiter_id == waiter.waiter_id
+    assert generation == waiter.wake_generation
+
+    assert :ok = ExecutionAdmission.cancel_wait(waiter)
+  end
+
+  test "coordinator dedupes duplicate notification scopes and expires once per batch" do
+    Application.put_env(:favn_orchestrator, :storage_adapter, WakeCountingStorageAdapter)
+    Application.put_env(:favn_orchestrator, :storage_adapter_opts, owner: self())
+
+    scope = %{kind: :pool, key: "github_api", limit: 1}
+    duplicate_scope = %{kind: "pool", key: "github_api", limit: 1}
+
+    FavnOrchestrator.ExecutionAdmission.Coordinator.notify_scopes([
+      scope,
+      duplicate_scope,
+      scope
+    ])
+
+    assert_receive :expired_waiters, 1_000
+    assert_receive {:listed_waiters, {"pool", "github_api"}}, 1_000
+    refute_received :expired_waiters
+    refute_received {:listed_waiters, {"pool", "github_api"}}
   end
 
   test "acquire_or_wait rechecks admission after registering waiter" do

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -265,10 +265,37 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert {:ok, ^blocked} = Storage.try_acquire_execution_lease(blocked)
     assert {:ok, [^blocked]} = Storage.list_execution_leases()
 
+    pool_scope = %{kind: :pool, key: "pool-#{label}", limit: 10}
+    run_a_first = execution_lease(run.id, "step-run-a-first", now, [pool_scope])
+    run_a_second = execution_lease(run.id, "step-run-a-second", now, [pool_scope])
+    run_b_id = "run_contract_other_#{label}_#{System.unique_integer([:positive])}"
+    run_b_lease = execution_lease(run_b_id, "step-run-b", now, [pool_scope])
+
+    assert {:ok, ^run_a_first} = Storage.try_acquire_execution_lease(run_a_first)
+    assert {:ok, ^run_a_second} = Storage.try_acquire_execution_lease(run_a_second)
+    assert {:ok, ^run_b_lease} = Storage.try_acquire_execution_lease(run_b_lease)
+
     assert {:ok, release} = Storage.release_execution_leases_for_run(run.id)
     assert release.run_id == run.id
-    assert release.released_count == 1
-    assert release.scopes == [%{kind: :run, key: run.id, limit: 1}]
+    assert release.released_count == 3
+
+    assert Enum.sort_by(release.scopes, &{to_string(&1.kind), &1.key}) ==
+             Enum.sort_by(
+               [%{kind: :run, key: run.id, limit: 1}, pool_scope],
+               &{
+                 to_string(&1.kind),
+                 &1.key
+               }
+             )
+
+    assert {:ok, [^run_b_lease]} = Storage.list_execution_leases()
+
+    assert {:ok, idempotent_release} = Storage.release_execution_leases_for_run(run.id)
+    assert idempotent_release.released_count == 0
+    assert idempotent_release.scopes == []
+    assert {:ok, [^run_b_lease]} = Storage.list_execution_leases()
+
+    assert :ok = Storage.release_execution_lease(run_b_lease.lease_id)
     assert {:ok, []} = Storage.list_execution_leases()
 
     assert {:ok, ^blocked} = Storage.try_acquire_execution_lease(blocked)

--- a/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
+++ b/apps/favn_orchestrator/test/integration/storage_adapter_contract_test.exs
@@ -264,6 +264,14 @@ defmodule FavnOrchestrator.Integration.StorageAdapterContractTest do
     assert :ok = Storage.release_execution_lease(lease.lease_id)
     assert {:ok, ^blocked} = Storage.try_acquire_execution_lease(blocked)
     assert {:ok, [^blocked]} = Storage.list_execution_leases()
+
+    assert {:ok, release} = Storage.release_execution_leases_for_run(run.id)
+    assert release.run_id == run.id
+    assert release.released_count == 1
+    assert release.scopes == [%{kind: :run, key: run.id, limit: 1}]
+    assert {:ok, []} = Storage.list_execution_leases()
+
+    assert {:ok, ^blocked} = Storage.try_acquire_execution_lease(blocked)
     assert {:ok, 1} = Storage.expire_execution_leases(DateTime.add(now, 6, :second))
     assert {:ok, []} = Storage.list_execution_leases()
 

--- a/apps/favn_orchestrator/test/readiness_test.exs
+++ b/apps/favn_orchestrator/test/readiness_test.exs
@@ -93,6 +93,11 @@ defmodule FavnOrchestrator.ReadinessTest do
     def release_execution_lease(_lease_id, _opts), do: :ok
 
     @impl true
+    def release_execution_leases_for_run(run_id, _opts) do
+      {:ok, FavnOrchestrator.ExecutionAdmission.LeaseRelease.new(run_id, 0, [])}
+    end
+
+    @impl true
     def expire_execution_leases(_now, _opts), do: {:ok, 0}
 
     @impl true

--- a/apps/favn_orchestrator/test/repair_runtime_state_test.exs
+++ b/apps/favn_orchestrator/test/repair_runtime_state_test.exs
@@ -32,6 +32,7 @@ defmodule FavnOrchestrator.Repair.RuntimeStateTest do
     defdelegate list_global_run_events(filters, opts), to: Memory
     defdelegate try_acquire_execution_lease(lease, opts), to: Memory
     defdelegate release_execution_lease(lease_id, opts), to: Memory
+    defdelegate release_execution_leases_for_run(run_id, opts), to: Memory
     defdelegate expire_execution_leases(now, opts), to: Memory
     defdelegate list_execution_leases(opts), to: Memory
     defdelegate upsert_execution_admission_waiter(waiter, opts), to: Memory

--- a/apps/favn_orchestrator/test/run_server_test.exs
+++ b/apps/favn_orchestrator/test/run_server_test.exs
@@ -308,6 +308,7 @@ defmodule FavnOrchestrator.RunServerTest do
     defdelegate list_global_run_events(filters, opts), to: Memory
     defdelegate try_acquire_execution_lease(lease, opts), to: Memory
     defdelegate release_execution_lease(lease_id, opts), to: Memory
+    defdelegate release_execution_leases_for_run(run_id, opts), to: Memory
     defdelegate expire_execution_leases(now, opts), to: Memory
     defdelegate list_execution_leases(opts), to: Memory
     defdelegate upsert_execution_admission_waiter(waiter, opts), to: Memory

--- a/apps/favn_orchestrator/test/storage_facade_test.exs
+++ b/apps/favn_orchestrator/test/storage_facade_test.exs
@@ -62,6 +62,11 @@ defmodule Favn.StorageFacadeTest do
     def release_execution_lease(_lease_id, _opts), do: :ok
 
     @impl true
+    def release_execution_leases_for_run(run_id, _opts) do
+      {:ok, FavnOrchestrator.ExecutionAdmission.LeaseRelease.new(run_id, 0, [])}
+    end
+
+    @impl true
     def expire_execution_leases(_now, _opts), do: {:ok, 0}
 
     @impl true
@@ -247,6 +252,11 @@ defmodule Favn.StorageFacadeTest do
 
     @impl true
     def release_execution_lease(_lease_id, _opts), do: :ok
+
+    @impl true
+    def release_execution_leases_for_run(run_id, _opts) do
+      {:ok, FavnOrchestrator.ExecutionAdmission.LeaseRelease.new(run_id, 0, [])}
+    end
 
     @impl true
     def expire_execution_leases(_now, _opts), do: {:ok, 0}

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -454,7 +454,7 @@ defmodule Favn.Storage.Adapter.Postgres do
         with {:ok, leases} <- list_execution_leases_for_run(repo, run_id),
              lease_ids <- Enum.map(leases, & &1.lease_id),
              :ok <- delete_execution_lease_scopes(repo, lease_ids),
-             {:ok, released_count} <- delete_execution_leases_for_run(repo, run_id) do
+             {:ok, released_count} <- delete_execution_leases_by_ids(repo, lease_ids) do
           {:ok, LeaseRelease.new(run_id, released_count, released_execution_scopes(leases))}
         else
           {:error, reason} -> repo.rollback(reason)
@@ -3551,17 +3551,19 @@ defmodule Favn.Storage.Adapter.Postgres do
   defp delete_execution_leases(_repo, []), do: :ok
 
   defp delete_execution_leases(repo, lease_ids) do
-    placeholders = Enum.map_join(1..length(lease_ids), ",", &"$#{&1}")
-    sql = "DELETE FROM favn_execution_leases WHERE lease_id IN (#{placeholders})"
-
-    case SQL.query(repo, sql, lease_ids) do
-      {:ok, _result} -> :ok
+    case delete_execution_leases_by_ids(repo, lease_ids) do
+      {:ok, _count} -> :ok
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp delete_execution_leases_for_run(repo, run_id) do
-    case SQL.query(repo, "DELETE FROM favn_execution_leases WHERE run_id = $1", [run_id]) do
+  defp delete_execution_leases_by_ids(_repo, []), do: {:ok, 0}
+
+  defp delete_execution_leases_by_ids(repo, lease_ids) do
+    placeholders = Enum.map_join(1..length(lease_ids), ",", &"$#{&1}")
+    sql = "DELETE FROM favn_execution_leases WHERE lease_id IN (#{placeholders})"
+
+    case SQL.query(repo, sql, lease_ids) do
       {:ok, result} -> {:ok, Map.get(result, :num_rows, 0)}
       {:error, reason} -> {:error, reason}
     end

--- a/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
+++ b/apps/favn_storage_postgres/lib/favn/storage/adapter/postgres.ex
@@ -13,6 +13,7 @@ defmodule Favn.Storage.Adapter.Postgres do
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
   alias FavnOrchestrator.CursorPage
+  alias FavnOrchestrator.ExecutionAdmission.LeaseRelease
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -441,6 +442,26 @@ defmodule Favn.Storage.Adapter.Postgres do
       end)
       |> case do
         {:ok, :ok} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def release_execution_leases_for_run(run_id, opts) when is_binary(run_id) and is_list(opts) do
+    with {:ok, repo} <- resolve_repo(opts) do
+      repo.transact(fn ->
+        with {:ok, leases} <- list_execution_leases_for_run(repo, run_id),
+             lease_ids <- Enum.map(leases, & &1.lease_id),
+             :ok <- delete_execution_lease_scopes(repo, lease_ids),
+             {:ok, released_count} <- delete_execution_leases_for_run(repo, run_id) do
+          {:ok, LeaseRelease.new(run_id, released_count, released_execution_scopes(leases))}
+        else
+          {:error, reason} -> repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, release} -> {:ok, release}
         {:error, reason} -> {:error, reason}
       end
     end
@@ -1850,6 +1871,8 @@ defmodule Favn.Storage.Adapter.Postgres do
 
   defp decode_materialization_claim_row([record_payload]),
     do: MaterializationClaimCodec.decode(record_payload)
+
+  defp decode_execution_lease_row([lease_payload]), do: ExecutionLeaseCodec.decode(lease_payload)
 
   defp decode_execution_admission_waiter_row([waiter_payload]),
     do: ExecutionAdmissionWaiterCodec.decode(waiter_payload)
@@ -3364,6 +3387,18 @@ defmodule Favn.Storage.Adapter.Postgres do
     end
   end
 
+  defp list_execution_leases_for_run(repo, run_id) do
+    sql = "SELECT lease_payload FROM favn_execution_leases WHERE run_id = $1 FOR UPDATE"
+
+    query_and_decode_rows(repo, sql, [run_id], &decode_execution_lease_row/1)
+  end
+
+  defp released_execution_scopes(leases) do
+    leases
+    |> Enum.flat_map(& &1.scopes)
+    |> Enum.uniq_by(&ExecutionLeaseCodec.scope_identity/1)
+  end
+
   defp lock_execution_lease_scopes(repo, scopes) do
     scopes
     |> Enum.map(&ExecutionLeaseCodec.scope_identity/1)
@@ -3521,6 +3556,13 @@ defmodule Favn.Storage.Adapter.Postgres do
 
     case SQL.query(repo, sql, lease_ids) do
       {:ok, _result} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp delete_execution_leases_for_run(repo, run_id) do
+    case SQL.query(repo, "DELETE FROM favn_execution_leases WHERE run_id = $1", [run_id]) do
+      {:ok, result} -> {:ok, Map.get(result, :num_rows, 0)}
       {:error, reason} -> {:error, reason}
     end
   end

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -458,7 +458,7 @@ defmodule Favn.Storage.Adapter.SQLite do
         with {:ok, leases} <- list_execution_leases_for_run(repo, run_id),
              lease_ids <- Enum.map(leases, & &1.lease_id),
              :ok <- delete_execution_lease_scopes(repo, lease_ids),
-             {:ok, released_count} <- delete_execution_leases_for_run(repo, run_id) do
+             {:ok, released_count} <- delete_execution_leases_by_ids(repo, lease_ids) do
           {:ok, LeaseRelease.new(run_id, released_count, released_execution_scopes(leases))}
         else
           {:error, reason} -> repo.rollback(reason)
@@ -4161,17 +4161,19 @@ defmodule Favn.Storage.Adapter.SQLite do
   defp delete_execution_leases(_repo, []), do: :ok
 
   defp delete_execution_leases(repo, lease_ids) do
-    placeholders = Enum.map_join(1..length(lease_ids), ",", &"?#{&1}")
-    sql = "DELETE FROM favn_execution_leases WHERE lease_id IN (#{placeholders})"
-
-    case SQL.query(repo, sql, lease_ids) do
-      {:ok, _result} -> :ok
+    case delete_execution_leases_by_ids(repo, lease_ids) do
+      {:ok, _count} -> :ok
       {:error, reason} -> {:error, reason}
     end
   end
 
-  defp delete_execution_leases_for_run(repo, run_id) do
-    case SQL.query(repo, "DELETE FROM favn_execution_leases WHERE run_id = ?1", [run_id]) do
+  defp delete_execution_leases_by_ids(_repo, []), do: {:ok, 0}
+
+  defp delete_execution_leases_by_ids(repo, lease_ids) do
+    placeholders = Enum.map_join(1..length(lease_ids), ",", &"?#{&1}")
+    sql = "DELETE FROM favn_execution_leases WHERE lease_id IN (#{placeholders})"
+
+    case SQL.query(repo, sql, lease_ids) do
       {:ok, result} -> {:ok, Map.get(result, :num_rows, 0)}
       {:error, reason} -> {:error, reason}
     end

--- a/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
+++ b/apps/favn_storage_sqlite/lib/favn/storage/adapter/sqlite.ex
@@ -13,6 +13,7 @@ defmodule Favn.Storage.Adapter.SQLite do
   alias FavnOrchestrator.Backfill.CoverageBaseline
   alias FavnOrchestrator.Backfill.Progress, as: BackfillProgress
   alias FavnOrchestrator.CursorPage
+  alias FavnOrchestrator.ExecutionAdmission.LeaseRelease
   alias FavnOrchestrator.MaterializationClaim
   alias FavnOrchestrator.Page
   alias FavnOrchestrator.RunState
@@ -445,6 +446,26 @@ defmodule Favn.Storage.Adapter.SQLite do
       end)
       |> case do
         {:ok, :ok} -> :ok
+        {:error, reason} -> {:error, reason}
+      end
+    end
+  end
+
+  @impl true
+  def release_execution_leases_for_run(run_id, opts) when is_binary(run_id) and is_list(opts) do
+    with {:ok, repo} <- repo_name(opts) do
+      repo.transact(fn ->
+        with {:ok, leases} <- list_execution_leases_for_run(repo, run_id),
+             lease_ids <- Enum.map(leases, & &1.lease_id),
+             :ok <- delete_execution_lease_scopes(repo, lease_ids),
+             {:ok, released_count} <- delete_execution_leases_for_run(repo, run_id) do
+          {:ok, LeaseRelease.new(run_id, released_count, released_execution_scopes(leases))}
+        else
+          {:error, reason} -> repo.rollback(reason)
+        end
+      end)
+      |> case do
+        {:ok, release} -> {:ok, release}
         {:error, reason} -> {:error, reason}
       end
     end
@@ -1851,6 +1872,8 @@ defmodule Favn.Storage.Adapter.SQLite do
 
   defp decode_materialization_claim_row([record_payload]),
     do: MaterializationClaimCodec.decode(record_payload)
+
+  defp decode_execution_lease_row([lease_payload]), do: ExecutionLeaseCodec.decode(lease_payload)
 
   defp decode_execution_admission_waiter_row([waiter_payload]),
     do: ExecutionAdmissionWaiterCodec.decode(waiter_payload)
@@ -3986,6 +4009,18 @@ defmodule Favn.Storage.Adapter.SQLite do
     end
   end
 
+  defp list_execution_leases_for_run(repo, run_id) do
+    sql = "SELECT lease_payload FROM favn_execution_leases WHERE run_id = ?1"
+
+    decode_rows(repo, sql, [run_id], &decode_execution_lease_row/1)
+  end
+
+  defp released_execution_scopes(leases) do
+    leases
+    |> Enum.flat_map(& &1.scopes)
+    |> Enum.uniq_by(&ExecutionLeaseCodec.scope_identity/1)
+  end
+
   defp ensure_execution_lease_capacity(repo, scopes, %DateTime{} = now) do
     timestamp = DateTime.to_iso8601(now)
 
@@ -4131,6 +4166,13 @@ defmodule Favn.Storage.Adapter.SQLite do
 
     case SQL.query(repo, sql, lease_ids) do
       {:ok, _result} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  defp delete_execution_leases_for_run(repo, run_id) do
+    case SQL.query(repo, "DELETE FROM favn_execution_leases WHERE run_id = ?1", [run_id]) do
+      {:ok, result} -> {:ok, Map.get(result, :num_rows, 0)}
       {:error, reason} -> {:error, reason}
     end
   end

--- a/apps/favn_test_support/priv/fixtures/assets/runner_assets.ex
+++ b/apps/favn_test_support/priv/fixtures/assets/runner_assets.ex
@@ -300,6 +300,11 @@ defmodule Favn.Test.Fixtures.Assets.Runner.TerminalFailingStore do
   def release_execution_lease(_lease_id, _opts), do: :ok
 
   @impl true
+  def release_execution_leases_for_run(run_id, _opts) do
+    {:ok, FavnOrchestrator.ExecutionAdmission.LeaseRelease.new(run_id, 0, [])}
+  end
+
+  @impl true
   def expire_execution_leases(_now, _opts), do: {:ok, 0}
 
   @impl true


### PR DESCRIPTION
## Summary
- Add a storage callback and lease release result for keyed execution lease release by run.
- Update admission cleanup to avoid global lease scans and wake waiters using released scopes.
- Implement equivalent memory, SQLite, and Postgres adapter behavior and dedupe coordinator wakeup batches.

## Tests
- `mix format`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test --exclude acceptance --exclude slow --exclude browser test/execution_admission_test.exs test/integration/storage_adapter_contract_test.exs`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test --exclude acceptance --exclude slow --exclude browser test/diagnostics_test.exs test/readiness_test.exs test/storage_facade_test.exs test/repair_runtime_state_test.exs test/run_server_test.exs`
- `MIX_ENV=test mix do --app favn_storage_sqlite cmd mix test --exclude acceptance --exclude slow --exclude browser test/adapter_test.exs`
- `MIX_ENV=test mix do --app favn_storage_postgres cmd mix test --exclude acceptance --exclude slow --exclude browser test/adapter_test.exs`
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_storage_sqlite cmd mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_storage_postgres cmd mix compile --warnings-as-errors`
- `MIX_ENV=test mix do --app favn_test_support cmd mix compile --warnings-as-errors`
- `git diff --check`

Closes #421