### PR TITLE
Fix schedule list for unscheduled windows

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/scheduler/manifest_entries.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/scheduler/manifest_entries.ex
@@ -22,24 +22,25 @@ defmodule FavnOrchestrator.Scheduler.ManifestEntries do
   end
 
   defp build_entry(%Version{} = version, %Index{} = index, %Pipeline{} = pipeline) do
-    with {:ok, schedule} <- resolve_schedule(index, pipeline.schedule),
-         :ok <- validate_window_for_schedule(pipeline.window, schedule) do
+    with {:ok, schedule} <- resolve_schedule(index, pipeline.schedule) do
       case schedule do
         nil ->
           {:ok, nil}
 
         %Schedule{} = value ->
-          {:ok,
-           %{
-             module: pipeline.module,
-             id: pipeline.name,
-             pipeline: pipeline,
-             schedule: value,
-             window: pipeline.window,
-             schedule_fingerprint: fingerprint(value, pipeline.window),
-             manifest_version_id: version.manifest_version_id,
-             manifest_content_hash: version.content_hash
-           }}
+          with :ok <- validate_window_for_schedule(pipeline.window, value) do
+            {:ok,
+             %{
+               module: pipeline.module,
+               id: pipeline.name,
+               pipeline: pipeline,
+               schedule: value,
+               window: pipeline.window,
+               schedule_fingerprint: fingerprint(value, pipeline.window),
+               manifest_version_id: version.manifest_version_id,
+               manifest_content_hash: version.content_hash
+             }}
+          end
       end
     end
   end

--- a/apps/favn_orchestrator/test/scheduler/runtime_test.exs
+++ b/apps/favn_orchestrator/test/scheduler/runtime_test.exs
@@ -326,6 +326,14 @@ defmodule FavnOrchestrator.Scheduler.RuntimeTest do
     assert {:error, :scheduler_state_get_failed} = FavnOrchestrator.list_schedule_entries()
   end
 
+  test "schedule list fallback ignores unscheduled windowed pipelines" do
+    version = unscheduled_window_manifest_version("mv_scheduler_unscheduled_window")
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    assert {:ok, []} = FavnOrchestrator.list_schedule_entries()
+  end
+
   test "schedule list fallback propagates scheduler state bootstrap write errors" do
     version = scheduler_manifest_version("mv_scheduler_list_put_error")
     assert :ok = FavnOrchestrator.register_manifest(version)
@@ -1017,6 +1025,29 @@ defmodule FavnOrchestrator.Scheduler.RuntimeTest do
           active: true
         }
       ]
+    }
+
+    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
+    version
+  end
+
+  defp unscheduled_window_manifest_version(manifest_version_id) do
+    manifest = %Manifest{
+      assets: [
+        %Asset{ref: {MyApp.Assets.Raw, :asset}, module: MyApp.Assets.Raw, name: :asset}
+      ],
+      pipelines: [
+        %Pipeline{
+          module: MyApp.Pipelines.Monthly,
+          name: :monthly,
+          selectors: [{:asset, {MyApp.Assets.Raw, :asset}}],
+          deps: :all,
+          schedule: nil,
+          window: :month,
+          metadata: %{owner: :scheduler}
+        }
+      ],
+      schedules: []
     }
 
     {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)

--- a/apps/favn_orchestrator/test/scheduler/runtime_test.exs
+++ b/apps/favn_orchestrator/test/scheduler/runtime_test.exs
@@ -327,7 +327,13 @@ defmodule FavnOrchestrator.Scheduler.RuntimeTest do
   end
 
   test "schedule list fallback ignores unscheduled windowed pipelines" do
-    version = unscheduled_window_manifest_version("mv_scheduler_unscheduled_window")
+    version =
+      scheduler_manifest_version("mv_scheduler_unscheduled_window",
+        schedule: nil,
+        schedules: [],
+        window: :month
+      )
+
     assert :ok = FavnOrchestrator.register_manifest(version)
     assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
 
@@ -992,6 +998,20 @@ defmodule FavnOrchestrator.Scheduler.RuntimeTest do
   end
 
   defp scheduler_manifest_version(manifest_version_id, opts \\ []) do
+    schedules =
+      Keyword.get(opts, :schedules, [
+        %Schedule{
+          module: MyApp.Schedules,
+          name: :daily,
+          ref: {MyApp.Schedules, :daily},
+          cron: Keyword.get(opts, :cron, "* * * * *"),
+          timezone: Keyword.get(opts, :timezone, "Etc/UTC"),
+          missed: Keyword.get(opts, :missed, :one),
+          overlap: Keyword.get(opts, :overlap, :forbid),
+          active: true
+        }
+      ])
+
     manifest = %Manifest{
       assets: [
         %Asset{ref: {MyApp.Assets.Raw, :asset}, module: MyApp.Assets.Raw, name: :asset},
@@ -1008,46 +1028,12 @@ defmodule FavnOrchestrator.Scheduler.RuntimeTest do
           name: :daily,
           selectors: [{:asset, {MyApp.Assets.Gold, :asset}}],
           deps: :all,
-          schedule: {:ref, {MyApp.Schedules, :daily}},
+          schedule: Keyword.get(opts, :schedule, {:ref, {MyApp.Schedules, :daily}}),
           window: Keyword.get(opts, :window),
           metadata: %{owner: :scheduler}
         }
       ],
-      schedules: [
-        %Schedule{
-          module: MyApp.Schedules,
-          name: :daily,
-          ref: {MyApp.Schedules, :daily},
-          cron: Keyword.get(opts, :cron, "* * * * *"),
-          timezone: Keyword.get(opts, :timezone, "Etc/UTC"),
-          missed: Keyword.get(opts, :missed, :one),
-          overlap: Keyword.get(opts, :overlap, :forbid),
-          active: true
-        }
-      ]
-    }
-
-    {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)
-    version
-  end
-
-  defp unscheduled_window_manifest_version(manifest_version_id) do
-    manifest = %Manifest{
-      assets: [
-        %Asset{ref: {MyApp.Assets.Raw, :asset}, module: MyApp.Assets.Raw, name: :asset}
-      ],
-      pipelines: [
-        %Pipeline{
-          module: MyApp.Pipelines.Monthly,
-          name: :monthly,
-          selectors: [{:asset, {MyApp.Assets.Raw, :asset}}],
-          deps: :all,
-          schedule: nil,
-          window: :month,
-          metadata: %{owner: :scheduler}
-        }
-      ],
-      schedules: []
+      schedules: schedules
     }
 
     {:ok, version} = Version.new(manifest, manifest_version_id: manifest_version_id)


### PR DESCRIPTION
## Summary
- Skip unscheduled pipelines before validating scheduler window policies so `/schedules` fallback discovery does not crash.
- Add a regression test for an active manifest containing a windowed pipeline with no schedule.

## Verification
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test test/scheduler/runtime_test.exs`
- `mix format`
- `mix compile --warnings-as-errors`