### PR TITLE
Harden UI/API error boundaries

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -1675,6 +1675,11 @@ defmodule FavnOrchestrator do
 
   @doc """
   Lists persisted run events for one run.
+
+  This public facade is bounded for operator/API callers: `:limit` defaults to
+  `100` and is capped at `500`; `:after_sequence` is an optional non-negative
+  cursor. Orchestrator-internal repair/projection code that intentionally needs
+  an unbounded adapter read should call the storage boundary directly.
   """
   @spec list_run_events(run_id(), keyword()) :: {:ok, [RunEvent.t()]} | {:error, term()}
   def list_run_events(run_id, opts \\ []) when is_binary(run_id) and is_list(opts) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator.ex
@@ -42,6 +42,7 @@ defmodule FavnOrchestrator do
   alias FavnOrchestrator.RefreshPolicy
   alias FavnOrchestrator.RunReadModel
   alias FavnOrchestrator.RunEvent
+  alias FavnOrchestrator.RunEvents.Query, as: RunEventQuery
   alias FavnOrchestrator.RunManager
   alias FavnOrchestrator.RuntimeConfig
   alias FavnOrchestrator.Scheduler.ManifestEntries
@@ -1677,7 +1678,7 @@ defmodule FavnOrchestrator do
   """
   @spec list_run_events(run_id(), keyword()) :: {:ok, [RunEvent.t()]} | {:error, term()}
   def list_run_events(run_id, opts \\ []) when is_binary(run_id) and is_list(opts) do
-    with :ok <- validate_run_event_opts(opts),
+    with {:ok, opts} <- RunEventQuery.normalize_opts(opts),
          {:ok, events} <- Storage.list_run_events(run_id, opts) do
       {:ok, Enum.map(events, &RunEvent.from_map/1)}
     end
@@ -1917,22 +1918,6 @@ defmodule FavnOrchestrator do
       running: Enum.count(entries, &(&1.runtime_state == :running)),
       queued: Enum.count(entries, &(&1.runtime_state == :queued))
     }
-  end
-
-  defp validate_run_event_opts(opts) do
-    after_sequence = Keyword.get(opts, :after_sequence)
-    limit = Keyword.get(opts, :limit)
-
-    cond do
-      not is_nil(after_sequence) and (not is_integer(after_sequence) or after_sequence < 0) ->
-        {:error, :invalid_opts}
-
-      not is_nil(limit) and (not is_integer(limit) or limit <= 0) ->
-        {:error, :invalid_opts}
-
-      true ->
-        :ok
-    end
   end
 
   defp run_event_cursor_valid?(_run_id, nil), do: {:ok, true}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/error_response.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/error_response.ex
@@ -1,0 +1,20 @@
+defmodule FavnOrchestrator.API.ErrorResponse do
+  @moduledoc """
+  Stable private API error response contracts.
+
+  Detailed internal reasons belong in server logs. Values returned from this
+  module are safe to expose to API clients and browser callers.
+  """
+
+  @type response :: {pos_integer(), String.t(), String.t(), map()}
+
+  @doc """
+  Maps boundary failures to stable API error tuples.
+  """
+  @spec response(term()) :: response()
+  def response(:idempotency_completion_failed) do
+    {500, "internal_error", "Command outcome is unknown", %{outcome: "unknown"}}
+  end
+
+  def response(:request_failed), do: {400, "bad_request", "Request failed", %{}}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
@@ -2461,7 +2461,8 @@ defmodule FavnOrchestrator.API.Router do
   end
 
   defp backfill_range_error({:invalid_backfill_range_request, value}) do
-    {:ok, "Invalid backfill range request", %{value: inspect(value)}}
+    Logger.error("invalid backfill range request: #{inspect(value)}")
+    {:ok, "Invalid backfill range request", %{reason: "invalid_backfill_range_request"}}
   end
 
   defp backfill_range_error({:missing_backfill_reference, _opts}) do
@@ -2469,11 +2470,13 @@ defmodule FavnOrchestrator.API.Router do
   end
 
   defp backfill_range_error({:invalid_last_request, value}) do
-    {:ok, "Invalid relative backfill range", %{value: inspect(value)}}
+    Logger.error("invalid relative backfill range: #{inspect(value)}")
+    {:ok, "Invalid relative backfill range", %{reason: "invalid_last_request"}}
   end
 
   defp backfill_range_error({:invalid_window_policy_kind, kind}) do
-    {:ok, "Invalid backfill window kind", %{kind: inspect(kind)}}
+    Logger.error("invalid backfill window policy kind: #{inspect(kind)}")
+    {:ok, "Invalid backfill window kind", %{reason: "invalid_window_policy_kind"}}
   end
 
   defp backfill_range_error({:invalid_window_value, kind, value}) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/router.ex
@@ -11,10 +11,13 @@ defmodule FavnOrchestrator.API.Router do
   alias FavnOrchestrator
   alias FavnOrchestrator.API.Config
   alias FavnOrchestrator.API.DTO
+  alias FavnOrchestrator.API.ErrorResponse
+  alias FavnOrchestrator.API.SSE
   alias FavnOrchestrator.Auth
   alias FavnOrchestrator.Auth.ServiceTokens
   alias FavnOrchestrator.Idempotency
   alias FavnOrchestrator.RunEvent
+  alias FavnOrchestrator.RunEvents.Query, as: RunEventQuery
 
   @read_model_status_filters %{
     "pending" => :pending,
@@ -561,7 +564,8 @@ defmodule FavnOrchestrator.API.Router do
   get "/api/orchestrator/v1/runs/:run_id/events" do
     with :ok <- ensure_service_auth(conn),
          {:ok, _session, _actor} <- ensure_actor_context(conn, :viewer),
-         {:ok, events} <- FavnOrchestrator.list_run_events(run_id, run_event_opts(conn.params)) do
+         {:ok, opts} <- RunEventQuery.from_params(conn.params),
+         {:ok, events} <- FavnOrchestrator.list_run_events(run_id, opts) do
       data(conn, 200, %{items: Enum.map(events, &DTO.run_event/1)})
     else
       {:error, :invalid_opts} ->
@@ -692,7 +696,7 @@ defmodule FavnOrchestrator.API.Router do
 
           {:error, reason} ->
             Logger.error("run.submit failed after request validation: #{inspect(reason)}")
-            {:error, 400, "bad_request", "Request failed", %{reason: inspect(reason)}}
+            {:error, 400, "bad_request", "Request failed", %{}}
         end
       end)
     else
@@ -829,7 +833,7 @@ defmodule FavnOrchestrator.API.Router do
               {:error, 422, "validation_failed", "Invalid backfill range request", %{}}
 
             {:error, reason} when is_tuple(reason) ->
-              command_backfill_range_error(reason)
+              command_operator_validation_error(reason) || command_backfill_range_error(reason)
 
             {:error, :active_manifest_not_set} ->
               {:error, 404, "not_found", "Active manifest is not set", %{}}
@@ -867,7 +871,10 @@ defmodule FavnOrchestrator.API.Router do
         error(conn, 422, "validation_failed", "Invalid backfill range request")
 
       {:error, reason} when is_tuple(reason) ->
-        range_error(conn, reason)
+        case command_operator_validation_error(reason) do
+          {:error, status, code, message, details} -> error(conn, status, code, message, details)
+          nil -> range_error(conn, reason)
+        end
 
       {:error, :active_manifest_not_set} ->
         error(conn, 404, "not_found", "Active manifest is not set")
@@ -1608,31 +1615,52 @@ defmodule FavnOrchestrator.API.Router do
       {:ok, status, payload, resource_type, resource_id} ->
         response_body = DTO.normalize(payload)
 
-        :ok =
-          Idempotency.complete(record.id, %{
-            status: :completed,
-            response_status: status,
-            response_body: response_body,
-            resource_type: resource_type,
-            resource_id: resource_id
-          })
+        attrs = %{
+          status: :completed,
+          response_status: status,
+          response_body: response_body,
+          resource_type: resource_type,
+          resource_id: resource_id
+        }
 
-        data(conn, status, response_body)
+        case Idempotency.complete(record.id, attrs) do
+          :ok ->
+            data(conn, status, response_body)
+
+          {:error, reason} ->
+            log_idempotency_completion_failure(conn, record, attrs, reason)
+            error_response(conn, ErrorResponse.response(:idempotency_completion_failed))
+        end
 
       {:error, status, code, message, details} ->
         response_body = DTO.normalize(%{code: code, message: message, details: details})
 
-        :ok =
-          Idempotency.complete(record.id, %{
-            status: :failed,
-            response_status: status,
-            response_body: response_body,
-            resource_type: nil,
-            resource_id: nil
-          })
+        attrs = %{
+          status: :failed,
+          response_status: status,
+          response_body: response_body,
+          resource_type: nil,
+          resource_id: nil
+        }
 
-        error(conn, status, code, message, details)
+        case Idempotency.complete(record.id, attrs) do
+          :ok ->
+            error(conn, status, code, message, details)
+
+          {:error, reason} ->
+            log_idempotency_completion_failure(conn, record, attrs, reason)
+            error_response(conn, ErrorResponse.response(:idempotency_completion_failed))
+        end
     end
+  end
+
+  defp log_idempotency_completion_failure(conn, record, attrs, reason) do
+    Logger.error(
+      "idempotency.complete failed operation=#{inspect(record.operation)} " <>
+        "record_id=#{record.id} resource_type=#{inspect(attrs.resource_type)} " <>
+        "resource_id=#{inspect(attrs.resource_id)} request_id=#{inspect(request_id(conn))} " <>
+        "reason=#{inspect(reason)}"
+    )
   end
 
   defp replay_idempotent_response(conn, %{status: :completed} = record) do
@@ -1931,16 +1959,27 @@ defmodule FavnOrchestrator.API.Router do
   end
 
   defp backfill_submit_opts(params, range_request) when is_map(params) do
-    {:ok,
-     []
-     |> Keyword.put(:range_request, range_request)
-     |> maybe_put_string_opt(:coverage_baseline_id, Map.get(params, "coverage_baseline_id"))
-     |> maybe_put_map_opt(:metadata, Map.get(params, "metadata"))
-     |> maybe_put_opt(:refresh, Map.get(params, "refresh"))
-     |> maybe_put_opt(:refresh_policy, Map.get(params, "refresh_policy"))
-     |> maybe_put_positive_int_opt(:max_attempts, Map.get(params, "max_attempts"))
-     |> maybe_put_non_neg_int_opt(:retry_backoff_ms, Map.get(params, "retry_backoff_ms"))
-     |> maybe_put_positive_int_opt(:timeout_ms, Map.get(params, "timeout_ms"))}
+    with {:ok, coverage_baseline_id} <-
+           optional_non_empty_binary(
+             Map.get(params, "coverage_baseline_id"),
+             :coverage_baseline_id
+           ),
+         {:ok, max_attempts} <-
+           optional_positive_int(Map.get(params, "max_attempts"), :max_attempts),
+         {:ok, retry_backoff_ms} <-
+           optional_non_neg_int(Map.get(params, "retry_backoff_ms"), :retry_backoff_ms),
+         {:ok, timeout_ms} <- optional_positive_int(Map.get(params, "timeout_ms"), :timeout_ms) do
+      {:ok,
+       []
+       |> Keyword.put(:range_request, range_request)
+       |> maybe_put_string_opt(:coverage_baseline_id, coverage_baseline_id)
+       |> maybe_put_map_opt(:metadata, Map.get(params, "metadata"))
+       |> maybe_put_opt(:refresh, Map.get(params, "refresh"))
+       |> maybe_put_opt(:refresh_policy, Map.get(params, "refresh_policy"))
+       |> maybe_put_positive_int_opt(:max_attempts, max_attempts)
+       |> maybe_put_non_neg_int_opt(:retry_backoff_ms, retry_backoff_ms)
+       |> maybe_put_positive_int_opt(:timeout_ms, timeout_ms)}
+    end
   end
 
   defp backfill_window_rerun_opts(params) when is_map(params) do
@@ -2096,12 +2135,6 @@ defmodule FavnOrchestrator.API.Router do
     end
   end
 
-  defp run_event_opts(params) do
-    []
-    |> maybe_put_int_opt(:after_sequence, Map.get(params, "after_sequence"))
-    |> maybe_put_int_opt(:limit, Map.get(params, "limit"))
-  end
-
   defp run_filters(params) when is_map(params) do
     with {:ok, limit} <- pagination_int(Map.get(params, "limit", "100"), 1, 500),
          {:ok, opts} <- maybe_put_status_filter([limit: limit], Map.get(params, "status")) do
@@ -2111,21 +2144,6 @@ defmodule FavnOrchestrator.API.Router do
       {:error, _reason} = error -> error
     end
   end
-
-  defp maybe_put_int_opt(opts, _key, nil), do: opts
-
-  defp maybe_put_int_opt(opts, key, value) when is_binary(value) do
-    case Integer.parse(value) do
-      {int, ""} -> Keyword.put(opts, key, int)
-      _ -> opts
-    end
-  end
-
-  defp maybe_put_int_opt(opts, key, value) when is_integer(value) do
-    Keyword.put(opts, key, value)
-  end
-
-  defp maybe_put_int_opt(opts, _key, _value), do: opts
 
   defp pagination_filters(params) when is_map(params) do
     with {:ok, limit} <- pagination_int(Map.get(params, "limit", "100"), 1, 500),
@@ -2188,6 +2206,33 @@ defmodule FavnOrchestrator.API.Router do
     do: Keyword.put(opts, key, value)
 
   defp maybe_put_non_neg_int_opt(opts, _key, _value), do: opts
+
+  defp optional_positive_int(nil, _field), do: {:ok, nil}
+  defp optional_positive_int(value, _field) when is_integer(value) and value > 0, do: {:ok, value}
+
+  defp optional_positive_int(value, field),
+    do: {:error, {invalid_operator_numeric_field(field), value}}
+
+  defp optional_non_neg_int(nil, _field), do: {:ok, nil}
+  defp optional_non_neg_int(value, _field) when is_integer(value) and value >= 0, do: {:ok, value}
+
+  defp optional_non_neg_int(value, field),
+    do: {:error, {invalid_operator_numeric_field(field), value}}
+
+  defp optional_non_empty_binary(nil, _field), do: {:ok, nil}
+
+  defp optional_non_empty_binary(value, _field) when is_binary(value) and value != "",
+    do: {:ok, value}
+
+  defp optional_non_empty_binary(value, field),
+    do: {:error, {invalid_operator_text_field(field), value}}
+
+  defp invalid_operator_numeric_field(:max_attempts), do: :invalid_operator_max_attempts
+  defp invalid_operator_numeric_field(:retry_backoff_ms), do: :invalid_operator_retry_backoff_ms
+  defp invalid_operator_numeric_field(:timeout_ms), do: :invalid_operator_timeout_ms
+
+  defp invalid_operator_text_field(:coverage_baseline_id),
+    do: :invalid_operator_coverage_baseline_id
 
   defp maybe_put_status_filter(opts, nil), do: {:ok, opts}
   defp maybe_put_status_filter(opts, ""), do: {:ok, opts}
@@ -2322,6 +2367,10 @@ defmodule FavnOrchestrator.API.Router do
     |> send_resp(status, body)
   end
 
+  defp error_response(conn, {status, code, message, details}) do
+    error(conn, status, code, message, details)
+  end
+
   defp range_error(conn, reason) do
     case backfill_range_error(reason) do
       {:ok, message, details} -> error(conn, 422, "validation_failed", message, details)
@@ -2335,6 +2384,36 @@ defmodule FavnOrchestrator.API.Router do
       :error -> {:error, 400, "bad_request", "Request failed", %{}}
     end
   end
+
+  defp command_operator_validation_error({reason, _value})
+       when reason in [
+              :invalid_operator_max_attempts,
+              :invalid_operator_retry_backoff_ms,
+              :invalid_operator_timeout_ms,
+              :invalid_operator_coverage_baseline_id
+            ] do
+    {:error, 422, "validation_failed", operator_validation_message(reason),
+     %{field: operator_validation_field(reason)}}
+  end
+
+  defp command_operator_validation_error(_reason), do: nil
+
+  defp operator_validation_message(:invalid_operator_max_attempts), do: "Invalid max_attempts"
+
+  defp operator_validation_message(:invalid_operator_retry_backoff_ms),
+    do: "Invalid retry_backoff_ms"
+
+  defp operator_validation_message(:invalid_operator_timeout_ms), do: "Invalid timeout_ms"
+
+  defp operator_validation_message(:invalid_operator_coverage_baseline_id),
+    do: "Invalid coverage_baseline_id"
+
+  defp operator_validation_field(:invalid_operator_max_attempts), do: "max_attempts"
+  defp operator_validation_field(:invalid_operator_retry_backoff_ms), do: "retry_backoff_ms"
+  defp operator_validation_field(:invalid_operator_timeout_ms), do: "timeout_ms"
+
+  defp operator_validation_field(:invalid_operator_coverage_baseline_id),
+    do: "coverage_baseline_id"
 
   defp window_policy_error({:missing_window_request, kind}) do
     {:ok, "Pipeline requires an explicit #{kind} window", %{kind: atom_name(kind)}}
@@ -2356,7 +2435,8 @@ defmodule FavnOrchestrator.API.Router do
   end
 
   defp window_policy_error({:invalid_window_request, reason}) do
-    {:ok, "Invalid window request", %{reason: inspect(reason)}}
+    Logger.error("invalid window request: #{inspect(reason)}")
+    {:ok, "Invalid window request", %{reason: "invalid_window_request"}}
   end
 
   defp window_policy_error({:invalid_window_value, kind, value}) do
@@ -2544,7 +2624,11 @@ defmodule FavnOrchestrator.API.Router do
         {:ok, "retry: #{@sse_retry_ms}\n\n", initial_cursor(stream)},
         fn event, {:ok, body, _cursor} ->
           cursor = event_cursor(stream, event)
-          {:ok, body <> sse_run_event_body(event, stream, cursor), cursor}
+
+          case sse_run_event_body(event, stream, cursor) do
+            {:ok, event_body} -> {:ok, body <> event_body, cursor}
+            {:error, reason} -> raise ArgumentError, "invalid SSE event: #{inspect(reason)}"
+          end
         end
       )
 
@@ -2566,9 +2650,16 @@ defmodule FavnOrchestrator.API.Router do
                                                                       {:ok, conn, _cursor} ->
       cursor = event_cursor(stream, event)
 
-      case chunk(conn, sse_run_event_body(event, stream, cursor)) do
-        {:ok, conn} -> {:cont, {:ok, conn, cursor}}
-        {:error, reason} -> {:halt, {:error, reason}}
+      case sse_run_event_body(event, stream, cursor) do
+        {:ok, body} ->
+          case chunk(conn, body) do
+            {:ok, conn} -> {:cont, {:ok, conn, cursor}}
+            {:error, reason} -> {:halt, {:error, reason}}
+          end
+
+        {:error, reason} ->
+          Logger.error("sse.run_event encode failed: #{inspect(reason)}")
+          {:halt, {:error, reason}}
       end
     end)
   end
@@ -2583,9 +2674,16 @@ defmodule FavnOrchestrator.API.Router do
           {:ok, hydrated} ->
             next_cursor = event_cursor(stream, hydrated)
 
-            case chunk(conn, sse_run_event_body(hydrated, stream, next_cursor)) do
-              {:ok, conn} -> sse_live_loop(conn, stream, next_cursor, heartbeat_ref)
-              {:error, _reason} -> conn
+            case sse_run_event_body(hydrated, stream, next_cursor) do
+              {:ok, body} ->
+                case chunk(conn, body) do
+                  {:ok, conn} -> sse_live_loop(conn, stream, next_cursor, heartbeat_ref)
+                  {:error, _reason} -> conn
+                end
+
+              {:error, reason} ->
+                Logger.error("sse.run_event encode failed: #{inspect(reason)}")
+                sse_live_loop(conn, stream, cursor, heartbeat_ref)
             end
 
           {:error, _reason} ->
@@ -2638,10 +2736,12 @@ defmodule FavnOrchestrator.API.Router do
   defp unsubscribe_sse_stream({:global, _sequence}), do: FavnOrchestrator.unsubscribe_runs()
 
   defp sse_run_event_body(event, stream, cursor) do
-    event_name = event_name(event.event_type)
-    payload = Jason.encode!(sse_event_payload(event, stream, cursor, event_name))
+    with {:ok, event_name} <- SSE.field(:event, event.event_type),
+         {:ok, cursor} <- SSE.field(:id, cursor) do
+      payload = Jason.encode!(sse_event_payload(event, stream, cursor, event_name))
 
-    "id: #{cursor}\nevent: #{event_name}\ndata: #{payload}\n\n"
+      {:ok, "id: #{cursor}\nevent: #{event_name}\ndata: #{payload}\n\n"}
+    end
   end
 
   defp sse_ready_body(stream, nil) when is_binary(stream) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/sse.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/sse.ex
@@ -1,0 +1,32 @@
+defmodule FavnOrchestrator.API.SSE do
+  @moduledoc """
+  Line-safe Server-Sent Events field encoding for orchestrator streams.
+
+  JSON payloads remain Jason-encoded by callers. This module is only for SSE
+  control fields, where CR/LF characters can forge additional fields or events.
+  """
+
+  @safe_field ~r/\A[a-zA-Z0-9_.:-]{1,128}\z/
+
+  @type field_name :: :event | :id
+
+  @doc """
+  Encodes one SSE control field value or rejects it when it is not line-safe.
+  """
+  @spec field(field_name(), atom() | String.t()) :: {:ok, String.t()} | {:error, term()}
+  def field(name, value) when name in [:event, :id] do
+    value = stringify(value)
+
+    if is_binary(value) and String.match?(value, @safe_field) do
+      {:ok, value}
+    else
+      {:error, {:invalid_sse_field, name, value}}
+    end
+  end
+
+  def field(name, value), do: {:error, {:invalid_sse_field, name, value}}
+
+  defp stringify(value) when is_atom(value) and not is_nil(value), do: Atom.to_string(value)
+  defp stringify(value) when is_binary(value), do: value
+  defp stringify(_value), do: nil
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/api/sse.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/api/sse.ex
@@ -6,7 +6,7 @@ defmodule FavnOrchestrator.API.SSE do
   control fields, where CR/LF characters can forge additional fields or events.
   """
 
-  @safe_field ~r/\A[a-zA-Z0-9_.:-]{1,128}\z/
+  alias FavnOrchestrator.RunEvents.EventType
 
   @type field_name :: :event | :id
 
@@ -17,7 +17,7 @@ defmodule FavnOrchestrator.API.SSE do
   def field(name, value) when name in [:event, :id] do
     value = stringify(value)
 
-    if is_binary(value) and String.match?(value, @safe_field) do
+    if EventType.line_safe?(value) do
       {:ok, value}
     else
       {:error, {:invalid_sse_field, name, value}}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/input.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/input.ex
@@ -93,6 +93,24 @@ defmodule FavnOrchestrator.OperatorCommands.Input do
   def timeout_ms(value) when is_integer(value) and value > 0, do: {:ok, value}
   def timeout_ms(value), do: {:error, {:invalid_operator_timeout_ms, value}}
 
+  def positive_integer(nil, _field), do: {:ok, nil}
+
+  def positive_integer(value, _field) when is_integer(value) and value > 0,
+    do: {:ok, value}
+
+  def positive_integer(value, field), do: {:error, {invalid_numeric_field(field), value}}
+
+  def non_neg_integer(nil, _field), do: {:ok, nil}
+
+  def non_neg_integer(value, _field) when is_integer(value) and value >= 0,
+    do: {:ok, value}
+
+  def non_neg_integer(value, field), do: {:error, {invalid_numeric_field(field), value}}
+
+  def non_empty_binary(nil, _field), do: {:ok, nil}
+  def non_empty_binary(value, _field) when is_binary(value) and value != "", do: {:ok, value}
+  def non_empty_binary(value, field), do: {:error, {invalid_text_field(field), value}}
+
   defp normalize_window_result(original, fun) do
     case fun.() do
       {:ok, %WindowRequest{} = request} -> {:ok, request}
@@ -101,6 +119,14 @@ defmodule FavnOrchestrator.OperatorCommands.Input do
   rescue
     _exception -> {:error, {:invalid_operator_window, original}}
   end
+
+  defp invalid_numeric_field(:max_attempts), do: :invalid_operator_max_attempts
+  defp invalid_numeric_field(:retry_backoff_ms), do: :invalid_operator_retry_backoff_ms
+  defp invalid_numeric_field(:timeout_ms), do: :invalid_operator_timeout_ms
+  defp invalid_numeric_field(field), do: {:invalid_operator_numeric_field, field}
+
+  defp invalid_text_field(:coverage_baseline_id), do: :invalid_operator_coverage_baseline_id
+  defp invalid_text_field(field), do: {:invalid_operator_text_field, field}
 
   defp refresh_mode(:force, modes), do: maybe_refresh_mode(:force_all, modes, :force)
 

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_backfill_request.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator_commands/pipeline_backfill_request.ex
@@ -15,7 +15,7 @@ defmodule FavnOrchestrator.OperatorCommands.PipelineBackfillRequest do
           coverage_baseline_id: String.t() | nil,
           max_attempts: pos_integer() | nil,
           retry_backoff_ms: non_neg_integer() | nil,
-          timeout_ms: non_neg_integer() | nil
+          timeout_ms: pos_integer() | nil
         }
 
   defstruct refresh_mode: :auto,
@@ -41,16 +41,26 @@ defmodule FavnOrchestrator.OperatorCommands.PipelineBackfillRequest do
     range_value = Input.field(input, :range, Input.field(input, :range_request))
 
     with {:ok, refresh_mode} <- Input.pipeline_refresh_mode(refresh_value),
-         {:ok, range} <- Input.range(range_value) do
+         {:ok, range} <- Input.range(range_value),
+         {:ok, coverage_baseline_id} <-
+           Input.non_empty_binary(
+             Input.field(input, :coverage_baseline_id),
+             :coverage_baseline_id
+           ),
+         {:ok, max_attempts} <-
+           Input.positive_integer(Input.field(input, :max_attempts), :max_attempts),
+         {:ok, retry_backoff_ms} <-
+           Input.non_neg_integer(Input.field(input, :retry_backoff_ms), :retry_backoff_ms),
+         {:ok, timeout_ms} <- Input.timeout_ms(Input.field(input, :timeout_ms)) do
       {:ok,
        %__MODULE__{
          refresh_mode: refresh_mode,
          range: range,
          metadata: Input.field(input, :metadata),
-         coverage_baseline_id: Input.field(input, :coverage_baseline_id),
-         max_attempts: Input.field(input, :max_attempts),
-         retry_backoff_ms: Input.field(input, :retry_backoff_ms),
-         timeout_ms: Input.field(input, :timeout_ms)
+         coverage_baseline_id: coverage_baseline_id,
+         max_attempts: max_attempts,
+         retry_backoff_ms: retry_backoff_ms,
+         timeout_ms: timeout_ms
        }}
     end
   end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_events/event_type.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_events/event_type.ex
@@ -1,0 +1,21 @@
+defmodule FavnOrchestrator.RunEvents.EventType do
+  @moduledoc """
+  Line-safe run-event type contract used by persistence and SSE framing.
+
+  Event types are stored and streamed as SSE `event:` names, so they must stay on
+  one line and use a compact, predictable character set.
+  """
+
+  @safe_pattern ~r/\A[a-zA-Z0-9_.:-]{1,128}\z/
+
+  @doc """
+  Returns true when a value can be safely used as a run-event type or SSE field.
+  """
+  @spec line_safe?(atom() | String.t()) :: boolean()
+  def line_safe?(value) when is_atom(value) and not is_nil(value) do
+    value |> Atom.to_string() |> line_safe?()
+  end
+
+  def line_safe?(value) when is_binary(value), do: String.match?(value, @safe_pattern)
+  def line_safe?(_value), do: false
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/run_events/query.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/run_events/query.ex
@@ -1,0 +1,77 @@
+defmodule FavnOrchestrator.RunEvents.Query do
+  @moduledoc """
+  Bounded run-event query parsing for public orchestrator boundaries.
+  """
+
+  @default_limit 100
+  @max_limit 500
+
+  @type opts :: [after_sequence: non_neg_integer(), limit: pos_integer()]
+
+  @doc """
+  Parses HTTP query parameters into bounded run-event read options.
+  """
+  @spec from_params(map()) :: {:ok, opts()} | {:error, :invalid_opts}
+  def from_params(params) when is_map(params) do
+    with {:ok, after_sequence} <- optional_non_neg_int(Map.get(params, "after_sequence")),
+         {:ok, limit} <- optional_limit(Map.get(params, "limit")) do
+      opts = [limit: limit]
+
+      opts =
+        if is_nil(after_sequence),
+          do: opts,
+          else: Keyword.put(opts, :after_sequence, after_sequence)
+
+      {:ok, opts}
+    end
+  end
+
+  def from_params(_params), do: {:error, :invalid_opts}
+
+  @doc """
+  Normalizes facade options and applies the public default limit.
+  """
+  @spec normalize_opts(keyword()) :: {:ok, opts()} | {:error, :invalid_opts}
+  def normalize_opts(opts) when is_list(opts) do
+    with {:ok, after_sequence} <- optional_non_neg_int(Keyword.get(opts, :after_sequence)),
+         {:ok, limit} <- optional_limit(Keyword.get(opts, :limit)) do
+      normalized = [limit: limit]
+
+      normalized =
+        if is_nil(after_sequence),
+          do: normalized,
+          else: Keyword.put(normalized, :after_sequence, after_sequence)
+
+      {:ok, normalized}
+    end
+  end
+
+  def normalize_opts(_opts), do: {:error, :invalid_opts}
+
+  defp optional_non_neg_int(nil), do: {:ok, nil}
+  defp optional_non_neg_int(value) when is_integer(value) and value >= 0, do: {:ok, value}
+
+  defp optional_non_neg_int(value) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} when int >= 0 -> {:ok, int}
+      _other -> {:error, :invalid_opts}
+    end
+  end
+
+  defp optional_non_neg_int(_value), do: {:error, :invalid_opts}
+
+  defp optional_limit(nil), do: {:ok, @default_limit}
+  defp optional_limit(value), do: positive_int(value, 1, @max_limit)
+
+  defp positive_int(value, min, max) when is_integer(value) and value >= min and value <= max,
+    do: {:ok, value}
+
+  defp positive_int(value, min, max) when is_binary(value) do
+    case Integer.parse(value) do
+      {int, ""} when int >= min and int <= max -> {:ok, int}
+      _other -> {:error, :invalid_opts}
+    end
+  end
+
+  defp positive_int(_value, _min, _max), do: {:error, :invalid_opts}
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_event_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_event_codec.ex
@@ -1,6 +1,7 @@
 defmodule FavnOrchestrator.Storage.RunEventCodec do
   @moduledoc false
 
+  alias FavnOrchestrator.RunEvents.EventType
   alias FavnOrchestrator.Storage.JsonSafe
 
   @format "favn.run_event.storage.v1"
@@ -83,7 +84,7 @@ defmodule FavnOrchestrator.Storage.RunEventCodec do
   defp validate_run_id(_run_id, value), do: {:error, {:invalid_run_event_field, :run_id, value}}
 
   defp validate_event_type(value) when is_atom(value) and not is_nil(value) do
-    if safe_event_type?(Atom.to_string(value)) do
+    if EventType.line_safe?(value) do
       {:ok, value}
     else
       {:error, {:invalid_run_event_field, :event_type, value}}
@@ -91,7 +92,7 @@ defmodule FavnOrchestrator.Storage.RunEventCodec do
   end
 
   defp validate_event_type(value) when is_binary(value) do
-    if safe_event_type?(value) do
+    if EventType.line_safe?(value) do
       {:ok, value}
     else
       {:error, {:invalid_run_event_field, :event_type, value}}
@@ -99,9 +100,6 @@ defmodule FavnOrchestrator.Storage.RunEventCodec do
   end
 
   defp validate_event_type(value), do: {:error, {:invalid_run_event_field, :event_type, value}}
-
-  defp safe_event_type?(value) when is_binary(value),
-    do: String.match?(value, ~r/\A[a-zA-Z0-9_.:-]{1,128}\z/)
 
   defp normalize_occurred_at(nil), do: {:ok, DateTime.utc_now()}
   defp normalize_occurred_at(%DateTime{} = occurred_at), do: {:ok, occurred_at}

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_event_codec.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/run_event_codec.ex
@@ -15,13 +15,15 @@ defmodule FavnOrchestrator.Storage.RunEventCodec do
   @spec decode(String.t()) :: {:ok, map()} | {:error, term()}
   def decode(payload) when is_binary(payload) do
     with {:ok, %{"format" => @format, "schema_version" => 1} = dto} <- Jason.decode(payload),
+         {:ok, event_type} <-
+           validate_event_type(existing_atom_or_string(Map.get(dto, "event_type"))),
          {:ok, occurred_at} <- normalize_occurred_at(Map.get(dto, "occurred_at")) do
       {:ok,
        %{
          schema_version: 1,
          run_id: Map.get(dto, "run_id"),
          sequence: Map.get(dto, "sequence"),
-         event_type: existing_atom_or_string(Map.get(dto, "event_type")),
+         event_type: event_type,
          entity: entity_from_dto(Map.get(dto, "entity")),
          occurred_at: occurred_at,
          status: existing_atom_or_string(Map.get(dto, "status")),
@@ -80,9 +82,26 @@ defmodule FavnOrchestrator.Storage.RunEventCodec do
   defp validate_run_id(run_id, run_id), do: :ok
   defp validate_run_id(_run_id, value), do: {:error, {:invalid_run_event_field, :run_id, value}}
 
-  defp validate_event_type(value) when is_atom(value) and not is_nil(value), do: {:ok, value}
-  defp validate_event_type(value) when is_binary(value) and value != "", do: {:ok, value}
+  defp validate_event_type(value) when is_atom(value) and not is_nil(value) do
+    if safe_event_type?(Atom.to_string(value)) do
+      {:ok, value}
+    else
+      {:error, {:invalid_run_event_field, :event_type, value}}
+    end
+  end
+
+  defp validate_event_type(value) when is_binary(value) do
+    if safe_event_type?(value) do
+      {:ok, value}
+    else
+      {:error, {:invalid_run_event_field, :event_type, value}}
+    end
+  end
+
   defp validate_event_type(value), do: {:error, {:invalid_run_event_field, :event_type, value}}
+
+  defp safe_event_type?(value) when is_binary(value),
+    do: String.match?(value, ~r/\A[a-zA-Z0-9_.:-]{1,128}\z/)
 
   defp normalize_occurred_at(nil), do: {:ok, DateTime.utc_now()}
   defp normalize_occurred_at(%DateTime{} = occurred_at), do: {:ok, occurred_at}

--- a/apps/favn_orchestrator/test/api/router_test.exs
+++ b/apps/favn_orchestrator/test/api/router_test.exs
@@ -98,6 +98,23 @@ defmodule FavnOrchestrator.API.RouterTest do
     end
   end
 
+  defmodule IdempotencyCompletionFailingStorage do
+    alias FavnOrchestrator.Storage.Adapter.Memory
+
+    for {name, arity} <- Favn.Storage.Adapter.behaviour_info(:callbacks),
+        {name, arity} != {:complete_idempotency_record, 3} do
+      args = Macro.generate_arguments(arity, __MODULE__)
+
+      def unquote(name)(unquote_splicing(args)) do
+        apply(Memory, unquote(name), [unquote_splicing(args)])
+      end
+    end
+
+    def complete_idempotency_record(_record_id, _attrs, _opts) do
+      {:error, {:write_failed, "internal-secret-path"}}
+    end
+  end
+
   setup do
     previous_tokens = Application.get_env(:favn_orchestrator, :api_service_tokens)
     previous_client = Application.get_env(:favn_orchestrator, :runner_client)
@@ -108,6 +125,7 @@ defmodule FavnOrchestrator.API.RouterTest do
     previous_roles = Application.get_env(:favn_orchestrator, :auth_bootstrap_roles)
     previous_api_server = Application.get_env(:favn_orchestrator, :api_server)
     previous_local_dev_mode = Application.get_env(:favn_orchestrator, :local_dev_mode)
+    previous_storage_adapter = Application.get_env(:favn_orchestrator, :storage_adapter)
 
     Application.put_env(:favn_orchestrator, :api_service_tokens, [
       [
@@ -140,6 +158,7 @@ defmodule FavnOrchestrator.API.RouterTest do
       restore_env(:favn_orchestrator, :auth_bootstrap_roles, previous_roles)
       restore_env(:favn_orchestrator, :api_server, previous_api_server)
       restore_env(:favn_orchestrator, :local_dev_mode, previous_local_dev_mode)
+      restore_env(:favn_orchestrator, :storage_adapter, previous_storage_adapter)
       Process.delete(:runner_register_manifest_result)
       maybe_stop_auth_store(auth_start)
     end)
@@ -730,6 +749,52 @@ defmodule FavnOrchestrator.API.RouterTest do
 
     assert response.status == 410
     assert %{"error" => %{"code" => "cursor_expired"}} = Jason.decode!(response.resp_body)
+  end
+
+  test "run event query params are strict and bounded" do
+    seed_run_events!("run_events_query", Enum.to_list(1..120))
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password-long")
+
+    request = fn params ->
+      conn(:get, "/api/orchestrator/v1/runs/run_events_query/events", params)
+      |> put_req_header("authorization", "Bearer test-service-token")
+      |> put_req_header("x-favn-actor-id", actor.id)
+      |> put_req_header("x-favn-session-token", session.token)
+      |> Router.call(@opts)
+    end
+
+    default_response = request.(%{})
+    assert default_response.status == 200
+    assert %{"data" => %{"items" => default_items}} = Jason.decode!(default_response.resp_body)
+    assert length(default_items) == 100
+
+    bounded_response = request.(%{"after_sequence" => "2", "limit" => "2"})
+    assert bounded_response.status == 200
+
+    assert %{"data" => %{"items" => [%{"sequence" => 3}, %{"sequence" => 4}]}} =
+             Jason.decode!(bounded_response.resp_body)
+
+    max_response = request.(%{"limit" => "500"})
+    assert max_response.status == 200
+
+    for params <- [
+          %{"limit" => "abc"},
+          %{"limit" => "-1"},
+          %{"limit" => "0"},
+          %{"limit" => "1.5"},
+          %{"limit" => ["1"]},
+          %{"limit" => true},
+          %{"limit" => "501"},
+          %{"after_sequence" => "abc"},
+          %{"after_sequence" => "-1"},
+          %{"after_sequence" => "1.5"},
+          %{"after_sequence" => ["1"]},
+          %{"after_sequence" => true}
+        ] do
+      response = request.(params)
+      assert response.status == 422
+      assert %{"error" => %{"code" => "validation_failed"}} = Jason.decode!(response.resp_body)
+    end
   end
 
   test "password login returns invalid credentials without rate-limiting branch" do
@@ -1342,6 +1407,43 @@ defmodule FavnOrchestrator.API.RouterTest do
     assert [%{action: "run.submit"}] = Auth.list_audit(limit: 10)
   end
 
+  test "run submission returns unknown outcome when idempotency completion fails after mutation" do
+    Application.put_env(:favn_orchestrator, :storage_adapter, IdempotencyCompletionFailingStorage)
+
+    version = dependency_manifest_version("mv_run_idempotency_completion_failure")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password-long")
+
+    payload = %{
+      target: %{type: "asset", id: "asset:Elixir.MyApp.Assets.Gold:asset"},
+      manifest_selection: %{mode: "version", manifest_version_id: version.manifest_version_id},
+      dependencies: "none"
+    }
+
+    response =
+      conn(:post, "/api/orchestrator/v1/runs", payload)
+      |> put_req_header("authorization", "Bearer test-service-token")
+      |> put_req_header("x-favn-actor-id", actor.id)
+      |> put_req_header("x-favn-session-token", session.token)
+      |> put_idempotency_key("run-submit-completion-fails")
+      |> Router.call(@opts)
+
+    assert response.status == 500
+
+    assert %{
+             "error" => %{
+               "code" => "internal_error",
+               "message" => "Command outcome is unknown",
+               "details" => %{"outcome" => "unknown"}
+             }
+           } = Jason.decode!(response.resp_body)
+
+    refute response.resp_body =~ "internal-secret-path"
+    assert {:ok, runs} = Storage.list_runs()
+    assert Enum.any?(runs, &(&1.manifest_version_id == version.manifest_version_id))
+  end
+
   test "run submission returns in-progress for duplicate while original is reserved" do
     version = dependency_manifest_version("mv_run_idempotency_in_progress")
     assert :ok = FavnOrchestrator.register_manifest(version)
@@ -1870,6 +1972,56 @@ defmodule FavnOrchestrator.API.RouterTest do
            } = Jason.decode!(response.resp_body)
 
     assert requested > 500
+  end
+
+  test "backfill submit endpoint rejects invalid operator option fields" do
+    version = schedule_manifest_version("mv_backfill_invalid_options_http")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+
+    {:ok, session, actor} = Auth.password_login("admin", "admin-password-long")
+
+    for {field, value, message} <- [
+          {"max_attempts", 0, "Invalid max_attempts"},
+          {"retry_backoff_ms", -1, "Invalid retry_backoff_ms"},
+          {"timeout_ms", 0, "Invalid timeout_ms"},
+          {"coverage_baseline_id", "", "Invalid coverage_baseline_id"}
+        ] do
+      response =
+        conn(
+          :post,
+          "/api/orchestrator/v1/backfills",
+          Map.put(
+            %{
+              "target" => %{
+                "type" => "pipeline",
+                "id" => "pipeline:Elixir.MyApp.Pipelines.DailyOrders"
+              },
+              "manifest_selection" => %{
+                "mode" => "version",
+                "manifest_version_id" => version.manifest_version_id
+              },
+              "range" => %{
+                "from" => "2026-01-01",
+                "to" => "2026-01-02",
+                "kind" => "day",
+                "timezone" => "Etc/UTC"
+              }
+            },
+            field,
+            value
+          )
+        )
+        |> put_req_header("authorization", "Bearer test-service-token")
+        |> put_req_header("x-favn-actor-id", actor.id)
+        |> put_req_header("x-favn-session-token", session.token)
+        |> put_idempotency_key("backfill-invalid-option-#{field}")
+        |> Router.call(@opts)
+
+      assert response.status == 422
+
+      assert %{"error" => %{"message" => ^message, "details" => %{"field" => ^field}}} =
+               Jason.decode!(response.resp_body)
+    end
   end
 
   test "backfill submit endpoint reports invalid range window values clearly" do

--- a/apps/favn_orchestrator/test/api/sse_test.exs
+++ b/apps/favn_orchestrator/test/api/sse_test.exs
@@ -2,6 +2,7 @@ defmodule FavnOrchestrator.API.SSETest do
   use ExUnit.Case, async: true
 
   alias FavnOrchestrator.API.SSE
+  alias FavnOrchestrator.Storage.RunEventCodec
 
   test "encodes valid event and id fields" do
     assert {:ok, "run_updated"} = SSE.field(:event, :run_updated)
@@ -13,5 +14,18 @@ defmodule FavnOrchestrator.API.SSETest do
     for value <- ["run\nupdated", "run\rupdated", "run_updated\n\nid: forged\nevent: forged"] do
       assert {:error, {:invalid_sse_field, :event, ^value}} = SSE.field(:event, value)
     end
+  end
+
+  test "run event normalization and SSE reject the same forged payload" do
+    event_type = "run_updated\n\nid: forged\nevent: forged"
+
+    assert {:error, {:invalid_run_event_field, :event_type, ^event_type}} =
+             RunEventCodec.normalize("run_forged_sse", %{
+               sequence: 1,
+               event_type: event_type,
+               occurred_at: DateTime.utc_now()
+             })
+
+    assert {:error, {:invalid_sse_field, :event, ^event_type}} = SSE.field(:event, event_type)
   end
 end

--- a/apps/favn_orchestrator/test/api/sse_test.exs
+++ b/apps/favn_orchestrator/test/api/sse_test.exs
@@ -1,0 +1,17 @@
+defmodule FavnOrchestrator.API.SSETest do
+  use ExUnit.Case, async: true
+
+  alias FavnOrchestrator.API.SSE
+
+  test "encodes valid event and id fields" do
+    assert {:ok, "run_updated"} = SSE.field(:event, :run_updated)
+    assert {:ok, "custom.run:updated-1"} = SSE.field(:event, "custom.run:updated-1")
+    assert {:ok, "run:run_1:10"} = SSE.field(:id, "run:run_1:10")
+  end
+
+  test "rejects CR LF and forged SSE fields" do
+    for value <- ["run\nupdated", "run\rupdated", "run_updated\n\nid: forged\nevent: forged"] do
+      assert {:error, {:invalid_sse_field, :event, ^value}} = SSE.field(:event, value)
+    end
+  end
+end

--- a/apps/favn_orchestrator/test/operator_commands/request_test.exs
+++ b/apps/favn_orchestrator/test/operator_commands/request_test.exs
@@ -91,4 +91,35 @@ defmodule FavnOrchestrator.OperatorCommands.RequestTest do
     assert {:error, {:invalid_operator_range, %{kind: "day"}}} =
              PipelineBackfillRequest.from_input(%{range: %{kind: "day"}})
   end
+
+  test "pipeline backfill requests validate optional DTO fields" do
+    base = %{range: %{kind: "day", from: "2026-05-01", to: "2026-05-03"}}
+
+    assert {:ok, request} =
+             PipelineBackfillRequest.from_input(
+               Map.merge(base, %{
+                 max_attempts: 2,
+                 retry_backoff_ms: 0,
+                 timeout_ms: 1_000,
+                 coverage_baseline_id: "baseline_1"
+               })
+             )
+
+    assert request.max_attempts == 2
+    assert request.retry_backoff_ms == 0
+    assert request.timeout_ms == 1_000
+    assert request.coverage_baseline_id == "baseline_1"
+
+    assert {:error, {:invalid_operator_max_attempts, 0}} =
+             PipelineBackfillRequest.from_input(Map.put(base, :max_attempts, 0))
+
+    assert {:error, {:invalid_operator_retry_backoff_ms, -1}} =
+             PipelineBackfillRequest.from_input(Map.put(base, :retry_backoff_ms, -1))
+
+    assert {:error, {:invalid_operator_timeout_ms, 0}} =
+             PipelineBackfillRequest.from_input(Map.put(base, :timeout_ms, 0))
+
+    assert {:error, {:invalid_operator_coverage_baseline_id, ""}} =
+             PipelineBackfillRequest.from_input(Map.put(base, :coverage_baseline_id, ""))
+  end
 end

--- a/apps/favn_orchestrator/test/storage/run_event_codec_test.exs
+++ b/apps/favn_orchestrator/test/storage/run_event_codec_test.exs
@@ -35,6 +35,17 @@ defmodule FavnOrchestrator.Storage.RunEventCodecTest do
     assert normalized.data == %{"attempt" => 1}
   end
 
+  test "normalizes valid string event types" do
+    assert {:ok, normalized} =
+             RunEventCodec.normalize("run_string_event", %{
+               sequence: 1,
+               event_type: "custom.run:updated-1",
+               occurred_at: DateTime.utc_now()
+             })
+
+    assert normalized.event_type == "custom.run:updated-1"
+  end
+
   test "accepts ISO8601 timestamps" do
     now = DateTime.utc_now() |> DateTime.to_iso8601()
 
@@ -81,6 +92,41 @@ defmodule FavnOrchestrator.Storage.RunEventCodecTest do
                event_type: :run_started,
                occurred_at: 1
              })
+  end
+
+  test "rejects unsafe event types before persistence" do
+    for event_type <- ["run\nupdated", "run\rupdated", "run_updated\n\nid: forged\nevent: forged"] do
+      assert {:error, {:invalid_run_event_field, :event_type, ^event_type}} =
+               RunEventCodec.normalize("run_unsafe_event", %{
+                 sequence: 1,
+                 event_type: event_type,
+                 occurred_at: DateTime.utc_now()
+               })
+    end
+
+    assert {:error, {:invalid_run_event_field, :event_type, :"run\nupdated"}} =
+             RunEventCodec.normalize("run_unsafe_atom_event", %{
+               sequence: 1,
+               event_type: :"run\nupdated",
+               occurred_at: DateTime.utc_now()
+             })
+  end
+
+  test "rejects unsafe decoded event types" do
+    payload =
+      Jason.encode!(%{
+        "format" => "favn.run_event.storage.v1",
+        "schema_version" => 1,
+        "run_id" => "run_decode_injection",
+        "sequence" => 1,
+        "event_type" => "run_updated\n\nevent: forged",
+        "entity" => "run",
+        "occurred_at" => DateTime.utc_now() |> DateTime.to_iso8601(),
+        "data" => %{}
+      })
+
+    assert {:error, {:invalid_run_event_json, {:invalid_run_event_field, :event_type, _}}} =
+             RunEventCodec.decode(payload)
   end
 
   test "encodes run events as explicit JSON-safe DTOs" do

--- a/apps/favn_view/lib/favn_view/asset_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_detail_live.ex
@@ -325,7 +325,7 @@ defmodule FavnView.AssetDetailLive do
   defp load_asset(asset_id) do
     target_id = AssetRoute.from_param(asset_id)
 
-    case active_asset_detail(target_id) do
+    case FavnOrchestrator.active_asset_detail(target_id) do
       {:ok, detail} ->
         {:ok, asset_from_detail(detail)}
 
@@ -346,14 +346,6 @@ defmodule FavnView.AssetDetailLive do
 
   defp asset_from_state({:ok, asset}), do: asset
   defp asset_from_state(_state), do: nil
-
-  defp active_asset_detail(target_id) do
-    Application.get_env(
-      :favn_view,
-      :active_asset_detail_fun,
-      &FavnOrchestrator.active_asset_detail/1
-    ).(target_id)
-  end
 
   defp actor_context(socket) do
     %Scope{} = scope = socket.assigns.current_scope

--- a/apps/favn_view/lib/favn_view/asset_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_detail_live.ex
@@ -3,6 +3,8 @@ defmodule FavnView.AssetDetailLive do
 
   use FavnView, :live_view
 
+  require Logger
+
   alias FavnView.AssetRoute
   alias FavnView.Components.AssetCataloguePage
   alias FavnView.Components.AssetDetailPage
@@ -11,14 +13,21 @@ defmodule FavnView.AssetDetailLive do
   alias FavnView.Auth.Scope
 
   @valid_modes ~w(timeline runs lineage docs code details)
+  @dependency_choices ~w(all none)
+  @refresh_choices ~w(auto missing force_selected force_selected_upstream force_all)
+  @source_choices ~w(refresh_timeline data_coverage_timeline)
+  @window_kind_choices ~w(hour day month year)
+  @timezone_pattern ~r/\A[A-Za-z0-9_+\-\/]{1,64}\z/
 
   @impl true
   def mount(%{"asset_id" => asset_id}, _session, socket) do
-    asset = load_asset(asset_id)
+    asset_state = load_asset(asset_id)
+    asset = asset_from_state(asset_state)
 
     socket =
       assign(socket,
         asset_id: asset_id,
+        asset_state: asset_state,
         asset: asset,
         active_mode: :timeline,
         active_timeline: :refresh,
@@ -129,8 +138,9 @@ defmodule FavnView.AssetDetailLive do
 
   def handle_event("change_run_config", params, socket) do
     run_config = run_config_from_params(params, socket.assigns.run_config)
+    error = validate_run_config(run_config, socket.assigns.selected_window)
 
-    {:noreply, assign(socket, :run_config, run_config)}
+    {:noreply, assign(socket, run_config: run_config, selected_window_error: error)}
   end
 
   def handle_event("run_selected_window", params, socket) do
@@ -155,6 +165,14 @@ defmodule FavnView.AssetDetailLive do
            socket,
            :selected_window_error,
            disabled_reason_label(selected_window.run_disabled_reason)
+         )}
+
+      error = validate_run_config(run_config, selected_window) ->
+        {:noreply,
+         assign(socket,
+           run_config: run_config,
+           submitting_window_run?: false,
+           selected_window_error: error
          )}
 
       true ->
@@ -185,6 +203,8 @@ defmodule FavnView.AssetDetailLive do
          |> push_navigate(to: ~p"/runs/#{run_id}")}
 
       {:error, reason} ->
+        Logger.error("asset.run submit failed reason=#{inspect(reason)}")
+
         {:noreply,
          assign(socket,
            submitting_window_run?: false,
@@ -263,7 +283,26 @@ defmodule FavnView.AssetDetailLive do
     />
 
     <AppShell.app_shell
-      :if={!@asset}
+      :if={match?({:error, _reason}, @asset_state)}
+      title={asset_error_title(@asset_state)}
+      subtitle={@asset_id}
+      nav_items={@nav_items}
+    >
+      <div class="mx-auto w-full max-w-4xl">
+        <GlassPanel.glass_panel class="p-8 text-center" data-testid="asset-backend-error-state">
+          <h2 class="text-xl font-medium">{asset_error_title(@asset_state)}</h2>
+          <p class="mt-2 text-base-content/60">
+            {asset_error_message(@asset_state)}
+          </p>
+          <.link navigate={~p"/assets"} class="btn btn-primary btn-soft mt-6">
+            Back to catalogue
+          </.link>
+        </GlassPanel.glass_panel>
+      </div>
+    </AppShell.app_shell>
+
+    <AppShell.app_shell
+      :if={match?({:not_found, _id}, @asset_state)}
       title="Asset not found"
       subtitle={@asset_id}
       nav_items={@nav_items}
@@ -286,10 +325,34 @@ defmodule FavnView.AssetDetailLive do
   defp load_asset(asset_id) do
     target_id = AssetRoute.from_param(asset_id)
 
-    case FavnOrchestrator.active_asset_detail(target_id) do
-      {:ok, detail} -> asset_from_detail(detail)
-      {:error, _reason} -> nil
+    case active_asset_detail(target_id) do
+      {:ok, detail} ->
+        {:ok, asset_from_detail(detail)}
+
+      {:error, :not_found} ->
+        {:not_found, asset_id}
+
+      {:error, :active_manifest_not_set} ->
+        {:error, :active_manifest_not_set}
+
+      {:error, reason} ->
+        Logger.error(
+          "asset_detail.load failed asset_id=#{inspect(asset_id)} reason=#{inspect(reason)}"
+        )
+
+        {:error, :backend_unavailable}
     end
+  end
+
+  defp asset_from_state({:ok, asset}), do: asset
+  defp asset_from_state(_state), do: nil
+
+  defp active_asset_detail(target_id) do
+    Application.get_env(
+      :favn_view,
+      :active_asset_detail_fun,
+      &FavnOrchestrator.active_asset_detail/1
+    ).(target_id)
   end
 
   defp actor_context(socket) do
@@ -543,6 +606,54 @@ defmodule FavnView.AssetDetailLive do
   end
 
   defp run_config_from_params(_params, current_config), do: current_config || default_run_config()
+
+  defp validate_run_config(config, selected_window) do
+    cond do
+      config.dependencies not in @dependency_choices ->
+        "Dependency choice is invalid."
+
+      config.refresh not in @refresh_choices ->
+        "Refresh choice is invalid."
+
+      is_nil(selected_window) and window_context_requested?(config) and
+          config.source not in @source_choices ->
+        "Window source is invalid."
+
+      is_nil(selected_window) and window_context_requested?(config) and
+          config.kind not in @window_kind_choices ->
+        "Window kind is invalid."
+
+      is_nil(selected_window) and window_context_requested?(config) and blank?(config.value) ->
+        "Window range start is required."
+
+      is_nil(selected_window) and range_requested?(config) and blank?(config.to) ->
+        "Window range end is required."
+
+      window_context_requested?(config) and not valid_timezone?(config.timezone) ->
+        "Timezone is invalid."
+
+      true ->
+        nil
+    end
+  end
+
+  defp window_context_requested?(config),
+    do: not blank?(Map.get(config, :value)) or not blank?(Map.get(config, :to))
+
+  defp range_requested?(config), do: not blank?(Map.get(config, :to))
+
+  defp blank?(value), do: not is_binary(value) or String.trim(value) == ""
+  defp valid_timezone?(value) when is_binary(value), do: String.match?(value, @timezone_pattern)
+  defp valid_timezone?(_value), do: false
+
+  defp asset_error_title({:error, :active_manifest_not_set}), do: "Active manifest not set"
+  defp asset_error_title({:error, _reason}), do: "Unable to load asset"
+
+  defp asset_error_message({:error, :active_manifest_not_set}) do
+    "Set an active manifest before opening asset details."
+  end
+
+  defp asset_error_message({:error, _reason}), do: "Backend unavailable. Try again later."
 
   defp disabled_reason_label(:asset_has_no_window_policy), do: "This asset has no window policy."
   defp disabled_reason_label(:invalid_window), do: "This window cannot be run."

--- a/apps/favn_view/lib/favn_view/logs_live_support.ex
+++ b/apps/favn_view/lib/favn_view/logs_live_support.ex
@@ -4,6 +4,8 @@ defmodule FavnView.LogsLiveSupport do
   import Phoenix.Component, only: [assign: 2, assign: 3]
   import Phoenix.LiveView, only: [connected?: 1]
 
+  require Logger
+
   alias Favn.Log.Filter
   alias FavnView.Components.AssetCataloguePage
   alias FavnView.LogsViewModel
@@ -74,6 +76,10 @@ defmodule FavnView.LogsLiveSupport do
         run_context_from_public(summary, Map.get(detail, :steps, []))
 
       {:error, reason} ->
+        Logger.error(
+          "logs.run_context failed run_id=#{inspect(run_id)} reason=#{inspect(reason)}"
+        )
+
         %{
           found?: false,
           id: run_id,
@@ -274,5 +280,5 @@ defmodule FavnView.LogsLiveSupport do
   defp target_label(%{asset_ref: target}), do: LogsViewModel.ref_label(target)
 
   defp error_label(:not_found), do: "Run not found"
-  defp error_label(reason), do: "Unable to load run: #{inspect(reason)}"
+  defp error_label(_reason), do: "Unable to load run"
 end

--- a/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
@@ -188,7 +188,7 @@ defmodule FavnView.PipelineDetailLive do
   defp load_pipeline(pipeline_id) do
     target_id = AssetRoute.from_param(pipeline_id)
 
-    case active_pipeline_detail(target_id) do
+    case FavnOrchestrator.active_pipeline_detail(target_id) do
       {:ok, detail} ->
         {:ok, pipeline_from_detail(detail)}
 
@@ -209,14 +209,6 @@ defmodule FavnView.PipelineDetailLive do
 
   defp pipeline_from_state({:ok, pipeline}), do: pipeline
   defp pipeline_from_state(_state), do: nil
-
-  defp active_pipeline_detail(target_id) do
-    Application.get_env(
-      :favn_view,
-      :active_pipeline_detail_fun,
-      &FavnOrchestrator.active_pipeline_detail/1
-    ).(target_id)
-  end
 
   defp actor_context(socket) do
     %Scope{} = scope = socket.assigns.current_scope

--- a/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
+++ b/apps/favn_view/lib/favn_view/pipeline_detail_live.ex
@@ -3,6 +3,8 @@ defmodule FavnView.PipelineDetailLive do
 
   use FavnView, :live_view
 
+  require Logger
+
   alias FavnView.AssetRoute
   alias FavnView.Components.AppShell
   alias FavnView.Components.GlassPanel
@@ -12,14 +14,19 @@ defmodule FavnView.PipelineDetailLive do
   alias FavnView.Auth.Scope
 
   @valid_modes ~w(runs assets more)
+  @refresh_choices ~w(missing force auto force_all)
+  @window_kind_choices ~w(hour day month year)
+  @timezone_pattern ~r/\A[A-Za-z0-9_+\-\/]{1,64}\z/
 
   @impl true
   def mount(%{"pipeline_id" => pipeline_id}, _session, socket) do
-    pipeline = load_pipeline(pipeline_id)
+    pipeline_state = load_pipeline(pipeline_id)
+    pipeline = pipeline_from_state(pipeline_state)
 
     socket =
       assign(socket,
         pipeline_id: pipeline_id,
+        pipeline_state: pipeline_state,
         pipeline: pipeline,
         active_mode: :runs,
         run_error: nil,
@@ -62,6 +69,7 @@ defmodule FavnView.PipelineDetailLive do
          |> push_navigate(to: ~p"/runs/#{run_id}")}
 
       {:error, reason} ->
+        Logger.error("pipeline.run submit failed reason=#{inspect(reason)}")
         {:noreply, assign(socket, :run_error, submit_error_label(reason))}
     end
   end
@@ -83,6 +91,7 @@ defmodule FavnView.PipelineDetailLive do
     pipeline = socket.assigns.pipeline
 
     with true <- pipeline.can_backfill?,
+         nil <- validate_backfill_config(config),
          {:ok, run_id} <-
            FavnOrchestrator.submit_operator_pipeline_backfill(
              actor_context(socket),
@@ -102,7 +111,16 @@ defmodule FavnView.PipelineDetailLive do
            backfill_error: "Backfill requires a windowed pipeline."
          )}
 
+      error when is_binary(error) ->
+        {:noreply,
+         assign(socket,
+           backfill_config: config,
+           backfill_error: error
+         )}
+
       {:error, reason} ->
+        Logger.error("pipeline.backfill submit failed reason=#{inspect(reason)}")
+
         {:noreply,
          assign(socket,
            backfill_config: config,
@@ -128,7 +146,26 @@ defmodule FavnView.PipelineDetailLive do
     />
 
     <AppShell.app_shell
-      :if={!@pipeline}
+      :if={match?({:error, _reason}, @pipeline_state)}
+      title={pipeline_error_title(@pipeline_state)}
+      subtitle={@pipeline_id}
+      nav_items={@nav_items}
+    >
+      <div class="mx-auto w-full max-w-4xl">
+        <GlassPanel.glass_panel class="p-8 text-center" data-testid="pipeline-backend-error-state">
+          <h2 class="text-xl font-medium">{pipeline_error_title(@pipeline_state)}</h2>
+          <p class="mt-2 text-base-content/60">
+            {pipeline_error_message(@pipeline_state)}
+          </p>
+          <.link navigate={~p"/pipelines"} class="btn btn-primary btn-soft mt-6">
+            Back to pipelines
+          </.link>
+        </GlassPanel.glass_panel>
+      </div>
+    </AppShell.app_shell>
+
+    <AppShell.app_shell
+      :if={match?({:not_found, _id}, @pipeline_state)}
       title="Pipeline not found"
       subtitle={@pipeline_id}
       nav_items={@nav_items}
@@ -151,10 +188,34 @@ defmodule FavnView.PipelineDetailLive do
   defp load_pipeline(pipeline_id) do
     target_id = AssetRoute.from_param(pipeline_id)
 
-    case FavnOrchestrator.active_pipeline_detail(target_id) do
-      {:ok, detail} -> pipeline_from_detail(detail)
-      {:error, _reason} -> nil
+    case active_pipeline_detail(target_id) do
+      {:ok, detail} ->
+        {:ok, pipeline_from_detail(detail)}
+
+      {:error, :not_found} ->
+        {:not_found, pipeline_id}
+
+      {:error, :active_manifest_not_set} ->
+        {:error, :active_manifest_not_set}
+
+      {:error, reason} ->
+        Logger.error(
+          "pipeline_detail.load failed pipeline_id=#{inspect(pipeline_id)} reason=#{inspect(reason)}"
+        )
+
+        {:error, :backend_unavailable}
     end
+  end
+
+  defp pipeline_from_state({:ok, pipeline}), do: pipeline
+  defp pipeline_from_state(_state), do: nil
+
+  defp active_pipeline_detail(target_id) do
+    Application.get_env(
+      :favn_view,
+      :active_pipeline_detail_fun,
+      &FavnOrchestrator.active_pipeline_detail/1
+    ).(target_id)
   end
 
   defp actor_context(socket) do
@@ -208,6 +269,37 @@ defmodule FavnView.PipelineDetailLive do
       refresh: params |> Map.get("refresh", "missing") |> String.trim()
     }
   end
+
+  defp validate_backfill_config(config) do
+    cond do
+      config.kind not in @window_kind_choices ->
+        "Window kind is invalid."
+
+      config.refresh not in @refresh_choices ->
+        "Refresh choice is invalid."
+
+      config.from == "" ->
+        "Backfill range start is required."
+
+      config.to == "" ->
+        "Backfill range end is required."
+
+      not String.match?(config.timezone, @timezone_pattern) ->
+        "Timezone is invalid."
+
+      true ->
+        nil
+    end
+  end
+
+  defp pipeline_error_title({:error, :active_manifest_not_set}), do: "Active manifest not set"
+  defp pipeline_error_title({:error, _reason}), do: "Unable to load pipeline"
+
+  defp pipeline_error_message({:error, :active_manifest_not_set}) do
+    "Set an active manifest before opening pipeline details."
+  end
+
+  defp pipeline_error_message({:error, _reason}), do: "Backend unavailable. Try again later."
 
   defp normalize_window_kind(kind) when kind in [:hour, :day, :month, :year], do: kind
   defp normalize_window_kind(:hourly), do: :hour
@@ -402,7 +494,7 @@ defmodule FavnView.PipelineDetailLive do
 
   defp submit_error_label(:forbidden), do: "Operator role required to submit runs."
   defp submit_error_label(:not_found), do: "Pipeline not found."
-  defp submit_error_label(reason), do: "Submit failed: #{inspect(reason)}"
+  defp submit_error_label(_reason), do: "Submit failed."
 
   defp humanize(value) do
     value

--- a/apps/favn_view/lib/favn_view/runs_list_live.ex
+++ b/apps/favn_view/lib/favn_view/runs_list_live.ex
@@ -3,6 +3,8 @@ defmodule FavnView.RunsListLive do
 
   use FavnView, :live_view
 
+  require Logger
+
   alias FavnView.Components.RunsListPage
   alias FavnView.LiveRefresh
   alias FavnView.LogsViewModel
@@ -166,8 +168,12 @@ defmodule FavnView.RunsListLive do
 
   defp load_groups(filters) do
     case page_execution_groups(orchestrator_filters(filters)) do
-      {:ok, %{items: groups}} -> {Enum.map(groups, &group_from_public/1), nil}
-      {:error, reason} -> {[], inspect(reason)}
+      {:ok, %{items: groups}} ->
+        {Enum.map(groups, &group_from_public/1), nil}
+
+      {:error, reason} ->
+        Logger.error("runs.list failed: #{inspect(reason)}")
+        {[], "Backend unavailable"}
     end
   end
 
@@ -290,7 +296,15 @@ defmodule FavnView.RunsListLive do
           update(socket, :group_details, &Map.put(&1, group_id, detail_from_public(detail)))
 
         {:error, reason} ->
-          update(socket, :group_details, &Map.put(&1, group_id, %{error: inspect(reason)}))
+          Logger.error(
+            "runs.group_detail failed group_id=#{inspect(group_id)} reason=#{inspect(reason)}"
+          )
+
+          update(
+            socket,
+            :group_details,
+            &Map.put(&1, group_id, %{error: "Unable to load run group"})
+          )
       end
     end
   end

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -436,6 +436,40 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(view, ~s([data-testid="pipeline-runs-table"]), "run_daily...ndowed")
   end
 
+  test "pipeline detail renders not-found separately", %{conn: conn} do
+    {:ok, not_found_view, not_found_html} = live(conn, ~p"/pipelines/not_real")
+    assert not_found_html =~ "Pipeline not found"
+    assert has_element?(not_found_view, ~s([data-testid="pipeline-not-found-state"]))
+  end
+
+  test "pipeline detail renders active manifest missing separately", %{conn: conn} do
+    put_test_env(:active_pipeline_detail_fun, fn _target_id ->
+      {:error, :active_manifest_not_set}
+    end)
+
+    {:ok, missing_view, missing_html} = live(conn, pipeline_detail_path())
+    assert missing_html =~ "Active manifest not set"
+    assert has_element?(missing_view, ~s([data-testid="pipeline-backend-error-state"]))
+  end
+
+  test "pipeline detail renders backend failures without internal reasons", %{conn: conn} do
+    put_test_env(:active_pipeline_detail_fun, fn _target_id ->
+      {:error, {:storage_failed, :secret}}
+    end)
+
+    {:ok, failed_view, failed_html} = live(conn, pipeline_detail_path())
+    assert failed_html =~ "Unable to load pipeline"
+
+    assert has_element?(
+             failed_view,
+             ~s([data-testid="pipeline-backend-error-state"]),
+             "Backend unavailable"
+           )
+
+    refute failed_html =~ "storage_failed"
+    refute failed_html =~ "secret"
+  end
+
   test "pipeline detail does not invent an implicit window for normal pipeline runs", %{
     conn: conn
   } do
@@ -525,6 +559,25 @@ defmodule FavnView.PageLiveTest do
                  include_upstream?: false
                }
            end)
+  end
+
+  test "pipeline backfill form rejects invalid local choices", %{conn: conn} do
+    {:ok, view, _html} = live(conn, pipeline_detail_path())
+
+    html =
+      view
+      |> element(~s([data-testid="pipeline-backfill-form"]))
+      |> render_submit(%{
+        "backfill" => %{
+          "from" => "",
+          "to" => "2026-01-02",
+          "kind" => "quarter",
+          "timezone" => "Etc/UTC",
+          "refresh" => "sometimes"
+        }
+      })
+
+    assert html =~ "Window kind is invalid."
   end
 
   test "viewer cannot submit a pipeline backfill with a forged LiveView event", %{conn: _conn} do
@@ -792,6 +845,28 @@ defmodule FavnView.PageLiveTest do
     assert has_element?(run_view, ~s([data-testid="run-overview-panel"]))
   end
 
+  test "run asset form rejects invalid local choices before submit", %{conn: conn} do
+    {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
+    open_run_config(view)
+
+    html =
+      view
+      |> element(~s([data-testid="run-config-form"]))
+      |> render_submit(%{
+        "run_config" => %{
+          "dependencies" => "upstream",
+          "refresh" => "auto",
+          "source" => "refresh_timeline",
+          "kind" => "day",
+          "value" => "2026-06-12",
+          "to" => "2026-06-13",
+          "timezone" => "Etc/UTC"
+        }
+      })
+
+    assert html =~ "Dependency choice is invalid."
+  end
+
   test "viewer cannot submit an asset run with a forged LiveView event", %{conn: _conn} do
     conn = authenticate_conn(build_conn(), :viewer)
     {:ok, view, _html} = live(conn, detail_path(:customer_orders_daily))
@@ -1039,6 +1114,32 @@ defmodule FavnView.PageLiveTest do
 
     assert html =~ "Asset not found"
     assert has_element?(view, ~s([data-testid="asset-not-found-state"]))
+  end
+
+  test "asset detail renders active manifest missing separately", %{conn: conn} do
+    put_test_env(:active_asset_detail_fun, fn _target_id -> {:error, :active_manifest_not_set} end)
+
+    {:ok, missing_view, missing_html} = live(conn, detail_path(:customer_orders_daily))
+    assert missing_html =~ "Active manifest not set"
+    assert has_element?(missing_view, ~s([data-testid="asset-backend-error-state"]))
+  end
+
+  test "asset detail renders backend failures without internal reasons", %{conn: conn} do
+    put_test_env(:active_asset_detail_fun, fn _target_id ->
+      {:error, {:storage_failed, :secret}}
+    end)
+
+    {:ok, failed_view, failed_html} = live(conn, detail_path(:customer_orders_daily))
+    assert failed_html =~ "Unable to load asset"
+
+    assert has_element?(
+             failed_view,
+             ~s([data-testid="asset-backend-error-state"]),
+             "Backend unavailable"
+           )
+
+    refute failed_html =~ "storage_failed"
+    refute failed_html =~ "secret"
   end
 
   test "renders existing run detail overview", %{conn: conn} do

--- a/apps/favn_view/test/favn_view/page_live_test.exs
+++ b/apps/favn_view/test/favn_view/page_live_test.exs
@@ -25,6 +25,38 @@ defmodule FavnView.PageLiveTest do
   alias FavnOrchestrator.Storage
   alias FavnOrchestrator.Storage.Adapter.Memory
 
+  defmodule ManifestReadFailingStorage do
+    alias FavnOrchestrator.Storage.Adapter.Memory
+
+    for {name, arity} <- Favn.Storage.Adapter.behaviour_info(:callbacks),
+        {name, arity} != {:get_manifest_version, 2} do
+      args = Macro.generate_arguments(arity, __MODULE__)
+
+      def unquote(name)(unquote_splicing(args)) do
+        apply(Memory, unquote(name), [unquote_splicing(args)])
+      end
+    end
+
+    def get_manifest_version(_manifest_version_id, _opts) do
+      {:error, {:storage_failed, :secret_manifest_path}}
+    end
+  end
+
+  defmodule ActiveManifestUnsetStorage do
+    alias FavnOrchestrator.Storage.Adapter.Memory
+
+    for {name, arity} <- Favn.Storage.Adapter.behaviour_info(:callbacks),
+        {name, arity} != {:get_active_manifest_version, 1} do
+      args = Macro.generate_arguments(arity, __MODULE__)
+
+      def unquote(name)(unquote_splicing(args)) do
+        apply(Memory, unquote(name), [unquote_splicing(args)])
+      end
+    end
+
+    def get_active_manifest_version(_opts), do: {:error, :active_manifest_not_set}
+  end
+
   setup %{conn: conn} do
     ensure_auth_store_started()
     :ok = AuthStore.reset()
@@ -443,21 +475,19 @@ defmodule FavnView.PageLiveTest do
   end
 
   test "pipeline detail renders active manifest missing separately", %{conn: conn} do
-    put_test_env(:active_pipeline_detail_fun, fn _target_id ->
-      {:error, :active_manifest_not_set}
-    end)
+    path = pipeline_detail_path()
+    put_orchestrator_test_env(:storage_adapter, ActiveManifestUnsetStorage)
 
-    {:ok, missing_view, missing_html} = live(conn, pipeline_detail_path())
+    {:ok, missing_view, missing_html} = live(conn, path)
     assert missing_html =~ "Active manifest not set"
     assert has_element?(missing_view, ~s([data-testid="pipeline-backend-error-state"]))
   end
 
   test "pipeline detail renders backend failures without internal reasons", %{conn: conn} do
-    put_test_env(:active_pipeline_detail_fun, fn _target_id ->
-      {:error, {:storage_failed, :secret}}
-    end)
+    path = pipeline_detail_path()
+    put_orchestrator_test_env(:storage_adapter, ManifestReadFailingStorage)
 
-    {:ok, failed_view, failed_html} = live(conn, pipeline_detail_path())
+    {:ok, failed_view, failed_html} = live(conn, path)
     assert failed_html =~ "Unable to load pipeline"
 
     assert has_element?(
@@ -467,7 +497,7 @@ defmodule FavnView.PageLiveTest do
            )
 
     refute failed_html =~ "storage_failed"
-    refute failed_html =~ "secret"
+    refute failed_html =~ "secret_manifest_path"
   end
 
   test "pipeline detail does not invent an implicit window for normal pipeline runs", %{
@@ -1117,19 +1147,19 @@ defmodule FavnView.PageLiveTest do
   end
 
   test "asset detail renders active manifest missing separately", %{conn: conn} do
-    put_test_env(:active_asset_detail_fun, fn _target_id -> {:error, :active_manifest_not_set} end)
+    path = detail_path(:customer_orders_daily)
+    put_orchestrator_test_env(:storage_adapter, ActiveManifestUnsetStorage)
 
-    {:ok, missing_view, missing_html} = live(conn, detail_path(:customer_orders_daily))
+    {:ok, missing_view, missing_html} = live(conn, path)
     assert missing_html =~ "Active manifest not set"
     assert has_element?(missing_view, ~s([data-testid="asset-backend-error-state"]))
   end
 
   test "asset detail renders backend failures without internal reasons", %{conn: conn} do
-    put_test_env(:active_asset_detail_fun, fn _target_id ->
-      {:error, {:storage_failed, :secret}}
-    end)
+    path = detail_path(:customer_orders_daily)
+    put_orchestrator_test_env(:storage_adapter, ManifestReadFailingStorage)
 
-    {:ok, failed_view, failed_html} = live(conn, detail_path(:customer_orders_daily))
+    {:ok, failed_view, failed_html} = live(conn, path)
     assert failed_html =~ "Unable to load asset"
 
     assert has_element?(
@@ -1139,7 +1169,7 @@ defmodule FavnView.PageLiveTest do
            )
 
     refute failed_html =~ "storage_failed"
-    refute failed_html =~ "secret"
+    refute failed_html =~ "secret_manifest_path"
   end
 
   test "renders existing run detail overview", %{conn: conn} do
@@ -3586,6 +3616,18 @@ defmodule FavnView.PageLiveTest do
       case original do
         :__missing__ -> Application.delete_env(:favn_view, key)
         value -> Application.put_env(:favn_view, key, value)
+      end
+    end)
+  end
+
+  defp put_orchestrator_test_env(key, value) do
+    original = Application.get_env(:favn_orchestrator, key, :__missing__)
+    Application.put_env(:favn_orchestrator, key, value)
+
+    on_exit(fn ->
+      case original do
+        :__missing__ -> Application.delete_env(:favn_orchestrator, key)
+        value -> Application.put_env(:favn_orchestrator, key, value)
       end
     end)
   end


### PR DESCRIPTION
## Summary
- Add orchestrator-owned SSE field safety and run-event query parsing contracts
- Handle idempotency completion failures as unknown command outcomes with stable API errors
- Replace user-facing inspected errors with stable API/UI messages and add detail-page backend error states
- Add narrow LiveView form validation and pipeline backfill DTO validation

## Tests
- mix format
- MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/storage/run_event_codec_test.exs test/api/sse_test.exs test/operator_commands/request_test.exs test/api/router_test.exs
- MIX_ENV=test mix do --app favn_view cmd mix test test/favn_view/page_live_test.exs
- mix compile --warnings-as-errors

Full umbrella tests were not run per request.