### PR TITLE
Add asset catalogue lineage view

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage.ex
@@ -226,6 +226,7 @@ defmodule FavnOrchestrator.Operator.Lineage do
     |> maybe_put_limit(:max_visible_asset_nodes, limit_opts, 160, 300)
     |> maybe_put_limit(:max_visible_edges, limit_opts, 300, 600)
     |> maybe_put_limit(:max_dependency_previews_per_edge, limit_opts, 5, 20)
+    |> maybe_put_limit(:max_inspector_adjacent_groups, limit_opts, 12, 50)
     |> maybe_put_limit(:group_asset_page_size, limit_opts, 50, 100)
     |> maybe_put_limit(:search_page_size, limit_opts, 20, 50)
     |> Map.put(
@@ -712,6 +713,9 @@ defmodule FavnOrchestrator.Operator.Lineage do
   end
 
   defp group_inspector(%Graph{} = graph, %GroupNode{} = group) do
+    {upstream, hidden_upstream_count} = adjacent_groups(graph, group.id, :upstream)
+    {downstream, hidden_downstream_count} = adjacent_groups(graph, group.id, :downstream)
+
     %GroupInspector{
       id: group.id,
       title: group.label,
@@ -724,8 +728,10 @@ defmodule FavnOrchestrator.Operator.Lineage do
       },
       health_summary: group.status_counts,
       top_issues: group.top_issues,
-      upstream: adjacent_groups(graph, group.id, :upstream),
-      downstream: adjacent_groups(graph, group.id, :downstream),
+      upstream: upstream,
+      downstream: downstream,
+      hidden_upstream_count: hidden_upstream_count,
+      hidden_downstream_count: hidden_downstream_count,
       actions: [
         %{label: "Drill into group", kind: :drill_in},
         %{label: "View all assets", kind: :assets}
@@ -734,13 +740,18 @@ defmodule FavnOrchestrator.Operator.Lineage do
   end
 
   defp asset_inspector(%Graph{} = graph, %AssetNode{} = asset) do
+    {upstream, hidden_upstream_count} = adjacent_groups(graph, asset.group_id, :upstream)
+    {downstream, hidden_downstream_count} = adjacent_groups(graph, asset.group_id, :downstream)
+
     %AssetInspector{
       id: asset.id,
       title: asset.label,
       asset: asset,
       latest_run: latest_run(asset),
-      upstream: adjacent_groups(graph, asset.group_id, :upstream),
-      downstream: adjacent_groups(graph, asset.group_id, :downstream),
+      upstream: upstream,
+      downstream: downstream,
+      hidden_upstream_count: hidden_upstream_count,
+      hidden_downstream_count: hidden_downstream_count,
       actions: [%{label: "Open asset", kind: :asset}, %{label: "Explain lineage", kind: :explain}]
     }
   end
@@ -761,23 +772,29 @@ defmodule FavnOrchestrator.Operator.Lineage do
   defp latest_run(%AssetNode{latest_run_id: nil}), do: nil
   defp latest_run(%AssetNode{} = asset), do: %{id: asset.latest_run_id, status: asset.run_status}
 
-  defp adjacent_groups(graph, group_id, direction) do
-    graph.edges
-    |> Enum.filter(fn edge ->
-      case direction do
-        :upstream -> edge.to == group_id
-        :downstream -> edge.from == group_id
-      end
-    end)
-    |> Enum.map(fn edge ->
-      related_id = if direction == :upstream, do: edge.from, else: edge.to
+  defp adjacent_groups(%Graph{} = graph, group_id, direction) do
+    limit = graph.limits.max_inspector_adjacent_groups
 
-      %{
-        id: related_id,
-        label: graph_label(graph, related_id),
-        dependency_count: edge.dependency_count
-      }
-    end)
+    items =
+      graph.edges
+      |> Enum.filter(fn edge ->
+        case direction do
+          :upstream -> edge.to == group_id
+          :downstream -> edge.from == group_id
+        end
+      end)
+      |> Enum.map(fn edge ->
+        related_id = if direction == :upstream, do: edge.from, else: edge.to
+
+        %{
+          id: related_id,
+          label: graph_label(graph, related_id),
+          dependency_count: edge.dependency_count
+        }
+      end)
+      |> Enum.sort_by(&{String.downcase(&1.label), &1.id})
+
+    {Enum.take(items, limit), max(length(items) - limit, 0)}
   end
 
   defp graph_label(%Graph{} = graph, id) do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage.ex
@@ -1,0 +1,849 @@
+defmodule FavnOrchestrator.Operator.Lineage do
+  @moduledoc """
+  Public same-BEAM facade for bounded operator asset lineage views.
+
+  The facade builds a grouped, runtime-enriched graph from one pinned manifest
+  version and current target-status rows. It keeps graph payloads bounded and
+  returns explicit DTO structs so browser-facing code does not stitch together
+  storage, scheduler, runner, or manifest internals.
+  """
+
+  alias Favn.Manifest.Asset
+  alias Favn.Manifest.Index
+  alias Favn.Manifest.Version
+  alias Favn.RelationRef
+  alias FavnOrchestrator.Operator.Lineage.AssetInspector
+  alias FavnOrchestrator.Operator.Lineage.AssetNode
+  alias FavnOrchestrator.Operator.Lineage.Edge
+  alias FavnOrchestrator.Operator.Lineage.EdgeInspector
+  alias FavnOrchestrator.Operator.Lineage.Error
+  alias FavnOrchestrator.Operator.Lineage.Graph
+  alias FavnOrchestrator.Operator.Lineage.GroupInspector
+  alias FavnOrchestrator.Operator.Lineage.GroupNode
+  alias FavnOrchestrator.Operator.Lineage.Limits
+  alias FavnOrchestrator.Operator.Lineage.SearchResult
+  alias FavnOrchestrator.Operator.Lineage.Summary
+  alias FavnOrchestrator.Page
+  alias FavnOrchestrator.Storage
+  alias FavnOrchestrator.TargetStatus
+
+  @layers [:raw, :staging, :core, :marts, :dashboards]
+  @scope_values [:global, :asset, :group]
+  @view_modes [:all, :upstream, :downstream, :impact, :freshness]
+  @status_keys [:fresh, :stale, :failed, :running, :unknown]
+  @status_priority %{failed: 0, stale: 1, running: 2, unknown: 3, fresh: 4}
+
+  @type error :: Error.t()
+
+  @type graph_opts :: [
+          manifest_version_id: String.t() | :active,
+          scope: Graph.scope(),
+          selected_id: String.t() | nil,
+          view_mode: Graph.view_mode(),
+          filters: map(),
+          expanded_group_ids: [String.t()],
+          limit: keyword(),
+          timeout_ms: pos_integer()
+        ]
+
+  @doc """
+  Returns a bounded grouped lineage graph for one manifest version.
+  """
+  @spec get_graph(graph_opts()) :: {:ok, Graph.t()} | {:error, error()}
+  def get_graph(opts \\ []) when is_list(opts) do
+    with {:ok, request} <- normalize_graph_opts(opts),
+         {:ok, version} <- fetch_version(request.manifest_version_id),
+         {:ok, index} <- Index.build_from_version(version),
+         assets <- List.wrap(version.manifest.assets),
+         targets <- Enum.map(assets, &asset_target/1),
+         {:ok, statuses} <- target_statuses(version.manifest_version_id, targets) do
+      graph = build_graph(version, index, assets, targets, statuses, request)
+      {:ok, graph}
+    else
+      {:error, %Error{} = error} -> {:error, error}
+      {:error, reason} -> {:error, normalize_error(reason)}
+    end
+  end
+
+  @doc """
+  Returns the inspector payload for one lineage group.
+  """
+  @spec get_group(String.t(), keyword()) :: {:ok, GroupInspector.t()} | {:error, error()}
+  def get_group(group_id, opts \\ []) when is_binary(group_id) and is_list(opts) do
+    with {:ok, graph} <- get_graph(Keyword.put(opts, :selected_id, group_id)),
+         {:ok, group} <- fetch_group(graph, group_id) do
+      {:ok, group_inspector(graph, group)}
+    end
+  end
+
+  @doc """
+  Returns the inspector payload for one lineage asset.
+  """
+  @spec get_asset(String.t(), keyword()) :: {:ok, AssetInspector.t()} | {:error, error()}
+  def get_asset(asset_id, opts \\ []) when is_binary(asset_id) and is_list(opts) do
+    with {:ok, graph} <- get_graph(Keyword.put(opts, :selected_id, asset_id)),
+         {:ok, asset} <- fetch_asset_node(graph, asset_id) do
+      {:ok, asset_inspector(graph, asset)}
+    end
+  end
+
+  @doc """
+  Returns the inspector payload for one lineage dependency edge.
+  """
+  @spec get_edge(String.t(), keyword()) :: {:ok, EdgeInspector.t()} | {:error, error()}
+  def get_edge(edge_id, opts \\ []) when is_binary(edge_id) and is_list(opts) do
+    with {:ok, graph} <- get_graph(Keyword.put(opts, :selected_id, edge_id)),
+         {:ok, edge} <- fetch_edge(graph, edge_id) do
+      {:ok, edge_inspector(graph, edge)}
+    end
+  end
+
+  @doc """
+  Searches visible lineage groups, schemas, and asset labels with bounded pages.
+  """
+  @spec search(String.t(), keyword()) :: {:ok, Page.t(SearchResult.t())} | {:error, error()}
+  def search(query, opts \\ []) when is_binary(query) and is_list(opts) do
+    with {:ok, graph} <- get_graph(opts),
+         {:ok, page_opts} <- Page.normalize_opts(page_opts(opts, graph.limits.search_page_size)) do
+      normalized = normalize_query(query)
+
+      results =
+        graph
+        |> search_results()
+        |> Enum.filter(&search_match?(&1, normalized))
+        |> Enum.sort_by(&{result_rank(&1.kind), String.downcase(&1.label), &1.id})
+        |> Enum.drop(Keyword.fetch!(page_opts, :offset))
+
+      {:ok, Page.from_fetched(results, page_opts)}
+    else
+      {:error, :invalid_pagination} -> {:error, normalize_error(:invalid_pagination)}
+      {:error, %Error{} = error} -> {:error, error}
+      {:error, reason} -> {:error, normalize_error(reason)}
+    end
+  end
+
+  @doc """
+  Lists assets belonging to a lineage group with bounded offset pagination.
+  """
+  @spec list_group_assets(String.t(), keyword()) ::
+          {:ok, Page.t(AssetNode.t())} | {:error, error()}
+  def list_group_assets(group_id, opts \\ []) when is_binary(group_id) and is_list(opts) do
+    with {:ok, graph} <- get_graph(opts),
+         {:ok, group} <- fetch_group(graph, group_id),
+         {:ok, page_opts} <-
+           Page.normalize_opts(page_opts(opts, graph.limits.group_asset_page_size)) do
+      assets =
+        group.preview_assets
+        |> Enum.sort_by(
+          &{Map.fetch!(@status_priority, &1.freshness_status), String.downcase(&1.label), &1.id}
+        )
+        |> Enum.drop(Keyword.fetch!(page_opts, :offset))
+
+      {:ok, Page.from_fetched(assets, page_opts)}
+    else
+      {:error, :invalid_pagination} -> {:error, normalize_error(:invalid_pagination)}
+      {:error, %Error{} = error} -> {:error, error}
+      {:error, reason} -> {:error, normalize_error(reason)}
+    end
+  end
+
+  defp normalize_graph_opts(opts) do
+    with {:ok, scope} <-
+           normalize_enum(Keyword.get(opts, :scope, :global), @scope_values, :invalid_scope),
+         {:ok, view_mode} <-
+           normalize_enum(Keyword.get(opts, :view_mode, :all), @view_modes, :invalid_view_mode) do
+      limit_opts = Keyword.get(opts, :limit, [])
+      graph_limit_opts = if Keyword.keyword?(limit_opts), do: limit_opts, else: []
+      limits = normalize_limits(graph_limit_opts, Keyword.get(opts, :timeout_ms))
+
+      {:ok,
+       %{
+         manifest_version_id: Keyword.get(opts, :manifest_version_id, :active),
+         scope: scope,
+         selected_id: Keyword.get(opts, :selected_id),
+         view_mode: view_mode,
+         filters: Keyword.get(opts, :filters, %{}),
+         expanded_group_ids: MapSet.new(List.wrap(Keyword.get(opts, :expanded_group_ids, []))),
+         limits: limits
+       }}
+    else
+      {:error, :invalid_scope} ->
+        {:error, %Error{code: :invalid_scope, message: "Invalid lineage scope."}}
+
+      {:error, :invalid_view_mode} ->
+        {:error, %Error{code: :invalid_scope, message: "Invalid lineage view mode."}}
+    end
+  end
+
+  defp normalize_enum(value, allowed, error) when is_atom(value) do
+    if value in allowed, do: {:ok, value}, else: {:error, error}
+  end
+
+  defp normalize_enum(value, allowed, error) when is_binary(value) do
+    atom = String.to_existing_atom(value)
+    normalize_enum(atom, allowed, error)
+  rescue
+    ArgumentError -> {:error, error}
+  end
+
+  defp normalize_enum(_value, _allowed, error), do: {:error, error}
+
+  defp normalize_limits(limit_opts, timeout_ms) do
+    base = %Limits{}
+
+    base
+    |> maybe_put_limit(:max_visible_groups, limit_opts, 40, 80)
+    |> maybe_put_limit(:max_preview_assets_per_group, limit_opts, 4, 10)
+    |> maybe_put_limit(:max_visible_asset_nodes, limit_opts, 160, 300)
+    |> maybe_put_limit(:max_visible_edges, limit_opts, 300, 600)
+    |> maybe_put_limit(:max_dependency_previews_per_edge, limit_opts, 5, 20)
+    |> maybe_put_limit(:group_asset_page_size, limit_opts, 50, 100)
+    |> maybe_put_limit(:search_page_size, limit_opts, 20, 50)
+    |> Map.put(
+      :timeout_ms,
+      clamp_integer(timeout_ms || Keyword.get(limit_opts, :timeout_ms, 250), 1, 1_000, 250)
+    )
+  end
+
+  defp maybe_put_limit(%Limits{} = limits, key, opts, default, max) do
+    Map.put(limits, key, clamp_integer(Keyword.get(opts, key, default), 1, max, default))
+  end
+
+  defp clamp_integer(value, min, max, _default) when is_integer(value),
+    do: value |> max(min) |> min(max)
+
+  defp clamp_integer(_value, _min, _max, default), do: default
+
+  defp fetch_version(:active) do
+    with {:ok, manifest_version_id} <- FavnOrchestrator.active_manifest() do
+      fetch_version(manifest_version_id)
+    else
+      {:error, _reason} ->
+        {:error,
+         %Error{
+           code: :active_manifest_not_found,
+           message: "No active manifest is available.",
+           retryable?: true
+         }}
+    end
+  end
+
+  defp fetch_version(manifest_version_id) when is_binary(manifest_version_id) do
+    case FavnOrchestrator.get_manifest(manifest_version_id) do
+      {:ok, %Version{} = version} ->
+        {:ok, version}
+
+      {:error, :not_found} ->
+        {:error, %Error{code: :manifest_not_found, message: "Manifest version was not found."}}
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  defp fetch_version(_value),
+    do: {:error, %Error{code: :manifest_not_found, message: "Manifest version was not found."}}
+
+  defp target_statuses(manifest_version_id, targets) do
+    target_ids = Enum.map(targets, & &1.target_id)
+
+    with {:ok, statuses} <- Storage.list_target_statuses(manifest_version_id, :asset, target_ids) do
+      {:ok,
+       Map.new(targets, fn target ->
+         status =
+           Map.get(statuses, target.target_id) ||
+             TargetStatus.unknown(
+               manifest_version_id,
+               :asset,
+               target.target_id,
+               target.asset_ref_text
+             )
+
+         {target.target_id, status}
+       end)}
+    end
+  end
+
+  defp build_graph(%Version{} = version, %Index{} = index, assets, targets, statuses, request) do
+    target_by_ref = Map.new(targets, &{&1.ref, &1})
+    status_by_ref = Map.new(targets, &{&1.ref, Map.fetch!(statuses, &1.target_id)})
+    group_contexts = build_group_contexts(assets, target_by_ref, status_by_ref, request)
+    {groups, asset_nodes_by_id, group_by_ref} = build_group_nodes(group_contexts, request)
+    edges = build_edges(version, index, group_by_ref, asset_nodes_by_id, request)
+    visible_groups = Enum.take(groups, request.limits.max_visible_groups)
+    visible_ids = MapSet.new(Enum.map(visible_groups, & &1.id))
+
+    visible_edges =
+      edges
+      |> Enum.filter(&(&1.from in visible_ids and &1.to in visible_ids))
+      |> Enum.take(request.limits.max_visible_edges)
+
+    %Graph{
+      manifest_version_id: version.manifest_version_id,
+      scope: request.scope,
+      selected_id: request.selected_id,
+      view_mode: request.view_mode,
+      nodes: visible_groups,
+      groups: visible_groups,
+      edges: visible_edges,
+      summary:
+        summary(length(assets), length(groups), length(edges), visible_groups, visible_edges),
+      limits: request.limits,
+      layout: %{direction: :left_to_right, layers: @layers},
+      generated_at: DateTime.utc_now()
+    }
+  end
+
+  defp build_group_contexts(assets, target_by_ref, status_by_ref, request) do
+    assets
+    |> Enum.group_by(&group_key/1)
+    |> Enum.map(fn {key, grouped_assets} ->
+      asset_nodes =
+        Enum.map(
+          grouped_assets,
+          &asset_node(
+            &1,
+            Map.fetch!(target_by_ref, &1.ref),
+            Map.fetch!(status_by_ref, &1.ref),
+            key,
+            request
+          )
+        )
+
+      %{key: key, assets: grouped_assets, asset_nodes: asset_nodes}
+    end)
+    |> Enum.sort_by(fn %{key: key, asset_nodes: asset_nodes} ->
+      {layer_rank(key.layer), String.downcase(key.label), length(asset_nodes)}
+    end)
+  end
+
+  defp build_group_nodes(group_contexts, request) do
+    ranked =
+      group_contexts
+      |> Enum.group_by(& &1.key.layer)
+      |> Enum.flat_map(fn {_layer, contexts} ->
+        contexts
+        |> Enum.with_index()
+        |> Enum.map(fn {context, rank} -> Map.put(context, :rank, rank) end)
+      end)
+
+    Enum.reduce(ranked, {[], %{}, %{}}, fn context, {groups, asset_nodes_by_id, group_by_ref} ->
+      asset_nodes = sort_asset_nodes(context.asset_nodes)
+      preview = Enum.take(asset_nodes, request.limits.max_preview_assets_per_group)
+      state = group_state(context.key.id, request, context.key.layer)
+
+      group = %GroupNode{
+        id: context.key.id,
+        label: context.key.label,
+        system: context.key.system,
+        schema: context.key.schema,
+        layer: context.key.layer,
+        type: context.key.type,
+        state: state,
+        asset_count: length(asset_nodes),
+        preview_asset_ids: Enum.map(preview, & &1.id),
+        preview_assets: preview,
+        hidden_asset_count: max(length(asset_nodes) - length(preview), 0),
+        status_counts: status_counts(asset_nodes),
+        top_issues: top_issues(asset_nodes),
+        position_hint: %{layer: context.key.layer, rank: context.rank},
+        selected?: request.selected_id == context.key.id
+      }
+
+      next_asset_nodes = Map.merge(asset_nodes_by_id, Map.new(asset_nodes, &{&1.id, &1}))
+
+      next_group_by_ref =
+        Enum.reduce(context.assets, group_by_ref, &Map.put(&2, &1.ref, group.id))
+
+      {[group | groups], next_asset_nodes, next_group_by_ref}
+    end)
+    |> then(fn {groups, asset_nodes_by_id, group_by_ref} ->
+      {Enum.sort_by(
+         groups,
+         &{layer_rank(&1.layer), &1.position_hint.rank, String.downcase(&1.label)}
+       ), asset_nodes_by_id, group_by_ref}
+    end)
+  end
+
+  defp build_edges(
+         %Version{} = version,
+         %Index{} = index,
+         group_by_ref,
+         asset_nodes_by_id,
+         request
+       ) do
+    raw_edges =
+      case version.manifest.graph.edges do
+        [] -> edges_from_assets(List.wrap(version.manifest.assets))
+        edges -> edges
+      end
+
+    raw_edges
+    |> Enum.reduce(%{}, fn %{from: from, to: to}, acc ->
+      from_group = Map.get(group_by_ref, from)
+      to_group = Map.get(group_by_ref, to)
+
+      if is_nil(from_group) or is_nil(to_group) or from_group == to_group do
+        acc
+      else
+        key = {from_group, to_group}
+        from_asset = Map.get(asset_nodes_by_id, TargetStatus.target_id_for_asset(from))
+        to_asset = Map.get(asset_nodes_by_id, TargetStatus.target_id_for_asset(to))
+        dep = %{from: asset_label(index, from_asset, from), to: asset_label(index, to_asset, to)}
+
+        Map.update(acc, key, [dep], &[dep | &1])
+      end
+    end)
+    |> Enum.map(fn {{from, to}, deps} -> edge(from, to, deps, request) end)
+    |> Enum.sort_by(&{&1.from, &1.to})
+  end
+
+  defp edges_from_assets(assets) do
+    Enum.flat_map(assets, fn asset ->
+      Enum.map(List.wrap(asset.depends_on), &%{from: &1, to: asset.ref})
+    end)
+  end
+
+  defp edge(from, to, deps, request) do
+    deps = Enum.sort_by(deps, &{&1.from, &1.to})
+    preview = Enum.take(deps, request.limits.max_dependency_previews_per_edge)
+
+    %Edge{
+      id: "edge:#{from}->#{to}",
+      from: from,
+      to: to,
+      dependency_count: length(deps),
+      aggregated?: length(deps) > 1,
+      preview_dependencies: preview,
+      hidden_dependency_count: max(length(deps) - length(preview), 0),
+      selected?: request.selected_id == "edge:#{from}->#{to}"
+    }
+  end
+
+  defp asset_target(%Asset{} = asset) do
+    %{
+      ref: asset.ref,
+      target_id: TargetStatus.target_id_for_asset(asset.ref),
+      asset_ref_text: TargetStatus.ref_text(asset.ref)
+    }
+  end
+
+  defp asset_node(%Asset{} = asset, target, status, group_key, request) do
+    %AssetNode{
+      id: target.target_id,
+      label: asset_label(asset),
+      asset_ref: asset.ref,
+      asset_ref_text: target.asset_ref_text,
+      group_id: group_key.id,
+      schema: group_key.schema,
+      layer: group_key.layer,
+      kind: asset.type || :asset,
+      freshness_status: product_status(status),
+      run_status: status.latest_run_status,
+      latest_run_id: status.latest_run_id,
+      selected?: request.selected_id == target.target_id,
+      position_hint: %{layer: group_key.layer}
+    }
+  end
+
+  defp group_key(%Asset{} = asset) do
+    relation = relation_ref(asset.relation)
+    metadata = normalize_map(asset.metadata)
+    layer = lineage_layer(asset, relation, metadata)
+
+    system =
+      first_text([
+        metadata[:system],
+        metadata["system"],
+        relation && relation.connection,
+        relation && relation.catalog
+      ])
+
+    schema =
+      first_text([
+        metadata[:schema],
+        metadata["schema"],
+        relation && relation.schema,
+        layer_schema(layer)
+      ])
+
+    label = group_label(layer, system, schema, asset)
+    id = "group:#{layer}:#{slug(system || schema || label)}"
+
+    %{id: id, label: label, system: system, schema: schema, layer: layer, type: group_type(layer)}
+  end
+
+  defp group_state(group_id, request, layer) do
+    cond do
+      MapSet.member?(request.expanded_group_ids, group_id) -> :expanded_full
+      request.selected_id == group_id -> :expanded_preview
+      layer in [:raw, :staging] -> :expanded_preview
+      true -> :collapsed
+    end
+  end
+
+  defp relation_ref(nil), do: nil
+
+  defp relation_ref(relation) do
+    RelationRef.new!(relation)
+  rescue
+    ArgumentError -> nil
+  end
+
+  defp lineage_layer(%Asset{} = asset, relation, metadata) do
+    explicit =
+      first_text([
+        metadata[:lineage_layer],
+        metadata["lineage_layer"],
+        metadata[:layer],
+        metadata["layer"]
+      ])
+
+    text =
+      Enum.join(
+        [
+          explicit,
+          relation && relation.catalog,
+          relation && relation.schema,
+          relation && relation.name,
+          Atom.to_string(asset.name || :asset)
+        ],
+        ":"
+      )
+
+    normalized = String.downcase(text)
+
+    cond do
+      String.contains?(normalized, "dashboard") or String.contains?(normalized, "report") ->
+        :dashboards
+
+      String.contains?(normalized, "mart") or String.contains?(normalized, "marts") ->
+        :marts
+
+      String.contains?(normalized, "staging") or String.contains?(normalized, "stg") ->
+        :staging
+
+      String.contains?(normalized, "raw") or asset.type == :source ->
+        :raw
+
+      true ->
+        :core
+    end
+  end
+
+  defp layer_schema(:raw), do: "raw"
+  defp layer_schema(:staging), do: "staging"
+  defp layer_schema(:marts), do: "marts"
+  defp layer_schema(:dashboards), do: "dashboards"
+  defp layer_schema(:core), do: "core"
+
+  defp group_type(:raw), do: :source_system
+  defp group_type(:dashboards), do: :dashboard
+  defp group_type(:core), do: :domain
+  defp group_type(_layer), do: :schema
+
+  defp group_label(:raw, system, _schema, _asset) when is_binary(system),
+    do: "#{titleize(system)} raw"
+
+  defp group_label(:staging, system, _schema, _asset) when is_binary(system),
+    do: "staging.#{slug(system)}"
+
+  defp group_label(:marts, _system, schema, _asset) when is_binary(schema),
+    do: "marts · #{schema}"
+
+  defp group_label(:dashboards, _system, schema, _asset) when is_binary(schema),
+    do: "#{titleize(schema)} dashboards"
+
+  defp group_label(layer, _system, schema, _asset) when is_binary(schema),
+    do: "#{layer} · #{schema}"
+
+  defp group_label(layer, _system, _schema, asset), do: "#{layer} · #{asset_label(asset)}"
+
+  defp asset_label(%Asset{relation: relation} = asset) do
+    case relation_ref(relation) do
+      %RelationRef{name: name} when is_binary(name) -> name
+      _ -> asset.name |> Atom.to_string()
+    end
+  end
+
+  defp asset_label(_index, %AssetNode{label: label}, _ref), do: label
+  defp asset_label(_index, _node, {_module, name}), do: Atom.to_string(name)
+
+  defp product_status(%TargetStatus{status: :running}), do: :running
+  defp product_status(%TargetStatus{status: :failed}), do: :failed
+  defp product_status(%TargetStatus{status: :unknown}), do: :unknown
+
+  defp product_status(%TargetStatus{freshness_status: status})
+       when status in [:stale, :expired, :blocked], do: :stale
+
+  defp product_status(%TargetStatus{status: :healthy}), do: :fresh
+
+  defp sort_asset_nodes(asset_nodes) do
+    Enum.sort_by(
+      asset_nodes,
+      &{Map.fetch!(@status_priority, &1.freshness_status), String.downcase(&1.label), &1.id}
+    )
+  end
+
+  defp status_counts(asset_nodes) do
+    Enum.reduce(asset_nodes, empty_status_counts(), fn asset, acc ->
+      Map.update!(acc, asset.freshness_status, &(&1 + 1))
+    end)
+  end
+
+  defp empty_status_counts, do: Map.new(@status_keys, &{&1, 0})
+
+  defp top_issues(asset_nodes) do
+    counts = status_counts(asset_nodes)
+
+    [
+      issue(:failed, "Failed", counts.failed),
+      issue(:stale, "Stale", counts.stale),
+      issue(:running, "Running", counts.running)
+    ]
+    |> Enum.reject(&(&1.count == 0))
+  end
+
+  defp issue(kind, label, count), do: %{kind: kind, label: label, count: count}
+
+  defp summary(total_assets, total_groups, total_edges, visible_groups, visible_edges) do
+    visible_status_counts =
+      Enum.reduce(
+        visible_groups,
+        empty_status_counts(),
+        &merge_status_counts(&2, &1.status_counts)
+      )
+
+    visible_asset_count = Enum.reduce(visible_groups, 0, &(&1.asset_count + &2))
+
+    %Summary{
+      total_assets: total_assets,
+      visible_assets: visible_asset_count,
+      total_groups: total_groups,
+      visible_groups: length(visible_groups),
+      total_edges: total_edges,
+      visible_edges: length(visible_edges),
+      status_counts: visible_status_counts,
+      truncated?: total_groups > length(visible_groups) or total_edges > length(visible_edges)
+    }
+  end
+
+  defp merge_status_counts(left, right) do
+    Map.new(@status_keys, &{&1, Map.get(left, &1, 0) + Map.get(right, &1, 0)})
+  end
+
+  defp fetch_group(%Graph{} = graph, group_id) do
+    case Enum.find(graph.groups, &(&1.id == group_id)) do
+      %GroupNode{} = group -> {:ok, group}
+      nil -> {:error, %Error{code: :node_not_found, message: "Lineage group was not found."}}
+    end
+  end
+
+  defp fetch_asset_node(%Graph{} = graph, asset_id) do
+    graph.groups
+    |> Enum.flat_map(& &1.preview_assets)
+    |> Enum.find(&(&1.id == asset_id))
+    |> case do
+      %AssetNode{} = asset -> {:ok, asset}
+      nil -> {:error, %Error{code: :node_not_found, message: "Lineage asset was not found."}}
+    end
+  end
+
+  defp fetch_edge(%Graph{} = graph, edge_id) do
+    case Enum.find(graph.edges, &(&1.id == edge_id)) do
+      %Edge{} = edge -> {:ok, edge}
+      nil -> {:error, %Error{code: :node_not_found, message: "Lineage edge was not found."}}
+    end
+  end
+
+  defp group_inspector(%Graph{} = graph, %GroupNode{} = group) do
+    %GroupInspector{
+      id: group.id,
+      title: group.label,
+      group: group,
+      about: %{
+        system: group.system,
+        schema: group.schema,
+        type: group.type,
+        asset_count: group.asset_count
+      },
+      health_summary: group.status_counts,
+      top_issues: group.top_issues,
+      upstream: adjacent_groups(graph, group.id, :upstream),
+      downstream: adjacent_groups(graph, group.id, :downstream),
+      actions: [
+        %{label: "Drill into group", kind: :drill_in},
+        %{label: "View all assets", kind: :assets}
+      ]
+    }
+  end
+
+  defp asset_inspector(%Graph{} = graph, %AssetNode{} = asset) do
+    %AssetInspector{
+      id: asset.id,
+      title: asset.label,
+      asset: asset,
+      latest_run: latest_run(asset),
+      upstream: adjacent_groups(graph, asset.group_id, :upstream),
+      downstream: adjacent_groups(graph, asset.group_id, :downstream),
+      actions: [%{label: "Open asset", kind: :asset}, %{label: "Explain lineage", kind: :explain}]
+    }
+  end
+
+  defp edge_inspector(%Graph{} = graph, %Edge{} = edge) do
+    %EdgeInspector{
+      id: edge.id,
+      title: "#{edge.dependency_count} dependencies",
+      edge: edge,
+      upstream_label: graph_label(graph, edge.from),
+      downstream_label: graph_label(graph, edge.to),
+      dependencies: edge.preview_dependencies,
+      affected_statuses: %{},
+      actions: [%{label: "View dependency list", kind: :dependencies}]
+    }
+  end
+
+  defp latest_run(%AssetNode{latest_run_id: nil}), do: nil
+  defp latest_run(%AssetNode{} = asset), do: %{id: asset.latest_run_id, status: asset.run_status}
+
+  defp adjacent_groups(graph, group_id, direction) do
+    graph.edges
+    |> Enum.filter(fn edge ->
+      case direction do
+        :upstream -> edge.to == group_id
+        :downstream -> edge.from == group_id
+      end
+    end)
+    |> Enum.map(fn edge ->
+      related_id = if direction == :upstream, do: edge.from, else: edge.to
+
+      %{
+        id: related_id,
+        label: graph_label(graph, related_id),
+        dependency_count: edge.dependency_count
+      }
+    end)
+  end
+
+  defp graph_label(%Graph{} = graph, id) do
+    graph.groups
+    |> Enum.find(&(&1.id == id))
+    |> case do
+      %GroupNode{label: label} -> label
+      _ -> id
+    end
+  end
+
+  defp search_results(%Graph{} = graph) do
+    group_results =
+      Enum.map(graph.groups, fn group ->
+        %SearchResult{
+          id: group.id,
+          kind: :group,
+          label: group.label,
+          subtitle: group.schema,
+          status: dominant_status(group.status_counts)
+        }
+      end)
+
+    asset_results =
+      graph.groups
+      |> Enum.flat_map(& &1.preview_assets)
+      |> Enum.map(fn asset ->
+        %SearchResult{
+          id: asset.id,
+          kind: :asset,
+          label: asset.label,
+          subtitle: asset.asset_ref_text,
+          status: asset.freshness_status
+        }
+      end)
+
+    schema_results =
+      graph.groups
+      |> Enum.map(& &1.schema)
+      |> Enum.reject(&is_nil/1)
+      |> Enum.uniq()
+      |> Enum.map(&%SearchResult{id: "schema:#{slug(&1)}", kind: :schema, label: &1})
+
+    group_results ++ asset_results ++ schema_results
+  end
+
+  defp dominant_status(%{failed: failed}) when failed > 0, do: :failed
+  defp dominant_status(%{stale: stale}) when stale > 0, do: :stale
+  defp dominant_status(%{running: running}) when running > 0, do: :running
+  defp dominant_status(%{unknown: unknown}) when unknown > 0, do: :unknown
+  defp dominant_status(_counts), do: :fresh
+
+  defp search_match?(_result, ""), do: true
+
+  defp search_match?(result, query),
+    do:
+      String.contains?(
+        normalize_query(result.label <> " " <> to_string(result.subtitle || "")),
+        query
+      )
+
+  defp result_rank(:group), do: 0
+  defp result_rank(:asset), do: 1
+  defp result_rank(:schema), do: 2
+
+  defp page_opts(opts, default_limit) do
+    [limit: Keyword.get(opts, :limit, default_limit), offset: Keyword.get(opts, :offset, 0)]
+  end
+
+  defp normalize_error(%Error{} = error), do: error
+
+  defp normalize_error(:invalid_pagination),
+    do: %Error{code: :invalid_scope, message: "Invalid lineage pagination."}
+
+  defp normalize_error({:storage_failed, reason}),
+    do: %Error{
+      code: :storage_unavailable,
+      message: "Lineage storage is unavailable.",
+      retryable?: true,
+      details: %{reason: inspect(reason)}
+    }
+
+  defp normalize_error(reason),
+    do: %Error{
+      code: :lineage_projection_unavailable,
+      message: "Lineage projection is unavailable.",
+      retryable?: true,
+      details: %{reason: inspect(reason)}
+    }
+
+  defp normalize_map(value) when is_map(value), do: value
+  defp normalize_map(_value), do: %{}
+
+  defp first_text(values) do
+    values
+    |> Enum.find_value(fn
+      value when is_atom(value) and not is_nil(value) -> Atom.to_string(value)
+      value when is_binary(value) and value != "" -> value
+      value -> if(is_nil(value), do: nil, else: to_string(value))
+    end)
+  end
+
+  defp layer_rank(layer), do: Enum.find_index(@layers, &(&1 == layer)) || length(@layers)
+
+  defp titleize(value) when is_binary(value) do
+    value
+    |> String.replace(["_", "-"], " ")
+    |> String.split(" ", trim: true)
+    |> Enum.map_join(" ", &String.capitalize/1)
+  end
+
+  defp slug(value) when is_binary(value) do
+    value
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "_")
+    |> String.trim("_")
+  end
+
+  defp normalize_query(value) do
+    value
+    |> String.downcase()
+    |> String.trim()
+  end
+end

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage.ex
@@ -28,8 +28,8 @@ defmodule FavnOrchestrator.Operator.Lineage do
   alias FavnOrchestrator.TargetStatus
 
   @layers [:raw, :staging, :core, :marts, :dashboards]
-  @scope_values [:global, :asset, :group]
-  @view_modes [:all, :upstream, :downstream, :impact, :freshness]
+  @scope_values [:global]
+  @view_modes [:all]
   @status_keys [:fresh, :stale, :failed, :running, :unknown]
   @status_priority %{failed: 0, stale: 1, running: 2, unknown: 3, fresh: 4}
 
@@ -51,14 +51,8 @@ defmodule FavnOrchestrator.Operator.Lineage do
   """
   @spec get_graph(graph_opts()) :: {:ok, Graph.t()} | {:error, error()}
   def get_graph(opts \\ []) when is_list(opts) do
-    with {:ok, request} <- normalize_graph_opts(opts),
-         {:ok, version} <- fetch_version(request.manifest_version_id),
-         {:ok, index} <- Index.build_from_version(version),
-         assets <- List.wrap(version.manifest.assets),
-         targets <- Enum.map(assets, &asset_target/1),
-         {:ok, statuses} <- target_statuses(version.manifest_version_id, targets) do
-      graph = build_graph(version, index, assets, targets, statuses, request)
-      {:ok, graph}
+    with {:ok, model} <- read_model(opts) do
+      {:ok, model.graph}
     else
       {:error, %Error{} = error} -> {:error, error}
       {:error, reason} -> {:error, normalize_error(reason)}
@@ -70,9 +64,9 @@ defmodule FavnOrchestrator.Operator.Lineage do
   """
   @spec get_group(String.t(), keyword()) :: {:ok, GroupInspector.t()} | {:error, error()}
   def get_group(group_id, opts \\ []) when is_binary(group_id) and is_list(opts) do
-    with {:ok, graph} <- get_graph(Keyword.put(opts, :selected_id, group_id)),
-         {:ok, group} <- fetch_group(graph, group_id) do
-      {:ok, group_inspector(graph, group)}
+    with {:ok, model} <- read_model(Keyword.put(opts, :selected_id, group_id)),
+         {:ok, group} <- fetch_group(model.groups, group_id) do
+      {:ok, group_inspector(model_graph(model), group)}
     end
   end
 
@@ -81,9 +75,9 @@ defmodule FavnOrchestrator.Operator.Lineage do
   """
   @spec get_asset(String.t(), keyword()) :: {:ok, AssetInspector.t()} | {:error, error()}
   def get_asset(asset_id, opts \\ []) when is_binary(asset_id) and is_list(opts) do
-    with {:ok, graph} <- get_graph(Keyword.put(opts, :selected_id, asset_id)),
-         {:ok, asset} <- fetch_asset_node(graph, asset_id) do
-      {:ok, asset_inspector(graph, asset)}
+    with {:ok, model} <- read_model(Keyword.put(opts, :selected_id, asset_id)),
+         {:ok, asset} <- fetch_asset_node(model.asset_nodes_by_id, asset_id) do
+      {:ok, asset_inspector(model_graph(model), asset)}
     end
   end
 
@@ -92,9 +86,9 @@ defmodule FavnOrchestrator.Operator.Lineage do
   """
   @spec get_edge(String.t(), keyword()) :: {:ok, EdgeInspector.t()} | {:error, error()}
   def get_edge(edge_id, opts \\ []) when is_binary(edge_id) and is_list(opts) do
-    with {:ok, graph} <- get_graph(Keyword.put(opts, :selected_id, edge_id)),
-         {:ok, edge} <- fetch_edge(graph, edge_id) do
-      {:ok, edge_inspector(graph, edge)}
+    with {:ok, model} <- read_model(Keyword.put(opts, :selected_id, edge_id)),
+         {:ok, edge} <- fetch_edge(model.edges, edge_id) do
+      {:ok, edge_inspector(model_graph(model), edge)}
     end
   end
 
@@ -103,12 +97,13 @@ defmodule FavnOrchestrator.Operator.Lineage do
   """
   @spec search(String.t(), keyword()) :: {:ok, Page.t(SearchResult.t())} | {:error, error()}
   def search(query, opts \\ []) when is_binary(query) and is_list(opts) do
-    with {:ok, graph} <- get_graph(opts),
-         {:ok, page_opts} <- Page.normalize_opts(page_opts(opts, graph.limits.search_page_size)) do
+    with {:ok, model} <- read_model(opts),
+         {:ok, page_opts} <-
+           Page.normalize_opts(page_opts(opts, model.graph.limits.search_page_size)) do
       normalized = normalize_query(query)
 
       results =
-        graph
+        model
         |> search_results()
         |> Enum.filter(&search_match?(&1, normalized))
         |> Enum.sort_by(&{result_rank(&1.kind), String.downcase(&1.label), &1.id})
@@ -128,12 +123,12 @@ defmodule FavnOrchestrator.Operator.Lineage do
   @spec list_group_assets(String.t(), keyword()) ::
           {:ok, Page.t(AssetNode.t())} | {:error, error()}
   def list_group_assets(group_id, opts \\ []) when is_binary(group_id) and is_list(opts) do
-    with {:ok, graph} <- get_graph(opts),
-         {:ok, group} <- fetch_group(graph, group_id),
+    with {:ok, model} <- read_model(opts),
+         {:ok, _group} <- fetch_group(model.groups, group_id),
          {:ok, page_opts} <-
-           Page.normalize_opts(page_opts(opts, graph.limits.group_asset_page_size)) do
+           Page.normalize_opts(page_opts(opts, model.graph.limits.group_asset_page_size)) do
       assets =
-        group.preview_assets
+        Map.get(model.group_assets_by_id, group_id, [])
         |> Enum.sort_by(
           &{Map.fetch!(@status_priority, &1.freshness_status), String.downcase(&1.label), &1.id}
         )
@@ -147,11 +142,28 @@ defmodule FavnOrchestrator.Operator.Lineage do
     end
   end
 
+  defp read_model(opts) do
+    started_at = System.monotonic_time(:millisecond)
+
+    with {:ok, request} <- normalize_graph_opts(opts),
+         :ok <- check_timeout(started_at, request.limits.timeout_ms),
+         {:ok, version} <- fetch_version(request.manifest_version_id),
+         :ok <- check_timeout(started_at, request.limits.timeout_ms),
+         {:ok, index} <- Index.build_from_version(version),
+         assets <- List.wrap(version.manifest.assets),
+         targets <- Enum.map(assets, &asset_target/1),
+         {:ok, statuses} <- target_statuses(version.manifest_version_id, targets),
+         :ok <- check_timeout(started_at, request.limits.timeout_ms) do
+      {:ok, build_model(version, index, assets, targets, statuses, request)}
+    end
+  end
+
   defp normalize_graph_opts(opts) do
     with {:ok, scope} <-
            normalize_enum(Keyword.get(opts, :scope, :global), @scope_values, :invalid_scope),
          {:ok, view_mode} <-
-           normalize_enum(Keyword.get(opts, :view_mode, :all), @view_modes, :invalid_view_mode) do
+           normalize_enum(Keyword.get(opts, :view_mode, :all), @view_modes, :invalid_view_mode),
+         :ok <- validate_filters(Keyword.get(opts, :filters, %{})) do
       limit_opts = Keyword.get(opts, :limit, [])
       graph_limit_opts = if Keyword.keyword?(limit_opts), do: limit_opts, else: []
       limits = normalize_limits(graph_limit_opts, Keyword.get(opts, :timeout_ms))
@@ -172,6 +184,23 @@ defmodule FavnOrchestrator.Operator.Lineage do
 
       {:error, :invalid_view_mode} ->
         {:error, %Error{code: :invalid_scope, message: "Invalid lineage view mode."}}
+
+      {:error, :unsupported_filters} ->
+        {:error, %Error{code: :invalid_scope, message: "Lineage filters are not supported yet."}}
+    end
+  end
+
+  defp validate_filters(filters) when filters in [%{}, nil], do: :ok
+  defp validate_filters(_filters), do: {:error, :unsupported_filters}
+
+  defp check_timeout(started_at, timeout_ms) do
+    elapsed_ms = System.monotonic_time(:millisecond) - started_at
+
+    if elapsed_ms > timeout_ms do
+      {:error,
+       %Error{code: :query_timeout, message: "Lineage query timed out.", retryable?: true}}
+    else
+      :ok
     end
   end
 
@@ -264,12 +293,19 @@ defmodule FavnOrchestrator.Operator.Lineage do
     end
   end
 
-  defp build_graph(%Version{} = version, %Index{} = index, assets, targets, statuses, request) do
+  defp build_model(%Version{} = version, %Index{} = index, assets, targets, statuses, request) do
     target_by_ref = Map.new(targets, &{&1.ref, &1})
     status_by_ref = Map.new(targets, &{&1.ref, Map.fetch!(statuses, &1.target_id)})
     group_contexts = build_group_contexts(assets, target_by_ref, status_by_ref, request)
     {groups, asset_nodes_by_id, group_by_ref} = build_group_nodes(group_contexts, request)
     edges = build_edges(version, index, group_by_ref, asset_nodes_by_id, request)
+
+    group_assets_by_id =
+      asset_nodes_by_id
+      |> Map.values()
+      |> Enum.group_by(& &1.group_id, & &1)
+      |> Map.new(fn {group_id, assets} -> {group_id, sort_asset_nodes(assets)} end)
+
     visible_groups = Enum.take(groups, request.limits.max_visible_groups)
     visible_ids = MapSet.new(Enum.map(visible_groups, & &1.id))
 
@@ -278,7 +314,7 @@ defmodule FavnOrchestrator.Operator.Lineage do
       |> Enum.filter(&(&1.from in visible_ids and &1.to in visible_ids))
       |> Enum.take(request.limits.max_visible_edges)
 
-    %Graph{
+    graph = %Graph{
       manifest_version_id: version.manifest_version_id,
       scope: request.scope,
       selected_id: request.selected_id,
@@ -292,7 +328,18 @@ defmodule FavnOrchestrator.Operator.Lineage do
       layout: %{direction: :left_to_right, layers: @layers},
       generated_at: DateTime.utc_now()
     }
+
+    %{
+      graph: graph,
+      groups: groups,
+      edges: edges,
+      asset_nodes_by_id: asset_nodes_by_id,
+      group_assets_by_id: group_assets_by_id
+    }
   end
+
+  defp model_graph(model),
+    do: %{model.graph | groups: model.groups, nodes: model.groups, edges: model.edges}
 
   defp build_group_contexts(assets, target_by_ref, status_by_ref, request) do
     assets
@@ -468,10 +515,21 @@ defmodule FavnOrchestrator.Operator.Lineage do
       ])
 
     label = group_label(layer, system, schema, asset)
-    id = "group:#{layer}:#{slug(system || schema || label)}"
+    id = group_id(layer, system, schema, label)
 
     %{id: id, label: label, system: system, schema: schema, layer: layer, type: group_type(layer)}
   end
+
+  defp group_id(:raw, system, _schema, label), do: "group:raw:#{slug(system || label)}"
+
+  defp group_id(:staging, system, schema, label),
+    do: "group:staging:#{slug(system || label)}:#{slug(schema || label)}"
+
+  defp group_id(layer, _system, schema, label) when layer in [:core, :marts, :dashboards],
+    do: "group:#{layer}:#{slug(schema || label)}"
+
+  defp group_id(layer, system, schema, label),
+    do: "group:#{layer}:#{slug(system || schema || label)}"
 
   defp group_state(group_id, request, layer) do
     cond do
@@ -632,25 +690,22 @@ defmodule FavnOrchestrator.Operator.Lineage do
     Map.new(@status_keys, &{&1, Map.get(left, &1, 0) + Map.get(right, &1, 0)})
   end
 
-  defp fetch_group(%Graph{} = graph, group_id) do
-    case Enum.find(graph.groups, &(&1.id == group_id)) do
+  defp fetch_group(groups, group_id) when is_list(groups) do
+    case Enum.find(groups, &(&1.id == group_id)) do
       %GroupNode{} = group -> {:ok, group}
       nil -> {:error, %Error{code: :node_not_found, message: "Lineage group was not found."}}
     end
   end
 
-  defp fetch_asset_node(%Graph{} = graph, asset_id) do
-    graph.groups
-    |> Enum.flat_map(& &1.preview_assets)
-    |> Enum.find(&(&1.id == asset_id))
-    |> case do
-      %AssetNode{} = asset -> {:ok, asset}
-      nil -> {:error, %Error{code: :node_not_found, message: "Lineage asset was not found."}}
+  defp fetch_asset_node(asset_nodes_by_id, asset_id) when is_map(asset_nodes_by_id) do
+    case Map.fetch(asset_nodes_by_id, asset_id) do
+      {:ok, %AssetNode{} = asset} -> {:ok, asset}
+      :error -> {:error, %Error{code: :node_not_found, message: "Lineage asset was not found."}}
     end
   end
 
-  defp fetch_edge(%Graph{} = graph, edge_id) do
-    case Enum.find(graph.edges, &(&1.id == edge_id)) do
+  defp fetch_edge(edges, edge_id) when is_list(edges) do
+    case Enum.find(edges, &(&1.id == edge_id)) do
       %Edge{} = edge -> {:ok, edge}
       nil -> {:error, %Error{code: :node_not_found, message: "Lineage edge was not found."}}
     end
@@ -734,9 +789,9 @@ defmodule FavnOrchestrator.Operator.Lineage do
     end
   end
 
-  defp search_results(%Graph{} = graph) do
+  defp search_results(model) when is_map(model) do
     group_results =
-      Enum.map(graph.groups, fn group ->
+      Enum.map(model.groups, fn group ->
         %SearchResult{
           id: group.id,
           kind: :group,
@@ -747,8 +802,8 @@ defmodule FavnOrchestrator.Operator.Lineage do
       end)
 
     asset_results =
-      graph.groups
-      |> Enum.flat_map(& &1.preview_assets)
+      model.asset_nodes_by_id
+      |> Map.values()
       |> Enum.map(fn asset ->
         %SearchResult{
           id: asset.id,
@@ -760,7 +815,7 @@ defmodule FavnOrchestrator.Operator.Lineage do
       end)
 
     schema_results =
-      graph.groups
+      model.groups
       |> Enum.map(& &1.schema)
       |> Enum.reject(&is_nil/1)
       |> Enum.uniq()

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage/dtos.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage/dtos.ex
@@ -34,6 +34,7 @@ defmodule FavnOrchestrator.Operator.Lineage.Limits do
           max_visible_asset_nodes: pos_integer(),
           max_visible_edges: pos_integer(),
           max_dependency_previews_per_edge: pos_integer(),
+          max_inspector_adjacent_groups: pos_integer(),
           group_asset_page_size: pos_integer(),
           search_page_size: pos_integer(),
           timeout_ms: pos_integer()
@@ -44,6 +45,7 @@ defmodule FavnOrchestrator.Operator.Lineage.Limits do
             max_visible_asset_nodes: 160,
             max_visible_edges: 300,
             max_dependency_previews_per_edge: 5,
+            max_inspector_adjacent_groups: 12,
             group_asset_page_size: 50,
             search_page_size: 20,
             timeout_ms: 250
@@ -214,8 +216,8 @@ defmodule FavnOrchestrator.Operator.Lineage.Graph do
   alias FavnOrchestrator.Operator.Lineage.Limits
   alias FavnOrchestrator.Operator.Lineage.Summary
 
-  @type view_mode :: :all | :upstream | :downstream | :impact | :freshness
-  @type scope :: :global | :asset | :group
+  @type view_mode :: :all
+  @type scope :: :global
 
   @type t :: %__MODULE__{
           manifest_version_id: String.t(),
@@ -263,6 +265,8 @@ defmodule FavnOrchestrator.Operator.Lineage.GroupInspector do
           top_issues: [map()],
           upstream: [map()],
           downstream: [map()],
+          hidden_upstream_count: non_neg_integer(),
+          hidden_downstream_count: non_neg_integer(),
           actions: [map()]
         }
 
@@ -276,6 +280,8 @@ defmodule FavnOrchestrator.Operator.Lineage.GroupInspector do
     top_issues: [],
     upstream: [],
     downstream: [],
+    hidden_upstream_count: 0,
+    hidden_downstream_count: 0,
     actions: []
   ]
 end
@@ -294,11 +300,23 @@ defmodule FavnOrchestrator.Operator.Lineage.AssetInspector do
           latest_run: map() | nil,
           upstream: [map()],
           downstream: [map()],
+          hidden_upstream_count: non_neg_integer(),
+          hidden_downstream_count: non_neg_integer(),
           actions: [map()]
         }
 
   @enforce_keys [:id, :title, :asset]
-  defstruct [:id, :title, :asset, :latest_run, upstream: [], downstream: [], actions: []]
+  defstruct [
+    :id,
+    :title,
+    :asset,
+    :latest_run,
+    upstream: [],
+    downstream: [],
+    hidden_upstream_count: 0,
+    hidden_downstream_count: 0,
+    actions: []
+  ]
 end
 
 defmodule FavnOrchestrator.Operator.Lineage.EdgeInspector do

--- a/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage/dtos.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/operator/lineage/dtos.ex
@@ -1,0 +1,352 @@
+defmodule FavnOrchestrator.Operator.Lineage.Error do
+  @moduledoc """
+  Normalized error returned by the operator lineage facade.
+  """
+
+  @type code ::
+          :active_manifest_not_found
+          | :manifest_not_found
+          | :invalid_scope
+          | :node_not_found
+          | :query_timeout
+          | :storage_unavailable
+          | :lineage_projection_unavailable
+
+  @type t :: %__MODULE__{
+          code: code(),
+          message: String.t(),
+          retryable?: boolean(),
+          details: map()
+        }
+
+  @enforce_keys [:code, :message]
+  defstruct [:code, :message, retryable?: false, details: %{}]
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.Limits do
+  @moduledoc """
+  Bounded payload limits for lineage graph and inspector requests.
+  """
+
+  @type t :: %__MODULE__{
+          max_visible_groups: pos_integer(),
+          max_preview_assets_per_group: pos_integer(),
+          max_visible_asset_nodes: pos_integer(),
+          max_visible_edges: pos_integer(),
+          max_dependency_previews_per_edge: pos_integer(),
+          group_asset_page_size: pos_integer(),
+          search_page_size: pos_integer(),
+          timeout_ms: pos_integer()
+        }
+
+  defstruct max_visible_groups: 40,
+            max_preview_assets_per_group: 4,
+            max_visible_asset_nodes: 160,
+            max_visible_edges: 300,
+            max_dependency_previews_per_edge: 5,
+            group_asset_page_size: 50,
+            search_page_size: 20,
+            timeout_ms: 250
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.Summary do
+  @moduledoc """
+  Aggregate lineage graph counts used by the operator UI.
+  """
+
+  @type status_counts :: %{
+          fresh: non_neg_integer(),
+          stale: non_neg_integer(),
+          failed: non_neg_integer(),
+          running: non_neg_integer(),
+          unknown: non_neg_integer()
+        }
+
+  @type t :: %__MODULE__{
+          total_assets: non_neg_integer(),
+          visible_assets: non_neg_integer(),
+          total_groups: non_neg_integer(),
+          visible_groups: non_neg_integer(),
+          total_edges: non_neg_integer(),
+          visible_edges: non_neg_integer(),
+          status_counts: status_counts(),
+          truncated?: boolean()
+        }
+
+  defstruct total_assets: 0,
+            visible_assets: 0,
+            total_groups: 0,
+            visible_groups: 0,
+            total_edges: 0,
+            visible_edges: 0,
+            status_counts: %{fresh: 0, stale: 0, failed: 0, running: 0, unknown: 0},
+            truncated?: false
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.AssetNode do
+  @moduledoc """
+  Operator-facing asset node or bounded asset preview.
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          label: String.t(),
+          asset_ref: Favn.Ref.t(),
+          asset_ref_text: String.t(),
+          group_id: String.t(),
+          schema: String.t() | nil,
+          layer: atom(),
+          kind: atom(),
+          freshness_status: atom(),
+          run_status: atom() | nil,
+          latest_run_id: String.t() | nil,
+          selected?: boolean(),
+          position_hint: map() | nil
+        }
+
+  @enforce_keys [:id, :label, :asset_ref, :asset_ref_text, :group_id, :layer, :kind]
+  defstruct [
+    :id,
+    :label,
+    :asset_ref,
+    :asset_ref_text,
+    :group_id,
+    :schema,
+    :layer,
+    :kind,
+    :latest_run_id,
+    :position_hint,
+    freshness_status: :unknown,
+    run_status: nil,
+    selected?: false
+  ]
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.GroupNode do
+  @moduledoc """
+  Grouped lineage node rendered as the default bounded graph unit.
+  """
+
+  alias FavnOrchestrator.Operator.Lineage.AssetNode
+  alias FavnOrchestrator.Operator.Lineage.Summary
+
+  @type state :: :collapsed | :expanded_preview | :expanded_full
+  @type group_type :: :source_system | :schema | :domain | :dashboard | :asset_group
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          label: String.t(),
+          system: String.t() | nil,
+          schema: String.t() | nil,
+          layer: atom(),
+          type: group_type(),
+          state: state(),
+          asset_count: non_neg_integer(),
+          preview_asset_ids: [String.t()],
+          preview_assets: [AssetNode.t()],
+          hidden_asset_count: non_neg_integer(),
+          status_counts: Summary.status_counts(),
+          top_issues: [map()],
+          position_hint: map(),
+          selected?: boolean()
+        }
+
+  @enforce_keys [:id, :label, :layer, :type, :position_hint]
+  defstruct [
+    :id,
+    :label,
+    :system,
+    :schema,
+    :layer,
+    :type,
+    :position_hint,
+    state: :collapsed,
+    asset_count: 0,
+    preview_asset_ids: [],
+    preview_assets: [],
+    hidden_asset_count: 0,
+    status_counts: %{fresh: 0, stale: 0, failed: 0, running: 0, unknown: 0},
+    top_issues: [],
+    selected?: false
+  ]
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.Edge do
+  @moduledoc """
+  Aggregated or concrete dependency edge in the lineage graph.
+  """
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          from: String.t(),
+          to: String.t(),
+          kind: atom(),
+          dependency_count: pos_integer(),
+          status: atom(),
+          aggregated?: boolean(),
+          preview_dependencies: [map()],
+          hidden_dependency_count: non_neg_integer(),
+          selected?: boolean()
+        }
+
+  @enforce_keys [:id, :from, :to]
+  defstruct [
+    :id,
+    :from,
+    :to,
+    kind: :dependency,
+    dependency_count: 1,
+    status: :healthy,
+    aggregated?: true,
+    preview_dependencies: [],
+    hidden_dependency_count: 0,
+    selected?: false
+  ]
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.Graph do
+  @moduledoc """
+  Bounded lineage graph read model for operator pages.
+  """
+
+  alias FavnOrchestrator.Operator.Lineage.Edge
+  alias FavnOrchestrator.Operator.Lineage.GroupNode
+  alias FavnOrchestrator.Operator.Lineage.Limits
+  alias FavnOrchestrator.Operator.Lineage.Summary
+
+  @type view_mode :: :all | :upstream | :downstream | :impact | :freshness
+  @type scope :: :global | :asset | :group
+
+  @type t :: %__MODULE__{
+          manifest_version_id: String.t(),
+          scope: scope(),
+          selected_id: String.t() | nil,
+          view_mode: view_mode(),
+          nodes: [GroupNode.t() | FavnOrchestrator.Operator.Lineage.AssetNode.t()],
+          edges: [Edge.t()],
+          groups: [GroupNode.t()],
+          summary: Summary.t(),
+          limits: Limits.t(),
+          layout: map(),
+          generated_at: DateTime.t()
+        }
+
+  @enforce_keys [:manifest_version_id, :scope, :view_mode, :summary, :limits, :generated_at]
+  defstruct [
+    :manifest_version_id,
+    :scope,
+    :selected_id,
+    :summary,
+    :limits,
+    :generated_at,
+    view_mode: :all,
+    nodes: [],
+    edges: [],
+    groups: [],
+    layout: %{direction: :left_to_right, layers: [:raw, :staging, :core, :marts, :dashboards]}
+  ]
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.GroupInspector do
+  @moduledoc """
+  Inspector read model for a selected lineage group.
+  """
+
+  alias FavnOrchestrator.Operator.Lineage.GroupNode
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          title: String.t(),
+          group: GroupNode.t(),
+          about: map(),
+          health_summary: map(),
+          top_issues: [map()],
+          upstream: [map()],
+          downstream: [map()],
+          actions: [map()]
+        }
+
+  @enforce_keys [:id, :title, :group]
+  defstruct [
+    :id,
+    :title,
+    :group,
+    about: %{},
+    health_summary: %{},
+    top_issues: [],
+    upstream: [],
+    downstream: [],
+    actions: []
+  ]
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.AssetInspector do
+  @moduledoc """
+  Inspector read model for a selected lineage asset.
+  """
+
+  alias FavnOrchestrator.Operator.Lineage.AssetNode
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          title: String.t(),
+          asset: AssetNode.t(),
+          latest_run: map() | nil,
+          upstream: [map()],
+          downstream: [map()],
+          actions: [map()]
+        }
+
+  @enforce_keys [:id, :title, :asset]
+  defstruct [:id, :title, :asset, :latest_run, upstream: [], downstream: [], actions: []]
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.EdgeInspector do
+  @moduledoc """
+  Inspector read model for an aggregated dependency edge.
+  """
+
+  alias FavnOrchestrator.Operator.Lineage.Edge
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          title: String.t(),
+          edge: Edge.t(),
+          upstream_label: String.t() | nil,
+          downstream_label: String.t() | nil,
+          affected_statuses: map(),
+          dependencies: [map()],
+          actions: [map()]
+        }
+
+  @enforce_keys [:id, :title, :edge]
+  defstruct [
+    :id,
+    :title,
+    :edge,
+    :upstream_label,
+    :downstream_label,
+    affected_statuses: %{},
+    dependencies: [],
+    actions: []
+  ]
+end
+
+defmodule FavnOrchestrator.Operator.Lineage.SearchResult do
+  @moduledoc """
+  Search result returned by the lineage operator facade.
+  """
+
+  @type kind :: :group | :asset | :schema
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          kind: kind(),
+          label: String.t(),
+          subtitle: String.t() | nil,
+          status: atom() | nil
+        }
+
+  @enforce_keys [:id, :kind, :label]
+  defstruct [:id, :kind, :label, :subtitle, :status]
+end

--- a/apps/favn_orchestrator/test/operator/lineage_test.exs
+++ b/apps/favn_orchestrator/test/operator/lineage_test.exs
@@ -1,0 +1,116 @@
+defmodule FavnOrchestrator.Operator.LineageTest do
+  use ExUnit.Case, async: false
+
+  alias Favn.Manifest
+  alias Favn.Manifest.Asset
+  alias Favn.Manifest.Graph
+  alias Favn.Manifest.Version
+  alias FavnOrchestrator.Operator.Lineage
+  alias FavnOrchestrator.Operator.Lineage.EdgeInspector
+  alias FavnOrchestrator.Operator.Lineage.GroupInspector
+  alias FavnOrchestrator.Storage.Adapter.Memory
+
+  setup do
+    put_orchestrator_env(:storage_adapter, Memory)
+    put_orchestrator_env(:storage_adapter_opts, [])
+    Memory.reset()
+    on_exit(&Memory.reset/0)
+
+    version = manifest_version()
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    {:ok, version: version}
+  end
+
+  test "get_graph returns a bounded grouped left-to-right overview", %{version: version} do
+    assert {:ok, graph} = Lineage.get_graph()
+
+    assert graph.manifest_version_id == version.manifest_version_id
+    assert graph.layout.direction == :left_to_right
+    assert graph.summary.total_assets == 5
+    assert graph.summary.visible_groups == 3
+
+    assert github = Enum.find(graph.groups, &(&1.id == "group:raw:github"))
+    assert github.label == "Github raw"
+    assert github.asset_count == 2
+    assert github.hidden_asset_count == 0
+    assert github.status_counts.unknown == 2
+
+    assert staging = Enum.find(graph.groups, &(&1.id == "group:staging:github"))
+    assert staging.label == "staging.github"
+
+    assert edge = Enum.find(graph.edges, &(&1.from == github.id and &1.to == staging.id))
+    assert edge.dependency_count == 2
+    assert edge.aggregated?
+  end
+
+  test "inspectors are loaded through selected graph facades" do
+    assert {:ok, %GroupInspector{} = inspector} = Lineage.get_group("group:raw:github")
+    assert inspector.title == "Github raw"
+    assert [%{dependency_count: 2, label: "staging.github"}] = inspector.downstream
+
+    assert {:ok, graph} = Lineage.get_graph()
+
+    edge =
+      Enum.find(graph.edges, &(&1.from == "group:raw:github" and &1.to == "group:staging:github"))
+
+    assert {:ok, %EdgeInspector{} = edge_inspector} = Lineage.get_edge(edge.id)
+    assert edge_inspector.edge.dependency_count == 2
+    assert edge_inspector.upstream_label == "Github raw"
+    assert edge_inspector.downstream_label == "staging.github"
+  end
+
+  test "search returns bounded group and asset results" do
+    assert {:ok, page} = Lineage.search("orders", limit: 3)
+
+    assert Enum.any?(page.items, &(&1.label == "stg_orders"))
+    assert page.limit == 3
+  end
+
+  defp manifest_version do
+    assets = [
+      asset(:raw_issues, :source, :github, "raw", "raw", []),
+      asset(:raw_pull_requests, :source, :github, "raw", "raw", []),
+      asset(:stg_issues, :sql, :github, "staging", "staging", [{__MODULE__.Assets, :raw_issues}]),
+      asset(:stg_orders, :sql, :github, "staging", "staging", [
+        {__MODULE__.Assets, :raw_pull_requests}
+      ]),
+      asset(:fct_orders, :sql, :warehouse, "core", "core", [{__MODULE__.Assets, :stg_orders}])
+    ]
+
+    assert {:ok, graph} = Graph.build(assets)
+
+    manifest = %Manifest{assets: assets, graph: graph}
+    assert {:ok, version} = Version.new(manifest, manifest_version_id: "mv_lineage_test")
+    version
+  end
+
+  defp asset(name, type, connection, catalog, schema, depends_on) do
+    %Asset{
+      ref: {__MODULE__.Assets, name},
+      module: __MODULE__.Assets,
+      name: name,
+      type: type,
+      depends_on: depends_on,
+      relation: %{
+        connection: connection,
+        catalog: catalog,
+        schema: schema,
+        name: Atom.to_string(name)
+      }
+    }
+  end
+
+  defp put_orchestrator_env(key, value) do
+    original = Application.get_env(:favn_orchestrator, key, :__missing__)
+    Application.put_env(:favn_orchestrator, key, value)
+
+    on_exit(fn ->
+      case original do
+        :__missing__ -> Application.delete_env(:favn_orchestrator, key)
+        value -> Application.put_env(:favn_orchestrator, key, value)
+      end
+    end)
+  end
+end

--- a/apps/favn_orchestrator/test/operator/lineage_test.exs
+++ b/apps/favn_orchestrator/test/operator/lineage_test.exs
@@ -28,16 +28,16 @@ defmodule FavnOrchestrator.Operator.LineageTest do
 
     assert graph.manifest_version_id == version.manifest_version_id
     assert graph.layout.direction == :left_to_right
-    assert graph.summary.total_assets == 5
-    assert graph.summary.visible_groups == 3
+    assert graph.summary.total_assets == 10
+    assert graph.summary.visible_groups == 4
 
     assert github = Enum.find(graph.groups, &(&1.id == "group:raw:github"))
     assert github.label == "Github raw"
-    assert github.asset_count == 2
-    assert github.hidden_asset_count == 0
-    assert github.status_counts.unknown == 2
+    assert github.asset_count == 6
+    assert github.hidden_asset_count == 2
+    assert github.status_counts.unknown == 6
 
-    assert staging = Enum.find(graph.groups, &(&1.id == "group:staging:github"))
+    assert staging = Enum.find(graph.groups, &(&1.id == "group:staging:github:staging"))
     assert staging.label == "staging.github"
 
     assert edge = Enum.find(graph.edges, &(&1.from == github.id and &1.to == staging.id))
@@ -53,12 +53,40 @@ defmodule FavnOrchestrator.Operator.LineageTest do
     assert {:ok, graph} = Lineage.get_graph()
 
     edge =
-      Enum.find(graph.edges, &(&1.from == "group:raw:github" and &1.to == "group:staging:github"))
+      Enum.find(
+        graph.edges,
+        &(&1.from == "group:raw:github" and &1.to == "group:staging:github:staging")
+      )
 
     assert {:ok, %EdgeInspector{} = edge_inspector} = Lineage.get_edge(edge.id)
     assert edge_inspector.edge.dependency_count == 2
     assert edge_inspector.upstream_label == "Github raw"
     assert edge_inspector.downstream_label == "staging.github"
+  end
+
+  test "hidden group assets are pageable, searchable, and inspectable" do
+    assert {:ok, page} = Lineage.list_group_assets("group:raw:github", limit: 10)
+    assert length(page.items) == 6
+    assert Enum.any?(page.items, &(&1.label == "raw_users"))
+
+    hidden_id = target_id(:raw_users)
+    assert {:ok, asset_inspector} = Lineage.get_asset(hidden_id)
+    assert asset_inspector.asset.label == "raw_users"
+
+    assert {:ok, search_page} = Lineage.search("raw_users", limit: 5)
+    assert Enum.any?(search_page.items, &(&1.id == hidden_id))
+  end
+
+  test "schemas on the same connection remain distinct groups" do
+    assert {:ok, graph} = Lineage.get_graph()
+
+    assert Enum.find(graph.groups, &(&1.id == "group:core:core"))
+    assert Enum.find(graph.groups, &(&1.id == "group:core:finance"))
+  end
+
+  test "unsupported graph options fail explicitly" do
+    assert {:error, %{code: :invalid_scope}} = Lineage.get_graph(view_mode: :upstream)
+    assert {:error, %{code: :invalid_scope}} = Lineage.get_graph(filters: %{status: :failed})
   end
 
   test "search returns bounded group and asset results" do
@@ -70,13 +98,18 @@ defmodule FavnOrchestrator.Operator.LineageTest do
 
   defp manifest_version do
     assets = [
+      asset(:raw_comments, :source, :github, "raw", "raw", []),
       asset(:raw_issues, :source, :github, "raw", "raw", []),
+      asset(:raw_labels, :source, :github, "raw", "raw", []),
       asset(:raw_pull_requests, :source, :github, "raw", "raw", []),
+      asset(:raw_users, :source, :github, "raw", "raw", []),
+      asset(:raw_workflows, :source, :github, "raw", "raw", []),
       asset(:stg_issues, :sql, :github, "staging", "staging", [{__MODULE__.Assets, :raw_issues}]),
       asset(:stg_orders, :sql, :github, "staging", "staging", [
         {__MODULE__.Assets, :raw_pull_requests}
       ]),
-      asset(:fct_orders, :sql, :warehouse, "core", "core", [{__MODULE__.Assets, :stg_orders}])
+      asset(:fct_orders, :sql, :warehouse, "core", "core", [{__MODULE__.Assets, :stg_orders}]),
+      asset(:fct_revenue, :sql, :warehouse, "core", "finance", [])
     ]
 
     assert {:ok, graph} = Graph.build(assets)
@@ -101,6 +134,8 @@ defmodule FavnOrchestrator.Operator.LineageTest do
       }
     }
   end
+
+  defp target_id(name), do: "asset:#{Atom.to_string(__MODULE__.Assets)}:#{name}"
 
   defp put_orchestrator_env(key, value) do
     original = Application.get_env(:favn_orchestrator, key, :__missing__)

--- a/apps/favn_orchestrator/test/operator/lineage_test.exs
+++ b/apps/favn_orchestrator/test/operator/lineage_test.exs
@@ -6,6 +6,7 @@ defmodule FavnOrchestrator.Operator.LineageTest do
   alias Favn.Manifest.Graph
   alias Favn.Manifest.Version
   alias FavnOrchestrator.Operator.Lineage
+  alias FavnOrchestrator.Operator.Lineage.AssetInspector
   alias FavnOrchestrator.Operator.Lineage.EdgeInspector
   alias FavnOrchestrator.Operator.Lineage.GroupInspector
   alias FavnOrchestrator.Storage.Adapter.Memory
@@ -77,6 +78,25 @@ defmodule FavnOrchestrator.Operator.LineageTest do
     assert Enum.any?(search_page.items, &(&1.id == hidden_id))
   end
 
+  test "group and asset inspectors expose bounded adjacent groups" do
+    version = fanout_manifest_version()
+    assert :ok = FavnOrchestrator.register_manifest(version)
+    assert :ok = FavnOrchestrator.activate_manifest(version.manifest_version_id)
+
+    assert {:ok, %GroupInspector{} = group_inspector} =
+             Lineage.get_group("group:raw:source", limit: [max_inspector_adjacent_groups: 2])
+
+    assert length(group_inspector.downstream) == 2
+    assert group_inspector.hidden_downstream_count == 2
+    assert group_inspector.hidden_upstream_count == 0
+
+    assert {:ok, %AssetInspector{} = asset_inspector} =
+             Lineage.get_asset(target_id(:raw_events), limit: [max_inspector_adjacent_groups: 2])
+
+    assert length(asset_inspector.downstream) == 2
+    assert asset_inspector.hidden_downstream_count == 2
+  end
+
   test "schemas on the same connection remain distinct groups" do
     assert {:ok, graph} = Lineage.get_graph()
 
@@ -116,6 +136,30 @@ defmodule FavnOrchestrator.Operator.LineageTest do
 
     manifest = %Manifest{assets: assets, graph: graph}
     assert {:ok, version} = Version.new(manifest, manifest_version_id: "mv_lineage_test")
+    version
+  end
+
+  defp fanout_manifest_version do
+    assets = [
+      asset(:raw_events, :source, :source, "raw", "raw", []),
+      asset(:domain_a_orders, :sql, :warehouse, "core", "domain_a", [
+        {__MODULE__.Assets, :raw_events}
+      ]),
+      asset(:domain_b_orders, :sql, :warehouse, "core", "domain_b", [
+        {__MODULE__.Assets, :raw_events}
+      ]),
+      asset(:domain_c_orders, :sql, :warehouse, "core", "domain_c", [
+        {__MODULE__.Assets, :raw_events}
+      ]),
+      asset(:domain_d_orders, :sql, :warehouse, "core", "domain_d", [
+        {__MODULE__.Assets, :raw_events}
+      ])
+    ]
+
+    assert {:ok, graph} = Graph.build(assets)
+
+    manifest = %Manifest{assets: assets, graph: graph}
+    assert {:ok, version} = Version.new(manifest, manifest_version_id: "mv_lineage_fanout_test")
     version
   end
 

--- a/apps/favn_view/assets/js/app.js
+++ b/apps/favn_view/assets/js/app.js
@@ -64,6 +64,51 @@ const Hooks = {
       if (terminal) terminal.scrollTop = terminal.scrollHeight
     }
   },
+  LineageCanvas: {
+    mounted() {
+      this.scale = Number.parseFloat(this.el.dataset.zoom || "62") / 100
+      this.pan = {x: 0, y: 0}
+      this.drag = null
+      this.content = this.el.querySelector(".lineage-canvas-content")
+      this.applyTransform()
+
+      this.el.addEventListener("pointerdown", event => {
+        if (event.target.closest("button,a,input,select,textarea")) return
+        this.drag = {x: event.clientX, y: event.clientY, pan: {...this.pan}}
+        this.el.setPointerCapture(event.pointerId)
+      })
+
+      this.el.addEventListener("pointermove", event => {
+        if (!this.drag) return
+        this.pan = {
+          x: this.drag.pan.x + event.clientX - this.drag.x,
+          y: this.drag.pan.y + event.clientY - this.drag.y,
+        }
+        this.applyTransform()
+      })
+
+      this.el.addEventListener("pointerup", event => {
+        this.drag = null
+        if (this.el.hasPointerCapture(event.pointerId)) this.el.releasePointerCapture(event.pointerId)
+      })
+
+      this.el.addEventListener("wheel", event => {
+        event.preventDefault()
+        const delta = event.deltaY > 0 ? -0.06 : 0.06
+        this.scale = Math.max(0.35, Math.min(1.4, this.scale + delta))
+        this.applyTransform()
+      }, {passive: false})
+    },
+    updated() {
+      this.scale = Number.parseFloat(this.el.dataset.zoom || String(this.scale * 100)) / 100
+      this.content = this.el.querySelector(".lineage-canvas-content")
+      this.applyTransform()
+    },
+    applyTransform() {
+      if (!this.content) return
+      this.content.style.transform = `translate(${this.pan.x}px, ${this.pan.y}px) scale(${this.scale})`
+    }
+  },
   FavnTimeline: {
     mounted() {
       this.userPaused = false

--- a/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
@@ -5,9 +5,11 @@ defmodule FavnView.AssetCatalogueLive do
 
   alias FavnView.AssetRoute
   alias FavnView.Components.AssetCataloguePage
+  alias FavnOrchestrator.Operator.Lineage
 
   @default_filters %{search: "", connection: "all", catalogue: "all"}
-  @valid_modes ~w(list)
+  @valid_modes ~w(list lineage)
+  @valid_lineage_modes ~w(all upstream downstream impact freshness)
 
   @impl true
   def mount(_params, _session, socket) do
@@ -19,6 +21,16 @@ defmodule FavnView.AssetCatalogueLive do
         assets: assets,
         filters: @default_filters,
         active_mode: :list,
+        lineage_view_mode: :all,
+        lineage_graph: nil,
+        lineage_inspector: nil,
+        lineage_selected_id: nil,
+        lineage_selected_kind: nil,
+        lineage_loading: false,
+        lineage_error: nil,
+        lineage_search: "",
+        lineage_zoom: 62,
+        lineage_inspector_open?: true,
         loading: false,
         error: error,
         nav_items: AssetCataloguePage.nav_items(),
@@ -27,6 +39,16 @@ defmodule FavnView.AssetCatalogueLive do
       )
 
     {:ok, socket}
+  end
+
+  @impl true
+  def handle_params(params, _uri, socket) do
+    active_mode = normalize_mode(Map.get(params, "mode"))
+
+    {:noreply,
+     socket
+     |> assign(:active_mode, active_mode)
+     |> maybe_load_lineage()}
   end
 
   @impl true
@@ -41,10 +63,62 @@ defmodule FavnView.AssetCatalogueLive do
   end
 
   def handle_event("set_mode", %{"mode" => mode}, socket) when mode in @valid_modes do
-    {:noreply, assign(socket, :active_mode, String.to_existing_atom(mode))}
+    {:noreply, push_patch(socket, to: ~p"/assets?#{mode_query(mode)}")}
+  end
+
+  def handle_event("set_mode", %{"mode" => mode}, socket) when mode in @valid_lineage_modes do
+    {:noreply,
+     socket
+     |> assign(:lineage_view_mode, String.to_existing_atom(mode))
+     |> load_lineage()}
   end
 
   def handle_event("set_mode", _params, socket), do: {:noreply, socket}
+
+  def handle_event("search_lineage", %{"search" => search}, socket) do
+    {:noreply, assign(socket, :lineage_search, search)}
+  end
+
+  def handle_event("select_node", %{"id" => id, "kind" => kind}, socket)
+      when kind in ["group", "asset"] do
+    {:noreply,
+     socket
+     |> assign(
+       lineage_selected_id: id,
+       lineage_selected_kind: String.to_existing_atom(kind),
+       lineage_inspector_open?: true
+     )
+     |> load_lineage_inspector()}
+  end
+
+  def handle_event("select_edge", %{"id" => id}, socket) do
+    {:noreply,
+     socket
+     |> assign(
+       lineage_selected_id: id,
+       lineage_selected_kind: :edge,
+       lineage_inspector_open?: true
+     )
+     |> load_lineage_inspector()}
+  end
+
+  def handle_event("close_inspector", _params, socket) do
+    {:noreply, assign(socket, :lineage_inspector_open?, false)}
+  end
+
+  def handle_event("zoom_in", _params, socket) do
+    {:noreply, update(socket, :lineage_zoom, &min(&1 + 8, 140))}
+  end
+
+  def handle_event("zoom_out", _params, socket) do
+    {:noreply, update(socket, :lineage_zoom, &max(&1 - 8, 35))}
+  end
+
+  def handle_event("fit_graph", _params, socket),
+    do: {:noreply, assign(socket, :lineage_zoom, 62)}
+
+  def handle_event("toggle_filters", _params, socket), do: {:noreply, socket}
+  def handle_event("toggle_fullscreen", _params, socket), do: {:noreply, socket}
 
   @impl true
   def render(assigns) do
@@ -58,9 +132,108 @@ defmodule FavnView.AssetCatalogueLive do
       nav_items={@nav_items}
       connection_options={@connection_options}
       catalogue_options={@catalogue_options}
+      lineage_graph={@lineage_graph}
+      lineage_inspector={@lineage_inspector}
+      lineage_loading={@lineage_loading}
+      lineage_error={@lineage_error}
+      lineage_search={@lineage_search}
+      lineage_zoom={@lineage_zoom}
+      lineage_inspector_open?={@lineage_inspector_open?}
     />
     """
   end
+
+  defp maybe_load_lineage(%{assigns: %{active_mode: :lineage}} = socket), do: load_lineage(socket)
+  defp maybe_load_lineage(socket), do: socket
+
+  defp load_lineage(socket) do
+    opts = [
+      view_mode: socket.assigns.lineage_view_mode,
+      selected_id: socket.assigns.lineage_selected_id
+    ]
+
+    case get_graph(opts) do
+      {:ok, graph} ->
+        socket
+        |> assign(lineage_graph: graph, lineage_error: nil, lineage_loading: false)
+        |> load_lineage_inspector()
+
+      {:error, error} ->
+        assign(socket,
+          lineage_graph: nil,
+          lineage_inspector: nil,
+          lineage_error: error,
+          lineage_loading: false
+        )
+    end
+  end
+
+  defp load_lineage_inspector(%{assigns: %{lineage_selected_id: nil}} = socket),
+    do: assign(socket, :lineage_inspector, nil)
+
+  defp load_lineage_inspector(
+         %{
+           assigns: %{
+             lineage_selected_kind: :group,
+             lineage_selected_id: id,
+             lineage_view_mode: view_mode
+           }
+         } = socket
+       ) do
+    assign_lineage_inspector(socket, get_group(id, view_mode: view_mode))
+  end
+
+  defp load_lineage_inspector(
+         %{
+           assigns: %{
+             lineage_selected_kind: :asset,
+             lineage_selected_id: id,
+             lineage_view_mode: view_mode
+           }
+         } = socket
+       ) do
+    assign_lineage_inspector(socket, get_asset(id, view_mode: view_mode))
+  end
+
+  defp load_lineage_inspector(
+         %{
+           assigns: %{
+             lineage_selected_kind: :edge,
+             lineage_selected_id: id,
+             lineage_view_mode: view_mode
+           }
+         } = socket
+       ) do
+    assign_lineage_inspector(socket, get_edge(id, view_mode: view_mode))
+  end
+
+  defp load_lineage_inspector(socket), do: assign(socket, :lineage_inspector, nil)
+
+  defp assign_lineage_inspector(socket, {:ok, inspector}),
+    do: assign(socket, lineage_inspector: inspector, lineage_error: nil)
+
+  defp assign_lineage_inspector(socket, {:error, _error}),
+    do: assign(socket, :lineage_inspector, nil)
+
+  defp normalize_mode(mode) when mode in @valid_modes, do: String.to_existing_atom(mode)
+  defp normalize_mode(_mode), do: :list
+
+  defp mode_query("list"), do: %{}
+  defp mode_query(:list), do: %{}
+  defp mode_query(mode), do: %{mode: mode}
+
+  defp get_graph(opts), do: configured_fun(:lineage_get_graph_fun, &Lineage.get_graph/1).(opts)
+
+  defp get_group(id, opts),
+    do: configured_fun(:lineage_get_group_fun, &Lineage.get_group/2).(id, opts)
+
+  defp get_asset(id, opts),
+    do: configured_fun(:lineage_get_asset_fun, &Lineage.get_asset/2).(id, opts)
+
+  defp get_edge(id, opts),
+    do: configured_fun(:lineage_get_edge_fun, &Lineage.get_edge/2).(id, opts)
+
+  defp configured_fun(key, default), do: Application.get_env(:favn_view, key, default)
 
   defp normalize_filters(params) do
     %{
@@ -83,7 +256,7 @@ defmodule FavnView.AssetCatalogueLive do
   end
 
   defp load_assets do
-    case FavnOrchestrator.active_asset_catalogue() do
+    case configured_fun(:active_asset_catalogue_fun, &FavnOrchestrator.active_asset_catalogue/0).() do
       {:ok, entries} ->
         {Enum.map(entries, &asset_from_entry/1), nil}
 

--- a/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
+++ b/apps/favn_view/lib/favn_view/asset_catalogue_live.ex
@@ -9,7 +9,7 @@ defmodule FavnView.AssetCatalogueLive do
 
   @default_filters %{search: "", connection: "all", catalogue: "all"}
   @valid_modes ~w(list lineage)
-  @valid_lineage_modes ~w(all upstream downstream impact freshness)
+  @valid_lineage_modes ~w(all)
 
   @impl true
   def mount(_params, _session, socket) do
@@ -75,10 +75,6 @@ defmodule FavnView.AssetCatalogueLive do
 
   def handle_event("set_mode", _params, socket), do: {:noreply, socket}
 
-  def handle_event("search_lineage", %{"search" => search}, socket) do
-    {:noreply, assign(socket, :lineage_search, search)}
-  end
-
   def handle_event("select_node", %{"id" => id, "kind" => kind}, socket)
       when kind in ["group", "asset"] do
     {:noreply,
@@ -116,9 +112,6 @@ defmodule FavnView.AssetCatalogueLive do
 
   def handle_event("fit_graph", _params, socket),
     do: {:noreply, assign(socket, :lineage_zoom, 62)}
-
-  def handle_event("toggle_filters", _params, socket), do: {:noreply, socket}
-  def handle_event("toggle_fullscreen", _params, socket), do: {:noreply, socket}
 
   @impl true
   def render(assigns) do

--- a/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_catalogue_page.ex
@@ -7,6 +7,7 @@ defmodule FavnView.Components.AssetCataloguePage do
 
   alias FavnView.Components.AppShell
   alias FavnView.Components.GlassPanel
+  alias FavnView.Components.LineagePage
   alias FavnView.Components.ModeRail
 
   attr :assets, :list, required: true
@@ -17,6 +18,14 @@ defmodule FavnView.Components.AssetCataloguePage do
   attr :nav_items, :list, required: true
   attr :connection_options, :list, required: true
   attr :catalogue_options, :list, required: true
+  attr :lineage_graph, :any, default: nil
+  attr :lineage_inspector, :any, default: nil
+  attr :lineage_loading, :boolean, default: false
+  attr :lineage_error, :any, default: nil
+  attr :lineage_search, :string, default: ""
+  attr :lineage_zoom, :integer, default: 62
+  attr :lineage_inspector_open?, :boolean, default: true
+  attr :lineage_canvas_hook?, :boolean, default: true
 
   def asset_catalogue_page(assigns) do
     ~H"""
@@ -24,12 +33,20 @@ defmodule FavnView.Components.AssetCataloguePage do
       title="Asset catalogue"
       subtitle="Browse and monitor all assets"
       nav_items={@nav_items}
+      content_scroll?={@active_mode != :lineage}
     >
-      <div class="mx-auto w-full max-w-[120rem] pb-24 lg:pb-0" data-testid="asset-catalogue-page">
+      <div
+        class={[
+          "mx-auto flex w-full max-w-[120rem] flex-1 flex-col",
+          @active_mode == :lineage && "min-h-0 pb-20 lg:pb-0",
+          @active_mode != :lineage && "pb-24 lg:pb-0"
+        ]}
+        data-testid="asset-catalogue-page"
+      >
         <.loading_state :if={@loading} />
         <.error_state :if={!@loading && @error} />
 
-        <div :if={!@loading && !@error} class="space-y-3.5 lg:space-y-5">
+        <div :if={!@loading && !@error && @active_mode == :list} class="space-y-3.5 lg:space-y-5">
           <div id="asset-filters" data-testid="asset-filters">
             <.asset_catalogue_filters
               filters={@filters}
@@ -46,6 +63,19 @@ defmodule FavnView.Components.AssetCataloguePage do
 
           <.asset_card_list :if={@assets != []} assets={@assets} />
         </div>
+
+        <LineagePage.lineage_explorer
+          :if={!@loading && !@error && @active_mode == :lineage}
+          graph={@lineage_graph}
+          inspector={@lineage_inspector}
+          view_mode={:all}
+          search={@lineage_search}
+          loading={@lineage_loading}
+          error={@lineage_error}
+          zoom={@lineage_zoom}
+          inspector_open?={@lineage_inspector_open?}
+          canvas_hook?={@lineage_canvas_hook?}
+        />
       </div>
 
       <:mode_rail>
@@ -303,7 +333,7 @@ defmodule FavnView.Components.AssetCataloguePage do
   def catalogue_modes do
     [
       %{id: :list, label: "List", icon: "hero-list-bullet"},
-      %{id: :tree, label: "Tree", icon: "hero-share", disabled: true},
+      %{id: :lineage, label: "Lineage", icon: "hero-share"},
       %{id: :filters, label: "Filters", icon: "hero-funnel", disabled: true},
       %{id: :more, label: "More", icon: "hero-ellipsis-vertical", disabled: true}
     ]
@@ -318,7 +348,6 @@ defmodule FavnView.Components.AssetCataloguePage do
         href: "/pipelines",
         active: active == :pipelines
       },
-      %{label: "Lineage", icon: "hero-share", href: "#"},
       %{label: "Storage", icon: "hero-circle-stack", href: "#"},
       %{label: "Runs", icon: "hero-rocket-launch", href: "/runs", active: active == :runs},
       %{

--- a/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
+++ b/apps/favn_view/lib/favn_view/components/asset_detail_page.ex
@@ -417,7 +417,6 @@ defmodule FavnView.Components.AssetDetailPage do
   def sample_nav_items do
     [
       %{label: "Assets", icon: "hero-sparkles", href: "/assets", active: true},
-      %{label: "Lineage", icon: "hero-share", href: "#"},
       %{label: "Storage", icon: "hero-circle-stack", href: "#"},
       %{label: "Runs", icon: "hero-rocket-launch", href: "#"},
       %{label: "Alerts", icon: "hero-bell", href: "#"},

--- a/apps/favn_view/lib/favn_view/components/lineage_page.ex
+++ b/apps/favn_view/lib/favn_view/components/lineage_page.ex
@@ -1,0 +1,1206 @@
+defmodule FavnView.Components.LineagePage do
+  @moduledoc """
+  Componentized operator asset lineage DAG page.
+  """
+
+  use FavnView, :html
+
+  alias FavnOrchestrator.Operator.Lineage.AssetInspector
+  alias FavnOrchestrator.Operator.Lineage.AssetNode
+  alias FavnOrchestrator.Operator.Lineage.Edge
+  alias FavnOrchestrator.Operator.Lineage.EdgeInspector
+  alias FavnOrchestrator.Operator.Lineage.Graph
+  alias FavnOrchestrator.Operator.Lineage.GroupInspector
+  alias FavnOrchestrator.Operator.Lineage.GroupNode
+  alias FavnOrchestrator.Operator.Lineage.Limits
+  alias FavnOrchestrator.Operator.Lineage.Summary
+  alias FavnView.Components.AppShell
+  alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.GlassPanel
+
+  @canvas_width 1_560
+  @canvas_height 820
+  @layers [:raw, :staging, :core, :marts, :dashboards]
+
+  attr :graph, :any, default: nil
+  attr :inspector, :any, default: nil
+  attr :view_mode, :atom, default: :all
+  attr :search, :string, default: ""
+  attr :loading, :boolean, default: false
+  attr :error, :any, default: nil
+  attr :nav_items, :list, default: []
+  attr :zoom, :integer, default: 62
+  attr :canvas_hook?, :boolean, default: true
+  attr :inspector_open?, :boolean, default: true
+
+  def lineage_page(assigns) do
+    assigns = assign_new(assigns, :nav_items, fn -> AssetCataloguePage.nav_items(:assets) end)
+
+    ~H"""
+    <AppShell.app_shell
+      title="Asset lineage"
+      subtitle={lineage_subtitle(@graph)}
+      status="Live"
+      status_tone={:success}
+      nav_items={@nav_items}
+      back_href={~p"/assets"}
+      back_label="Back to assets"
+      content_scroll?={false}
+    >
+      <.lineage_explorer
+        graph={@graph}
+        inspector={@inspector}
+        view_mode={@view_mode}
+        search={@search}
+        loading={@loading}
+        error={@error}
+        zoom={@zoom}
+        canvas_hook?={@canvas_hook?}
+        inspector_open?={@inspector_open?}
+      />
+    </AppShell.app_shell>
+    """
+  end
+
+  attr :graph, :any, default: nil
+  attr :inspector, :any, default: nil
+  attr :view_mode, :atom, default: :all
+  attr :search, :string, default: ""
+  attr :loading, :boolean, default: false
+  attr :error, :any, default: nil
+  attr :zoom, :integer, default: 62
+  attr :canvas_hook?, :boolean, default: true
+  attr :inspector_open?, :boolean, default: true
+
+  def lineage_explorer(assigns) do
+    ~H"""
+    <div class="flex min-h-0 flex-1 flex-col gap-3" data-testid="lineage-page">
+      <.loading_state :if={@loading} />
+      <.error_state :if={!@loading && @error} error={@error} />
+      <.empty_state :if={!@loading && !@error && is_nil(@graph)} />
+
+      <div :if={!@loading && !@error && @graph} class="flex min-h-0 flex-1 flex-col gap-3">
+        <.lineage_toolbar view_mode={@view_mode} search={@search} zoom={@zoom} />
+
+        <div class={[
+          "grid min-h-0 flex-1 gap-3",
+          @inspector_open? && "xl:grid-cols-[minmax(0,1fr)_22rem] 2xl:grid-cols-[minmax(0,1fr)_24rem]"
+        ]}>
+          <.lineage_canvas graph={@graph} zoom={@zoom} canvas_hook?={@canvas_hook?} />
+          <.lineage_inspector :if={@inspector_open?} inspector={@inspector} graph={@graph} />
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :view_mode, :atom, required: true
+  attr :search, :string, required: true
+  attr :zoom, :integer, required: true
+
+  def lineage_toolbar(assigns) do
+    ~H"""
+    <div
+      class="flex shrink-0 flex-col gap-2 lg:flex-row lg:items-center lg:justify-between"
+      data-testid="lineage-toolbar"
+    >
+      <form phx-change="search_lineage" phx-submit="search_lineage" class="flex min-w-0 flex-1 gap-2">
+        <label class="input input-sm favn-surface-control min-w-0 flex-1 gap-3 px-4 focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-primary">
+          <.icon name="hero-magnifying-glass" class="size-5 shrink-0 text-base-content/60" />
+          <span class="sr-only">Search lineage</span>
+          <input
+            type="search"
+            name="search"
+            value={@search}
+            placeholder="Search assets, groups, or schemas..."
+            autocomplete="off"
+            phx-debounce="200"
+          />
+          <kbd class="kbd kbd-xs border-base-content/10 bg-base-100/20 text-base-content/50">K</kbd>
+        </label>
+
+        <button
+          type="button"
+          class="btn btn-sm favn-surface-control gap-2 px-4"
+          phx-click="toggle_filters"
+        >
+          <.icon name="hero-funnel" class="size-4" />
+          <span class="hidden sm:inline">Filters</span>
+        </button>
+      </form>
+
+      <div class="flex items-center gap-2 overflow-x-auto pb-1 lg:pb-0">
+        <div
+          class="join favn-surface-control min-h-0 rounded-box p-1"
+          role="tablist"
+          aria-label="Lineage view modes"
+        >
+          <button
+            :for={mode <- view_modes()}
+            type="button"
+            class={[
+              "join-item btn btn-ghost btn-xs h-8 rounded-field px-3 text-xs font-normal",
+              @view_mode == mode.id && "bg-primary/15 text-primary"
+            ]}
+            phx-click="set_mode"
+            phx-value-mode={mode.id}
+            aria-pressed={@view_mode == mode.id}
+          >
+            {mode.label}
+          </button>
+        </div>
+
+        <button
+          type="button"
+          class="btn btn-sm favn-surface-control gap-2 px-3"
+          phx-click="fit_graph"
+          data-lineage-command="fit"
+          aria-label="Fit graph"
+        >
+          <.icon name="hero-arrows-pointing-in" class="size-4" />
+          <span class="hidden xl:inline">Fit graph</span>
+        </button>
+
+        <div class="join favn-surface-control min-h-0 rounded-box p-1">
+          <button
+            type="button"
+            class="join-item btn btn-ghost btn-xs h-8 px-3"
+            phx-click="zoom_out"
+            data-lineage-command="zoom-out"
+            aria-label="Zoom out"
+          >
+            <.icon name="hero-minus" class="size-4" />
+          </button>
+          <span class="join-item flex h-8 min-w-14 items-center justify-center border-x border-base-content/10 px-3 text-xs text-base-content/70">
+            {@zoom}%
+          </span>
+          <button
+            type="button"
+            class="join-item btn btn-ghost btn-xs h-8 px-3"
+            phx-click="zoom_in"
+            data-lineage-command="zoom-in"
+            aria-label="Zoom in"
+          >
+            <.icon name="hero-plus" class="size-4" />
+          </button>
+        </div>
+
+        <button
+          type="button"
+          class="btn btn-sm btn-square favn-surface-control"
+          phx-click="toggle_fullscreen"
+          aria-label="Fullscreen"
+        >
+          <.icon name="hero-arrows-pointing-out" class="size-4" />
+        </button>
+      </div>
+    </div>
+    """
+  end
+
+  attr :graph, :any, required: true
+  attr :zoom, :integer, required: true
+  attr :canvas_hook?, :boolean, default: true
+
+  def lineage_canvas(assigns) do
+    positions = layout_positions(assigns.graph.nodes)
+
+    assigns =
+      assigns
+      |> assign(:positions, positions)
+      |> assign(:canvas_width, @canvas_width)
+      |> assign(:canvas_height, @canvas_height)
+
+    ~H"""
+    <section
+      class="favn-surface-panel relative min-h-[34rem] overflow-hidden rounded-box border border-primary/20"
+      data-testid="lineage-canvas-shell"
+    >
+      <div class="absolute inset-0 bg-base-100/20"></div>
+      <div
+        class="absolute inset-0 opacity-80"
+        style="background-image: radial-gradient(color-mix(in oklab, var(--color-primary) 24%, transparent) 1px, transparent 1px); background-size: 18px 18px; mask-image: radial-gradient(circle at 46% 46%, black, transparent 78%);"
+      >
+      </div>
+
+      <div
+        class="relative h-full min-h-[34rem] overflow-hidden"
+        id="lineage-canvas"
+        phx-hook={if(@canvas_hook?, do: "LineageCanvas")}
+        data-testid="lineage-canvas"
+        data-zoom={@zoom}
+      >
+        <div
+          class="lineage-canvas-content absolute left-0 top-0 origin-top-left transition-transform duration-150"
+          style={"width: #{@canvas_width}px; height: #{@canvas_height}px; transform: scale(#{@zoom / 100});"}
+          data-testid="lineage-canvas-content"
+        >
+          <.layer_headers />
+
+          <svg
+            class="pointer-events-none absolute inset-0 size-full overflow-visible"
+            viewBox={"0 0 #{@canvas_width} #{@canvas_height}"}
+            aria-hidden="true"
+          >
+            <defs>
+              <marker
+                id="lineage-arrow"
+                markerWidth="8"
+                markerHeight="8"
+                refX="6"
+                refY="4"
+                orient="auto"
+                markerUnits="strokeWidth"
+              >
+                <path d="M 0 0 L 8 4 L 0 8 z" class="fill-primary/80" />
+              </marker>
+            </defs>
+            <path
+              :for={edge <- @graph.edges}
+              d={edge_path(edge, @positions)}
+              class={[
+                "fill-none stroke-2",
+                edge.selected? &&
+                  "stroke-primary drop-shadow-[0_0_10px_color-mix(in_oklab,var(--color-primary)_80%,transparent)]",
+                !edge.selected? && edge.status == :warning && "stroke-warning/70",
+                !edge.selected? && edge.status != :warning && "stroke-success/60"
+              ]}
+              marker-end="url(#lineage-arrow)"
+            />
+          </svg>
+
+          <button
+            :for={edge <- @graph.edges}
+            type="button"
+            class="absolute z-20 rounded-field border border-primary/25 bg-base-100/80 px-2 py-1 text-[0.65rem] text-base-content/80 shadow-lg backdrop-blur transition hover:border-primary hover:text-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary"
+            style={edge_label_style(edge, @positions)}
+            phx-click="select_edge"
+            phx-value-id={edge.id}
+            data-testid="lineage-edge-label"
+            aria-label={"Inspect #{edge.dependency_count} dependencies"}
+          >
+            {edge.dependency_count} deps
+          </button>
+
+          <.lineage_node
+            :for={node <- @graph.nodes}
+            node={node}
+            position={Map.fetch!(@positions, node.id)}
+          />
+        </div>
+      </div>
+
+      <.lineage_hint_strip />
+      <.lineage_minimap graph={@graph} positions={@positions} />
+    </section>
+    """
+  end
+
+  defp layer_headers(assigns) do
+    assigns = assign(assigns, :layers, @layers)
+
+    ~H"""
+    <div
+      :for={layer <- @layers}
+      class="absolute top-8 z-10 text-xs text-base-content/75"
+      style={"left: #{layer_x(layer)}px; width: 220px;"}
+    >
+      <div class="flex items-center gap-2">
+        <.icon name={layer_icon(layer)} class="size-4 text-primary/80" />
+        <span class="font-medium">{layer_label(layer)}</span>
+      </div>
+      <p class="mt-1 text-[0.65rem] text-base-content/45">{layer_caption(layer)}</p>
+    </div>
+    """
+  end
+
+  attr :node, :any, required: true
+  attr :position, :map, required: true
+
+  def lineage_node(%{node: %GroupNode{}} = assigns) do
+    ~H"""
+    <button
+      type="button"
+      class={[
+        "absolute z-30 block rounded-box border p-4 text-left shadow-2xl backdrop-blur transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary",
+        "border-primary/25 bg-base-200/65 hover:border-primary/60 hover:bg-base-200/80",
+        @node.selected? &&
+          "border-primary bg-primary/10 shadow-[0_0_0_1px_color-mix(in_oklab,var(--color-primary)_60%,transparent),0_0_32px_color-mix(in_oklab,var(--color-primary)_44%,transparent)]"
+      ]}
+      style={node_style(@position)}
+      phx-click="select_node"
+      phx-value-id={@node.id}
+      phx-value-kind="group"
+      data-testid="lineage-group-node"
+      aria-label={"Inspect #{@node.label} lineage group"}
+    >
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex min-w-0 items-start gap-3">
+          <span class="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-field border border-primary/25 bg-primary/10 text-primary">
+            <.icon name={node_icon(@node)} class="size-5" />
+          </span>
+          <div class="min-w-0">
+            <h2 class="truncate text-sm font-semibold text-base-content">{@node.label}</h2>
+            <p class="mt-0.5 truncate text-[0.68rem] text-base-content/55">
+              {asset_count_label(@node)}
+            </p>
+          </div>
+        </div>
+        <span class="rounded-field border border-base-content/10 p-1 text-base-content/55">
+          <.icon name="hero-chevron-down" class="size-4" />
+        </span>
+      </div>
+
+      <div class="mt-3 flex flex-wrap gap-x-3 gap-y-1 text-[0.65rem]">
+        <.status_count status={:fresh} count={@node.status_counts.fresh} />
+        <.status_count status={:stale} count={@node.status_counts.stale} />
+        <.status_count status={:failed} count={@node.status_counts.failed} />
+        <.status_count status={:running} count={@node.status_counts.running} />
+      </div>
+
+      <div :if={@node.state != :collapsed} class="mt-3 space-y-1.5">
+        <div
+          :for={asset <- @node.preview_assets}
+          class="flex items-center gap-2 rounded-field border border-base-content/10 bg-base-100/30 px-2.5 py-1.5 text-xs text-base-content/80"
+        >
+          <.icon name="hero-circle-stack" class="size-4 shrink-0 text-base-content/60" />
+          <span class="min-w-0 flex-1 truncate">{asset.label}</span>
+          <span class={status_dot_class(asset.freshness_status)}></span>
+        </div>
+        <div
+          :if={@node.hidden_asset_count > 0}
+          class="rounded-field border border-base-content/10 bg-base-100/20 px-2.5 py-1.5 text-xs text-base-content/55"
+        >
+          +{@node.hidden_asset_count} more
+        </div>
+      </div>
+    </button>
+    """
+  end
+
+  def lineage_node(%{node: %AssetNode{}} = assigns) do
+    ~H"""
+    <button
+      type="button"
+      class={[
+        "absolute z-30 flex items-center gap-3 rounded-box border p-3 text-left shadow-xl backdrop-blur transition focus-visible:outline focus-visible:outline-2 focus-visible:outline-primary",
+        "border-primary/20 bg-base-200/70 hover:border-primary/60",
+        @node.selected? &&
+          "border-primary bg-primary/10 shadow-[0_0_28px_color-mix(in_oklab,var(--color-primary)_42%,transparent)]"
+      ]}
+      style={node_style(@position)}
+      phx-click="select_node"
+      phx-value-id={@node.id}
+      phx-value-kind="asset"
+      data-testid="lineage-asset-node"
+      aria-label={"Inspect #{@node.label} lineage asset"}
+    >
+      <span class="flex size-8 shrink-0 items-center justify-center rounded-field border border-primary/25 bg-primary/10 text-primary">
+        <.icon name="hero-cube-transparent" class="size-5" />
+      </span>
+      <div class="min-w-0 flex-1">
+        <h2 class="truncate text-sm font-semibold text-base-content">{@node.label}</h2>
+        <p class="truncate text-[0.68rem] text-base-content/50">
+          {@node.schema || @node.layer} · {@node.kind}
+        </p>
+      </div>
+      <span class={status_dot_class(@node.freshness_status)}></span>
+    </button>
+    """
+  end
+
+  attr :status, :atom, required: true
+  attr :count, :integer, required: true
+
+  def status_count(assigns) do
+    ~H"""
+    <span class={status_text_class(@status)}>
+      <span class={status_dot_class(@status)}></span>
+      {@count} {status_label(@status)}
+    </span>
+    """
+  end
+
+  attr :inspector, :any, default: nil
+  attr :graph, Graph, required: true
+
+  def lineage_inspector(assigns) do
+    ~H"""
+    <aside
+      class="favn-surface-panel min-h-0 overflow-hidden rounded-box border border-primary/20"
+      data-testid="lineage-inspector"
+    >
+      <.group_inspector :if={match?(%GroupInspector{}, @inspector)} inspector={@inspector} />
+      <.asset_inspector :if={match?(%AssetInspector{}, @inspector)} inspector={@inspector} />
+      <.edge_inspector :if={match?(%EdgeInspector{}, @inspector)} inspector={@inspector} />
+      <.empty_inspector :if={is_nil(@inspector)} graph={@graph} />
+    </aside>
+    """
+  end
+
+  attr :inspector, :any, required: true
+
+  def group_inspector(assigns) do
+    ~H"""
+    <div class="flex h-full min-h-0 flex-col">
+      <.inspector_header
+        title={@inspector.title}
+        subtitle={@inspector.group.schema || "group"}
+        status={dominant_status(@inspector.group.status_counts)}
+        icon="hero-circle-stack"
+        close_event="close_inspector"
+      />
+      <div class="min-h-0 flex-1 space-y-5 overflow-y-auto p-4">
+        <.inspector_section title="About this group">
+          <.definition label="System" value={@inspector.about.system || "-"} />
+          <.definition label="Schema" value={@inspector.about.schema || "-"} />
+          <.definition
+            label="Type"
+            value={@inspector.about.type |> to_string() |> String.replace("_", " ")}
+          />
+          <.definition label="Assets" value={Integer.to_string(@inspector.about.asset_count)} />
+        </.inspector_section>
+
+        <.inspector_section title="Health summary">
+          <.health_bar
+            label="Fresh"
+            status={:fresh}
+            count={@inspector.health_summary.fresh}
+            total={@inspector.group.asset_count}
+          />
+          <.health_bar
+            label="Stale"
+            status={:stale}
+            count={@inspector.health_summary.stale}
+            total={@inspector.group.asset_count}
+          />
+          <.health_bar
+            label="Failed"
+            status={:failed}
+            count={@inspector.health_summary.failed}
+            total={@inspector.group.asset_count}
+          />
+          <.health_bar
+            label="Running"
+            status={:running}
+            count={@inspector.health_summary.running}
+            total={@inspector.group.asset_count}
+          />
+        </.inspector_section>
+
+        <.inspector_section title="Top issues">
+          <div :if={@inspector.top_issues == []} class="text-sm text-base-content/55">
+            No active issues.
+          </div>
+          <div
+            :for={issue <- @inspector.top_issues}
+            class="flex items-center justify-between rounded-field border border-base-content/10 bg-base-100/20 px-3 py-2 text-sm"
+          >
+            <span class="flex items-center gap-2">
+              <.icon name="hero-exclamation-triangle" class="size-4 text-warning" /> {issue.label}
+            </span>
+            <span class="text-base-content/55">{issue.count}</span>
+          </div>
+        </.inspector_section>
+
+        <.dependency_list title="Downstream" items={@inspector.downstream} />
+        <.dependency_list title="Upstream" items={@inspector.upstream} />
+      </div>
+      <.inspector_actions actions={@inspector.actions} />
+    </div>
+    """
+  end
+
+  attr :inspector, :any, required: true
+
+  def asset_inspector(assigns) do
+    ~H"""
+    <div class="flex h-full min-h-0 flex-col">
+      <.inspector_header
+        title={@inspector.title}
+        subtitle={@inspector.asset.asset_ref_text}
+        status={@inspector.asset.freshness_status}
+        icon="hero-cube-transparent"
+        close_event="close_inspector"
+      />
+      <div class="min-h-0 flex-1 space-y-5 overflow-y-auto p-4">
+        <.inspector_section title="Asset detail">
+          <.definition label="Schema" value={@inspector.asset.schema || "-"} />
+          <.definition label="Layer" value={to_string(@inspector.asset.layer)} />
+          <.definition label="Kind" value={to_string(@inspector.asset.kind)} />
+          <.definition label="Freshness" value={status_label(@inspector.asset.freshness_status)} />
+        </.inspector_section>
+        <.inspector_section title="Latest run">
+          <div :if={is_nil(@inspector.latest_run)} class="text-sm text-base-content/55">
+            No run evidence yet.
+          </div>
+          <.definition :if={@inspector.latest_run} label="Run" value={@inspector.latest_run.id} />
+          <.definition
+            :if={@inspector.latest_run}
+            label="Status"
+            value={to_string(@inspector.latest_run.status)}
+          />
+        </.inspector_section>
+        <.dependency_list title="Downstream" items={@inspector.downstream} />
+        <.dependency_list title="Upstream" items={@inspector.upstream} />
+      </div>
+      <.inspector_actions actions={@inspector.actions} />
+    </div>
+    """
+  end
+
+  attr :inspector, :any, required: true
+
+  def edge_inspector(assigns) do
+    ~H"""
+    <div class="flex h-full min-h-0 flex-col">
+      <.inspector_header
+        title={@inspector.title}
+        subtitle="dependency edge"
+        status={@inspector.edge.status}
+        icon="hero-share"
+        close_event="close_inspector"
+      />
+      <div class="min-h-0 flex-1 space-y-5 overflow-y-auto p-4">
+        <.inspector_section title="Dependency path">
+          <.definition label="From" value={@inspector.upstream_label || @inspector.edge.from} />
+          <.definition label="To" value={@inspector.downstream_label || @inspector.edge.to} />
+          <.definition
+            label="Dependencies"
+            value={Integer.to_string(@inspector.edge.dependency_count)}
+          />
+        </.inspector_section>
+        <.inspector_section title="Preview dependencies">
+          <div
+            :for={dependency <- @inspector.dependencies}
+            class="rounded-field border border-base-content/10 bg-base-100/20 px-3 py-2 text-xs text-base-content/70"
+          >
+            {dependency.from} -> {dependency.to}
+          </div>
+        </.inspector_section>
+      </div>
+      <.inspector_actions actions={@inspector.actions} />
+    </div>
+    """
+  end
+
+  attr :title, :string, required: true
+  attr :subtitle, :string, default: nil
+  attr :status, :atom, default: :unknown
+  attr :icon, :string, required: true
+  attr :close_event, :string, default: nil
+
+  def inspector_header(assigns) do
+    ~H"""
+    <header class="border-b border-base-content/10 p-4">
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex min-w-0 items-start gap-3">
+          <span class="flex size-9 shrink-0 items-center justify-center rounded-field border border-primary/25 bg-primary/10 text-primary">
+            <.icon name={@icon} class="size-5" />
+          </span>
+          <div class="min-w-0">
+            <h2 class="truncate text-base font-semibold">{@title}</h2>
+            <p :if={@subtitle} class="truncate text-xs text-base-content/55">{@subtitle}</p>
+          </div>
+        </div>
+        <div class="flex items-center gap-2">
+          <span class={status_pill_class(@status)}>
+            <span class={status_dot_class(@status)}></span>
+            {status_label(@status)}
+          </span>
+          <button
+            :if={@close_event}
+            type="button"
+            class="btn btn-ghost btn-xs btn-square favn-icon-button"
+            phx-click={@close_event}
+            aria-label="Close lineage inspector"
+            data-testid="lineage-inspector-close"
+          >
+            <.icon name="hero-x-mark" class="size-4" />
+          </button>
+        </div>
+      </div>
+    </header>
+    """
+  end
+
+  attr :graph, :any, required: true
+
+  def empty_inspector(assigns) do
+    ~H"""
+    <div class="relative flex h-full min-h-96 flex-col items-center justify-center p-8 text-center">
+      <button
+        type="button"
+        class="btn btn-ghost btn-xs btn-square favn-icon-button absolute right-3 top-3"
+        phx-click="close_inspector"
+        aria-label="Close lineage inspector"
+        data-testid="lineage-inspector-close"
+      >
+        <.icon name="hero-x-mark" class="size-4" />
+      </button>
+      <span class="flex size-12 items-center justify-center rounded-box border border-primary/25 bg-primary/10 text-primary">
+        <.icon name="hero-share" class="size-6" />
+      </span>
+      <h2 class="mt-4 text-base font-semibold">Select lineage context</h2>
+      <p class="mt-2 max-w-xs text-sm text-base-content/55">
+        Select a group, asset, or dependency edge to inspect health, impact, and downstream relationships.
+      </p>
+      <p class="mt-4 text-xs text-base-content/45">
+        {@graph.summary.visible_groups} groups · {@graph.summary.visible_edges} dependencies visible
+      </p>
+    </div>
+    """
+  end
+
+  attr :title, :string, required: true
+  slot :inner_block, required: true
+
+  def inspector_section(assigns) do
+    ~H"""
+    <section class="space-y-2.5 border-b border-base-content/10 pb-5 last:border-b-0">
+      <h3 class="text-sm font-medium text-base-content/90">{@title}</h3>
+      {render_slot(@inner_block)}
+    </section>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :value, :string, required: true
+
+  def definition(assigns) do
+    ~H"""
+    <div class="grid grid-cols-[6rem_minmax(0,1fr)] gap-3 text-sm">
+      <dt class="text-base-content/50">{@label}</dt>
+      <dd class="truncate text-base-content/85" title={@value}>{@value}</dd>
+    </div>
+    """
+  end
+
+  attr :label, :string, required: true
+  attr :status, :atom, required: true
+  attr :count, :integer, required: true
+  attr :total, :integer, required: true
+
+  def health_bar(assigns) do
+    assigns = assign(assigns, :percent, percent(assigns.count, assigns.total))
+
+    ~H"""
+    <div class="space-y-1.5">
+      <div class="flex items-center justify-between text-xs">
+        <span class={status_text_class(@status)}>
+          <span class={status_dot_class(@status)}></span> {@count} {@label}
+        </span>
+        <span class="text-base-content/45">{@percent}%</span>
+      </div>
+      <div class="h-1.5 overflow-hidden rounded-full bg-base-content/10">
+        <div class={health_bar_class(@status)} style={"width: #{@percent}%;"}></div>
+      </div>
+    </div>
+    """
+  end
+
+  attr :title, :string, required: true
+  attr :items, :list, required: true
+
+  def dependency_list(assigns) do
+    ~H"""
+    <.inspector_section title={@title}>
+      <div :if={@items == []} class="text-sm text-base-content/55">No visible dependencies.</div>
+      <div
+        :for={item <- @items}
+        class="flex items-center justify-between rounded-field border border-base-content/10 bg-base-100/20 px-3 py-2 text-sm"
+      >
+        <span class="truncate">{item.label}</span>
+        <span class="shrink-0 text-xs text-success">{item.dependency_count} deps</span>
+      </div>
+    </.inspector_section>
+    """
+  end
+
+  attr :actions, :list, default: []
+
+  def inspector_actions(assigns) do
+    ~H"""
+    <footer class="grid grid-cols-2 gap-2 border-t border-base-content/10 p-4">
+      <button :for={action <- @actions} type="button" class="btn btn-sm btn-outline btn-primary">
+        {action.label}
+      </button>
+    </footer>
+    """
+  end
+
+  def lineage_hint_strip(assigns) do
+    ~H"""
+    <div
+      class="absolute bottom-4 left-4 z-40 hidden rounded-box border border-base-content/10 bg-base-100/70 px-4 py-3 text-[0.68rem] text-base-content/65 shadow-xl backdrop-blur lg:flex lg:gap-5"
+      data-testid="lineage-hint-strip"
+    >
+      <span class="flex items-center gap-2">
+        <.icon name="hero-hand-raised" class="size-4" /> Pan
+        <span class="text-base-content/40">Click and drag</span>
+      </span>
+      <span class="flex items-center gap-2">
+        <.icon name="hero-magnifying-glass-plus" class="size-4" /> Zoom
+        <span class="text-base-content/40">Scroll or pinch</span>
+      </span>
+      <span class="flex items-center gap-2">
+        <.icon name="hero-cursor-arrow-rays" class="size-4" /> Select
+        <span class="text-base-content/40">Click a node</span>
+      </span>
+      <span class="flex items-center gap-2">
+        <.icon name="hero-plus-circle" class="size-4" /> Expand
+        <span class="text-base-content/40">Click group chevron</span>
+      </span>
+    </div>
+    """
+  end
+
+  attr :graph, :any, required: true
+  attr :positions, :map, required: true
+
+  def lineage_minimap(assigns) do
+    ~H"""
+    <div
+      class="absolute bottom-4 right-4 z-40 hidden w-64 rounded-box border border-primary/25 bg-base-100/75 p-3 shadow-xl backdrop-blur xl:block"
+      data-testid="lineage-minimap"
+    >
+      <div class="mb-2 flex justify-end gap-2 text-base-content/60">
+        <.icon name="hero-magnifying-glass" class="size-4" />
+        <.icon name="hero-arrows-pointing-in" class="size-4" />
+        <.icon name="hero-square-3-stack-3d" class="size-4" />
+      </div>
+      <div class="relative h-24 overflow-hidden rounded-field border border-primary/35 bg-primary/5">
+        <div
+          :for={node <- @graph.nodes}
+          class="absolute rounded-sm bg-primary/35"
+          style={minimap_node_style(Map.fetch!(@positions, node.id))}
+        >
+        </div>
+        <div
+          class="absolute inset-3 border border-primary bg-primary/5 shadow-[0_0_18px_color-mix(in_oklab,var(--color-primary)_32%,transparent)]"
+          data-testid="lineage-minimap-viewport"
+        >
+        </div>
+      </div>
+    </div>
+    """
+  end
+
+  def loading_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel
+      class="flex min-h-96 items-center justify-center p-10"
+      data-testid="lineage-loading-state"
+    >
+      <div class="text-center">
+        <span class="loading loading-ring loading-lg text-primary"></span>
+        <p class="mt-4 text-base-content/60">Loading asset lineage</p>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  attr :error, :any, required: true
+
+  def error_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel
+      class="mx-auto flex min-h-96 max-w-2xl items-center justify-center p-10 text-center"
+      data-testid="lineage-error-state"
+    >
+      <div>
+        <.icon name="hero-exclamation-triangle" class="mx-auto size-10 text-warning" />
+        <h2 class="mt-4 text-xl font-medium">Could not load lineage</h2>
+        <p class="mt-2 text-base-content/60">{safe_error_message(@error)}</p>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def empty_state(assigns) do
+    ~H"""
+    <GlassPanel.glass_panel
+      class="mx-auto flex min-h-96 max-w-2xl items-center justify-center p-10 text-center"
+      data-testid="lineage-empty-state"
+    >
+      <div>
+        <.icon name="hero-share" class="mx-auto size-10 text-primary" />
+        <h2 class="mt-4 text-xl font-medium">No lineage graph</h2>
+        <p class="mt-2 text-base-content/60">
+          Register and activate a manifest to inspect asset lineage.
+        </p>
+      </div>
+    </GlassPanel.glass_panel>
+    """
+  end
+
+  def sample_graph do
+    limits = %Limits{}
+
+    github =
+      group("group:raw:github", "GitHub raw", :raw, 0,
+        asset_count: 42,
+        system: "GitHub",
+        schema: "raw",
+        selected?: true,
+        counts: %{fresh: 36, stale: 3, failed: 1, running: 2, unknown: 0},
+        assets: ["raw_issues", "raw_pull_requests", "raw_commits", "raw_users"]
+      )
+
+    stripe =
+      group("group:raw:stripe", "Stripe raw", :raw, 1,
+        asset_count: 28,
+        system: "Stripe",
+        schema: "raw",
+        counts: %{fresh: 24, stale: 2, failed: 0, running: 2, unknown: 0},
+        assets: ["raw_payments", "raw_customers", "raw_refunds"]
+      )
+
+    stg_github =
+      group("group:staging:github", "staging.github", :staging, 0,
+        asset_count: 18,
+        system: "github",
+        schema: "staging",
+        assets: ["stg_issues", "stg_prs", "stg_commits"]
+      )
+
+    stg_stripe =
+      group("group:staging:stripe", "staging.stripe", :staging, 1,
+        asset_count: 16,
+        system: "stripe",
+        schema: "staging",
+        assets: ["stg_payments", "stg_customers", "stg_refunds"]
+      )
+
+    fct_orders = asset("asset:fct_orders", "fct_orders", :core, 0, :fresh, selected?: true)
+    dim_customer = asset("asset:dim_customer", "dim_customer", :core, 1, :fresh)
+    dim_product = asset("asset:dim_product", "dim_product", :core, 2, :fresh)
+    dim_date = asset("asset:dim_date", "dim_date", :core, 3, :fresh)
+    mart_sales = asset("asset:mart_sales", "mart_sales", :marts, 0, :fresh)
+    mart_revenue = asset("asset:mart_revenue", "mart_revenue", :marts, 1, :stale)
+    mart_customer = asset("asset:mart_customer_360", "mart_customer_360", :marts, 2, :fresh)
+
+    sales =
+      asset("asset:sales_overview", "Sales Overview", :dashboards, 0, :fresh, kind: :dashboard)
+
+    revenue =
+      asset("asset:revenue_analysis", "Revenue Analysis", :dashboards, 1, :stale,
+        kind: :dashboard
+      )
+
+    customer =
+      asset("asset:customer_360", "Customer 360", :dashboards, 2, :fresh, kind: :dashboard)
+
+    executive =
+      asset("asset:executive_kpi", "Executive KPI", :dashboards, 3, :fresh, kind: :dashboard)
+
+    nodes = [
+      github,
+      stripe,
+      stg_github,
+      stg_stripe,
+      dim_customer,
+      fct_orders,
+      dim_product,
+      dim_date,
+      mart_sales,
+      mart_revenue,
+      mart_customer,
+      sales,
+      revenue,
+      customer,
+      executive
+    ]
+
+    edges = [
+      edge(github.id, stg_github.id, 18),
+      edge(stripe.id, stg_stripe.id, 12),
+      edge(stg_github.id, fct_orders.id, 18),
+      edge(stg_stripe.id, fct_orders.id, 12),
+      edge(dim_customer.id, fct_orders.id, 1),
+      edge(dim_product.id, fct_orders.id, 1),
+      edge(dim_date.id, fct_orders.id, 1),
+      edge(fct_orders.id, mart_sales.id, 9),
+      edge(fct_orders.id, mart_revenue.id, 5, :warning),
+      edge(fct_orders.id, mart_customer.id, 4),
+      edge(mart_sales.id, sales.id, 1),
+      edge(mart_sales.id, revenue.id, 1, :warning),
+      edge(mart_revenue.id, revenue.id, 1, :warning),
+      edge(mart_customer.id, customer.id, 1),
+      edge(mart_customer.id, executive.id, 1)
+    ]
+
+    %Graph{
+      manifest_version_id: "storybook",
+      scope: :global,
+      selected_id: github.id,
+      view_mode: :all,
+      nodes: nodes,
+      groups: Enum.filter(nodes, &match?(%GroupNode{}, &1)),
+      edges: edges,
+      summary: %Summary{
+        total_assets: 1248,
+        visible_assets: 74,
+        total_groups: 96,
+        visible_groups: 18,
+        total_edges: 2930,
+        visible_edges: 86,
+        status_counts: %{fresh: 1090, stale: 82, failed: 9, running: 7, unknown: 60},
+        truncated?: true
+      },
+      limits: limits,
+      layout: %{direction: :left_to_right, layers: @layers},
+      generated_at: ~U[2026-05-27 12:00:00Z]
+    }
+  end
+
+  def sample_group_inspector do
+    graph = sample_graph()
+    group = hd(graph.groups)
+
+    %GroupInspector{
+      id: group.id,
+      title: group.label,
+      group: group,
+      about: %{system: "GitHub", schema: "raw", type: :source_system, asset_count: 42},
+      health_summary: group.status_counts,
+      top_issues: [
+        %{kind: :high_latency, label: "High latency", count: 2},
+        %{kind: :schema_drift, label: "Schema drift", count: 1}
+      ],
+      downstream: [
+        %{id: "group:staging:github", label: "staging.github", dependency_count: 18},
+        %{id: "asset:fct_orders", label: "fct_orders", dependency_count: 9}
+      ],
+      upstream: [],
+      actions: [
+        %{label: "Drill into group", kind: :drill_in},
+        %{label: "View all assets (42)", kind: :assets}
+      ]
+    }
+  end
+
+  defp group(id, label, layer, rank, opts) do
+    counts =
+      Keyword.get(opts, :counts, %{
+        fresh: Keyword.get(opts, :asset_count, 1),
+        stale: 0,
+        failed: 0,
+        running: 0,
+        unknown: 0
+      })
+
+    asset_count = Keyword.get(opts, :asset_count, length(Keyword.get(opts, :assets, [])))
+    preview_assets = Enum.map(Keyword.get(opts, :assets, []), &preview_asset(&1, id, layer))
+
+    %GroupNode{
+      id: id,
+      label: label,
+      system: Keyword.get(opts, :system),
+      schema: Keyword.get(opts, :schema),
+      layer: layer,
+      type: if(layer == :raw, do: :source_system, else: :schema),
+      state: :expanded_preview,
+      asset_count: asset_count,
+      preview_assets: preview_assets,
+      preview_asset_ids: Enum.map(preview_assets, & &1.id),
+      hidden_asset_count: max(asset_count - length(preview_assets), 0),
+      status_counts: counts,
+      top_issues: [],
+      position_hint: %{layer: layer, rank: rank},
+      selected?: Keyword.get(opts, :selected?, false)
+    }
+  end
+
+  defp preview_asset(label, group_id, layer) do
+    %AssetNode{
+      id: "asset:#{label}",
+      label: label,
+      asset_ref: {__MODULE__, String.to_atom(label)},
+      asset_ref_text: "#{__MODULE__}:#{label}",
+      group_id: group_id,
+      schema: to_string(layer),
+      layer: layer,
+      kind: :table,
+      freshness_status: :fresh
+    }
+  end
+
+  defp asset(id, label, layer, rank, status, opts \\ []) do
+    %AssetNode{
+      id: id,
+      label: label,
+      asset_ref: {__MODULE__, String.to_atom(id)},
+      asset_ref_text: "#{__MODULE__}:#{label}",
+      group_id: "group:#{layer}:#{id}",
+      schema: to_string(layer),
+      layer: layer,
+      kind: Keyword.get(opts, :kind, :table),
+      freshness_status: status,
+      selected?: Keyword.get(opts, :selected?, false),
+      position_hint: %{layer: layer, rank: rank}
+    }
+  end
+
+  defp edge(from, to, count, status \\ :healthy) do
+    %Edge{
+      id: "edge:#{from}->#{to}",
+      from: from,
+      to: to,
+      dependency_count: count,
+      status: status,
+      aggregated?: count > 1,
+      preview_dependencies: [%{from: from, to: to}],
+      hidden_dependency_count: max(count - 1, 0)
+    }
+  end
+
+  defp lineage_subtitle(nil), do: "sales marts · Production"
+  defp lineage_subtitle(%Graph{}), do: "sales marts · Production"
+
+  defp view_modes do
+    [
+      %{id: :all, label: "All"},
+      %{id: :upstream, label: "Upstream"},
+      %{id: :downstream, label: "Downstream"},
+      %{id: :impact, label: "Impact"},
+      %{id: :freshness, label: "Freshness"}
+    ]
+  end
+
+  defp layout_positions(nodes) do
+    nodes
+    |> Enum.with_index()
+    |> Map.new(fn {node, fallback_rank} ->
+      layer = node.position_hint[:layer] || node.layer
+      rank = node.position_hint[:rank] || fallback_rank
+      width = if match?(%GroupNode{}, node), do: 270, else: 180
+      height = node_height(node)
+
+      {node.id, %{x: layer_x(layer), y: node_y(layer, rank, node), width: width, height: height}}
+    end)
+  end
+
+  defp node_height(%GroupNode{state: :collapsed}), do: 88
+  defp node_height(%GroupNode{preview_assets: assets}), do: 130 + length(assets) * 34
+  defp node_height(%AssetNode{}), do: 72
+
+  defp layer_x(:raw), do: 30
+  defp layer_x(:staging), do: 360
+  defp layer_x(:core), do: 690
+  defp layer_x(:marts), do: 980
+  defp layer_x(:dashboards), do: 1270
+  defp layer_x(_layer), do: 690
+
+  defp node_y(:raw, rank, _node), do: 145 + rank * 330
+  defp node_y(:staging, rank, _node), do: 200 + rank * 280
+  defp node_y(:core, rank, _node), do: 210 + rank * 105
+  defp node_y(:marts, rank, _node), do: 260 + rank * 125
+  defp node_y(:dashboards, rank, _node), do: 220 + rank * 120
+  defp node_y(_layer, rank, _node), do: 180 + rank * 120
+
+  defp node_style(position) do
+    "left: #{position.x}px; top: #{position.y}px; width: #{position.width}px; min-height: #{position.height}px;"
+  end
+
+  defp edge_path(edge, positions) do
+    from = Map.fetch!(positions, edge.from)
+    to = Map.fetch!(positions, edge.to)
+    x1 = from.x + from.width
+    y1 = from.y + from.height / 2
+    x2 = to.x
+    y2 = to.y + to.height / 2
+    bend = max((x2 - x1) / 2, 70)
+
+    "M #{x1} #{y1} C #{x1 + bend} #{y1}, #{x2 - bend} #{y2}, #{x2} #{y2}"
+  end
+
+  defp edge_label_style(edge, positions) do
+    from = Map.fetch!(positions, edge.from)
+    to = Map.fetch!(positions, edge.to)
+    x = (from.x + from.width + to.x) / 2 - 22
+    y = (from.y + from.height / 2 + to.y + to.height / 2) / 2 - 14
+    "left: #{x}px; top: #{y}px;"
+  end
+
+  defp minimap_node_style(position) do
+    "left: #{position.x / @canvas_width * 100}%; top: #{position.y / @canvas_height * 100}%; width: #{max(position.width / @canvas_width * 100, 3)}%; height: #{max(position.height / @canvas_height * 100, 4)}%;"
+  end
+
+  defp layer_label(:raw), do: "Raw systems"
+  defp layer_label(:staging), do: "Staging"
+  defp layer_label(:core), do: "Core"
+  defp layer_label(:marts), do: "Marts"
+  defp layer_label(:dashboards), do: "Dashboards"
+
+  defp layer_caption(:raw), do: "2 systems"
+  defp layer_caption(:staging), do: "2 schemas"
+  defp layer_caption(:core), do: "6 schemas"
+  defp layer_caption(:marts), do: "8 schemas"
+  defp layer_caption(:dashboards), do: "12 dashboards"
+
+  defp layer_icon(:raw), do: "hero-cpu-chip"
+  defp layer_icon(:staging), do: "hero-circle-stack"
+  defp layer_icon(:core), do: "hero-cube-transparent"
+  defp layer_icon(:marts), do: "hero-squares-2x2"
+  defp layer_icon(:dashboards), do: "hero-presentation-chart-line"
+
+  defp node_icon(%GroupNode{layer: :raw}), do: "hero-circle-stack"
+  defp node_icon(%GroupNode{layer: :staging}), do: "hero-server-stack"
+  defp node_icon(%GroupNode{layer: :dashboards}), do: "hero-presentation-chart-line"
+  defp node_icon(%GroupNode{}), do: "hero-cube-transparent"
+
+  defp asset_count_label(%GroupNode{layer: :raw, asset_count: count}), do: "#{count} endpoints"
+  defp asset_count_label(%GroupNode{asset_count: count}), do: "#{count} assets"
+
+  defp percent(_count, 0), do: 0
+  defp percent(count, total), do: round(count / total * 100)
+
+  defp dominant_status(%{failed: failed}) when failed > 0, do: :failed
+  defp dominant_status(%{stale: stale}) when stale > 0, do: :stale
+  defp dominant_status(%{running: running}) when running > 0, do: :running
+  defp dominant_status(%{unknown: unknown}) when unknown > 0, do: :unknown
+  defp dominant_status(_counts), do: :fresh
+
+  defp status_label(:healthy), do: "Fresh"
+  defp status_label(:fresh), do: "Fresh"
+  defp status_label(:stale), do: "Stale"
+  defp status_label(:failed), do: "Failed"
+  defp status_label(:running), do: "Running"
+  defp status_label(:warning), do: "Stale"
+  defp status_label(_status), do: "Unknown"
+
+  defp status_dot_class(:fresh), do: "status status-xs status-success"
+  defp status_dot_class(:healthy), do: "status status-xs status-success"
+  defp status_dot_class(:stale), do: "status status-xs status-warning"
+  defp status_dot_class(:warning), do: "status status-xs status-warning"
+  defp status_dot_class(:failed), do: "status status-xs status-error"
+  defp status_dot_class(:running), do: "status status-xs status-info"
+  defp status_dot_class(_status), do: "status status-xs status-neutral"
+
+  defp status_text_class(:fresh), do: "inline-flex items-center gap-1 text-success"
+  defp status_text_class(:stale), do: "inline-flex items-center gap-1 text-warning"
+  defp status_text_class(:failed), do: "inline-flex items-center gap-1 text-error"
+  defp status_text_class(:running), do: "inline-flex items-center gap-1 text-info"
+  defp status_text_class(_status), do: "inline-flex items-center gap-1 text-base-content/55"
+
+  defp status_pill_class(status),
+    do: ["badge badge-sm badge-soft gap-2", status_badge_class(status)]
+
+  defp status_badge_class(:fresh), do: "badge-success"
+  defp status_badge_class(:healthy), do: "badge-success"
+  defp status_badge_class(:stale), do: "badge-warning"
+  defp status_badge_class(:warning), do: "badge-warning"
+  defp status_badge_class(:failed), do: "badge-error"
+  defp status_badge_class(:running), do: "badge-info"
+  defp status_badge_class(_status), do: "badge-neutral"
+
+  defp health_bar_class(:fresh), do: "h-full rounded-full bg-success"
+  defp health_bar_class(:stale), do: "h-full rounded-full bg-warning"
+  defp health_bar_class(:failed), do: "h-full rounded-full bg-error"
+  defp health_bar_class(:running), do: "h-full rounded-full bg-info"
+  defp health_bar_class(_status), do: "h-full rounded-full bg-neutral"
+
+  defp safe_error_message(%{message: message}) when is_binary(message), do: message
+  defp safe_error_message(_error), do: "Backend unavailable. Try again shortly."
+end

--- a/apps/favn_view/lib/favn_view/components/lineage_page.ex
+++ b/apps/favn_view/lib/favn_view/components/lineage_page.ex
@@ -104,7 +104,7 @@ defmodule FavnView.Components.LineagePage do
       class="flex shrink-0 flex-col gap-2 lg:flex-row lg:items-center lg:justify-between"
       data-testid="lineage-toolbar"
     >
-      <form phx-change="search_lineage" phx-submit="search_lineage" class="flex min-w-0 flex-1 gap-2">
+      <div class="flex min-w-0 flex-1 gap-2">
         <label class="input input-sm favn-surface-control min-w-0 flex-1 gap-3 px-4 focus-within:outline focus-within:outline-2 focus-within:outline-offset-2 focus-within:outline-primary">
           <.icon name="hero-magnifying-glass" class="size-5 shrink-0 text-base-content/60" />
           <span class="sr-only">Search lineage</span>
@@ -112,22 +112,13 @@ defmodule FavnView.Components.LineagePage do
             type="search"
             name="search"
             value={@search}
-            placeholder="Search assets, groups, or schemas..."
+            placeholder="Search lineage coming soon"
             autocomplete="off"
-            phx-debounce="200"
+            disabled
           />
           <kbd class="kbd kbd-xs border-base-content/10 bg-base-100/20 text-base-content/50">K</kbd>
         </label>
-
-        <button
-          type="button"
-          class="btn btn-sm favn-surface-control gap-2 px-4"
-          phx-click="toggle_filters"
-        >
-          <.icon name="hero-funnel" class="size-4" />
-          <span class="hidden sm:inline">Filters</span>
-        </button>
-      </form>
+      </div>
 
       <div class="flex items-center gap-2 overflow-x-auto pb-1 lg:pb-0">
         <div
@@ -140,10 +131,12 @@ defmodule FavnView.Components.LineagePage do
             type="button"
             class={[
               "join-item btn btn-ghost btn-xs h-8 rounded-field px-3 text-xs font-normal",
-              @view_mode == mode.id && "bg-primary/15 text-primary"
+              @view_mode == mode.id && "bg-primary/15 text-primary",
+              mode[:disabled] && "opacity-45"
             ]}
-            phx-click="set_mode"
+            phx-click={if(mode[:disabled], do: false, else: "set_mode")}
             phx-value-mode={mode.id}
+            disabled={mode[:disabled] || false}
             aria-pressed={@view_mode == mode.id}
           >
             {mode.label}
@@ -184,15 +177,6 @@ defmodule FavnView.Components.LineagePage do
             <.icon name="hero-plus" class="size-4" />
           </button>
         </div>
-
-        <button
-          type="button"
-          class="btn btn-sm btn-square favn-surface-control"
-          phx-click="toggle_fullscreen"
-          aria-label="Fullscreen"
-        >
-          <.icon name="hero-arrows-pointing-out" class="size-4" />
-        </button>
       </div>
     </div>
     """
@@ -235,7 +219,7 @@ defmodule FavnView.Components.LineagePage do
           style={"width: #{@canvas_width}px; height: #{@canvas_height}px; transform: scale(#{@zoom / 100});"}
           data-testid="lineage-canvas-content"
         >
-          <.layer_headers />
+          <.layer_headers graph={@graph} />
 
           <svg
             class="pointer-events-none absolute inset-0 size-full overflow-visible"
@@ -296,6 +280,8 @@ defmodule FavnView.Components.LineagePage do
     """
   end
 
+  attr :graph, :any, required: true
+
   defp layer_headers(assigns) do
     assigns = assign(assigns, :layers, @layers)
 
@@ -309,7 +295,7 @@ defmodule FavnView.Components.LineagePage do
         <.icon name={layer_icon(layer)} class="size-4 text-primary/80" />
         <span class="font-medium">{layer_label(layer)}</span>
       </div>
-      <p class="mt-1 text-[0.65rem] text-base-content/45">{layer_caption(layer)}</p>
+      <p class="mt-1 text-[0.65rem] text-base-content/45">{layer_caption(@graph, layer)}</p>
     </div>
     """
   end
@@ -1061,10 +1047,10 @@ defmodule FavnView.Components.LineagePage do
   defp view_modes do
     [
       %{id: :all, label: "All"},
-      %{id: :upstream, label: "Upstream"},
-      %{id: :downstream, label: "Downstream"},
-      %{id: :impact, label: "Impact"},
-      %{id: :freshness, label: "Freshness"}
+      %{id: :upstream, label: "Upstream", disabled: true},
+      %{id: :downstream, label: "Downstream", disabled: true},
+      %{id: :impact, label: "Impact", disabled: true},
+      %{id: :freshness, label: "Freshness", disabled: true}
     ]
   end
 
@@ -1133,11 +1119,18 @@ defmodule FavnView.Components.LineagePage do
   defp layer_label(:marts), do: "Marts"
   defp layer_label(:dashboards), do: "Dashboards"
 
-  defp layer_caption(:raw), do: "2 systems"
-  defp layer_caption(:staging), do: "2 schemas"
-  defp layer_caption(:core), do: "6 schemas"
-  defp layer_caption(:marts), do: "8 schemas"
-  defp layer_caption(:dashboards), do: "12 dashboards"
+  defp layer_caption(%Graph{} = graph, layer) do
+    count = Enum.count(graph.nodes, &(&1.layer == layer))
+
+    case layer do
+      :raw -> pluralize(count, "system", "systems")
+      :dashboards -> pluralize(count, "dashboard", "dashboards")
+      _layer -> pluralize(count, "group", "groups")
+    end
+  end
+
+  defp pluralize(1, singular, _plural), do: "1 #{singular}"
+  defp pluralize(count, _singular, plural), do: "#{count} #{plural}"
 
   defp layer_icon(:raw), do: "hero-cpu-chip"
   defp layer_icon(:staging), do: "hero-circle-stack"

--- a/apps/favn_view/storybook/components/asset_catalogue_page.story.exs
+++ b/apps/favn_view/storybook/components/asset_catalogue_page.story.exs
@@ -1,5 +1,6 @@
 defmodule FavnView.Storybook.Components.AssetCataloguePage do
   alias FavnView.Components.AssetCataloguePage
+  alias FavnView.Components.LineagePage
 
   use PhoenixStorybook.Story, :component
 
@@ -30,6 +31,27 @@ defmodule FavnView.Storybook.Components.AssetCataloguePage do
           nav_items: AssetCataloguePage.nav_items(),
           connection_options: AssetCataloguePage.connection_options(),
           catalogue_options: AssetCataloguePage.catalogue_options()
+        }
+      },
+      %Variation{
+        id: :lineage,
+        attributes: %{
+          assets: AssetCataloguePage.sample_assets(),
+          filters: %{search: "", connection: "all", catalogue: "all"},
+          active_mode: :lineage,
+          loading: false,
+          error: nil,
+          nav_items: AssetCataloguePage.nav_items(:assets),
+          connection_options: AssetCataloguePage.connection_options(),
+          catalogue_options: AssetCataloguePage.catalogue_options(),
+          lineage_graph: LineagePage.sample_graph(),
+          lineage_inspector: LineagePage.sample_group_inspector(),
+          lineage_loading: false,
+          lineage_error: nil,
+          lineage_search: "",
+          lineage_zoom: 62,
+          lineage_inspector_open?: true,
+          lineage_canvas_hook?: false
         }
       },
       %Variation{

--- a/apps/favn_view/storybook/components/lineage_page.story.exs
+++ b/apps/favn_view/storybook/components/lineage_page.story.exs
@@ -1,0 +1,78 @@
+defmodule FavnView.Storybook.Components.LineagePage do
+  alias FavnView.Components.LineagePage
+
+  use PhoenixStorybook.Story, :component
+
+  def function, do: &LineagePage.lineage_page/1
+  def layout, do: :one_column
+  def render_source, do: :function
+
+  def container, do: {:iframe, style: "width: 100%; height: 980px; border: 0;"}
+
+  def template do
+    """
+    <div data-theme="favn-dark">
+      <.psb-variation/>
+    </div>
+    """
+  end
+
+  def variations do
+    graph = LineagePage.sample_graph()
+
+    [
+      %Variation{
+        id: :full_page,
+        attributes: %{
+          graph: graph,
+          inspector: LineagePage.sample_group_inspector(),
+          view_mode: :all,
+          search: "",
+          loading: false,
+          error: nil,
+          zoom: 62,
+          canvas_hook?: false
+        }
+      },
+      %Variation{
+        id: :empty,
+        attributes: %{
+          graph: nil,
+          inspector: nil,
+          view_mode: :all,
+          search: "",
+          loading: false,
+          error: nil,
+          zoom: 62,
+          canvas_hook?: false
+        }
+      },
+      %Variation{
+        id: :loading,
+        attributes: %{
+          graph: nil,
+          inspector: nil,
+          view_mode: :all,
+          search: "",
+          loading: true,
+          error: nil,
+          zoom: 62,
+          canvas_hook?: false
+        }
+      },
+      %Variation{
+        id: :error,
+        attributes: %{
+          graph: nil,
+          inspector: nil,
+          view_mode: :all,
+          search: "",
+          loading: false,
+          error: %{message: "No active manifest is available."},
+          zoom: 62,
+          canvas_hook?: false
+        }
+      }
+    ]
+  end
+end

--- a/apps/favn_view/test/favn_view/lineage_live_test.exs
+++ b/apps/favn_view/test/favn_view/lineage_live_test.exs
@@ -27,7 +27,7 @@ defmodule FavnView.AssetCatalogueLineageTest do
     {:ok, view, html} = live(conn, ~p"/assets?mode=lineage")
 
     assert html =~ "Asset catalogue"
-    assert html =~ "Search assets, groups, or schemas"
+    assert html =~ "Search lineage coming soon"
     assert has_element?(view, ~s([data-testid="lineage-toolbar"]))
     assert has_element?(view, ~s([data-testid="lineage-canvas"]))
     assert has_element?(view, ~s([data-testid="lineage-inspector"]))
@@ -39,6 +39,8 @@ defmodule FavnView.AssetCatalogueLineageTest do
              view,
              ~s([data-testid="view-mode-rail"] button[aria-label="Lineage"][aria-pressed="true"])
            )
+
+    assert has_element?(view, ~s(button[phx-value-mode="upstream"][disabled]))
 
     refute html =~ "lineage-kpi-card"
   end

--- a/apps/favn_view/test/favn_view/lineage_live_test.exs
+++ b/apps/favn_view/test/favn_view/lineage_live_test.exs
@@ -1,0 +1,130 @@
+defmodule FavnView.AssetCatalogueLineageTest do
+  use FavnView.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+
+  alias FavnOrchestrator.Auth
+  alias FavnOrchestrator.Auth.Store, as: AuthStore
+  alias FavnView.Auth.BrowserSessionStore
+  alias FavnView.Components.LineagePage
+
+  setup %{conn: conn} do
+    ensure_auth_store_started()
+    :ok = AuthStore.reset()
+    :ok = BrowserSessionStore.reset()
+
+    graph = LineagePage.sample_graph()
+    inspector = LineagePage.sample_group_inspector()
+
+    put_view_env(:lineage_get_graph_fun, fn _opts -> {:ok, graph} end)
+    put_view_env(:lineage_get_group_fun, fn _id, _opts -> {:ok, inspector} end)
+    put_view_env(:active_asset_catalogue_fun, fn -> {:ok, asset_catalogue_entries()} end)
+
+    {:ok, conn: authenticate_conn(conn), graph: graph}
+  end
+
+  test "renders lineage as an asset catalogue mode without top KPI cards", %{conn: conn} do
+    {:ok, view, html} = live(conn, ~p"/assets?mode=lineage")
+
+    assert html =~ "Asset catalogue"
+    assert html =~ "Search assets, groups, or schemas"
+    assert has_element?(view, ~s([data-testid="lineage-toolbar"]))
+    assert has_element?(view, ~s([data-testid="lineage-canvas"]))
+    assert has_element?(view, ~s([data-testid="lineage-inspector"]))
+    assert has_element?(view, ~s([data-testid="lineage-minimap"]))
+    assert has_element?(view, ~s([data-testid="lineage-group-node"]), "GitHub raw")
+    assert has_element?(view, ~s([data-testid="lineage-edge-label"]), "18 deps")
+
+    assert has_element?(
+             view,
+             ~s([data-testid="view-mode-rail"] button[aria-label="Lineage"][aria-pressed="true"])
+           )
+
+    refute html =~ "lineage-kpi-card"
+  end
+
+  test "selecting a group loads the inspector through the lineage facade", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/assets?mode=lineage")
+
+    view
+    |> element(~s([data-testid="lineage-group-node"][phx-value-id="group:raw:github"]))
+    |> render_click()
+
+    assert has_element?(view, ~s([data-testid="lineage-inspector"]), "About this group")
+    assert render(view) =~ "Health summary"
+  end
+
+  test "lineage inspector can be closed to expand graph workspace", %{conn: conn} do
+    {:ok, view, _html} = live(conn, ~p"/assets?mode=lineage")
+
+    assert has_element?(view, ~s([data-testid="lineage-inspector"]))
+
+    view
+    |> element(~s([data-testid="lineage-inspector-close"]))
+    |> render_click()
+
+    refute has_element?(view, ~s([data-testid="lineage-inspector"]))
+    assert has_element?(view, ~s([data-testid="lineage-canvas"]))
+  end
+
+  test "renders sanitized lineage backend errors", %{conn: conn} do
+    put_view_env(:lineage_get_graph_fun, fn _opts ->
+      {:error,
+       %{message: "No active manifest is available.", details: %{secret: "do-not-render"}}}
+    end)
+
+    {:ok, view, html} = live(conn, ~p"/assets?mode=lineage")
+
+    assert has_element?(
+             view,
+             ~s([data-testid="lineage-error-state"]),
+             "No active manifest is available."
+           )
+
+    refute html =~ "do-not-render"
+  end
+
+  defp authenticate_conn(conn) do
+    username = "operator-#{System.unique_integer([:positive])}"
+
+    assert {:ok, _actor} =
+             Auth.create_actor(username, "operator-password-long", "Test Operator", [:operator])
+
+    conn
+    |> post(~p"/login", %{
+      "operator" => %{"username" => username, "password" => "operator-password-long"}
+    })
+    |> recycle()
+  end
+
+  defp ensure_auth_store_started do
+    case Process.whereis(AuthStore) do
+      nil -> start_supervised!({AuthStore, []})
+      _pid -> :ok
+    end
+  end
+
+  defp put_view_env(key, value) do
+    original = Application.get_env(:favn_view, key, :__missing__)
+    Application.put_env(:favn_view, key, value)
+
+    on_exit(fn ->
+      case original do
+        :__missing__ -> Application.delete_env(:favn_view, key)
+        value -> Application.put_env(:favn_view, key, value)
+      end
+    end)
+  end
+
+  defp asset_catalogue_entries do
+    [
+      %{
+        target_id: "asset:test:customer_orders_daily",
+        relation: %{name: "customer_orders_daily", connection: "snowflake", catalog: "sales"},
+        type: "table",
+        status: :healthy,
+        latest_run_at: DateTime.utc_now()
+      }
+    ]
+  end
+end

--- a/docs/ASSET_LINEAGE_DAG_PLAN.md
+++ b/docs/ASSET_LINEAGE_DAG_PLAN.md
@@ -1,0 +1,739 @@
+# Scalable Asset Lineage DAG View Plan
+
+## 1. Summary recommendation
+
+Build the Asset Lineage DAG as an orchestrator-owned operator read model rendered by a thin `favn_view` LiveView. The default graph should be a bounded overview of collapsible lineage groups, not a full asset graph. `favn_core` should continue to own static manifest graph contracts and indexes. `favn_orchestrator` should own the public lineage facade, runtime overlays, grouped graph DTOs, search, inspector DTOs, pagination, limits, and storage access. `favn_view` should own only UI interaction state, rendering, Storybook stories, and browser hooks.
+
+Recommended implementation shape:
+
+- Add `FavnOrchestrator.Operator.Lineage` as the public same-BEAM facade for view use.
+- Add explicit orchestrator DTO structs under `FavnOrchestrator.Operator.Lineage.*` for graph, nodes, edges, groups, summaries, limits, inspector payloads, search results, and errors.
+- Add small static graph helpers in `favn_core` only if they generalize existing manifest graph/index behavior, such as manifest-version graph indexing by asset ref and deterministic static edge access.
+- Use existing target-status and freshness read models for initial runtime overlays, then add a repairable lineage summary read model only when query cost or graph scale justifies persistence.
+- Use a boring HTML/SVG absolute-positioned canvas first, with a focused JS hook for pan/zoom/minimap/fit. Do not add a graph library unless edge routing and interaction complexity prove the simple approach insufficient.
+
+This should be delivered as a feature slice that first proves the grouped overview, inspector, and bounded graph contracts with deterministic mock Storybook data before wiring live data.
+
+## 2. Product/UX behavior
+
+The lineage page should prioritize overview, navigation, and operator diagnosis across hundreds or thousands of assets. The first paint must show the shape of the system, not every asset.
+
+Default behavior:
+
+- Show grouped containers by default.
+- Use left-to-right flow across `Raw systems`, `Staging`, `Core`, `Marts`, and `Dashboards`.
+- Default less relevant groups to `:collapsed`.
+- Default selected, searched, failed, running, or high-impact groups to `:expanded_preview`.
+- Use `:expanded_full` only after explicit drill-in or pagination.
+- Cap the first response so the canvas remains fast and legible.
+
+Required page layout:
+
+- Slim header with `Back to assets`, `Asset lineage`, a `Live` badge, and context subtitle such as `sales marts · Production`.
+- Compact toolbar with search, one `Filters` button, view tabs, fit graph, zoom controls, and optional fullscreen.
+- Main DAG canvas filling the page with subtle grid, pan/zoom, grouped containers, and left-to-right layout.
+- Right inspector panel that supports selected group, selected asset, selected edge, loading, empty, and error states.
+- Minimap at the bottom-right of the canvas.
+- Interaction hint strip at bottom-left for pan, zoom, select, and expand/collapse.
+
+Supported view modes:
+
+- `All`: bounded global grouped overview.
+- `Upstream`: focus graph around selected asset/group upstream closure with limits.
+- `Downstream`: focus graph around selected asset/group downstream closure with limits.
+- `Impact`: downstream blast-radius view emphasizing failed/stale/running impact.
+- `Freshness`: freshness-oriented styling and sorting, with stale/unknown upstream signals emphasized.
+
+Group visual contract:
+
+```text
+GitHub raw
+42 endpoints
+36 fresh · 3 stale · 1 failed · 2 running
+
+raw_issues
+raw_pull_requests
+raw_commits
+raw_users
++38 more
+```
+
+Group states:
+
+```elixir
+:collapsed
+:expanded_preview
+:expanded_full
+```
+
+Node types:
+
+```elixir
+:group
+:asset
+:external_system
+```
+
+Edge types:
+
+- Group-to-group dependencies.
+- Group-to-asset dependencies.
+- Asset-to-asset dependencies.
+- Aggregated dependencies with counts such as `18 deps`.
+- Clickable aggregated edge labels that load dependency details in the inspector first. Use a popover only for short previews after the inspector flow is stable.
+
+Inspector behavior:
+
+- Group inspector shows system, schema, type, asset count, health summary, top issues, downstream/upstream summaries, and actions.
+- Asset inspector shows asset name, schema/layer, freshness, latest run, upstream, downstream, run link, catalog link, and explain lineage.
+- Edge inspector shows dependency count, preview dependencies, upstream/downstream group names, affected statuses, and a paginated dependency list when expanded.
+- Empty inspector shows concise guidance: select a group, asset, or edge.
+- Loading inspector uses skeleton rows and preserves prior panel width to avoid layout shift.
+
+The DAG must not reintroduce top KPI cards. Health counts belong inside group nodes, edge labels, toolbar filter state, or the inspector.
+
+## 3. Data and contract design
+
+The boundary between `favn_orchestrator` and `favn_view` should use explicit DTO structs. These are operator/UI read models, so they belong in `favn_orchestrator`, not `favn_core`, unless a field is a true static manifest/domain contract.
+
+Recommended modules:
+
+```text
+FavnOrchestrator.Operator.Lineage
+FavnOrchestrator.Operator.Lineage.Graph
+FavnOrchestrator.Operator.Lineage.Group
+FavnOrchestrator.Operator.Lineage.Node
+FavnOrchestrator.Operator.Lineage.GroupNode
+FavnOrchestrator.Operator.Lineage.AssetNode
+FavnOrchestrator.Operator.Lineage.ExternalSystemNode
+FavnOrchestrator.Operator.Lineage.Edge
+FavnOrchestrator.Operator.Lineage.Summary
+FavnOrchestrator.Operator.Lineage.Limits
+FavnOrchestrator.Operator.Lineage.GroupInspector
+FavnOrchestrator.Operator.Lineage.AssetInspector
+FavnOrchestrator.Operator.Lineage.EdgeInspector
+FavnOrchestrator.Operator.Lineage.SearchResult
+FavnOrchestrator.Operator.Lineage.Page
+```
+
+Facade contract:
+
+```elixir
+@spec get_graph(keyword()) :: {:ok, Graph.t()} | {:error, error()}
+@spec get_group(String.t(), keyword()) :: {:ok, GroupInspector.t()} | {:error, error()}
+@spec get_asset(String.t(), keyword()) :: {:ok, AssetInspector.t()} | {:error, error()}
+@spec get_edge(String.t(), keyword()) :: {:ok, EdgeInspector.t()} | {:error, error()}
+@spec search(String.t(), keyword()) :: {:ok, Page.t(SearchResult.t())} | {:error, error()}
+@spec list_group_assets(String.t(), keyword()) :: {:ok, Page.t(AssetNode.t())} | {:error, error()}
+```
+
+`get_graph/1` options:
+
+```elixir
+manifest_version_id: String.t() | :active
+scope: :global | :asset | :group
+selected_id: String.t() | nil
+view_mode: :all | :upstream | :downstream | :impact | :freshness
+filters: map()
+expanded_group_ids: [String.t()]
+limit: keyword()
+timeout_ms: pos_integer()
+```
+
+Graph DTO:
+
+```elixir
+%LineageGraph{
+  manifest_version_id: "...",
+  scope: :global,
+  selected_id: nil,
+  nodes: [%LineageNode{}],
+  edges: [%LineageEdge{}],
+  groups: [%LineageGroup{}],
+  summary: %LineageSummary{},
+  limits: %LineageLimits{},
+  layout: %{direction: :left_to_right, layers: [...]},
+  generated_at: ~U[...]
+}
+```
+
+Group node DTO:
+
+```elixir
+%LineageGroupNode{
+  id: "group:raw:github",
+  label: "GitHub raw",
+  system: "GitHub",
+  schema: "raw",
+  layer: :raw,
+  type: :source_system,
+  state: :expanded_preview,
+  asset_count: 42,
+  preview_asset_ids: ["asset:raw_github_issues"],
+  preview_assets: [%LineageAssetPreview{}],
+  hidden_asset_count: 38,
+  status_counts: %{fresh: 36, stale: 3, failed: 1, running: 2, unknown: 0},
+  top_issues: [%{kind: :high_latency, label: "High latency", count: 2}],
+  position_hint: %{layer: :raw, rank: 0}
+}
+```
+
+Asset node DTO:
+
+```elixir
+%LineageAssetNode{
+  id: "asset:Elixir.MyApp.RawGithub:issues",
+  label: "raw_issues",
+  asset_ref: {Elixir.MyApp.RawGithub, :issues},
+  asset_ref_text: "Elixir.MyApp.RawGithub:issues",
+  group_id: "group:raw:github",
+  schema: "raw",
+  layer: :raw,
+  kind: :source,
+  freshness_status: :fresh,
+  run_status: :succeeded,
+  latest_run_id: "run_...",
+  selected?: false
+}
+```
+
+Edge DTO:
+
+```elixir
+%LineageEdge{
+  id: "edge:group:raw:github->group:staging:github",
+  from: "group:raw:github",
+  to: "group:staging:github",
+  kind: :dependency,
+  dependency_count: 18,
+  status: :healthy,
+  aggregated?: true,
+  preview_dependencies: [%{from: "raw_issues", to: "stg_issues"}],
+  hidden_dependency_count: 14
+}
+```
+
+Summary DTO:
+
+```elixir
+%LineageSummary{
+  total_assets: 1_248,
+  visible_assets: 74,
+  total_groups: 96,
+  visible_groups: 18,
+  total_edges: 2_930,
+  visible_edges: 86,
+  status_counts: %{fresh: 1_090, stale: 82, failed: 9, running: 7, unknown: 60},
+  truncated?: true
+}
+```
+
+Limits DTO:
+
+```elixir
+%LineageLimits{
+  max_visible_groups: 60,
+  max_preview_assets_per_group: 4,
+  max_visible_asset_nodes: 200,
+  max_visible_edges: 400,
+  max_dependency_previews_per_edge: 5,
+  group_asset_page_size: 50,
+  search_page_size: 25,
+  timeout_ms: 250
+}
+```
+
+Ownership decision:
+
+- `favn_core`: static manifest graph/index helpers only. Existing `Favn.Manifest.Graph`, `Favn.Manifest.Index`, and `Favn.Assets.GraphIndex` are reusable references. Add new static grouping metadata only if it is authoring/manifest-owned and useful outside the UI, such as explicit asset labels or relation/schema extraction.
+- `favn_orchestrator`: all lineage DTO structs, group summaries, runtime overlays, inspector data, search result DTOs, payload limits, read budgets, error normalization, and public facade.
+- `favn_view`: no DTO construction beyond view-specific CSS/layout normalization. The LiveView consumes orchestrator DTOs and stores browser/UI state.
+
+Failure return shape:
+
+```elixir
+{:error, %FavnOrchestrator.Operator.Lineage.Error{
+  code: :active_manifest_not_found | :manifest_not_found | :invalid_scope | :node_not_found |
+        :query_timeout | :storage_unavailable | :lineage_projection_unavailable,
+  message: String.t(),
+  retryable?: boolean(),
+  details: map()
+}}
+```
+
+## 4. App ownership and boundaries
+
+`favn_core` ownership:
+
+- Static manifest assets, refs, relation metadata, dependency edges, graph topology, and deterministic static graph indexes.
+- Potential additions: manifest graph adjacency helper by `Favn.Ref.t()`, relation/schema/layer extraction helper if it is manifest-domain behavior, and static grouping hints only when manifest-authored.
+- No runtime status, persisted operator state, selected node, view mode, search cursor, inspector DTOs, or UI layout state.
+
+`favn_orchestrator` ownership:
+
+- `FavnOrchestrator.Operator.Lineage` public facade.
+- Runtime-enriched graph read model.
+- Grouping strategy and group ids.
+- Status/freshness/run overlays.
+- Bounded child previews and paginated expansion.
+- Search across assets, groups, and schemas.
+- Inspector DTOs.
+- Query budgets, limits, pagination, storage access, batching, caching, telemetry, and error normalization.
+- Optional repairable lineage summary/read-model projection.
+
+`favn_view` ownership:
+
+- `LineageLive` route and URL params.
+- Visual expansion state, pan/zoom state, selected node/edge, active view mode, search input, open filter popover, and fullscreen state.
+- Page/component rendering and Storybook stories.
+- Browser hook for pan/zoom/minimap/fit/node selection.
+- Calls only `FavnOrchestrator.Operator.Lineage` facade functions.
+
+`favn_runner` ownership:
+
+- No direct lineage ownership for this feature.
+- Existing runner state may contribute only if already exposed through orchestrator-owned read models or future orchestrator projections.
+
+Plugins/adapters ownership:
+
+- No UI-specific leakage.
+- Storage adapters implement orchestrator storage contracts only.
+- SQL/DuckDB/plugin-specific source names may appear only through manifest metadata/relation DTOs or orchestrator-normalized labels.
+
+Boundary rules:
+
+- `favn_view` must not call `Favn.Manifest.Index`, `Favn.Assets.GraphIndex`, storage adapters, repos, runner modules, scheduler internals, compiler internals, or plugin internals.
+- Storybook stories must use deterministic local sample data shaped like public orchestrator DTOs.
+- LiveView tests should mock or seed only public orchestrator-facing behavior available to the view.
+
+## 5. Query/read-model optimization plan
+
+The initial graph load must return a bounded overview, never the full universe. Avoid broad scans followed by in-memory filtering in storage-backed paths. Static manifest traversal can operate in memory after loading a single manifest version because the manifest payload is already the pinned static contract, but runtime overlays must use keyed/batched reads.
+
+Public facade budgets:
+
+- `get_graph/1`: default `timeout_ms: 250`, max `1_000`.
+- `get_group/2`: default `timeout_ms: 200`, max `750`.
+- `get_asset/2`: default `timeout_ms: 200`, max `750`.
+- `get_edge/2`: default `timeout_ms: 200`, max `750`.
+- `search/2`: default `timeout_ms: 150`, max `500`.
+- Return `{:error, %LineageError{code: :query_timeout, retryable?: true}}` when the budget is exceeded.
+
+Initial limits:
+
+- `max_visible_groups`: 40 default, 80 hard max.
+- `max_preview_assets_per_group`: 4 default, 10 hard max.
+- `max_visible_asset_nodes`: 160 default, 300 hard max.
+- `max_visible_edges`: 300 default, 600 hard max.
+- `max_dependency_previews_per_edge`: 5 default, 20 hard max.
+- `group_asset_page_size`: 50 default, 100 hard max.
+- `search_page_size`: 20 default, 50 hard max.
+- Payload target: under 250 KB for initial overview; hard warning above 500 KB.
+
+Access patterns:
+
+- Get graph by manifest version: keyed `get_manifest(manifest_version_id)` or active manifest lookup, then build/read a manifest graph index from that single version. Do not list all manifests.
+- Get selected asset lineage: locate selected asset by `target_id` or asset ref in the manifest index, traverse bounded upstream/downstream closure from static graph, group results, then batch runtime status by visible asset target ids.
+- Get selected group lineage: resolve group id to a bounded group membership set using manifest-derived grouping index, include adjacent groups by static dependencies, then batch runtime status by visible/preview asset ids.
+- Get child assets for group: use group id and cursor over the group membership index, sorted by status priority and stable label. Return `Page.t(AssetNode.t())` with cursor semantics for large groups.
+- Get upstream/downstream for node: use static adjacency from manifest graph index; for group nodes, use aggregated group adjacency rather than expanding all assets unless the group is explicitly drilled into.
+- Runtime status/freshness overlay for many asset ids: use `Storage.list_target_statuses(manifest_version_id, :asset, target_ids)` in one chunked batch. Existing SQLite/Postgres adapters chunk `IN` queries at 250 ids and return a map, which avoids N+1.
+- Freshness detail for many assets: add or reuse a batched freshness query by concrete freshness keys. Existing `Storage.get_asset_freshness_states_by_keys/1` already chunks keys at 250. Prefer this over `list_asset_freshness(limit: Page.max_limit())` for lineage.
+- Search assets/groups/schemas: add an orchestrator lineage search index built from the manifest and optionally cached per manifest version. For storage-backed persisted search later, add keyed indexed columns instead of scanning run history.
+- Fetch inspector data: use keyed `get_group/2`, `get_asset/2`, or `get_edge/2`; each should batch only the related status and dependency ids needed for the inspector.
+
+Required storage access patterns:
+
+- `get_manifest_version(manifest_version_id)`.
+- `get_active_manifest_version()`.
+- `list_target_statuses(manifest_version_id, :asset, target_ids)` for overlay batches.
+- `get_target_status(manifest_version_id, :asset, target_id)` for selected asset inspector fallback.
+- `get_asset_freshness_states_by_keys(keys)` for batched freshness status where target status is insufficient.
+- `list_target_runs(manifest_version_id, :asset, asset_ref, limit: n)` for selected asset inspector history only, not for graph-wide overlays.
+- New: `lineage_group_summaries(manifest_version_id, group_ids)` only if group summaries become persisted.
+- New: `lineage_search(manifest_version_id, query, filters, cursor)` only if manifest in-memory search becomes too costly.
+
+Indexes already available:
+
+- `favn_manifest_versions(manifest_version_id)` primary key and unique `content_hash`.
+- `favn_target_statuses(manifest_version_id, target_kind, target_id)` unique index.
+- `favn_target_statuses(manifest_version_id, target_kind)` index.
+- `favn_target_statuses(manifest_version_id, target_kind, status, updated_at)` index.
+- `favn_asset_freshness_states(asset_ref_module, asset_ref_name, freshness_key)` unique index.
+- `favn_asset_freshness_states(manifest_version_id)` index.
+- `favn_asset_freshness_states(status, updated_at)` index.
+- Run target history is already served by `list_target_runs/4` and should remain inspector/detail-only.
+
+Likely new indexes if lineage projections are persisted:
+
+- `favn_lineage_groups(manifest_version_id, group_id)` unique.
+- `favn_lineage_groups(manifest_version_id, layer, status, sort_key)` for overview loading.
+- `favn_lineage_group_assets(manifest_version_id, group_id, sort_key, asset_target_id)` for group child pagination.
+- `favn_lineage_group_edges(manifest_version_id, from_group_id, to_group_id)` unique.
+- `favn_lineage_search(manifest_version_id, normalized_term, result_kind, result_id)` or backend-specific full-text index when needed.
+
+Batching opportunities:
+
+- Compute visible asset target ids once per graph request and call `list_target_statuses/3` once.
+- Compute freshness keys once per visible/selected asset set and call `get_asset_freshness_states_by_keys/1` once.
+- Build group status counts in one pass over the batched overlay map.
+- For edge previews, collect visible dependency pairs from static adjacency and cap per edge before attaching labels.
+- For inspector downstream/upstream summaries, batch statuses for all preview target ids together.
+
+Cache/read-model opportunities:
+
+- Cache static manifest lineage indexes in orchestrator memory keyed by `{manifest_version_id, content_hash}` with bounded ETS or persistent-term lifecycle. This avoids rebuilding grouping and adjacency on every LiveView event.
+- Cache search token index per manifest version in the same static cache.
+- Persist `favn_lineage_group_summaries` later if group summary aggregation over target status becomes costly or needs cross-node durability.
+- Make any persisted lineage projection repairable from manifest versions, target statuses, freshness state, and run snapshots/events.
+
+N+1 prevention:
+
+- No graph path should call `get_target_status/3` per asset.
+- No graph path should call `list_target_runs/4` per visible asset.
+- No group summary path should call freshness reads per asset.
+- Inspector paths may load one selected asset run history, but only after selection and with a limit.
+
+Pagination/cursor behavior:
+
+- Group child assets use cursor pagination with stable sort `{status_priority, label, asset_id}`.
+- Edge dependency details use cursor pagination with stable sort `{from_label, to_label, dependency_id}`.
+- Search uses cursor pagination with stable sort `{rank, label, id}`.
+- `expanded_full` for a large group renders the first page plus `has_more?`; follow-up pages append or replace children based on UI choice.
+
+## 6. Reuse and Refactor Opportunities
+
+Reuse as-is:
+
+- `FavnView.Components.AppShell` for the slim header, left navigation, Live badge, back link, and no-scroll content mode.
+- `FavnView.Components.IconNav` for the left vertical app navigation.
+- `FavnView.Components.GlassPanel` and CSS classes `favn-surface-panel`, `favn-surface-list`, `favn-surface-control`, `favn-surface-rail`, `favn-icon-button`, `favn-orbital-grid`, and `favn-status-glow` for Favn-native glass/HUD surfaces.
+- `FavnView.CoreComponents.icon/1` and existing Heroicons setup.
+- Existing Phoenix Storybook conventions under `apps/favn_view/storybook/components`.
+- `Favn.Manifest.Index`, `Favn.Manifest.Graph`, and `Favn.Assets.GraphIndex` as references for deterministic static graph behavior.
+- `FavnOrchestrator.TargetStatus` and `Storage.list_target_statuses/3` for batched current status overlays.
+- `FavnOrchestrator.AssetFreshnessState` and `Storage.get_asset_freshness_states_by_keys/1` for batched freshness detail.
+- `FavnOrchestrator.Page` / `CursorPage` patterns for bounded pagination semantics.
+
+Extend existing component:
+
+- Extend `AppShell.app_shell/1` with a `content_scroll?: false` usage for full-canvas pages rather than adding a second shell.
+- Extend the nav items in `AssetCataloguePage.nav_items/1` so `Lineage` points to the new route and can be active.
+- Extract status badge tone mapping from asset/schedule-specific components only if lineage needs the same mapping in multiple components.
+- Extend existing surface CSS with a lineage-specific canvas grid class only if `favn-orbital-grid` is too page-global for the DAG canvas.
+
+Extract reusable component:
+
+- `FavnView.Components.OperatorStatusBadge` if asset catalogue, lineage nodes, inspectors, and future pages need one shared status contract.
+- `FavnView.Components.HudToolbar` if lineage toolbar patterns repeat in schedules/assets after this feature.
+- `FavnView.Components.InspectorPanel` if right-side inspectors become common across lineage, assets, runs, and future storage pages.
+
+New component required:
+
+- `FavnView.Components.LineagePage` top-level page component.
+- `LineageToolbar`, `LineageCanvas`, `LineageGroupNode`, `LineageAssetNode`, `LineageEdge`, `LineageInspector`, `LineageMinimap`, and related lineage-specific components.
+- `assets/js` hook for pan/zoom/minimap/fit and canvas event translation.
+
+Defer:
+
+- Generic graph layout engine abstraction.
+- Persisted lineage projection tables before the in-memory manifest-index approach is measured.
+- Popover-heavy edge dependency exploration before inspector selection is stable.
+- External graph/canvas library until simple SVG/HTML cannot satisfy interaction/performance needs.
+- Full light-theme polish for lineage until dark Favn-native visual acceptance is met, while keeping token usage compatible.
+
+## 7. Component breakdown
+
+LiveView structure:
+
+```text
+FavnView.LineageLive
+  -> FavnView.Components.LineagePage.lineage_page/1
+    -> LineageHeader through AppShell
+    -> LineageToolbar
+    -> LineageCanvas
+      -> LineageLayerHeader
+      -> LineageGroupNode
+      -> LineageAssetNode
+      -> LineageEdge
+      -> LineageEdgeLabel
+      -> LineageMinimap
+      -> LineageControlsHint
+    -> LineageInspector
+      -> LineageGroupInspector
+      -> LineageAssetInspector
+      -> LineageEdgeInspector
+      -> LineageEmptyInspector
+      -> LineageLoadingInspector
+      -> LineageErrorInspector
+    -> LineageFilterPopover
+    -> LineageSearchResults
+```
+
+`LineageLive` responsibilities:
+
+- Parse URL params for selected id, view mode, filters, and search.
+- Call `FavnOrchestrator.Operator.Lineage.get_graph/1` and selected inspector facades.
+- Store UI-only state: selected id, selected type, expanded group ids, zoom level, pan position, active tab, search value, filter popover open state.
+- Push canvas commands to the JS hook for fit/zoom when needed.
+- Render exactly one top-level page component.
+
+`LineagePage` responsibilities:
+
+- Compose AppShell, toolbar, canvas, inspector, minimap, and states.
+- Keep layout responsive.
+- Avoid top cards.
+
+`LineageToolbar` responsibilities:
+
+- Search input with placeholder `Search assets, groups, or schemas...`.
+- Keyboard shortcut hint.
+- Single `Filters` button.
+- View tabs: `All`, `Upstream`, `Downstream`, `Impact`, `Freshness`.
+- Fit graph, zoom out, zoom percent, zoom in, and fullscreen button.
+
+`LineageCanvas` responsibilities:
+
+- Own visual board markup and data attributes used by the hook.
+- Render SVG edges behind HTML nodes or all-SVG if measurement proves simpler.
+- Render subtle grid and layer headers.
+- Use stable ids and `data-testid` selectors for Playwright/LiveView tests.
+
+Canvas implementation decision:
+
+- Start with HTML absolute-positioned nodes and SVG edges in one overlay.
+- Compute deterministic coarse positions server-side from layer/rank for Storybook and first implementation.
+- Let the JS hook apply transform for pan/zoom to a single canvas content wrapper.
+- Avoid a graph library for phase 1 because the required layout is grouped, layered, and bounded rather than arbitrary force-directed rendering.
+- Revisit a library only if edge routing, collision avoidance, accessibility, and minimap maintenance become more expensive than integration risk.
+
+JS hook responsibilities:
+
+```text
+LineageCanvasHook
+  pan canvas by pointer drag
+  wheel/pinch zoom with min/max bounds
+  fit-to-graph from node bounds
+  update minimap viewport
+  dispatch node select events
+  dispatch group expand/collapse events
+  dispatch edge hover/click events
+  preserve transform between LiveView patches
+```
+
+Accessibility requirements:
+
+- Nodes are buttons or links with accessible labels.
+- Edge labels are buttons when clickable.
+- Keyboard selection works with tab order and Enter/Space.
+- Toolbar controls have labels and `aria-pressed` for tabs.
+- Inspector headings use semantic structure.
+
+Responsive behavior:
+
+- Desktop: left nav, full header, toolbar, canvas, right inspector.
+- Tablet: inspector can collapse to a drawer.
+- Mobile: canvas remains usable but defaults to fit graph with inspector as bottom sheet or route-level panel. Mobile can be a follow-up if desktop is the first acceptance target, but controls must remain reachable.
+
+## 8. Storybook plan
+
+Every important visual component should have Phoenix Storybook coverage with deterministic mock data matching the approved mockup direction.
+
+Required stories:
+
+- `lineage_page.story.exs`: full lineage page mock at desktop 16:9.
+- `lineage_group_node.story.exs`: collapsed group node.
+- `lineage_group_node.story.exs`: expanded preview group node.
+- `lineage_group_node.story.exs`: selected group node with neon blue glow.
+- `lineage_asset_node.story.exs`: fresh asset node.
+- `lineage_asset_node.story.exs`: stale asset node.
+- `lineage_asset_node.story.exs`: failed asset node.
+- `lineage_asset_node.story.exs`: running asset node.
+- `lineage_edge.story.exs`: aggregated edge with dependency count.
+- `lineage_inspector.story.exs`: right inspector for group.
+- `lineage_inspector.story.exs`: right inspector for asset.
+- `lineage_toolbar.story.exs`: toolbar with search, filters button, tabs, fit, zoom, fullscreen.
+- `lineage_minimap.story.exs`: minimap with viewport rectangle.
+- `lineage_page.story.exs`: empty state.
+- `lineage_page.story.exs`: loading state.
+- `lineage_page.story.exs`: error state.
+- `lineage_page.story.exs`: large graph overview state.
+
+Mock data requirements:
+
+- Include `GitHub raw` with `42 endpoints`, `36 fresh`, `3 stale`, `1 failed`, `2 running`, preview assets `raw_issues`, `raw_pull_requests`, `raw_commits`, `raw_users`, and `+38 more`.
+- Include `Stripe raw`, `staging.github`, `staging.stripe`, `fct_orders`, `dim_customer`, `mart_sales`, `mart_revenue`, and dashboards.
+- Include aggregated edges with `18 deps`, `12 deps`, `9 deps`, `5 deps`, and `4 deps`.
+- Include group inspector matching the product example.
+- Include asset inspector for a failed or stale asset.
+- Include deterministic ids and `data-testid` values.
+
+Storybook routes should be the visual contract for Playwright verification before live data is complete.
+
+## 9. Playwright verification plan
+
+Use Playwright against Storybook first, then the LiveView route once wired.
+
+Desktop verification:
+
+- Open `http://127.0.0.1:4173/storybook` and navigate to the full lineage page story.
+- Set viewport to `1728x972` or `1440x900`.
+- Verify the page has a left icon nav, slim header, compact toolbar, main canvas, right inspector, minimap, and bottom-left hint strip.
+- Verify the DAG canvas uses most of the screen.
+- Verify no top KPI cards exist.
+- Verify filters are behind a single `Filters` button.
+- Verify view tabs are `All`, `Upstream`, `Downstream`, `Impact`, `Freshness`.
+- Verify `GitHub raw` group renders preview assets and `+38 more`.
+- Verify selected group glow uses Favn neon blue treatment.
+- Verify inspector supports selected group and displays health summary and actions.
+- Verify aggregated edge labels render dependency counts.
+- Click group expand/collapse and verify state changes.
+- Click an aggregated edge and verify the inspector changes to dependency details.
+- Click fit graph and zoom controls and verify transform/minimap updates.
+- Take a screenshot.
+- Compare against the approved mockup or project baseline where supported.
+
+Responsive verification:
+
+- Verify at `390x844` that navigation, toolbar, canvas controls, search, and inspector access remain reachable.
+- Verify at a tablet width if inspector collapse behavior changes.
+
+LiveView verification after wiring:
+
+- Open `/lineage` or the final route.
+- Verify active manifest fallback/loading/error states.
+- Verify selecting a group calls only the orchestrator facade by checking LiveView behavior and logs when needed.
+- Verify URL params can restore selected node and view mode.
+
+Document intentional deviations:
+
+- Any differences from the attached mockup must be listed in the PR or feature notes with product/design rationale.
+- Pixel-perfect priority applies to layout, density, selected state, surface strength, typography, grid, and inspector proportions.
+
+## 10. Focused test plan
+
+Run focused tests only for affected apps/components.
+
+`favn_core` static graph/index tests:
+
+```bash
+MIX_ENV=test mix do --app favn_core cmd mix test --no-compile test/manifest test/assets/graph_planner_parity_test.exs
+```
+
+`favn_orchestrator` facade and DTO tests:
+
+```bash
+MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile test/operator/lineage_test.exs
+```
+
+`favn_orchestrator` storage/read-model tests:
+
+```bash
+MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile test/storage/lineage_read_model_test.exs test/integration/storage_adapter_contract_test.exs
+```
+
+`favn_orchestrator` status/freshness aggregation tests:
+
+```bash
+MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile test/operator/lineage_status_aggregation_test.exs test/freshness/query_test.exs
+```
+
+`favn_orchestrator` search tests:
+
+```bash
+MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile test/operator/lineage_search_test.exs
+```
+
+`favn_view` component and LiveView tests:
+
+```bash
+MIX_ENV=test mix do --app favn_view cmd mix test --no-compile test/favn_view/lineage_live_test.exs
+```
+
+Storybook/visual checks:
+
+```bash
+cd apps/favn_view && mix assets.build
+```
+
+Browser verification:
+
+- Use Playwright MCP against `/storybook` and the final route.
+- Save screenshots from the full page story and selected states.
+
+General verification before finishing implementation:
+
+```bash
+mix format
+mix compile --warnings-as-errors
+```
+
+Do not run umbrella-wide `mix test` unless explicitly requested later. Add adapter-specific SQLite/Postgres tests only when a persisted lineage projection or new storage callback is introduced.
+
+## 11. Implementation phases
+
+Phase 1: visual contract and mock data
+
+- Add lineage DTO-shaped sample data in `favn_view` stories only.
+- Build page and component Storybook stories against deterministic mock data.
+- Implement `LineageCanvasHook` with static Storybook data for pan/zoom/minimap/fit.
+- Verify with Playwright against Storybook and refine visual fidelity.
+
+Phase 2: orchestrator DTO and static graph facade
+
+- Add `FavnOrchestrator.Operator.Lineage` DTO structs and facade skeleton.
+- Build static manifest grouping from active/passed manifest version.
+- Reuse `Favn.Manifest.Index` and `Favn.Manifest.Graph` behavior rather than reconstructing dependency semantics in `favn_view`.
+- Add unit tests for grouping, edge aggregation, limits, and error shapes.
+
+Phase 3: runtime overlays and inspector facade
+
+- Batch target status overlays with `Storage.list_target_statuses/3`.
+- Batch freshness overlays with `Storage.get_asset_freshness_states_by_keys/1` where needed.
+- Implement group, asset, and edge inspector DTOs.
+- Add tests proving no N+1 status/freshness reads for visible asset sets.
+
+Phase 4: LiveView route and interactions
+
+- Add `LineageLive` and route.
+- Wire toolbar, view modes, search, selected node/edge, expanded groups, and inspector loading.
+- Ensure `favn_view` calls only `FavnOrchestrator.Operator.Lineage`.
+- Add LiveView tests for rendering states, selection, expand/collapse, search, filters, and error state.
+
+Phase 5: search, pagination, and large graph behavior
+
+- Add lineage search over assets, groups, and schemas with bounded pages.
+- Add group asset pagination and edge dependency pagination.
+- Add large graph overview story and tests for truncation/limits.
+- Measure payload size and latency with synthetic hundreds/thousands asset manifests.
+
+Phase 6: optional persisted lineage read model
+
+- Add storage callbacks, SQLite/Postgres migrations, adapters, and repair path only if in-memory per-manifest grouping is too slow.
+- Keep projection repairable and scoped by manifest version.
+- Add adapter parity tests and index coverage.
+
+## 12. Risks / open questions
+
+- Grouping semantics need product approval. The first heuristic can group by relation/catalog/schema/layer plus source-system metadata, but Favn may need explicit manifest grouping metadata later.
+- Asset refs currently produce technical labels such as `Module:name`; the UI needs clean labels like `raw_issues`. Decide whether labels come from manifest metadata, relation table names, or normalized ref names.
+- Freshness terminology differs between internal statuses (`:ok`, `:skipped_fresh`, `:blocked`) and product labels (`fresh`, `stale`, `failed`, `running`, `unknown`). The orchestrator DTO must own the mapping.
+- `stale` may require freshness explanation, not just current target status. The facade must define when an asset is stale versus failed/unknown.
+- Large graph layout quality may exceed simple deterministic positioning. Defer a graph library decision until the first visual prototype is measured.
+- Live updates are not specified. The feature can start with manual refresh/LiveView events and later subscribe to orchestrator SSE/PubSub-derived updates if needed.
+- Persisted lineage projection could become necessary for thousands of assets, but adding tables too early may create migration and repair burden.
+- Mobile UX for a dense DAG is inherently constrained. The first acceptance target should be desktop 16:9, with mobile reachability rather than equal capability.
+- Pixel comparison support may not exist in the project today. If no baseline tooling exists, use Playwright screenshots and documented visual review.
+
+## 13. Explicit deferrals
+
+- No implementation in this planning slice.
+- No new graph/canvas dependency in the first implementation phase.
+- No top KPI cards.
+- No general SQL/data browser from lineage.
+- No runner-owned lineage API.
+- No storage/plugin-specific UI leakage.
+- No persisted lineage tables until performance data proves in-memory manifest indexing is insufficient.
+- No distributed live lineage update contract in the first slice.
+- No full arbitrary graph auto-layout engine until the grouped, layered layout fails concrete cases.
+- No broad umbrella tests for this feature unless explicitly requested later.


### PR DESCRIPTION
## Summary
- Add orchestrator-owned asset lineage DTOs and facade for bounded grouped graph, inspectors, search, and pagination.
- Add reusable lineage explorer UI and wire it into the asset catalogue mode rail as the Lineage view.
- Include the asset lineage DAG implementation plan and Storybook coverage for the visual contract.

## Review Fixes
- Keep full group membership behind the orchestrator facade while exposing only bounded graph previews.
- Make hidden assets searchable, pageable through `list_group_assets/2`, and inspectable through `get_asset/2`.
- Disable unsupported UI controls and reject unsupported facade options instead of silently returning fake upstream/downstream/filter views.
- Use layer-specific group ids to avoid schema collisions and derive layer captions from graph data.

## Verification
- mix format
- mix compile --warnings-as-errors
- mix assets.build
- MIX_ENV=test mix do --app favn_orchestrator cmd mix test --no-compile test/operator/lineage_test.exs
- MIX_ENV=test mix do --app favn_view cmd mix test --no-compile test/favn_view/lineage_live_test.exs test/favn_view/page_live_test.exs:101
- Playwright Storybook checks for asset catalogue lineage at desktop and mobile widths

## Notes
- Did not run umbrella test, per request.