### PR TITLE
Fix SQL catalog scope and error persistence

### DIFF
--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/json_safe.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/json_safe.ex
@@ -65,11 +65,24 @@ defmodule FavnOrchestrator.Storage.JsonSafe do
     }
   end
 
-  def error(%{__exception__: true} = exception) do
+  def error(%{__exception__: true, __struct__: module} = exception) do
     %{
       "kind" => "error",
-      "type" => exception.__struct__ |> Atom.to_string(),
+      "type" => Atom.to_string(module),
       "message" => safe_error_message(exception_message(exception) || exception),
+      "reason" => safe_error_reason(exception),
+      "redacted" => true,
+      "truncated" => false
+    }
+  end
+
+  def error(%{__exception__: true} = exception) do
+    message = Map.get(exception, :message) || Map.get(exception, "message") || exception
+
+    %{
+      "kind" => "error",
+      "type" => error_type(exception),
+      "message" => safe_error_message(message),
       "reason" => safe_error_reason(exception),
       "redacted" => true,
       "truncated" => false

--- a/apps/favn_orchestrator/lib/favn_orchestrator/storage/json_safe.ex
+++ b/apps/favn_orchestrator/lib/favn_orchestrator/storage/json_safe.ex
@@ -65,7 +65,7 @@ defmodule FavnOrchestrator.Storage.JsonSafe do
     }
   end
 
-  def error(%{__exception__: true, __struct__: module} = exception) do
+  def error(%{__exception__: true, __struct__: module} = exception) when is_atom(module) do
     %{
       "kind" => "error",
       "type" => Atom.to_string(module),
@@ -292,8 +292,10 @@ defmodule FavnOrchestrator.Storage.JsonSafe do
 
   defp exception_message(_value), do: nil
 
-  defp error_type(%{__exception__: true, __struct__: module}), do: Atom.to_string(module)
-  defp error_type(%{__struct__: module}), do: Atom.to_string(module)
+  defp error_type(%{__exception__: true, __struct__: module}) when is_atom(module),
+    do: Atom.to_string(module)
+
+  defp error_type(%{__struct__: module}) when is_atom(module), do: Atom.to_string(module)
   defp error_type(value) when is_atom(value), do: Atom.to_string(value)
   defp error_type(value) when is_map(value), do: "map"
   defp error_type(value) when is_tuple(value), do: "tuple"

--- a/apps/favn_orchestrator/test/storage/json_safe_test.exs
+++ b/apps/favn_orchestrator/test/storage/json_safe_test.exs
@@ -93,6 +93,19 @@ defmodule FavnOrchestrator.Storage.JsonSafeTest do
     assert_json_compatible!(normalized)
   end
 
+  test "normalizes exception-shaped maps with malformed struct metadata" do
+    normalized =
+      JsonSafe.error(%{
+        __exception__: true,
+        __struct__: "Adbc.Error",
+        message: "Binder Error: Catalog \"raw\" does not exist!"
+      })
+
+    assert normalized["type"] == "map"
+    assert normalized["message"] == "Binder Error: Catalog \"raw\" does not exist!"
+    assert_json_compatible!(normalized)
+  end
+
   test "normalizes explicit error terms as structured sanitized maps" do
     normalized =
       JsonSafe.error(%{

--- a/apps/favn_orchestrator/test/storage/json_safe_test.exs
+++ b/apps/favn_orchestrator/test/storage/json_safe_test.exs
@@ -78,6 +78,21 @@ defmodule FavnOrchestrator.Storage.JsonSafeTest do
     assert_json_compatible!(normalized)
   end
 
+  test "normalizes exception-shaped maps without struct metadata" do
+    normalized =
+      JsonSafe.error(%{
+        __exception__: true,
+        message: "Binder Error: Catalog \"raw\" does not exist!",
+        vendor_code: 0
+      })
+
+    assert normalized["kind"] == "error"
+    assert normalized["type"] == "map"
+    assert normalized["message"] == "Binder Error: Catalog \"raw\" does not exist!"
+    assert normalized["redacted"] == true
+    assert_json_compatible!(normalized)
+  end
+
   test "normalizes explicit error terms as structured sanitized maps" do
     normalized =
       JsonSafe.error(%{

--- a/apps/favn_runner/lib/favn/sql_asset/runtime.ex
+++ b/apps/favn_runner/lib/favn/sql_asset/runtime.ex
@@ -188,7 +188,7 @@ defmodule Favn.SQLAsset.Runtime do
   end
 
   defp materialize_render(%Definition{} = definition, %Render{} = rendered, opts) do
-    with_session(rendered.connection, opts, required_catalogs(rendered), fn session ->
+    with_session(rendered.connection, opts, required_catalogs(rendered, definition), fn session ->
       with {:ok, write_plan} <- MaterializationPlanner.build(session, definition, rendered),
            {:ok, result} <-
              SQLClient.materialize(
@@ -310,6 +310,24 @@ defmodule Favn.SQLAsset.Runtime do
 
     if catalogs == [], do: nil, else: catalogs
   end
+
+  defp required_catalogs(%Render{} = rendered, %Definition{} = definition) do
+    catalogs =
+      [rendered.relation | definition_relation_inputs(definition)]
+      |> Enum.concat(resolved_relations(rendered.resolved_asset_refs))
+      |> Enum.flat_map(&relation_catalog/1)
+      |> Enum.uniq()
+
+    if catalogs == [], do: nil, else: catalogs
+  end
+
+  defp definition_relation_inputs(%Definition{relation_inputs: inputs}) when is_list(inputs) do
+    Enum.map(inputs, fn input ->
+      Map.get(input, :relation_ref) || Map.get(input, "relation_ref")
+    end)
+  end
+
+  defp definition_relation_inputs(%Definition{}), do: []
 
   defp resolved_relations(refs) when is_list(refs) do
     Enum.map(refs, fn ref -> Map.get(ref, :relation) || Map.get(ref, "relation") end)

--- a/apps/favn_runner/lib/favn/sql_asset/runtime.ex
+++ b/apps/favn_runner/lib/favn/sql_asset/runtime.ex
@@ -49,8 +49,7 @@ defmodule Favn.SQLAsset.Runtime do
   def render(asset, opts \\ [])
 
   def render(%{type: :sql, module: module}, opts) when is_atom(module) and is_list(opts) do
-    with {:ok, %Definition{} = definition} <- fetch_definition(module),
-         {:ok, %Render{} = rendered} <- Renderer.render(definition, opts) do
+    with {:ok, _definition, %Render{} = rendered} <- render_sql_asset(module, opts) do
       {:ok, rendered}
     end
   end
@@ -72,9 +71,9 @@ defmodule Favn.SQLAsset.Runtime do
     limit = Keyword.get(opts, :limit, 100)
 
     with :ok <- validate_limit(limit),
-         {:ok, %Render{} = rendered} <- render(asset, opts),
+         {:ok, %Definition{} = definition, %Render{} = rendered} <- render_sql_asset(asset, opts),
          statement <- preview_statement(rendered.sql, limit),
-         {:ok, result} <- query_render(rendered, statement, :preview, opts) do
+         {:ok, result} <- query_render(definition, rendered, statement, :preview, opts) do
       {:ok, %Preview{render: rendered, limit: limit, statement: statement, result: result}}
     end
   end
@@ -83,9 +82,9 @@ defmodule Favn.SQLAsset.Runtime do
   def explain(%{} = asset, opts \\ []) when is_list(opts) do
     analyze? = Keyword.get(opts, :analyze?, false)
 
-    with {:ok, %Render{} = rendered} <- render(asset, opts),
+    with {:ok, %Definition{} = definition, %Render{} = rendered} <- render_sql_asset(asset, opts),
          statement <- explain_statement(rendered.sql, analyze?),
-         {:ok, result} <- query_render(rendered, statement, :explain, opts) do
+         {:ok, result} <- query_render(definition, rendered, statement, :explain, opts) do
       {:ok, %Explain{render: rendered, statement: statement, analyze?: analyze?, result: result}}
     end
   end
@@ -138,6 +137,29 @@ defmodule Favn.SQLAsset.Runtime do
     [params: ctx.params || %{}, runtime: runtime]
   end
 
+  defp render_sql_asset(%{type: :sql, module: module}, opts)
+       when is_atom(module) and is_list(opts),
+       do: render_sql_asset(module, opts)
+
+  defp render_sql_asset(%{} = asset, _opts) do
+    asset_ref = Map.get(asset, :ref)
+
+    {:error,
+     %Error{
+       type: :not_sql_asset,
+       phase: :render,
+       asset_ref: asset_ref,
+       message: "asset #{inspect(asset_ref)} is not a SQL asset"
+     }}
+  end
+
+  defp render_sql_asset(module, opts) when is_atom(module) and is_list(opts) do
+    with {:ok, %Definition{} = definition} <- fetch_definition(module),
+         {:ok, %Render{} = rendered} <- Renderer.render(definition, opts) do
+      {:ok, definition, rendered}
+    end
+  end
+
   defp fetch_definition(module) do
     case Compiler.fetch_definition(module) do
       {:ok, %Definition{} = definition} ->
@@ -173,32 +195,42 @@ defmodule Favn.SQLAsset.Runtime do
   defp explain_statement(sql, true), do: "EXPLAIN ANALYZE #{trim_sql(sql)}"
   defp explain_statement(sql, false), do: "EXPLAIN #{trim_sql(sql)}"
 
-  defp query_render(%Render{} = rendered, statement, phase, opts) do
-    with_session(rendered.connection, opts, required_catalogs(rendered), fn session ->
-      SQLClient.query(
-        session,
-        statement,
-        Keyword.merge(sql_operation_opts(opts),
-          params: adapter_params(rendered.params),
-          read_only?: true
+  defp query_render(%Definition{} = definition, %Render{} = rendered, statement, phase, opts) do
+    with_session(
+      rendered.connection,
+      opts,
+      session_required_catalogs(definition, rendered),
+      fn session ->
+        SQLClient.query(
+          session,
+          statement,
+          Keyword.merge(sql_operation_opts(opts),
+            params: adapter_params(rendered.params),
+            read_only?: true
+          )
         )
-      )
-    end)
+      end
+    )
     |> map_sql_result_error(rendered.asset_ref, phase)
   end
 
   defp materialize_render(%Definition{} = definition, %Render{} = rendered, opts) do
-    with_session(rendered.connection, opts, required_catalogs(rendered, definition), fn session ->
-      with {:ok, write_plan} <- MaterializationPlanner.build(session, definition, rendered),
-           {:ok, result} <-
-             SQLClient.materialize(
-               session,
-               write_plan,
-               Keyword.merge(sql_operation_opts(opts), params: adapter_params(rendered.params))
-             ) do
-        {:ok, write_plan, result}
+    with_session(
+      rendered.connection,
+      opts,
+      session_required_catalogs(definition, rendered),
+      fn session ->
+        with {:ok, write_plan} <- MaterializationPlanner.build(session, definition, rendered),
+             {:ok, result} <-
+               SQLClient.materialize(
+                 session,
+                 write_plan,
+                 Keyword.merge(sql_operation_opts(opts), params: adapter_params(rendered.params))
+               ) do
+          {:ok, write_plan, result}
+        end
       end
-    end)
+    )
     |> map_sql_result_error(rendered.asset_ref, :materialize)
   end
 
@@ -300,18 +332,9 @@ defmodule Favn.SQLAsset.Runtime do
 
   defp maybe_put_timeout(opts, _deadline_at), do: opts
 
-  defp required_catalogs(%Render{} = rendered) do
+  defp session_required_catalogs(%Definition{} = definition, %Render{} = rendered) do
     # Catalog scope comes from manifest-declared relation ownership and resolved
     # Favn asset references, not by parsing arbitrary SQL text.
-    catalogs =
-      [rendered.relation | resolved_relations(rendered.resolved_asset_refs)]
-      |> Enum.flat_map(&relation_catalog/1)
-      |> Enum.uniq()
-
-    if catalogs == [], do: nil, else: catalogs
-  end
-
-  defp required_catalogs(%Render{} = rendered, %Definition{} = definition) do
     catalogs =
       [rendered.relation | definition_relation_inputs(definition)]
       |> Enum.concat(resolved_relations(rendered.resolved_asset_refs))

--- a/apps/favn_runner/test/execution/sql_asset_test.exs
+++ b/apps/favn_runner/test/execution/sql_asset_test.exs
@@ -95,6 +95,21 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
     assert Keyword.fetch!(opts, :required_catalogs) == ["int", "raw"]
   end
 
+  test "preview and explain scope SQL sessions to declared relation input catalogs" do
+    asset = %{
+      type: :sql,
+      module: FavnRunner.ExecutionSQLAssetTest.PlainRelationInputSQLAsset
+    }
+
+    assert {:ok, _preview} = Favn.SQLAsset.Runtime.preview(asset)
+    assert_received {:connect_opts, :runner_sql_runtime, preview_opts}
+    assert Keyword.fetch!(preview_opts, :required_catalogs) == ["int", "raw"]
+
+    assert {:ok, _explain} = Favn.SQLAsset.Runtime.explain(asset)
+    assert_received {:connect_opts, :runner_sql_runtime, explain_opts}
+    assert Keyword.fetch!(explain_opts, :required_catalogs) == ["int", "raw"]
+  end
+
   test "executes manifest-pinned sql asset through declared runner SQL runtime" do
     ref = {FavnRunner.ExecutionSQLAssetTest.SQLAsset, :asset}
     version = register_sql_manifest!(ref)
@@ -539,6 +554,22 @@ end
 defmodule FavnRunner.ExecutionSQLAssetTest.SQLAsset do
 end
 
+defmodule FavnRunner.ExecutionSQLAssetTest.PlainRelationInputSQLAsset do
+  use Favn.Namespace,
+    relation: [connection: :runner_sql_runtime, catalog: "int", schema: "sales"]
+
+  use Favn.SQLAsset
+
+  @relation [name: "customers_normalized"]
+  @materialized :table
+  query do
+    ~SQL"""
+    select customer_id
+    from raw.crm.customers
+    """
+  end
+end
+
 defmodule FavnRunner.ExecutionSQLAssetTest.MissingPayloadSQLAsset do
 end
 
@@ -612,6 +643,9 @@ defmodule FavnRunner.ExecutionSQLAssetTest.FakeExecutionAdapter do
 
   def disconnect(:conn, _opts), do: :ok
   def capabilities(%Resolved{}, _opts), do: {:ok, %Capabilities{}}
+
+  def query(:conn, _statement, _opts),
+    do: {:ok, %Result{kind: :query, command: "SELECT", rows: [], columns: []}}
 
   def materialize(:conn, _write_plan, _opts),
     do: {:ok, %Result{command: :insert, rows_affected: 1}}

--- a/apps/favn_runner/test/execution/sql_asset_test.exs
+++ b/apps/favn_runner/test/execution/sql_asset_test.exs
@@ -3,6 +3,7 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
 
   alias Favn.Connection.Registry
   alias Favn.Connection.Resolved
+  alias Favn.Asset.RelationInput
   alias Favn.Contracts.RelationInspectionRequest
   alias Favn.Contracts.RunnerWork
   alias Favn.Manifest
@@ -51,6 +52,47 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
     assert result.status == :ok
     assert_received {:connect_opts, :runner_sql_runtime, opts}
     assert Keyword.fetch!(opts, :required_catalogs) == ["raw"]
+  end
+
+  test "manifest execution scopes SQL sessions to declared relation input catalogs" do
+    ref = {FavnRunner.ExecutionSQLAssetTest.SQLAsset, :asset}
+
+    relation =
+      RelationRef.new!(%{
+        connection: :runner_sql_runtime,
+        catalog: "int",
+        schema: "sales",
+        name: "customers_normalized"
+      })
+
+    raw_relation =
+      RelationRef.new!(%{
+        connection: :runner_sql_runtime,
+        catalog: "raw",
+        schema: "crm",
+        name: "customers"
+      })
+
+    version =
+      register_sql_manifest!(ref, relation, [
+        %RelationInput{
+          kind: :plain_relation,
+          relation_ref: raw_relation,
+          raw: "raw.crm.customers"
+        }
+      ])
+
+    work = %RunnerWork{
+      run_id: "run_sql_relation_input_catalog_scope",
+      manifest_version_id: version.manifest_version_id,
+      manifest_content_hash: version.content_hash,
+      asset_ref: ref
+    }
+
+    assert {:ok, result} = FavnRunner.run(work)
+    assert result.status == :ok
+    assert_received {:connect_opts, :runner_sql_runtime, opts}
+    assert Keyword.fetch!(opts, :required_catalogs) == ["int", "raw"]
   end
 
   test "executes manifest-pinned sql asset through declared runner SQL runtime" do
@@ -283,7 +325,7 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
     version
   end
 
-  defp register_sql_manifest!(ref, relation \\ nil) do
+  defp register_sql_manifest!(ref, relation \\ nil, relation_inputs \\ []) do
     relation =
       relation || RelationRef.new!(%{connection: :runner_sql_runtime, name: "manifest_sql_asset"})
 
@@ -309,6 +351,7 @@ defmodule FavnRunner.ExecutionSQLAssetTest do
             execution: %{entrypoint: :asset, arity: 1},
             relation: relation,
             materialization: :table,
+            relation_inputs: relation_inputs,
             sql_execution: %SQLExecution{
               sql: "SELECT 1 AS id",
               template: template,


### PR DESCRIPTION
## Summary
- Include manifest-declared SQL relation input catalogs when opening runner SQL sessions, so materializations can read from input catalogs like `raw` while writing to `int`.
- Normalize exception-shaped maps without `__struct__` in `JsonSafe.error/1`, preventing failure persistence from crashing on ADBC-style error payloads.
- Add focused regression coverage for both cases.

## Tests
- `MIX_ENV=test mix do --app favn_orchestrator cmd mix test --exclude acceptance --exclude slow --exclude browser test/storage/json_safe_test.exs`
- `MIX_ENV=test mix do --app favn_runner cmd mix test --exclude acceptance --exclude slow --exclude browser test/execution/sql_asset_test.exs`
- `mix compile --warnings-as-errors`