### PR TITLE
Reject terminal run execution admission

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission.ex
@@ -14,7 +14,6 @@ defmodule FavnOrchestrator.ExecutionAdmission do
 
   @default_lease_ttl_ms 300_000
   @lease_timeout_buffer_ms 60_000
-  @terminal_statuses [:ok, :partial, :error, :cancelled, :timed_out]
 
   @type lease :: map()
   @type queue_reason :: :pipeline_concurrency | :execution_pool | :global_concurrency
@@ -86,11 +85,13 @@ defmodule FavnOrchestrator.ExecutionAdmission do
     end
   end
 
-  defp validate_run_admissible(%RunState{id: run_id, status: status})
-       when status in @terminal_statuses,
-       do: {:error, {:run_not_admissible, run_id, status}}
-
-  defp validate_run_admissible(%RunState{}), do: :ok
+  defp validate_run_admissible(%RunState{id: run_id, status: status} = run) do
+    if RunState.terminal?(run) do
+      {:error, {:run_not_admissible, run_id, status}}
+    else
+      :ok
+    end
+  end
 
   @spec release(lease() | nil) :: :ok | {:error, term()}
   def release(nil), do: :ok

--- a/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission.ex
@@ -14,6 +14,7 @@ defmodule FavnOrchestrator.ExecutionAdmission do
 
   @default_lease_ttl_ms 300_000
   @lease_timeout_buffer_ms 60_000
+  @terminal_statuses [:ok, :partial, :error, :cancelled, :timed_out]
 
   @type lease :: map()
   @type queue_reason :: :pipeline_concurrency | :execution_pool | :global_concurrency
@@ -52,7 +53,8 @@ defmodule FavnOrchestrator.ExecutionAdmission do
   end
 
   defp acquire_result(%RunState{} = run, entry) when is_map(entry) do
-    with :ok <- validate_execution_pool(entry) do
+    with :ok <- validate_run_admissible(run),
+         :ok <- validate_execution_pool(entry) do
       scopes = admission_scopes(run, entry)
 
       if scopes == [] do
@@ -83,6 +85,12 @@ defmodule FavnOrchestrator.ExecutionAdmission do
       end
     end
   end
+
+  defp validate_run_admissible(%RunState{id: run_id, status: status})
+       when status in @terminal_statuses,
+       do: {:error, {:run_not_admissible, run_id, status}}
+
+  defp validate_run_admissible(%RunState{}), do: :ok
 
   @spec release(lease() | nil) :: :ok | {:error, term()}
   def release(nil), do: :ok

--- a/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/execution_admission.ex
@@ -86,10 +86,10 @@ defmodule FavnOrchestrator.ExecutionAdmission do
   end
 
   defp validate_run_admissible(%RunState{id: run_id, status: status} = run) do
-    if RunState.terminal?(run) do
-      {:error, {:run_not_admissible, run_id, status}}
-    else
+    if RunState.execution_admissible?(run) do
       :ok
+    else
+      {:error, {:run_not_admissible, run_id, status}}
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
@@ -269,12 +269,15 @@ defmodule FavnOrchestrator.RunManager do
 
   defp reject_backfill_parent_cancel(_run), do: :ok
 
-  defp build_cancel_snapshots(%RunState{status: status}, _reason)
-       when status in [:ok, :partial, :error, :cancelled, :timed_out] do
-    {:error, :run_already_terminal}
+  defp build_cancel_snapshots(%RunState{} = run, reason) do
+    if RunState.terminal?(run) do
+      {:error, :run_already_terminal}
+    else
+      build_active_cancel_snapshots(run, reason)
+    end
   end
 
-  defp build_cancel_snapshots(%RunState{} = run, reason) do
+  defp build_active_cancel_snapshots(%RunState{} = run, reason) do
     cancel_requested =
       RunState.transition(run,
         metadata:

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_manager.ex
@@ -270,7 +270,7 @@ defmodule FavnOrchestrator.RunManager do
   defp reject_backfill_parent_cancel(_run), do: :ok
 
   defp build_cancel_snapshots(%RunState{} = run, reason) do
-    if RunState.terminal?(run) do
+    if RunState.finalized?(run) do
       {:error, :run_already_terminal}
     else
       build_active_cancel_snapshots(run, reason)

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_manager/submission_builder.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_manager/submission_builder.ex
@@ -259,7 +259,7 @@ defmodule FavnOrchestrator.RunManager.SubmissionBuilder do
     run_id = Keyword.get(opts, :run_id, new_run_id())
     params = Keyword.get(opts, :params, source_run.params)
     trigger = Keyword.get(opts, :trigger, %{kind: :rerun, source_run_id: source_run.id})
-    metadata = Map.merge(source_run.metadata, Keyword.get(opts, :metadata, %{}))
+    metadata = Map.merge(rerun_base_metadata(source_run), Keyword.get(opts, :metadata, %{}))
     max_attempts = Keyword.get(opts, :max_attempts, source_run.max_attempts)
     retry_backoff_ms = Keyword.get(opts, :retry_backoff_ms, source_run.retry_backoff_ms)
     timeout_ms = Keyword.get(opts, :timeout_ms, source_run.timeout_ms)
@@ -355,6 +355,27 @@ defmodule FavnOrchestrator.RunManager.SubmissionBuilder do
     do: metadata
 
   defp maybe_put_pipeline_execution_policy(metadata), do: metadata
+
+  defp rerun_base_metadata(%RunState{metadata: metadata}) when is_map(metadata) do
+    Map.drop(metadata, [
+      :terminal_event_type,
+      "terminal_event_type",
+      :cancelled,
+      "cancelled",
+      :cancel_requested,
+      "cancel_requested",
+      :cancel_reason,
+      "cancel_reason",
+      :cancel_requested_at,
+      "cancel_requested_at",
+      :cancel_forward_error,
+      "cancel_forward_error",
+      :in_flight_execution_ids,
+      "in_flight_execution_ids"
+    ])
+  end
+
+  defp rerun_base_metadata(%RunState{}), do: %{}
 
   defp normalize_pipeline_window_request(nil, window_request),
     do: WindowRequest.from_value(window_request)

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server.ex
@@ -26,23 +26,28 @@ defmodule FavnOrchestrator.RunServer do
 
   @impl true
   def handle_continue(:execute, %{run_state: run_state, version: version} = state) do
-    running = RunState.transition(run_state, status: :running)
+    if RunState.terminal?(run_state) do
+      :ok = ExecutionAdmission.release_run(run_state.id)
+      {:stop, :normal, state |> Map.put(:run_state, run_state) |> Map.put(:execution_state, nil)}
+    else
+      running = RunState.transition(run_state, status: :running)
 
-    case Persistence.persist_run_step(running, :run_started, %{status: running.status}) do
-      :ok ->
-        case Execution.start_state(running, version) do
-          {:ok, execution_state} ->
-            state
-            |> Map.put(:run_state, running)
-            |> Map.put(:execution_state, execution_state)
-            |> continue_execution()
+      case Persistence.persist_run_step(running, :run_started, %{status: running.status}) do
+        :ok ->
+          case Execution.start_state(running, version) do
+            {:ok, execution_state} ->
+              state
+              |> Map.put(:run_state, running)
+              |> Map.put(:execution_state, execution_state)
+              |> continue_execution()
 
-          {:terminal, terminal} ->
-            finalize_terminal(state, terminal)
-        end
+            {:terminal, terminal} ->
+              finalize_terminal(state, terminal)
+          end
 
-      {:error, :external_cancel} ->
-        {:stop, :normal, %{state | run_state: Snapshots.cancelled_snapshot(running)}}
+        {:error, :external_cancel} ->
+          {:stop, :normal, %{state | run_state: Snapshots.cancelled_snapshot(running)}}
+      end
     end
   end
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server.ex
@@ -26,7 +26,7 @@ defmodule FavnOrchestrator.RunServer do
 
   @impl true
   def handle_continue(:execute, %{run_state: run_state, version: version} = state) do
-    if RunState.terminal?(run_state) do
+    if RunState.finalized?(run_state) do
       :ok = ExecutionAdmission.release_run(run_state.id)
       {:stop, :normal, state |> Map.put(:run_state, run_state) |> Map.put(:execution_state, nil)}
     else

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_server/execution/stage_admission.ex
@@ -155,6 +155,10 @@ defmodule FavnOrchestrator.RunServer.Execution.StageAdmission do
             waiter: waiter
           })
 
+        {:error, {:run_not_admissible, run_id, _status}}
+        when run_id == current_run.id ->
+          {:error, current_run, [], Enum.map(acc, & &1.node_key)}
+
         {:error, reason} ->
           failed = RunState.transition(current_run, status: :error, error: reason)
           {:error, failed, [], Enum.map(acc, & &1.node_key)}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_state.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_state.ex
@@ -103,9 +103,13 @@ defmodule FavnOrchestrator.RunState do
   @spec default_timeout_ms() :: pos_integer()
   def default_timeout_ms, do: @default_timeout_ms
 
-  @doc "Returns true when a persisted run snapshot has been terminalized."
-  @spec terminal?(t()) :: boolean()
-  def terminal?(%__MODULE__{metadata: metadata}), do: terminal_metadata?(metadata)
+  @doc "Returns true when a persisted run snapshot has been finalized."
+  @spec finalized?(t()) :: boolean()
+  def finalized?(%__MODULE__{metadata: metadata}), do: finalized_metadata?(metadata)
+
+  @doc "Returns true when the run can still admit execution work."
+  @spec execution_admissible?(t()) :: boolean()
+  def execution_admissible?(%__MODULE__{} = run), do: not finalized?(run)
 
   @doc "Returns true when the status represents terminal persisted run state."
   @spec terminal_status?(status() | term()) :: boolean()
@@ -113,7 +117,21 @@ defmodule FavnOrchestrator.RunState do
   def terminal_status?(status) when is_binary(status), do: status in @terminal_status_strings
   def terminal_status?(_status), do: false
 
-  defp terminal_metadata?(metadata) when is_map(metadata) do
+  @doc "Returns the persisted terminal event type for a terminal run status."
+  @spec terminal_event_type(status() | term()) :: atom() | nil
+  def terminal_event_type(:ok), do: :run_finished
+  def terminal_event_type("ok"), do: :run_finished
+  def terminal_event_type(:cancelled), do: :run_cancelled
+  def terminal_event_type("cancelled"), do: :run_cancelled
+  def terminal_event_type(:timed_out), do: :run_timed_out
+  def terminal_event_type("timed_out"), do: :run_timed_out
+  def terminal_event_type(:partial), do: :run_failed
+  def terminal_event_type("partial"), do: :run_failed
+  def terminal_event_type(:error), do: :run_failed
+  def terminal_event_type("error"), do: :run_failed
+  def terminal_event_type(_status), do: nil
+
+  defp finalized_metadata?(metadata) when is_map(metadata) do
     terminal_event_type =
       Map.get(metadata, :terminal_event_type) || Map.get(metadata, "terminal_event_type")
 
@@ -122,7 +140,7 @@ defmodule FavnOrchestrator.RunState do
     terminal_event_type?(terminal_event_type) or cancelled? == true
   end
 
-  defp terminal_metadata?(_metadata), do: false
+  defp finalized_metadata?(_metadata), do: false
 
   defp terminal_event_type?(value) when is_atom(value), do: value in @terminal_event_types
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_state.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_state.ex
@@ -5,7 +5,9 @@ defmodule FavnOrchestrator.RunState do
 
   @default_timeout_ms 30 * 60 * 1000
   @terminal_statuses [:ok, :partial, :error, :cancelled, :timed_out]
+  @terminal_status_strings Enum.map(@terminal_statuses, &Atom.to_string/1)
   @terminal_event_types [:run_finished, :run_failed, :run_cancelled, :run_timed_out]
+  @terminal_event_type_strings Enum.map(@terminal_event_types, &Atom.to_string/1)
 
   @type status :: :pending | :running | :ok | :partial | :error | :cancelled | :timed_out
 
@@ -103,13 +105,13 @@ defmodule FavnOrchestrator.RunState do
 
   @doc "Returns true when a persisted run snapshot has been terminalized."
   @spec terminal?(t()) :: boolean()
-  def terminal?(%__MODULE__{status: status, metadata: metadata, result: result}) do
-    terminal_metadata?(metadata) or terminal_result?(status, result)
-  end
+  def terminal?(%__MODULE__{metadata: metadata}), do: terminal_metadata?(metadata)
 
   @doc "Returns true when the status represents terminal persisted run state."
   @spec terminal_status?(status() | term()) :: boolean()
-  def terminal_status?(status), do: status in @terminal_statuses
+  def terminal_status?(status) when is_atom(status), do: status in @terminal_statuses
+  def terminal_status?(status) when is_binary(status), do: status in @terminal_status_strings
+  def terminal_status?(_status), do: false
 
   defp terminal_metadata?(metadata) when is_map(metadata) do
     terminal_event_type =
@@ -117,18 +119,17 @@ defmodule FavnOrchestrator.RunState do
 
     cancelled? = Map.get(metadata, :cancelled) || Map.get(metadata, "cancelled")
 
-    terminal_event_type in @terminal_event_types or cancelled? == true
+    terminal_event_type?(terminal_event_type) or cancelled? == true
   end
 
   defp terminal_metadata?(_metadata), do: false
 
-  defp terminal_result?(status, result) when is_map(result) do
-    result_status = Map.get(result, :status) || Map.get(result, "status")
+  defp terminal_event_type?(value) when is_atom(value), do: value in @terminal_event_types
 
-    terminal_status?(status) and result_status == status
-  end
+  defp terminal_event_type?(value) when is_binary(value),
+    do: value in @terminal_event_type_strings
 
-  defp terminal_result?(_status, _result), do: false
+  defp terminal_event_type?(_value), do: false
 
   @spec transition(t(), keyword()) :: t()
   def transition(%__MODULE__{} = run, attrs) when is_list(attrs) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_state.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_state.ex
@@ -4,6 +4,8 @@ defmodule FavnOrchestrator.RunState do
   """
 
   @default_timeout_ms 30 * 60 * 1000
+  @terminal_statuses [:ok, :partial, :error, :cancelled, :timed_out]
+  @terminal_event_types [:run_finished, :run_failed, :run_cancelled, :run_timed_out]
 
   @type status :: :pending | :running | :ok | :partial | :error | :cancelled | :timed_out
 
@@ -98,6 +100,35 @@ defmodule FavnOrchestrator.RunState do
   @doc false
   @spec default_timeout_ms() :: pos_integer()
   def default_timeout_ms, do: @default_timeout_ms
+
+  @doc "Returns true when a persisted run snapshot has been terminalized."
+  @spec terminal?(t()) :: boolean()
+  def terminal?(%__MODULE__{status: status, metadata: metadata, result: result}) do
+    terminal_metadata?(metadata) or terminal_result?(status, result)
+  end
+
+  @doc "Returns true when the status represents terminal persisted run state."
+  @spec terminal_status?(status() | term()) :: boolean()
+  def terminal_status?(status), do: status in @terminal_statuses
+
+  defp terminal_metadata?(metadata) when is_map(metadata) do
+    terminal_event_type =
+      Map.get(metadata, :terminal_event_type) || Map.get(metadata, "terminal_event_type")
+
+    cancelled? = Map.get(metadata, :cancelled) || Map.get(metadata, "cancelled")
+
+    terminal_event_type in @terminal_event_types or cancelled? == true
+  end
+
+  defp terminal_metadata?(_metadata), do: false
+
+  defp terminal_result?(status, result) when is_map(result) do
+    result_status = Map.get(result, :status) || Map.get(result, "status")
+
+    terminal_status?(status) and result_status == status
+  end
+
+  defp terminal_result?(_status, _result), do: false
 
   @spec transition(t(), keyword()) :: t()
   def transition(%__MODULE__{} = run, attrs) when is_list(attrs) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_state_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_state_codec.ex
@@ -8,7 +8,7 @@ defmodule FavnOrchestrator.Storage.RunStateCodec do
     with :ok <- validate_identity(run_state),
          :ok <- validate_asset_ref(run_state.asset_ref),
          :ok <- validate_event_seq(run_state.event_seq) do
-      {:ok, RunState.with_snapshot_hash(run_state)}
+      {:ok, run_state |> normalize_legacy_finalized_snapshot() |> RunState.with_snapshot_hash()}
     end
   end
 
@@ -46,4 +46,49 @@ defmodule FavnOrchestrator.Storage.RunStateCodec do
 
   defp validate_event_seq(event_seq) when is_integer(event_seq) and event_seq >= 0, do: :ok
   defp validate_event_seq(_value), do: {:error, :invalid_event_seq}
+
+  defp normalize_legacy_finalized_snapshot(%RunState{} = run_state) do
+    if legacy_finalized_snapshot?(run_state) do
+      %{
+        run_state
+        | metadata:
+            Map.put(run_state.metadata, :terminal_event_type, terminal_event_type(run_state))
+      }
+    else
+      run_state
+    end
+  end
+
+  defp legacy_finalized_snapshot?(%RunState{metadata: metadata} = run_state)
+       when is_map(metadata) do
+    RunState.terminal_status?(run_state.status) and not RunState.finalized?(run_state) and
+      terminal_result?(run_state.result, run_state.status)
+  end
+
+  defp legacy_finalized_snapshot?(%RunState{}), do: false
+
+  defp terminal_result?(%{status: result_status, asset_results: asset_results}, status)
+       when is_list(asset_results) do
+    matching_status?(result_status, status)
+  end
+
+  defp terminal_result?(%{"status" => result_status, "asset_results" => asset_results}, status)
+       when is_list(asset_results) do
+    matching_status?(result_status, status)
+  end
+
+  defp terminal_result?(_result, _status), do: false
+
+  defp matching_status?(left, right) when is_atom(left) and is_atom(right), do: left == right
+  defp matching_status?(left, right) when is_binary(left) and is_binary(right), do: left == right
+
+  defp matching_status?(left, right) when is_atom(left) and is_binary(right),
+    do: Atom.to_string(left) == right
+
+  defp matching_status?(left, right) when is_binary(left) and is_atom(right),
+    do: left == Atom.to_string(right)
+
+  defp matching_status?(_left, _right), do: false
+
+  defp terminal_event_type(%RunState{status: status}), do: RunState.terminal_event_type(status)
 end

--- a/apps/favn_orchestrator/test/api/router_test.exs
+++ b/apps/favn_orchestrator/test/api/router_test.exs
@@ -1084,7 +1084,8 @@ defmodule FavnOrchestrator.API.RouterTest do
 
     assert response.status == 200
     assert %{"data" => %{"run" => run}} = Jason.decode!(response.resp_body)
-    assert run["metadata"] == %{"source" => "test"}
+    assert run["metadata"]["source"] == "test"
+    assert run["metadata"]["terminal_event_type"] == "run_finished"
 
     assert [%{"asset_ref" => "Elixir.MyApp.Assets.Gold:asset", "meta" => meta}] =
              run["asset_results"]

--- a/apps/favn_orchestrator/test/execution_admission_test.exs
+++ b/apps/favn_orchestrator/test/execution_admission_test.exs
@@ -117,7 +117,7 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
 
     for status <- [:ok, :partial, :error, :cancelled, :timed_out] do
       run = run(id: "run-terminal-#{status}", max_concurrency: 1)
-      terminal = RunState.transition(run, status: status)
+      terminal = terminal_run(run, status)
       run_id = terminal.id
 
       assert {:error, {:run_not_admissible, ^run_id, ^status}} =
@@ -134,6 +134,14 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
     end
   end
 
+  test "intermediate step outcome statuses remain admissible before terminalization" do
+    run = run(max_concurrency: 1)
+    intermediate = RunState.transition(run, status: :ok)
+
+    assert {:ok, lease} = ExecutionAdmission.acquire(intermediate, %{asset_step_id: "step-1"})
+    assert lease.run_id == intermediate.id
+  end
+
   test "run lease cleanup is idempotent and does not reopen terminal admission" do
     run = run(max_concurrency: 1)
 
@@ -142,7 +150,7 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
     assert :ok = ExecutionAdmission.release_run(run.id)
     assert {:ok, []} = Storage.list_execution_leases()
 
-    terminal = RunState.transition(run, status: :cancelled)
+    terminal = terminal_run(run, :cancelled)
     run_id = terminal.id
 
     assert {:error, {:run_not_admissible, ^run_id, :cancelled}} =
@@ -258,6 +266,19 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
   end
 
   defp run_scope(%RunState{} = run), do: %{kind: :run, key: run.id, limit: 1}
+
+  defp terminal_run(%RunState{} = run, status) do
+    RunState.transition(run,
+      status: status,
+      result: %{status: status, asset_results: [], metadata: run.metadata},
+      metadata: Map.put(run.metadata, :terminal_event_type, terminal_event_type(status))
+    )
+  end
+
+  defp terminal_event_type(:ok), do: :run_finished
+  defp terminal_event_type(:cancelled), do: :run_cancelled
+  defp terminal_event_type(:timed_out), do: :run_timed_out
+  defp terminal_event_type(_status), do: :run_failed
 
   defp restore_env(app, key, nil), do: Application.delete_env(app, key)
   defp restore_env(app, key, value), do: Application.put_env(app, key, value)

--- a/apps/favn_orchestrator/test/execution_admission_test.exs
+++ b/apps/favn_orchestrator/test/execution_admission_test.exs
@@ -136,7 +136,7 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
 
   test "intermediate step outcome statuses remain admissible before terminalization" do
     run = run(max_concurrency: 1)
-    intermediate = RunState.transition(run, status: :ok)
+    intermediate = RunState.transition(run, status: :error, result: %{status: :error})
 
     assert {:ok, lease} = ExecutionAdmission.acquire(intermediate, %{asset_step_id: "step-1"})
     assert lease.run_id == intermediate.id

--- a/apps/favn_orchestrator/test/execution_admission_test.exs
+++ b/apps/favn_orchestrator/test/execution_admission_test.exs
@@ -120,6 +120,8 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
       terminal = terminal_run(run, status)
       run_id = terminal.id
 
+      refute RunState.execution_admissible?(terminal)
+
       assert {:error, {:run_not_admissible, ^run_id, ^status}} =
                ExecutionAdmission.acquire(terminal, entry)
 
@@ -134,12 +136,18 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
     end
   end
 
-  test "intermediate step outcome statuses remain admissible before terminalization" do
-    run = run(max_concurrency: 1)
-    intermediate = RunState.transition(run, status: :error, result: %{status: :error})
+  test "intermediate step outcome statuses remain admissible before finalization" do
+    for status <- [:error, :timed_out] do
+      run = run(id: "run-intermediate-#{status}", max_concurrency: 1)
+      intermediate = RunState.transition(run, status: status, error: %{type: status})
 
-    assert {:ok, lease} = ExecutionAdmission.acquire(intermediate, %{asset_step_id: "step-1"})
-    assert lease.run_id == intermediate.id
+      assert RunState.terminal_status?(status)
+      assert RunState.execution_admissible?(intermediate)
+      assert {:ok, lease} = ExecutionAdmission.acquire(intermediate, %{asset_step_id: "step-1"})
+      assert lease.run_id == intermediate.id
+
+      assert :ok = ExecutionAdmission.release(lease)
+    end
   end
 
   test "run lease cleanup is idempotent and does not reopen terminal admission" do

--- a/apps/favn_orchestrator/test/execution_admission_test.exs
+++ b/apps/favn_orchestrator/test/execution_admission_test.exs
@@ -112,6 +112,49 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
              })
   end
 
+  test "terminal runs cannot acquire leases or register waiters" do
+    entry = %{asset_step_id: "step-1"}
+
+    for status <- [:ok, :partial, :error, :cancelled, :timed_out] do
+      run = run(id: "run-terminal-#{status}", max_concurrency: 1)
+      terminal = RunState.transition(run, status: status)
+      run_id = terminal.id
+
+      assert {:error, {:run_not_admissible, ^run_id, ^status}} =
+               ExecutionAdmission.acquire(terminal, entry)
+
+      assert {:error, {:run_not_admissible, ^run_id, ^status}} =
+               ExecutionAdmission.acquire_or_wait(terminal, %{entry | asset_step_id: "step-2"},
+                 stage: 0,
+                 attempt: 1
+               )
+
+      assert {:ok, []} = Storage.list_execution_leases()
+      assert {:ok, []} = Storage.list_execution_admission_waiters_for_scope(run_scope(terminal))
+    end
+  end
+
+  test "run lease cleanup is idempotent and does not reopen terminal admission" do
+    run = run(max_concurrency: 1)
+
+    assert {:ok, _lease} = ExecutionAdmission.acquire(run, %{asset_step_id: "step-1"})
+    assert :ok = ExecutionAdmission.release_run(run.id)
+    assert :ok = ExecutionAdmission.release_run(run.id)
+    assert {:ok, []} = Storage.list_execution_leases()
+
+    terminal = RunState.transition(run, status: :cancelled)
+    run_id = terminal.id
+
+    assert {:error, {:run_not_admissible, ^run_id, :cancelled}} =
+             ExecutionAdmission.acquire_or_wait(terminal, %{asset_step_id: "step-2"},
+               stage: 0,
+               attempt: 1
+             )
+
+    assert {:ok, []} = Storage.list_execution_leases()
+    assert {:ok, []} = Storage.list_execution_admission_waiters_for_scope(run_scope(terminal))
+  end
+
   test "acquire_or_wait persists waiter and release wakes registered owner" do
     run = run(max_concurrency: 1)
     entry = %{asset_step_id: "step-1"}
@@ -213,6 +256,8 @@ defmodule FavnOrchestrator.ExecutionAdmissionTest do
       }
     )
   end
+
+  defp run_scope(%RunState{} = run), do: %{kind: :run, key: run.id, limit: 1}
 
   defp restore_env(app, key, nil), do: Application.delete_env(app, key)
   defp restore_env(app, key, value), do: Application.put_env(app, key, value)

--- a/apps/favn_orchestrator/test/run_server_test.exs
+++ b/apps/favn_orchestrator/test/run_server_test.exs
@@ -10,6 +10,7 @@ defmodule FavnOrchestrator.RunServerTest do
   alias Favn.Plan
   alias Favn.Window.Runtime
   alias FavnOrchestrator.RunServer
+  alias FavnOrchestrator.RunServer.Execution.StageAdmission
   alias FavnOrchestrator.RunState
   alias FavnOrchestrator.AssetFreshnessState
   alias FavnOrchestrator.MaterializationClaim.Identity, as: MaterializationClaimIdentity
@@ -545,6 +546,36 @@ defmodule FavnOrchestrator.RunServerTest do
     assert stored.metadata.in_flight_execution_ids == []
   end
 
+  test "run server refuses to dispatch terminal snapshots" do
+    {:ok, submit_log} = Agent.start_link(fn -> [] end)
+    Application.put_env(:favn_orchestrator, :runner_client, RunnerClientRecordingStub)
+    Application.put_env(:favn_orchestrator, :runner_client_opts, submit_log: submit_log)
+
+    version = manifest_version("mv_terminal_snapshot_dispatch_guard")
+
+    terminal =
+      "run_terminal_snapshot_dispatch_guard"
+      |> asset_run_state(version)
+      |> RunState.transition(
+        status: :cancelled,
+        error: {:cancelled, %{reason: :already_terminal}},
+        metadata: %{cancelled: true}
+      )
+
+    assert :ok = Storage.put_run(terminal)
+
+    assert {:ok, pid} = RunServer.start_link(%{run_state: terminal, version: version})
+    ref = Process.monitor(pid)
+
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}, 1_000
+    assert Agent.get(submit_log, & &1) == []
+
+    assert {:ok, stored} = Storage.get_run(terminal.id)
+    assert stored.status == :cancelled
+    assert stored.error == {:cancelled, %{reason: :already_terminal}}
+    assert {:ok, []} = Storage.list_run_events(terminal.id)
+  end
+
   test "run execution paths do not use blocking retry sleeps" do
     execution_source =
       File.read!(
@@ -1052,6 +1083,48 @@ defmodule FavnOrchestrator.RunServerTest do
     assert_receive {:DOWN, ^monitor_ref, :process, ^pid, :normal}, 1_000
     assert Agent.get(submit_log, & &1) == []
     assert {:ok, []} = Storage.list_execution_admission_waiters_for_scope(run_scope(run_state))
+    assert {:ok, []} = Storage.list_execution_leases()
+  end
+
+  test "pipeline admission rejection does not rewrite terminal runs to error" do
+    {:ok, submit_log} = Agent.start_link(fn -> [] end)
+    ref = {MyApp.Assets.PipelineTerminalAdmission.Asset, :asset}
+    refs = [ref]
+    node_key = {ref, nil}
+    plan = same_stage_plan(refs)
+    version = manifest_version_for_refs("mv_pipeline_terminal_admission", refs)
+
+    terminal =
+      "run_pipeline_terminal_admission"
+      |> pipeline_run_state(version, plan, refs)
+      |> RunState.transition(
+        status: :cancelled,
+        error: {:cancelled, %{reason: :already_terminal}},
+        metadata: %{
+          cancelled: true,
+          terminal_event_type: :run_cancelled,
+          pipeline_execution_policy: %{max_concurrency: 1}
+        }
+      )
+
+    assert {:error, rejected, [], []} =
+             StageAdmission.submit(%{
+               run: terminal,
+               version: version,
+               stage: 0,
+               node_keys: [node_key],
+               decisions: %{},
+               freshness_context: %{},
+               attempt: 1,
+               runner_client: RunnerClientRecordingStub,
+               runner_opts: [submit_log: submit_log]
+             })
+
+    assert rejected.status == :cancelled
+    assert rejected.error == {:cancelled, %{reason: :already_terminal}}
+    assert rejected.event_seq == terminal.event_seq
+    assert Agent.get(submit_log, & &1) == []
+    assert {:ok, []} = Storage.list_execution_admission_waiters_for_scope(run_scope(terminal))
     assert {:ok, []} = Storage.list_execution_leases()
   end
 

--- a/apps/favn_orchestrator/test/storage/run_state_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/run_state_codec_test.exs
@@ -50,6 +50,20 @@ defmodule FavnOrchestrator.Storage.RunStateCodecTest do
     assert asset_run_state.submit_kind == :backfill_asset
   end
 
+  test "terminal detection accepts JSON-restored metadata values" do
+    run_state =
+      RunState.new(
+        id: "run_codec_terminal_metadata",
+        manifest_version_id: "mv_codec",
+        manifest_content_hash: "hash_codec",
+        asset_ref: {MyApp.Asset, :asset},
+        metadata: %{"terminal_event_type" => "run_failed"}
+      )
+      |> RunState.transition(status: :error, result: nil)
+
+    assert RunState.terminal?(run_state)
+  end
+
   test "rejects invalid run identity" do
     run_state =
       RunState.new(

--- a/apps/favn_orchestrator/test/storage/run_state_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/run_state_codec_test.exs
@@ -61,7 +61,48 @@ defmodule FavnOrchestrator.Storage.RunStateCodecTest do
       )
       |> RunState.transition(status: :error, result: nil)
 
-    assert RunState.terminal?(run_state)
+    assert RunState.finalized?(run_state)
+    refute RunState.execution_admissible?(run_state)
+  end
+
+  test "normalizes legacy finalized snapshots that predate terminal metadata" do
+    run_state =
+      RunState.new(
+        id: "run_codec_legacy_terminal",
+        manifest_version_id: "mv_codec",
+        manifest_content_hash: "hash_codec",
+        asset_ref: {MyApp.Asset, :asset}
+      )
+      |> RunState.transition(
+        status: :error,
+        result: %{status: :error, asset_results: [], metadata: %{}}
+      )
+
+    refute RunState.finalized?(run_state)
+
+    assert {:ok, normalized} = RunStateCodec.from_record(Map.from_struct(run_state))
+    assert normalized.status == :error
+    assert normalized.metadata[:terminal_event_type] == :run_failed
+    assert RunState.finalized?(normalized)
+    refute RunState.execution_admissible?(normalized)
+  end
+
+  test "does not finalize active intermediate failure snapshots without terminal result" do
+    run_state =
+      RunState.new(
+        id: "run_codec_intermediate_failure",
+        manifest_version_id: "mv_codec",
+        manifest_content_hash: "hash_codec",
+        asset_ref: {MyApp.Asset, :asset}
+      )
+      |> RunState.transition(status: :error, error: %{type: :step_failed})
+
+    assert RunState.terminal_status?(run_state.status)
+    refute RunState.finalized?(run_state)
+
+    assert {:ok, normalized} = RunStateCodec.from_record(Map.from_struct(run_state))
+    refute RunState.finalized?(normalized)
+    assert RunState.execution_admissible?(normalized)
   end
 
   test "rejects invalid run identity" do


### PR DESCRIPTION
## Summary
- Reject execution admission for terminal run snapshots before creating leases or waiters.
- Cover terminal statuses and idempotent run lease cleanup with focused admission tests.

## Tests
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/execution_admission_test.exs`
- `mix compile --warnings-as-errors`